### PR TITLE
feat: 增强 Markdown 图片渲染组件

### DIFF
--- a/src/next-www/astro.config.mjs
+++ b/src/next-www/astro.config.mjs
@@ -4,6 +4,7 @@ import starlight from '@astrojs/starlight';
 
 import tailwindcss from '@tailwindcss/vite';
 import { fileURLToPath } from 'node:url';
+import { rehypeEnhancedImage } from './src/utils/rehype-enhanced-image.js';
 
 // https://astro.build/config
 export default defineConfig({
@@ -308,6 +309,9 @@ export default defineConfig({
         PageTitle: './src/components/override/PageTitle.astro',
         MarkdownContent: './src/components/override/MarkdownContent.astro',
         LanguageSelect: './src/components/override/LanguageSelect.astro',
+      },
+      markdown: {
+        rehypePlugins: [rehypeEnhancedImage],
       },
     }),
   ],

--- a/src/next-www/src/styles/markdown.css
+++ b/src/next-www/src/styles/markdown.css
@@ -60,4 +60,95 @@
   main[data-pagefind-body] .sl-heading-wrapper {
     @apply flex;
   }
+
+  /* 增强图片容器样式 */
+  main[data-pagefind-body] .enhanced-image-wrapper {
+    @apply my-8 mx-auto;
+    max-width: 100%;
+  }
+
+  main[data-pagefind-body] .enhanced-image-container {
+    @apply relative overflow-hidden rounded-xl border;
+    @apply bg-muted/30;
+    @apply shadow-lg;
+    @apply transition-all duration-300;
+    @apply border-border;
+    padding: 0.75rem;
+  }
+
+  /* 暗色模式下的容器样式 */
+  [data-theme='dark'] main[data-pagefind-body] .enhanced-image-container {
+    @apply border-border;
+    @apply shadow-xl;
+    background: hsl(var(--muted) / 0.2);
+  }
+
+  /* 图片本身样式 */
+  main[data-pagefind-body] .enhanced-image {
+    @apply block w-full h-auto;
+    @apply rounded-lg;
+    @apply transition-opacity duration-300;
+    margin: 0;
+    display: block;
+  }
+
+  /* SVG 特殊处理 */
+  main[data-pagefind-body] .enhanced-image-svg .enhanced-image-container {
+    @apply bg-transparent;
+    padding: 1rem;
+    border: 1px solid transparent;
+  }
+
+  main[data-pagefind-body] .enhanced-image-svg-element {
+    /* SVG 可以通过 CSS 变量控制颜色 */
+    /* 如果 SVG 内部使用了 currentColor，这里会生效 */
+    color: hsl(var(--foreground));
+    /* 确保 SVG 能够响应主题变化 */
+    transition: color 0.3s ease, filter 0.3s ease;
+  }
+
+  /* SVG 在暗色模式下的特殊处理 */
+  [data-theme='dark'] main[data-pagefind-body] .enhanced-image-svg-element {
+    /* 可以在这里覆盖 SVG 的颜色变量 */
+    filter: brightness(0.95);
+  }
+
+  /* 为 SVG 预留主题变量接口 */
+  main[data-pagefind-body] .enhanced-image-svg-element svg {
+    /* 如果 SVG 内部元素使用了 CSS 变量，这里可以设置 */
+    --svg-fill-primary: hsl(var(--foreground));
+    --svg-fill-secondary: hsl(var(--muted-foreground));
+    --svg-stroke-primary: hsl(var(--border));
+  }
+
+  /* 图片标题样式 */
+  main[data-pagefind-body] .enhanced-image-caption {
+    @apply mt-3 text-center text-sm;
+    @apply text-muted-foreground;
+    @apply leading-relaxed;
+  }
+
+  /* 响应式调整 */
+  @media (max-width: 768px) {
+    main[data-pagefind-body] .enhanced-image-wrapper {
+      @apply my-6;
+    }
+
+    main[data-pagefind-body] .enhanced-image-container {
+      padding: 0.5rem;
+      @apply rounded-lg;
+    }
+  }
+
+  /* 确保图片加载时的平滑过渡 */
+  main[data-pagefind-body] .enhanced-image {
+    opacity: 1;
+    transition: opacity 0.3s ease-in-out;
+  }
+
+  /* 图片加载失败时的样式 */
+  main[data-pagefind-body] .enhanced-image:not([src]),
+  main[data-pagefind-body] .enhanced-image[src=''] {
+    opacity: 0.5;
+  }
 }

--- a/src/next-www/src/utils/rehype-enhanced-image.ts
+++ b/src/next-www/src/utils/rehype-enhanced-image.ts
@@ -1,0 +1,77 @@
+import type { Root } from 'hast';
+import type { Plugin } from 'unified';
+import { visit } from 'unist-util-visit';
+
+/**
+ * Rehype 插件：增强 Markdown 图片渲染
+ * 为图片添加容器包装，支持主题变量和最佳实践
+ */
+export const rehypeEnhancedImage: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, 'element', (node, index, parent) => {
+      if (node.tagName === 'img' && parent && typeof index === 'number') {
+        const img = node;
+        const src = img.properties?.src as string | undefined;
+        const alt = (img.properties?.alt as string) || '';
+        
+        // 检测是否为 SVG
+        const isSvg = src?.endsWith('.svg') || src?.includes('.svg#') || src?.includes('data:image/svg+xml');
+        
+        // 获取现有的 class，如果有的话
+        const existingClass = (img.properties?.class as string) || '';
+        const imageClass = `enhanced-image ${isSvg ? 'enhanced-image-svg-element' : ''} ${existingClass}`.trim();
+        
+        // 创建包装容器
+        const wrapper = {
+          type: 'element',
+          tagName: 'figure',
+          properties: {
+            class: `enhanced-image-wrapper ${isSvg ? 'enhanced-image-svg' : ''}`,
+          },
+          children: [
+            {
+              type: 'element',
+              tagName: 'div',
+              properties: {
+                class: 'enhanced-image-container',
+              },
+              children: [
+                {
+                  ...img,
+                  properties: {
+                    ...img.properties,
+                    loading: img.properties?.loading || ('lazy' as const),
+                    decoding: img.properties?.decoding || ('async' as const),
+                    class: imageClass,
+                  },
+                },
+              ],
+            },
+            // 如果有 alt 文本，添加 figcaption
+            ...(alt && alt.trim()
+              ? [
+                  {
+                    type: 'element',
+                    tagName: 'figcaption',
+                    properties: {
+                      class: 'enhanced-image-caption',
+                    },
+                    children: [
+                      {
+                        type: 'text',
+                        value: alt,
+                      },
+                    ],
+                  },
+                ]
+              : []),
+          ],
+        };
+
+        // 替换原图片节点
+        parent.children[index] = wrapper;
+      }
+    });
+  };
+};
+


### PR DESCRIPTION
- 添加 rehype 插件自动包装 Markdown 图片
- 添加优雅的图片容器样式（圆角、阴影、边框）
- 支持 SVG 插画的主题变量适配
- 自动应用图片最佳实践（lazy loading、async decoding）
- 将 alt 文本渲染为图片标题（figcaption）
- 响应式设计和主题切换支持