### PR TITLE
feat: 新增了代码块组件

### DIFF
--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,0 +1,79 @@
+import { HighlightRule } from '@/www/components/doc-component';
+
+type MatchResult = {
+  text: string;
+  className: string; // 使用 null 标记没有被任何正则匹配的部分
+};
+
+export function splitByHighlightRules(input: string, rules: HighlightRule[]): MatchResult[] {
+  let results: MatchResult[] = [];
+  let currentIndex = 0;
+
+  while (currentIndex < input.length) {
+    let earliestMatch = {
+      index: Infinity,
+      endIndex: Infinity,
+      regexIndex: -1,
+      matchText: '',
+    };
+
+    // 找到最早的匹配结果
+    rules.forEach((rule, i) => {
+      let localIndex = input.substring(currentIndex).search(rule.regex);
+      if (localIndex !== -1) {
+        localIndex += currentIndex; // 转换为原始字符串中的索引
+        const matchResult = input.substring(localIndex).match(rule.regex);
+        if (matchResult) {
+          // 确保 matchResult 非空
+          const matchLength = matchResult[0].length;
+          if (localIndex < earliestMatch.index) {
+            earliestMatch = {
+              index: localIndex,
+              endIndex: localIndex + matchLength,
+              regexIndex: i,
+              matchText: input.substring(localIndex, localIndex + matchLength),
+            };
+          }
+        }
+      }
+    });
+
+    // 检查是否有未匹配的间隙
+    if (currentIndex < earliestMatch.index) {
+      results.push({ text: input.slice(currentIndex, earliestMatch.index), className: '' });
+    }
+
+    // 添加找到的最早匹配结果
+    if (earliestMatch.regexIndex !== -1) {
+      results.push({
+        text: earliestMatch.matchText,
+        className: rules[earliestMatch.regexIndex].className,
+      });
+      currentIndex = earliestMatch.endIndex; // 更新当前索引
+    } else {
+      // 如果没有匹配，退出循环
+      break;
+    }
+  }
+
+  return results;
+}
+
+export const HIGHLIGHT_RULE = {
+  htmlTagName: {
+    regex: /\b(div|span|a|p|ul|ol|li|h[1-6]|br|hr|input|form|script)\b(?=[^>]*>)/,
+    className: 'html-tag-name',
+  } as HighlightRule,
+  shadcnTagName: {
+    regex: /\b(shadcn-[a-z0-9-]*)\b/,
+    className: 'custom-html-tag-name',
+  } as HighlightRule,
+  prototypeTagName: {
+    regex: /\b(prototype-[a-z0-9-]*)\b/,
+    className: 'custom-html-tag-name',
+  } as HighlightRule,
+  upperCamelCase: {
+    regex: /\b[A-Z][a-z]+(?:[A-Z][a-z]+)*\b/,
+    className: 'upper-camel-case',
+  },
+} as const;

--- a/src/www/app/prototype/select/select-basic.ts
+++ b/src/www/app/prototype/select/select-basic.ts
@@ -1,8 +1,9 @@
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 
 export default class SelectBasic extends DocCode {
   protected _code = 'Code component is in development';
+  protected _highlightRules: HighlightRule[] = [];
 
   protected _preview = () => {
     const select = h('prototype-select', { 'default-value': 'Option 2' }, [

--- a/src/www/app/prototype/tansition/overlay-test.ts
+++ b/src/www/app/prototype/tansition/overlay-test.ts
@@ -1,10 +1,12 @@
 import PrototypeOverlay from '@/prototype/overlay/overlay';
 import { ShadcnButton } from '@/shadcn';
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 
 class OverlayTest extends DocCode {
   protected _code = 'Code component is in development';
+  protected _highlightRules: HighlightRule[] = [];
+
   protected _preview = () => {
     const button = h('shadcn-button', {}, ['Toggle Overlay']) as ShadcnButton;
     const overlay = h('prototype-overlay', { style: 'top: 20px' }, [
@@ -25,4 +27,3 @@ class OverlayTest extends DocCode {
 }
 
 customElements.define('overlay-test', OverlayTest);
-

--- a/src/www/app/prototype/tansition/transition-basic.ts
+++ b/src/www/app/prototype/tansition/transition-basic.ts
@@ -1,11 +1,29 @@
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 import '@/shadcn';
 import { ShadcnButton } from '@/shadcn';
 import PrototypeTransition from '@/prototype/transition/transition';
+import { HIGHLIGHT_RULE } from '@/utils/regex';
 
 export default class TransitionBasic extends DocCode {
-  protected _code = 'Code component is in development';
+  protected _code = `
+<prototype-transition id="transition" class="opacity-[0.95] size-[6.25rem] block rounded-xl bg-primary shadow-lg transition duration-[400ms] data-[closed]:scale-50 data-[closed]:rotate-[-120deg] data-[closed]:opacity-0 data-[leave]:duration-[200ms] data-[leave]:ease-in-out data-[leave]:data-[closed]:scale-95 data-[leave]:data-[closed]:rotate-[0deg]">
+</prototype-transition>
+<shadcn-button id="button" class="mt-10">Toggle Transition</shadcn-button>
+
+<script>
+  const button = document.getElementById('button');
+  const transition = document.getElementById('transition');
+  button?.onClick = () => {
+    transition.show = !transition.show;
+  }
+</script>`;
+  protected _highlightRules: HighlightRule[] = [
+    HIGHLIGHT_RULE.htmlTagName,
+    HIGHLIGHT_RULE.shadcnTagName,
+    HIGHLIGHT_RULE.upperCamelCase,
+    HIGHLIGHT_RULE.prototypeTagName,
+  ];
 
   protected _preview = () => {
     const toggleButton = h('shadcn-button', { class: 'mt-10' }, [

--- a/src/www/app/shadcn/button/button-basic.ts
+++ b/src/www/app/shadcn/button/button-basic.ts
@@ -1,9 +1,14 @@
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 import '@/shadcn';
+import { HIGHLIGHT_RULE } from '@/utils/regex';
 
 export default class ShadcnButtonBasic extends DocCode {
-  protected _code = 'Code component is in development';
+  protected _code = '<shadcn-button variant="primary">Button</shadcn-button>';
+  protected _highlightRules: HighlightRule[] = [
+    HIGHLIGHT_RULE.shadcnTagName,
+    HIGHLIGHT_RULE.upperCamelCase,
+  ];
 
   protected _preview = () => {
     return Div({}, [h('shadcn-button', { variant: 'primary' }, ['Button'])]);

--- a/src/www/app/shadcn/button/button-destructive.ts
+++ b/src/www/app/shadcn/button/button-destructive.ts
@@ -1,9 +1,14 @@
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 import '@/shadcn';
+import { HIGHLIGHT_RULE } from '@/utils/regex';
 
 export default class ShadcnButtonDestructive extends DocCode {
-  protected _code = 'Code component is in development';
+  protected _code = '<shadcn-button variant="destructive">Destructive</shadcn-button>';
+  protected _highlightRules: HighlightRule[] = [
+    HIGHLIGHT_RULE.shadcnTagName,
+    HIGHLIGHT_RULE.upperCamelCase,
+  ];
 
   protected _preview = () => {
     return Div({}, [h('shadcn-button', { variant: 'destructive' }, ['Destructive'])]);

--- a/src/www/app/shadcn/button/button-ghost.ts
+++ b/src/www/app/shadcn/button/button-ghost.ts
@@ -1,9 +1,14 @@
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 import '@/shadcn';
+import { HIGHLIGHT_RULE } from '@/utils/regex';
 
 export default class ShadcnButtonGhost extends DocCode {
-  protected _code = 'Code component is in development';
+  protected _code = '<shadcn-button variant="ghost">Ghost</shadcn-button>';
+  protected _highlightRules: HighlightRule[] = [
+    HIGHLIGHT_RULE.shadcnTagName,
+    HIGHLIGHT_RULE.upperCamelCase,
+  ];
 
   protected _preview = () => {
     return Div({}, [h('shadcn-button', { variant: 'ghost' }, ['Ghost'])]);

--- a/src/www/app/shadcn/button/button-link.ts
+++ b/src/www/app/shadcn/button/button-link.ts
@@ -1,12 +1,17 @@
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 import '@/shadcn';
+import { HIGHLIGHT_RULE } from '@/utils/regex';
 
 export default class ShadcnButtonLink extends DocCode {
-  protected _code = 'Code component is in development';
+  protected _code = '<shadcn-button variant="link">Link</shadcn-button>';
+  protected _highlightRules: HighlightRule[] = [
+    HIGHLIGHT_RULE.shadcnTagName,
+    HIGHLIGHT_RULE.upperCamelCase,
+  ];
 
   protected _preview = () => {
-    return Div({}, [h('shadcn-button', { variant: 'link' }, ['Button'])]);
+    return Div({}, [h('shadcn-button', { variant: 'link' }, ['Link'])]);
   };
 }
 

--- a/src/www/app/shadcn/button/button-outline.ts
+++ b/src/www/app/shadcn/button/button-outline.ts
@@ -1,9 +1,14 @@
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 import '@/shadcn';
+import { HIGHLIGHT_RULE } from '@/utils/regex';
 
 export default class ShadcnButtonOutline extends DocCode {
-  protected _code = 'Code component is in development';
+  protected _code = '<shadcn-button variant="outline">Outline</shadcn-button>';
+  protected _highlightRules: HighlightRule[] = [
+    HIGHLIGHT_RULE.shadcnTagName,
+    HIGHLIGHT_RULE.upperCamelCase,
+  ];
 
   protected _preview = () => {
     return Div({}, [h('shadcn-button', { variant: 'outline' }, ['Outline'])]);

--- a/src/www/app/shadcn/button/button-primary.ts
+++ b/src/www/app/shadcn/button/button-primary.ts
@@ -1,9 +1,14 @@
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 import '@/shadcn';
+import { HIGHLIGHT_RULE } from '@/utils/regex';
 
 export default class ShadcnButtonPrimary extends DocCode {
-  protected _code = 'Code component is in development';
+  protected _code = '<shadcn-button variant="primary">Primary</shadcn-button>';
+  protected _highlightRules: HighlightRule[] = [
+    HIGHLIGHT_RULE.shadcnTagName,
+    HIGHLIGHT_RULE.upperCamelCase,
+  ];
 
   protected _preview = () => {
     return Div({}, [h('shadcn-button', { variant: 'primary' }, ['Primary'])]);

--- a/src/www/app/shadcn/button/button-secondary.ts
+++ b/src/www/app/shadcn/button/button-secondary.ts
@@ -1,9 +1,14 @@
 import { Div, h } from '@/utils/dom';
-import { DocCode } from '@/www/components/doc-component';
+import { DocCode, HighlightRule } from '@/www/components/doc-component';
 import '@/shadcn';
+import { HIGHLIGHT_RULE } from '@/utils/regex';
 
 export default class ShadcnButtonSecondary extends DocCode {
-  protected _code = 'Code component is in development';
+  protected _code = '<shadcn-button>Secondary</shadcn-button>';
+  protected _highlightRules: HighlightRule[] = [
+    HIGHLIGHT_RULE.shadcnTagName,
+    HIGHLIGHT_RULE.upperCamelCase,
+  ];
 
   protected _preview = () => {
     return Div({}, [h('shadcn-button', {}, ['Secondary'])]);

--- a/src/www/app/shadcn/select/select-basic.ts
+++ b/src/www/app/shadcn/select/select-basic.ts
@@ -1,9 +1,11 @@
 import { Div, h } from '@/utils/dom';
 import { DocCode } from '@/www/components/doc-component';
 import '@/shadcn';
+import { HighlightRule } from '@/www/components/doc-component';
 
 export default class ShadcnSelectBasic extends DocCode {
   protected _code = 'Code component is in development';
+  protected _highlightRules: HighlightRule[] = [];
 
   protected _preview = () => {
     const select = h('shadcn-select', { 'default-value': 'Option 2' }, [

--- a/src/www/components/doc-component/doc-section/doc-code.ts
+++ b/src/www/components/doc-component/doc-section/doc-code.ts
@@ -1,6 +1,8 @@
-import { Div, h } from '@/utils/dom';
+import { Div, h, Span } from '@/utils/dom';
 import { DocContext } from '../interface';
 import { ContextConsumer } from '@/common';
+import { HighlightRule } from './interface';
+import { splitByHighlightRules } from '@/utils/regex';
 
 export default abstract class DocCode extends ContextConsumer<DocContext> {
   protected _key = 'doc';
@@ -13,10 +15,35 @@ export default abstract class DocCode extends ContextConsumer<DocContext> {
    * 代码块的代码内容
    */
   protected abstract _code: string;
+  protected abstract _highlightRules: HighlightRule[];
 
   connectedCallback() {
     super.connectedCallback();
     this._render();
+  }
+
+  private _renderCodeBlock() {
+    const codeBlock = h(
+      'pre',
+      // prettier-ignore
+      { class: 'mb-4 mt-6 max-h-[650px] overflow-x-auto rounded-lg border bg-zinc-950 py-4 dark:bg-zinc-900' },
+      [
+        h(
+          'code',
+          { class: 'flex flex-col relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm max-w-[calc(100vw-960px-6rem)]' },
+          this._code.trim().split('\n').map((line) =>
+            Span(
+              { class: 'px-4 py-0.5 w-full inline-block min-h-4' },
+              splitByHighlightRules(line, this._highlightRules).map((item) =>
+                Span({ class: item.className || 'text-muted-foreground' }, [item.text])
+              )
+            )
+          )
+        ),
+      ]
+    );
+
+    return codeBlock;
   }
 
   private _render() {
@@ -52,7 +79,7 @@ export default abstract class DocCode extends ContextConsumer<DocContext> {
             ]
           ),
         ]),
-        h('doc-tab-content', { value: 'Code', style: 'display: none' }, [this._code]),
+        h('doc-tab-content', { value: 'Code', style: 'display: none' }, [this._renderCodeBlock()]),
       ]),
     ]);
 

--- a/src/www/components/doc-component/doc-section/index.ts
+++ b/src/www/components/doc-component/doc-section/index.ts
@@ -1,1 +1,2 @@
 export { default as DocCode } from './doc-code';
+export type { HighlightRule } from './interface';

--- a/src/www/components/doc-component/doc-section/interface.ts
+++ b/src/www/components/doc-component/doc-section/interface.ts
@@ -1,0 +1,4 @@
+export interface HighlightRule {
+  regex: RegExp;
+  className: string;
+}

--- a/src/www/components/doc-component/index.ts
+++ b/src/www/components/doc-component/index.ts
@@ -4,5 +4,8 @@ import './doc-component';
 import './doc-tab';
 
 export { default as DocComponent } from './doc-component';
+
 export { DocCode } from './doc-section';
+export type { HighlightRule } from './doc-section';
+
 export type { Doc } from './interface';


### PR DESCRIPTION
`doc-code` 组件作为抽象类，有三个必须实现的属性
- `_preview` 预览组件的渲染逻辑
- `_code` 预览组件的代码实现
- `_highlightRules` 代码着色的规则