### PR TITLE
feat: 上下文组件升级 & trigger 能力抽象化

### DIFF
--- a/src/common/context/contextConsumer.ts
+++ b/src/common/context/contextConsumer.ts
@@ -15,7 +15,7 @@ export default abstract class ContextConsumer<T extends Object>
   protected _contextValue = {} as T;
   protected abstract _key: string;
 
-  onContextChange: (value: T) => void = () => {};
+  onContextChange: (value: T, changedKeys?: string[]) => void = () => {};
 
   // prettier-ignore
   get contextValue() { return this._contextValue; }
@@ -32,9 +32,9 @@ export default abstract class ContextConsumer<T extends Object>
     this[requestContextSymbol]();
   }
 
-  [setConsumerContextSymbol](value: Partial<T>) {
-    this._contextValue = { ...this._contextValue, ...value };
-    this.onContextChange(this._contextValue);
+  [setConsumerContextSymbol](value: T, changedKeys: string[]) {
+    this._contextValue = value;
+    this.onContextChange(this._contextValue, changedKeys);
   }
 
   [requestContextSymbol]() {

--- a/src/common/context/contextManager.ts
+++ b/src/common/context/contextManager.ts
@@ -147,12 +147,12 @@ export default class ContextManager {
    * @param value 新的 context 值
    * @returns
    */
-  updateContext<T extends Object>(provider: ContextProvider<T>, value: Partial<T>) {
+  updateContext<T extends Object>(provider: ContextProvider<T>, value: T, changedKeys: string[]) {
     const entry = this._providerEntryMap.get(provider.key)?.get(provider);
     if (!entry) return;
 
     entry.consumersSet.forEach((consumer) => {
-      consumer[setConsumerContextSymbol](value);
+      consumer[setConsumerContextSymbol](value, changedKeys);
     });
   }
 

--- a/src/common/context/contextProvider.ts
+++ b/src/common/context/contextProvider.ts
@@ -37,8 +37,9 @@ export default abstract class ContextProvider<T extends Object>
   }
 
   setContext(value: Partial<T>, notify = true) {
-    this._contextValue = { ...this._contextValue, ...value };
-    if (notify) ContextManager.getInstance().updateContext(this, value);
+    Object.assign(this._contextValue, value);
+    if (notify)
+      ContextManager.getInstance().updateContext<T>(this, this._contextValue, Object.keys(value));
   }
 
   private handleRequestContext(event: CustomEvent<RequestContextEventDetail<T>>) {
@@ -46,7 +47,11 @@ export default abstract class ContextProvider<T extends Object>
     if (this._key === key) {
       event.stopPropagation(); // 阻止事件传播到外部 provider
       ContextManager.getInstance().addConsumer(this, consumer);
-      ContextManager.getInstance().updateContext(this, this._contextValue);
+      ContextManager.getInstance().updateContext(
+        this,
+        this._contextValue,
+        Object.keys(this._contextValue)
+      );
     }
   }
 }

--- a/src/prototype/button/button.ts
+++ b/src/prototype/button/button.ts
@@ -1,8 +1,8 @@
-import { ContextConsumer } from '@/common';
 import { ButtonProps } from './interface';
+import { PrototypeTrigger } from '../trigger';
 
 export default class PrototypeButton<T extends Object>
-  extends ContextConsumer<T>
+  extends PrototypeTrigger<T>
   implements ButtonProps
 {
   protected _key = 'prototype-button';
@@ -84,10 +84,11 @@ export default class PrototypeButton<T extends Object>
   };
 
   connectedCallback() {
+    super.connectedCallback();
     this.addEventListener('click', this._handleClick);
     this.tabIndex = 0;
     // 键盘交互时，按下 Enter 键触发点击事件，同时也会立即触发 active 与 inactive 事件
-    this.addEventListener('keydown', this._handleEnterKeyDown);
+    this.addEventListener('keydown', this._handleEnterKeyDown as EventListener);
     // 鼠标交互时，鼠标进入和离开时触发
     this.addEventListener('mouseenter', this._handleMouseEnter);
     this.addEventListener('mouseleave', this._handleMouseLeave);
@@ -106,7 +107,7 @@ export default class PrototypeButton<T extends Object>
   disconectedCallback() {
     this.removeEventListener('click', this._handleClick);
     // 移除所有监听事件
-    this.removeEventListener('keydown', this._handleEnterKeyDown);
+    this.removeEventListener('keydown', this._handleEnterKeyDown as EventListener);
 
     this.removeEventListener('mouseenter', this._handleMouseEnter);
     this.removeEventListener('mouseleave', this._handleMouseLeave);

--- a/src/prototype/dialog/dialog-close.ts
+++ b/src/prototype/dialog/dialog-close.ts
@@ -1,0 +1,8 @@
+import { PrototypeTrigger } from '../trigger';
+import { DialogContext } from './interface';
+
+export default class PrototypeDialogClose extends PrototypeTrigger<DialogContext> {
+  protected _key = 'prototype-dialog';
+}
+
+customElements.define('prototype-dialog-close', PrototypeDialogClose);

--- a/src/prototype/dialog/dialog-content.ts
+++ b/src/prototype/dialog/dialog-content.ts
@@ -1,0 +1,15 @@
+import { PrototypeOverlay } from '../overlay';
+import { DialogContext } from './interface';
+
+export default class PrototypeDialogContent extends PrototypeOverlay<DialogContext> {
+  protected _key = 'prototype-dialog';
+  protected _target = document.body;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._contextValue.show = this.show.bind(this);
+    this._contextValue.close = this.close.bind(this);
+  }
+}
+
+customElements.define('prototype-dialog-content', PrototypeDialogContent);

--- a/src/prototype/dialog/dialog-trigger.ts
+++ b/src/prototype/dialog/dialog-trigger.ts
@@ -1,0 +1,8 @@
+import { PrototypeTrigger } from '../trigger';
+import { DialogContext } from './interface';
+
+export default class PrototypeDialogTrigger extends PrototypeTrigger<DialogContext> {
+  protected _key = 'prototype-dialog';
+}
+
+customElements.define('prototype-dialog-trigger', PrototypeDialogTrigger);

--- a/src/prototype/dialog/dialog.ts
+++ b/src/prototype/dialog/dialog.ts
@@ -1,0 +1,52 @@
+import { ContextProvider } from '@/common';
+import { DialogContext, DialogProps } from './interface';
+
+export default class PrototypeDialog extends ContextProvider<DialogContext> implements DialogProps {
+  protected _key = 'prototype-dialog';
+
+  /**
+   * 是否显示弹窗, 该属性为响应式属性
+   */
+  private _visible: boolean = false;
+  // prettier-ignore
+  get visible() { return this._visible; }
+  set visible(value) {
+    if (value === this._visible) return;
+    this._visible = value;
+    if (this._visible) {
+      this._show();
+      this.setAttribute('visible', '');
+    } else {
+      this._close();
+      this.removeAttribute('visible');
+    }
+  }
+
+  // prettier-ignore
+  private _show = () => { throw new Error('PrototypeDialog: _show 未初始化'); };
+  // prettier-ignore
+  private _close = () => { throw new Error('PrototypeDialog: _close 未初始化'); };
+  // prettier-ignore
+  get show() { return () => (this.visible = true); }
+  // prettier-ignore
+  get close() { return () => (this.visible = false); }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.visible = this.getAttribute('visible') !== null;
+    this.setContext({
+      visible: this.visible,
+    });
+  }
+
+  attributeChangedCallback(name: string, oldValue: any, newValue: any) {
+    const mapping: Record<string, any> = {
+      'visible': () => {
+        this.visible = newValue !== null;
+        this.visible && oldValue !== newValue ? this.show() : this.close();
+      },
+    };
+
+    mapping[name]?.();
+  }
+}

--- a/src/prototype/dialog/dialog.ts
+++ b/src/prototype/dialog/dialog.ts
@@ -14,18 +14,13 @@ export default class PrototypeDialog extends ContextProvider<DialogContext> impl
     if (value === this._visible) return;
     this._visible = value;
     if (this._visible) {
-      this._show();
+      this._contextValue.show();
       this.setAttribute('visible', '');
     } else {
-      this._close();
+      this._contextValue.close();
       this.removeAttribute('visible');
     }
   }
-
-  // prettier-ignore
-  private _show = () => { throw new Error('PrototypeDialog: _show 未初始化'); };
-  // prettier-ignore
-  private _close = () => { throw new Error('PrototypeDialog: _close 未初始化'); };
   // prettier-ignore
   get show() { return () => (this.visible = true); }
   // prettier-ignore
@@ -50,3 +45,5 @@ export default class PrototypeDialog extends ContextProvider<DialogContext> impl
     mapping[name]?.();
   }
 }
+
+customElements.define('prototype-dialog', PrototypeDialog);

--- a/src/prototype/dialog/index.ts
+++ b/src/prototype/dialog/index.ts
@@ -1,0 +1,4 @@
+export { default as PrototypeDialog } from './dialog';
+export { default as PrototypeDialogClose } from './dialog-close';
+export { default as PrototypeDialogContent } from './dialog-content';
+export { default as PrototypeDialogTrigger } from './dialog-trigger';

--- a/src/prototype/dialog/interface.ts
+++ b/src/prototype/dialog/interface.ts
@@ -1,0 +1,9 @@
+export interface DialogProps {
+  visible: boolean;
+}
+
+export interface DialogContext {
+  visible: boolean;
+  show: () => void;
+  close: () => void;
+}

--- a/src/prototype/index.ts
+++ b/src/prototype/index.ts
@@ -1,3 +1,17 @@
-import './button';
-import './transition';
-import './overlay';
+export { PrototypeButton } from './button';
+export {
+  PrototypeDialog,
+  PrototypeDialogClose,
+  PrototypeDialogContent,
+  PrototypeDialogTrigger,
+} from './dialog';
+export { PrototypeSelect, PrototypeSelectTrigger, PrototypeSelectItem } from './select';
+export { PrototypeTrigger } from './trigger';
+export { PrototypeOverlay } from './overlay';
+export {
+  PrototypeTab,
+  PrototypeTabContent,
+  PrototypeTabTrigger,
+  PrototypeTabIndicator,
+} from './tab';
+export { PrototypeTransition } from './transition';

--- a/src/prototype/overlay/overlay.ts
+++ b/src/prototype/overlay/overlay.ts
@@ -21,10 +21,12 @@ export default class PrototypeOverlay<T extends Object>
     while (this.firstChild) {
       this._content.appendChild(this.firstChild);
     }
-    this.target = this.getAttribute('target') ?? undefined;
+    if (!this._target) {
+      this.target = this.getAttribute('target') ?? undefined;
+      // Overlay 默认以自己的位置作为目标插入位置，如果有 target 则以 target 为准
+      this._target = this.target ? document.querySelector(this.target) || document.body : this;
+    }
 
-    // Overlay 默认以自己的位置作为目标插入位置，如果有 target 则以 target 为准
-    this._target = this.target ? document.querySelector(this.target) || document.body : this;
     // 找到 target 最近的 relative 父元素
     this._closestRelative = this._target === this ? this : this.findClosestRelative(this._target);
 

--- a/src/prototype/select/interface.ts
+++ b/src/prototype/select/interface.ts
@@ -25,6 +25,4 @@ export interface SelectContext {
   changeValue: (value: string, focus?: boolean) => void;
 
   selecting: boolean;
-
-  setContext: (value: Partial<SelectContext>, notify?: boolean) => void;
 }

--- a/src/prototype/select/select-content.ts
+++ b/src/prototype/select/select-content.ts
@@ -8,7 +8,6 @@ export default class PrototypeSelectContent extends PrototypeOverlay<SelectConte
     super.connectedCallback();
     this._contextValue.show = this.show.bind(this);
     this._contextValue.close = this.close.bind(this);
-    console.log(this._contextValue);
   }
 }
 

--- a/src/prototype/select/select-content.ts
+++ b/src/prototype/select/select-content.ts
@@ -6,21 +6,9 @@ export default class PrototypeSelectContent extends PrototypeOverlay<SelectConte
 
   connectedCallback() {
     super.connectedCallback();
-    this._contextValue.setContext({
-      show: () => {
-        this.show();
-        this._contextValue.setContext({
-          selecting: true,
-        });
-      },
-      close: () => {
-        this.close();
-        this._contextValue.setContext({
-          selecting: false,
-        });
-        // this._contextValue.focus();
-      },
-    });
+    this._contextValue.show = this.show.bind(this);
+    this._contextValue.close = this.close.bind(this);
+    console.log(this._contextValue);
   }
 }
 

--- a/src/prototype/select/select-trigger.ts
+++ b/src/prototype/select/select-trigger.ts
@@ -6,11 +6,10 @@ export default class PrototypeSelectTrigger extends PrototypeButton<SelectContex
 
   connectedCallback() {
     super.connectedCallback();
-    this._contextValue.setContext({
-      focus: this.focus.bind(this),
-    });
+    this._contextValue.focus = this.focus.bind(this);
 
     this.onClick = () => {
+      console.log(this._contextValue);
       this._contextValue.selecting ? this._contextValue.close() : this._contextValue.show();
     };
   }

--- a/src/prototype/select/select-trigger.ts
+++ b/src/prototype/select/select-trigger.ts
@@ -8,10 +8,8 @@ export default class PrototypeSelectTrigger extends PrototypeButton<SelectContex
     super.connectedCallback();
     this._contextValue.focus = this.focus.bind(this);
 
-    this.onClick = () => {
-      console.log(this._contextValue);
+    this.onClick = () =>
       this._contextValue.selecting ? this._contextValue.close() : this._contextValue.show();
-    };
   }
 }
 

--- a/src/prototype/select/select.ts
+++ b/src/prototype/select/select.ts
@@ -36,9 +36,7 @@ export default class PrototypeSelect extends ContextProvider<SelectContext> {
           value: this._value,
         });
       },
-      // setContext: this.setContext.bind(this),
     });
-    console.log(this._contextValue);
   }
 }
 

--- a/src/prototype/select/select.ts
+++ b/src/prototype/select/select.ts
@@ -36,8 +36,9 @@ export default class PrototypeSelect extends ContextProvider<SelectContext> {
           value: this._value,
         });
       },
-      setContext: this.setContext.bind(this),
+      // setContext: this.setContext.bind(this),
     });
+    console.log(this._contextValue);
   }
 }
 

--- a/src/prototype/tab/tab-trigger.ts
+++ b/src/prototype/tab/tab-trigger.ts
@@ -1,8 +1,8 @@
-import { ContextConsumer } from '@/common';
 import { TabContext, TabTrigerProps } from './interface';
+import { PrototypeTrigger } from '../trigger';
 
 export default class PrototypeTabTrigger
-  extends ContextConsumer<TabContext>
+  extends PrototypeTrigger<TabContext>
   implements TabTrigerProps
 {
   protected _key = 'prototype-tab';
@@ -30,7 +30,7 @@ export default class PrototypeTabTrigger
     };
 
     this.addEventListener('click', this._handleClick);
-    this.addEventListener('keydown', this._handleKeydown);
+    this.addEventListener('keydown', this._handleKeydown as EventListener);
 
     // 初始化默认选中状态
     if (this._value === this.contextValue.defaultValue) {
@@ -38,9 +38,13 @@ export default class PrototypeTabTrigger
     }
   }
 
+  attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
+    super.attributeChangedCallback(name, oldValue, newValue);
+  }
+
   disconectedCallback() {
     this.removeEventListener('click', this._handleClick);
-    this.removeEventListener('keydown', this._handleKeydown);
+    this.removeEventListener('keydown', this._handleKeydown as EventListener);
     this._contextValue.tabs.splice(this._contextValue.tabs.indexOf(this._value), 1);
     this._contextValue.tabRefs.splice(this._contextValue.tabRefs.indexOf(this), 1);
   }
@@ -52,11 +56,15 @@ export default class PrototypeTabTrigger
     const prevIndex =
       (currentIndex - 1 + this.contextValue.tabs.length) % this.contextValue.tabs.length;
 
-    if (event.key === 'ArrowRight' || event.key === 'ArrowDown')
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault();
       this.contextValue.changeTab(this.contextValue.tabs[nextIndex], true);
+    }
 
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp')
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault();
       this.contextValue.changeTab(this.contextValue.tabs[prevIndex], true);
+    }
   };
 }
 

--- a/src/prototype/transition/index.ts
+++ b/src/prototype/transition/index.ts
@@ -1,2 +1,2 @@
-export { default } from './transition';
+export { default as PrototypeTransition } from './transition';
 export type { TransitionProps } from './interface';

--- a/src/prototype/trigger/index.ts
+++ b/src/prototype/trigger/index.ts
@@ -1,0 +1,1 @@
+export { default as PrototypeTrigger } from './trigger';

--- a/src/prototype/trigger/trigger.ts
+++ b/src/prototype/trigger/trigger.ts
@@ -1,0 +1,87 @@
+/**
+ * Prototype Transition with Web Component
+ *
+ * @link https://github.com/guangliang2019/Prototype-UI/blob/main/src/prototype/trigger/trigger.ts
+ * @author guangliang2019
+ * @date 2024-08-28
+ */
+
+import { ContextConsumer } from '@/common';
+import { dfsFindElement } from '@/utils/dom';
+
+/**
+ * Trigger 组件，能够有效解决 Trigger 嵌套时的事件冲突问题
+ * Trigger 组件会代理各种 DOM 事件和监听，并移交给 _target
+ *
+ * _target 的寻找规则：Trigger 子树中第一个不是 Trigger 的元素，Trigger 没有子元素时以自身为 _target
+ *
+ * 在连接进 DOM 之前，需要添加的 EventListener 会被暂存，在 connectedCallback 时为 _target 添加
+ * 同理，在连接进 DOM 之前，dispatchEvent 会被暂存，在 connectedCallback 时触发
+ */
+export default class PrototypeTrigger<T extends Object> extends ContextConsumer<T> {
+  protected _key = 'prototype-trigger';
+  protected _target?: HTMLElement;
+  protected _pendingEventListeners: Parameters<HTMLElement['addEventListener']>[] = [];
+  protected _pendingDispatchEvents: Event[] = [];
+
+  addEventListener(...args: Parameters<HTMLElement['addEventListener']>): void {
+    if (this._target) {
+      this._target === this
+        ? super.addEventListener(...args)
+        : this._target.addEventListener(...args);
+    } else {
+      this._pendingEventListeners.push(args);
+    }
+  }
+
+  removeEventListener(...args: Parameters<HTMLElement['removeEventListener']>): void {
+    this._target!.removeEventListener(...args);
+  }
+
+  dispatchEvent(event: Event): boolean {
+    if (this._target) {
+      return this._target === this ? super.dispatchEvent(event) : this._target.dispatchEvent(event);
+    } else {
+      this._pendingDispatchEvents.push(event);
+    }
+    return false;
+  }
+
+  focus = (options?: FocusOptions) =>
+    this._target === this ? super.focus(options) : this._target?.focus(options);
+  blur = () => (this._target === this ? super.blur : this._target?.blur());
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.children.length > 1) {
+      throw new Error('Trigger 组件最多只允许有一个子元素。');
+    }
+    const target = dfsFindElement(
+      this,
+      (el) => !(el instanceof PrototypeTrigger) || el.children.length === 0
+    ) as HTMLElement;
+
+    this._target = target;
+
+    this._pendingEventListeners.forEach((args) => this.addEventListener(...args));
+    this._pendingDispatchEvents.forEach((event) => this.dispatchEvent(event));
+
+    this.tabIndex = -1;
+  }
+
+  static get observedAttributes(): string[] {
+    return ['tabindex'];
+  }
+
+  attributeChangedCallback(name: string, oldValue: string, newValue: string): void {
+    if (
+      this._target !== this &&
+      name === 'tabindex' &&
+      newValue !== null &&
+      oldValue !== newValue
+    ) {
+      this._target!.tabIndex = Number(newValue);
+      this.removeAttribute('tabindex');
+    }
+  }
+}

--- a/src/shadcn/button/button.ts
+++ b/src/shadcn/button/button.ts
@@ -1,5 +1,6 @@
 import { PrototypeButton } from '@/prototype/button';
 import { ShacnButtonProps, SHADCN_BUTTON_DEFAULT_PROPS } from './interface';
+import { CONFIG } from '../_config';
 
 export default class ShadcnButton<T extends Object = {}>
   extends PrototypeButton<T>
@@ -87,4 +88,4 @@ export default class ShadcnButton<T extends Object = {}>
   }
 }
 
-customElements.define('shadcn-button', ShadcnButton);
+customElements.define(`${CONFIG.shadcn.prefix}-button`, ShadcnButton);

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -3,6 +3,34 @@ type Props = {
   children?: (Node | string)[];
 };
 
+/**
+ * 使用深度优先搜索 (DFS) 在 DOM 中查找满足条件的第一个元素。
+ * @param rootElement 起始元素
+ * @param predicate 判断条件的函数，返回 true 表示找到了匹配的元素
+ * @returns {Element | null} 返回找到的元素或 null
+ */
+export function dfsFindElement(
+  rootElement: Element,
+  predicate: (element: Element) => boolean
+): Element | null {
+  // 首先检查根元素是否满足条件
+  if (predicate(rootElement)) {
+    return rootElement;
+  }
+
+  // 遍历子元素
+  const children = rootElement.children;
+  for (let i = 0; i < children.length; i++) {
+    const result = dfsFindElement(children[i], predicate);
+    if (result !== null) {
+      return result;
+    }
+  }
+
+  // 如果没有找到，返回 null
+  return null;
+}
+
 // 自定义 createElement 函数
 export function h<T extends HTMLElement>(
   tag: string,

--- a/src/www/components/doc-component/doc-section/doc-code.ts
+++ b/src/www/components/doc-component/doc-section/doc-code.ts
@@ -30,15 +30,21 @@ export default abstract class DocCode extends ContextConsumer<DocContext> {
       [
         h(
           'code',
-          { class: 'flex flex-col relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm max-w-[calc(100vw-960px-6rem)]' },
-          this._code.trim().split('\n').map((line) =>
-            Span(
-              { class: 'px-4 py-0.5 w-full inline-block min-h-4' },
-              splitByHighlightRules(line, this._highlightRules).map((item) =>
-                Span({ class: item.className || 'text-muted-foreground' }, [item.text])
+          {
+            class:
+              'flex flex-col relative rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm max-w-[calc(100vw-960px-6rem)]',
+          },
+          this._code
+            .trim()
+            .split('\n')
+            .map((line) =>
+              Span(
+                { class: 'px-4 py-0.5 w-full inline-block min-h-4' },
+                splitByHighlightRules(line, this._highlightRules).map((item) =>
+                  Span({ class: item.className || 'text-muted-foreground' }, [item.text])
+                )
               )
             )
-          )
         ),
       ]
     );


### PR DESCRIPTION
这次 PR 主要解决两个问题：
1. 每个 consumer 各自独立维护一份 context 并不合理，现在改成与 provider 共享同一个 context 对象的引用，也就是说
  - 现在 consumer 可以通过访问 this._contextValue 对上下文进行不会通知更新的修改，方便进行初始化
  - 只有通过 provider 的 setContext 方法，且 notify 设置为 true 的更新操作，才会触发 consumer 的 onContextChange
  - 顺便给 onContextChange 添加了一个可选参数，内容是本次更新的键名，consumer 可以根据这个参数进行性能优化，减少不必要的逻辑处理

2. 现在基本每个组件都会有 trigger，例如 tooltip 是 hover tooltipTrigger 一段时间之后弹出提示，dialog 是点击 dialogTrigger 触发弹窗，button 本身就是一个 trigger，点击时触发触发点击事件等等
  - 假设现在有一个既有 tooltip 点击后又触发 dialog 的 button，那么就会有三个可以获得焦点的组件嵌套在一起，这对于键盘导航来说是极度不合理的
  - 所以写了一个叫做 trigger 的基类，无论多少个 trigger 嵌套在一起，最终实际表现为一个复合了多种能力的 trigger
  - trigger 递归寻找第一个不是 trigger 的子元素作为实际事件与焦点的管理者，如果不存在合适的对象，他会以最内层的没有 children 的 trigger 作为目标对象。