### PR TITLE
Add anatomy order view and collection hooks

### DIFF
--- a/apps/www/src/content/docs/en/wiki/anatomy.md
+++ b/apps/www/src/content/docs/en/wiki/anatomy.md
@@ -4,3 +4,43 @@ description: 'Roles and structural relations inside a compound prototype family'
 ---
 
 `anatomy` describes stable roles and relations inside a compound prototype family, such as `root`, `trigger`, and `content`.
+
+It answers structural questions like:
+
+- which parts belong to the same family
+- which role each part claims
+- which roles may contain other roles
+
+It does not, by itself, define business collection semantics.
+
+## `anatomy.order`
+
+Some compound interactions need more than role membership. They also need an ordered host view:
+
+- which item comes before or after the current one
+- what index the current item occupies among peers
+- whether the effective host order has changed
+
+Proto UI handles this as an enhancement under `anatomy`, not as a new top-level `collection` runtime concept. `anatomy.order` is that ordered host view.
+
+It provides:
+
+- ordered queries such as `partsOf()`, `indexOfSelf()`, `prevOfSelf()`, `nextOfSelf()`
+- an internal order-change signal via `version()`
+
+This keeps the layering explicit:
+
+- `anatomy` defines family membership and structural relations
+- `anatomy.order` projects those parts into an ordered host view
+- higher-level hooks may build collection behavior on top of that view
+
+## What it does not do
+
+`anatomy.order` is still not a full collection model. It does not define:
+
+- selection state
+- item business metadata
+- roving focus policy
+- keyboard paging policy
+
+Those belong to higher-level hooks such as `asCollection()`, not to anatomy itself.

--- a/apps/www/src/content/docs/en/wiki/as-hook.md
+++ b/apps/www/src/content/docs/en/wiki/as-hook.md
@@ -5,3 +5,15 @@ description: 'A reusable logic unit for Proto UI prototypes'
 
 `asHook` is a reusable logic unit in Proto UI.  
 It is not an interaction subject by itself. Instead, it is attached to a prototype to reuse behavior such as button semantics, toggle semantics, or open-state logic.
+
+As compound prototypes evolve, an `asHook` may also be built on top of existing protocol capabilities. For example:
+
+- `anatomy.order` provides an ordered host view for parts in the same family
+- `asCollection()` and `asCollectionItem()` build a minimal collection interaction layer on top of that ordered view
+
+This is important for Proto UI's layering:
+
+- `anatomy.order` remains an enhancement of structural capability
+- `asCollection` remains reusable behavior built on top of that capability
+
+In other words, Proto UI does not need to introduce a new top-level `collection` runtime concept first. A higher-level semantic layer can still grow through `asHook` composition.

--- a/apps/www/src/content/docs/zh-cn/wiki/anatomy.md
+++ b/apps/www/src/content/docs/zh-cn/wiki/anatomy.md
@@ -42,3 +42,63 @@ description: 'Proto UI 中复合原型家族的角色和结构关系'
 - 哪些角色允许包含哪些角色
 
 这类关系在宿主层可能最终表现为 DOM 层级，但概念上它先属于原型协议，而不是 HTML 结构。
+
+## `anatomy.order` 是什么？
+
+在复合原型里，光知道“谁属于同一个 family、谁扮演 item / trigger / content”还不够。  
+很多交互还会继续追问：
+
+- 当前 item 在同类里排第几个
+- 前一个 / 后一个同类 part 是谁
+- 当前顺序是否发生了变化
+
+这时 Proto UI 不会直接把一个新的顶级 `collection` 概念塞进运行时。  
+更克制的做法是：让 `anatomy` 提供一个**有序宿主视图增强**，也就是 `anatomy.order`。
+
+它回答的不是新的结构事实，而是：
+
+> 在当前宿主里，这组 anatomy part 如果按“真实元素顺序”观察，会得到怎样的有序视图？
+
+## `anatomy.order` 提供什么能力？
+
+当前 `anatomy.order` 主要提供两类能力：
+
+- 有序查询：`parts()`、`partsOf()`、`indexOfSelf()`、`prevOfSelf()`、`nextOfSelf()`
+- 顺序变化信号：`version()`，以及内部可订阅的顺序变化通知
+
+这意味着原型作者可以在不引入完整 collection 语义的前提下，先手工实现很多“列表式交互分支”，例如：
+
+- 当前 trigger 在 tabs 里排第几个
+- 当前 item 的上一项 / 下一项是谁
+- 某个 root 是否需要根据成员顺序变化重新同步快照
+
+## 它仍然不是 collection
+
+这里要特别区分：
+
+- `anatomy.order` 是 anatomy 的有序宿主视图
+- `collection` 是建立在这层视图之上的更高层交互语义
+
+`anatomy.order` 不负责这些事情：
+
+- item 的业务元数据注册
+- selection 模型
+- roving focus 策略
+- `PageUp` / `PageDown` 之类键盘策略
+
+这些能力如果需要，应该继续由上层 `asHook` 来组织。
+
+## 它和真实元素顺序的关系是什么？
+
+在 Web 宿主里，`anatomy.order` 会优先按真实 DOM 元素顺序理解 part。  
+如果宿主没有可比较的真实顺序能力，它可以退回到宿主可提供的稳定顺序。
+
+因此，`anatomy.order` 解决的是：
+
+- “当前宿主里，这组 part 被怎样有序地看见”
+
+而不是：
+
+- “Proto UI 协议层永久定义了某个唯一、绝对的元素顺序”
+
+这也是为什么它被放在 `anatomy` 的增强层，而不是被提升成新的协议主语义。

--- a/apps/www/src/content/docs/zh-cn/wiki/as-hook.md
+++ b/apps/www/src/content/docs/zh-cn/wiki/as-hook.md
@@ -38,6 +38,20 @@ Proto UI 里的 prototype 负责描述交互主体。
 
 像 `switch`、`dropdown`、`hover-card` 这类原型，很多地方都依赖这种复用。
 
+随着复合原型继续变复杂，`asHook` 还可以建立在别的协议能力之上继续抽象。  
+例如：
+
+- `anatomy.order` 提供同 family part 的有序宿主视图
+- `asCollection()`、`asCollectionItem()` 则建立在这层视图上，继续抽出最小 collection 交互核
+
+这里的关键点是：
+
+- `anatomy.order` 仍然属于结构能力的增强
+- `asCollection` 才是基于这层能力组织出来的行为复用
+
+也就是说，Proto UI 不是先引入一个新的顶级 `collection` 概念，  
+而是先让 `asHook` 站在已有能力之上，逐步长出更高层语义。
+
 ## 常见误解
 
 ### asHook 不是“小一号的原型”

--- a/packages/adapters/base/src/index.ts
+++ b/packages/adapters/base/src/index.ts
@@ -1,6 +1,7 @@
 // packages/adapters/base/src/index.ts
 export * from './wiring/host-wiring';
 export * from './wiring/caps-builder';
+export * from './wiring/dom-order-observer';
 export * from './gate/event-gate';
 export * from './lifecycle/teardown';
 export * from './host/adapter-host';

--- a/packages/adapters/base/src/wiring/caps-builder.ts
+++ b/packages/adapters/base/src/wiring/caps-builder.ts
@@ -22,10 +22,14 @@ import {
 import {
   ANATOMY_GET_PROTO_CAP,
   ANATOMY_INSTANCE_TOKEN_CAP,
+  ANATOMY_ORDER_OBSERVER_CAP,
   ANATOMY_PARENT_CAP,
+  ANATOMY_ROOT_TARGET_CAP,
   type AnatomyInstanceToken,
+  type AnatomyOrderObserver,
   type AnatomyParentGetter,
   type AnatomyPrototypeGetter,
+  type AnatomyRootTargetGetter,
 } from '@proto.ui/module-anatomy';
 import {
   CONTEXT_INSTANCE_TOKEN_CAP,
@@ -88,6 +92,8 @@ export type CapsWiringBuilder = {
     instance: AnatomyInstanceToken;
     parent: AnatomyParentGetter;
     getPrototype: AnatomyPrototypeGetter;
+    root: AnatomyRootTargetGetter;
+    orderObserver?: AnatomyOrderObserver;
   }): CapsWiringBuilder;
   useAsTrigger(args: {
     instance: AsTriggerInstanceToken;
@@ -156,11 +162,13 @@ export function createCapsWiring(): CapsWiringBuilder {
       ]);
     },
 
-    useAnatomy({ instance, parent, getPrototype }) {
+    useAnatomy({ instance, parent, getPrototype, root, orderObserver }) {
       return add('anatomy', () => [
         [ANATOMY_INSTANCE_TOKEN_CAP, instance],
         [ANATOMY_PARENT_CAP, parent],
         [ANATOMY_GET_PROTO_CAP, getPrototype],
+        [ANATOMY_ROOT_TARGET_CAP, root],
+        ...(orderObserver ? [[ANATOMY_ORDER_OBSERVER_CAP, orderObserver] as const] : []),
       ]);
     },
 

--- a/packages/adapters/base/src/wiring/dom-order-observer.ts
+++ b/packages/adapters/base/src/wiring/dom-order-observer.ts
@@ -1,0 +1,19 @@
+import type { AnatomyOrderObserver, AnatomyRootTarget } from '@proto.ui/module-anatomy';
+
+function isNodeLike(value: unknown): value is Node {
+  return !!value && typeof (value as Node).nodeType === 'number';
+}
+
+export const createDomOrderObserver: AnatomyOrderObserver = (
+  target: AnatomyRootTarget,
+  notify: () => void
+) => {
+  if (typeof MutationObserver === 'undefined') return () => {};
+  if (!isNodeLike(target)) return () => {};
+
+  const observer = new MutationObserver(() => {
+    notify();
+  });
+  observer.observe(target, { childList: true, subtree: true });
+  return () => observer.disconnect();
+};

--- a/packages/adapters/react/src/runtime/modules.ts
+++ b/packages/adapters/react/src/runtime/modules.ts
@@ -1,4 +1,4 @@
-import { createCapsWiring } from '@proto.ui/adapter-base';
+import { createCapsWiring, createDomOrderObserver } from '@proto.ui/adapter-base';
 import type { EffectsPort } from '@proto.ui/core';
 import type { RawPropsSource } from '@proto.ui/module-props';
 import type { ExposeStateWebMode } from '@proto.ui/module-expose-state-web';
@@ -62,6 +62,8 @@ export function createReactModules<Props extends PropsBaseType>(args: {
       instance: el,
       parent: (inst) => getProtoParent(inst as HTMLElement),
       getPrototype: (inst) => getPrototypeByInstance(inst as HTMLElement),
+      root: (inst) => inst as HTMLElement,
+      orderObserver: createDomOrderObserver,
     })
     .useAsTrigger({
       instance: el,

--- a/packages/adapters/vue/src/runtime/modules.ts
+++ b/packages/adapters/vue/src/runtime/modules.ts
@@ -1,4 +1,4 @@
-import { createCapsWiring } from '@proto.ui/adapter-base';
+import { createCapsWiring, createDomOrderObserver } from '@proto.ui/adapter-base';
 import type { EffectsPort } from '@proto.ui/core';
 import type { RawPropsSource } from '@proto.ui/module-props';
 import type { ExposeStateWebMode } from '@proto.ui/module-expose-state-web';
@@ -62,6 +62,8 @@ export function createVueModules<Props extends PropsBaseType>(args: {
       instance: el,
       parent: (inst) => getProtoParent(inst as HTMLElement),
       getPrototype: (inst) => getPrototypeByInstance(inst as HTMLElement),
+      root: (inst) => inst as HTMLElement,
+      orderObserver: createDomOrderObserver,
     })
     .useAsTrigger({
       instance: el,

--- a/packages/adapters/web-component/src/runtime/modules.ts
+++ b/packages/adapters/web-component/src/runtime/modules.ts
@@ -1,4 +1,4 @@
-import { createCapsWiring } from '@proto.ui/adapter-base';
+import { createCapsWiring, createDomOrderObserver } from '@proto.ui/adapter-base';
 import type { EffectsPort } from '@proto.ui/core';
 import { type RawPropsSource } from '@proto.ui/module-props';
 import { type PropsBaseType } from '@proto.ui/types';
@@ -64,6 +64,8 @@ export function createWebComponentModules<Props extends PropsBaseType>(args: {
       instance: el,
       parent: (inst: unknown) => getProtoParent(inst as HTMLElement),
       getPrototype: (inst: unknown) => getPrototypeByInstance(inst as HTMLElement),
+      root: (inst: unknown) => inst as HTMLElement,
+      orderObserver: createDomOrderObserver,
     })
     .useAsTrigger({
       instance: el,

--- a/packages/core/src/anatomy.ts
+++ b/packages/core/src/anatomy.ts
@@ -52,6 +52,15 @@ export type AnatomyPartView = {
   hasHook(name: string): boolean;
 };
 
+export type AnatomyOrderView = {
+  version(family: AnatomyFamily): number;
+  parts(family: AnatomyFamily): readonly AnatomyPartView[];
+  partsOf(family: AnatomyFamily, role: string): readonly AnatomyPartView[];
+  indexOfSelf(family: AnatomyFamily, role: string): number;
+  prevOfSelf(family: AnatomyFamily, role: string): AnatomyPartView | null;
+  nextOfSelf(family: AnatomyFamily, role: string): AnatomyPartView | null;
+};
+
 export function createAnatomyFamily(debugName: string): AnatomyFamily {
   if (typeof debugName !== 'string' || debugName.length === 0) {
     throw new Error(`[Anatomy] debugName must be a non-empty string.`);

--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -21,6 +21,7 @@ import type {
   AnatomyClaimDecl,
   AnatomyFamily,
   AnatomyFamilyDecl,
+  AnatomyOrderView,
   AnatomyPartView,
 } from './anatomy';
 import { State, StateDefAPI } from './state';
@@ -90,6 +91,7 @@ export interface RunHandle<Props extends PropsBaseType> {
     has(family: AnatomyFamily, role: string): boolean;
     parts(family: AnatomyFamily): ReadonlyArray<AnatomyPartView>;
     partsOf(family: AnatomyFamily, role: string): ReadonlyArray<AnatomyPartView>;
+    order: AnatomyOrderView;
   };
 }
 

--- a/packages/core/src/prototype.ts
+++ b/packages/core/src/prototype.ts
@@ -155,6 +155,7 @@ export type AsHookCaller<
 export const __AS_HOOK_RUNTIME = Symbol.for('@proto.ui/asHook/runtime');
 export const __AS_HOOK_CURRENT_DEF = Symbol.for('@proto.ui/asHook/current-def');
 export const __AS_HOOK_PRIV_FACADES = Symbol.for('@proto.ui/asHook/priv-facades');
+export const __AS_HOOK_PRIV_PORTS = Symbol.for('@proto.ui/asHook/priv-ports');
 
 function normalizeAsHookRender(value: RenderFn | void): RenderFn | undefined {
   if (typeof value !== 'undefined' && typeof value !== 'function') {

--- a/packages/modules/anatomy/src/caps.ts
+++ b/packages/modules/anatomy/src/caps.ts
@@ -1,13 +1,24 @@
 import { cap } from '@proto.ui/core';
-import type { Prototype } from '@proto.ui/core';
+import type { Prototype, Unsubscribe } from '@proto.ui/core';
 
 export type AnatomyInstanceToken = unknown;
+export type AnatomyRootTarget = {
+  compareDocumentPosition?(other: unknown): number;
+};
 
 export type AnatomyParentGetter = (instance: AnatomyInstanceToken) => AnatomyInstanceToken | null;
 export type AnatomyPrototypeGetter = (instance: AnatomyInstanceToken) => Prototype<any> | null;
+export type AnatomyRootTargetGetter = (instance: AnatomyInstanceToken) => AnatomyRootTarget | null;
+export type AnatomyOrderObserver = (target: AnatomyRootTarget, notify: () => void) => Unsubscribe;
 
 export const ANATOMY_INSTANCE_TOKEN_CAP = cap<AnatomyInstanceToken>(
   '@proto.ui/anatomy/instanceToken'
 );
 export const ANATOMY_PARENT_CAP = cap<AnatomyParentGetter>('@proto.ui/anatomy/getParent');
 export const ANATOMY_GET_PROTO_CAP = cap<AnatomyPrototypeGetter>('@proto.ui/anatomy/getPrototype');
+export const ANATOMY_ROOT_TARGET_CAP = cap<AnatomyRootTargetGetter>(
+  '@proto.ui/anatomy/getRootTarget'
+);
+export const ANATOMY_ORDER_OBSERVER_CAP = cap<AnatomyOrderObserver>(
+  '@proto.ui/anatomy/orderObserver'
+);

--- a/packages/modules/anatomy/src/create.ts
+++ b/packages/modules/anatomy/src/create.ts
@@ -24,6 +24,14 @@ export function createAnatomyModule(ctx: ModuleFactoryArgs): AnatomyModule {
           has: (family, role) => impl.has(family, role),
           parts: (family) => impl.parts(family),
           partsOf: (family, role) => impl.partsOf(family, role),
+          order: {
+            version: (family) => impl.orderVersion(family),
+            parts: (family) => impl.orderedParts(family),
+            partsOf: (family, role) => impl.orderedPartsOf(family, role),
+            indexOfSelf: (family, role) => impl.indexOfSelf(family, role),
+            prevOfSelf: (family, role) => impl.prevOfSelf(family, role),
+            nextOfSelf: (family, role) => impl.nextOfSelf(family, role),
+          },
         },
         port: impl.port,
         hooks: {

--- a/packages/modules/anatomy/src/impl.ts
+++ b/packages/modules/anatomy/src/impl.ts
@@ -6,6 +6,7 @@ import type {
   AnatomyPartView,
   Prototype,
   ProtoPhase,
+  Unsubscribe,
   CapsVaultView,
 } from '@proto.ui/core';
 import { illegalPhase } from '@proto.ui/core';
@@ -15,13 +16,22 @@ import type { ExposePort } from '@proto.ui/module-expose';
 import {
   ANATOMY_GET_PROTO_CAP,
   ANATOMY_INSTANCE_TOKEN_CAP,
+  ANATOMY_ORDER_OBSERVER_CAP,
   ANATOMY_PARENT_CAP,
+  ANATOMY_ROOT_TARGET_CAP,
   type AnatomyInstanceToken,
+  type AnatomyOrderObserver,
   type AnatomyParentGetter,
   type AnatomyPrototypeGetter,
+  type AnatomyRootTarget,
+  type AnatomyRootTargetGetter,
 } from './caps';
 import { ANATOMY_ERROR, anatomyError } from './error';
-import type { AnatomyDiagnostic } from './types';
+import type {
+  AnatomyDiagnostic,
+  AnatomyOrderCallbackDispatcher,
+  AnatomyOrderChangeCb,
+} from './types';
 
 type HookTraceEntry = { name?: string };
 
@@ -49,7 +59,11 @@ type ClaimRecord = {
   profile?: string;
   prototype: Prototype<any> | null;
   exposePort: ExposePort;
+  getRootTarget: AnatomyRootTargetGetter;
 };
+
+const ORDER_FOLLOWING = typeof Node !== 'undefined' ? Node.DOCUMENT_POSITION_FOLLOWING : 4;
+const ORDER_PRECEDING = typeof Node !== 'undefined' ? Node.DOCUMENT_POSITION_PRECEDING : 2;
 
 const CENTER = (() => {
   const families = new Map<AnatomyFamily, NormalizedFamily>();
@@ -185,6 +199,14 @@ export class AnatomyModuleImpl extends ModuleBase {
   private readonly exposePort: ExposePort;
   private disposed = false;
   private claimFamilies = new Set<AnatomyFamily>();
+  private orderDispatch: AnatomyOrderCallbackDispatcher = (fn) => fn(undefined);
+  private orderListeners = new Map<AnatomyFamily, Set<AnatomyOrderChangeCb>>();
+  private orderObserverOff = new Map<AnatomyFamily, Unsubscribe>();
+  private orderVersionByFamily = new Map<AnatomyFamily, number>();
+  private orderSignatureByFamily = new Map<AnatomyFamily, string>();
+  private objectIds = new WeakMap<object, number>();
+  private primitiveIds = new Map<unknown, number>();
+  private nextIdentityId = 1;
 
   constructor(caps: CapsVaultView, prototypeName: string, exposePort: ExposePort) {
     super(caps);
@@ -241,6 +263,7 @@ export class AnatomyModuleImpl extends ModuleBase {
       profile: decl.profile,
       prototype: this.getPrototypeGetter()(instance),
       exposePort: this.exposePort,
+      getRootTarget: this.getRootTargetGetter(),
     });
     this.claimFamilies.add(family);
   }
@@ -264,6 +287,36 @@ export class AnatomyModuleImpl extends ModuleBase {
       .map((claim) => this.toPartView(claim));
   }
 
+  orderedParts(family: AnatomyFamily): readonly AnatomyPartView[] {
+    this.ensureCallback('run.anatomy.order.parts');
+    return this.orderedPartsInternal(family);
+  }
+
+  orderVersion(family: AnatomyFamily): number {
+    this.ensureCallback('run.anatomy.order.version');
+    return this.getOrderVersion(family);
+  }
+
+  orderedPartsOf(family: AnatomyFamily, role: string): readonly AnatomyPartView[] {
+    this.ensureCallback('run.anatomy.order.partsOf');
+    return this.orderedPartsOfInternal(family, role);
+  }
+
+  indexOfSelf(family: AnatomyFamily, role: string): number {
+    this.ensureCallback('run.anatomy.order.indexOfSelf');
+    return this.indexOfSelfInternal(family, role);
+  }
+
+  prevOfSelf(family: AnatomyFamily, role: string): AnatomyPartView | null {
+    this.ensureCallback('run.anatomy.order.prevOfSelf');
+    return this.prevOfSelfInternal(family, role);
+  }
+
+  nextOfSelf(family: AnatomyFamily, role: string): AnatomyPartView | null {
+    this.ensureCallback('run.anatomy.order.nextOfSelf');
+    return this.nextOfSelfInternal(family, role);
+  }
+
   readonly port = {
     getDiagnostics: (): readonly AnatomyDiagnostic[] => {
       const out: AnatomyDiagnostic[] = [];
@@ -272,6 +325,19 @@ export class AnatomyModuleImpl extends ModuleBase {
       }
       return out;
     },
+    order: {
+      version: (family: AnatomyFamily) => this.getOrderVersion(family),
+      parts: (family: AnatomyFamily) => this.orderedPartsInternal(family),
+      partsOf: (family: AnatomyFamily, role: string) => this.orderedPartsOfInternal(family, role),
+      indexOfSelf: (family: AnatomyFamily, role: string) => this.indexOfSelfInternal(family, role),
+      prevOfSelf: (family: AnatomyFamily, role: string) => this.prevOfSelfInternal(family, role),
+      nextOfSelf: (family: AnatomyFamily, role: string) => this.nextOfSelfInternal(family, role),
+    },
+    setOrderCallbackDispatcher: (dispatch: AnatomyOrderCallbackDispatcher) => {
+      this.orderDispatch = dispatch;
+    },
+    subscribeOrder: (family: AnatomyFamily, cb: AnatomyOrderChangeCb) =>
+      this.subscribeOrder(family, cb),
   };
 
   override onProtoPhase(phase: ProtoPhase): void {
@@ -282,6 +348,9 @@ export class AnatomyModuleImpl extends ModuleBase {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    for (const off of this.orderObserverOff.values()) off();
+    this.orderObserverOff.clear();
+    this.orderListeners.clear();
     if (this.claimFamilies.size === 0) return;
     if (!this.caps.has(ANATOMY_INSTANCE_TOKEN_CAP)) return;
 
@@ -290,6 +359,159 @@ export class AnatomyModuleImpl extends ModuleBase {
       CENTER.deleteClaim(instance, family);
     }
     this.claimFamilies.clear();
+  }
+
+  private getOrderedClaimsOf(family: AnatomyFamily, role: string): ClaimRecord[] {
+    const domain = this.resolveCurrentDomain(family);
+    return this.sortClaims(domain.claims.filter((claim) => claim.role === role));
+  }
+
+  private orderedPartsInternal(family: AnatomyFamily): readonly AnatomyPartView[] {
+    const domain = this.resolveCurrentDomain(family);
+    return this.sortClaims(domain.claims).map((claim) => this.toPartView(claim));
+  }
+
+  private orderedPartsOfInternal(family: AnatomyFamily, role: string): readonly AnatomyPartView[] {
+    return this.getOrderedClaimsOf(family, role).map((claim) => this.toPartView(claim));
+  }
+
+  private indexOfSelfInternal(family: AnatomyFamily, role: string): number {
+    const self = this.getSelfToken();
+    const claims = this.getOrderedClaimsOf(family, role);
+    return claims.findIndex((claim) => claim.instance === self);
+  }
+
+  private prevOfSelfInternal(family: AnatomyFamily, role: string): AnatomyPartView | null {
+    const self = this.getSelfToken();
+    const claims = this.getOrderedClaimsOf(family, role);
+    const index = claims.findIndex((claim) => claim.instance === self);
+    if (index <= 0) return null;
+    return this.toPartView(claims[index - 1]!);
+  }
+
+  private nextOfSelfInternal(family: AnatomyFamily, role: string): AnatomyPartView | null {
+    const self = this.getSelfToken();
+    const claims = this.getOrderedClaimsOf(family, role);
+    const index = claims.findIndex((claim) => claim.instance === self);
+    if (index < 0 || index >= claims.length - 1) return null;
+    return this.toPartView(claims[index + 1]!);
+  }
+
+  private subscribeOrder(family: AnatomyFamily, cb: AnatomyOrderChangeCb): Unsubscribe {
+    let set = this.orderListeners.get(family);
+    if (!set) {
+      set = new Set();
+      this.orderListeners.set(family, set);
+    }
+    set.add(cb);
+    this.primeOrderSignature(family);
+    this.ensureOrderObserver(family);
+    return () => {
+      const current = this.orderListeners.get(family);
+      current?.delete(cb);
+      if (!current || current.size > 0) return;
+      this.orderListeners.delete(family);
+      this.orderObserverOff.get(family)?.();
+      this.orderObserverOff.delete(family);
+    };
+  }
+
+  private ensureOrderObserver(family: AnatomyFamily): void {
+    if (this.orderObserverOff.has(family)) return;
+    if (!this.caps.has(ANATOMY_ORDER_OBSERVER_CAP)) return;
+
+    const observer = this.caps.get(ANATOMY_ORDER_OBSERVER_CAP) as AnatomyOrderObserver;
+    const target = this.getObservedRootTarget(family);
+    if (!target) return;
+
+    const off = observer(target, () => {
+      this.emitOrderChangeIfNeeded(family);
+    });
+    this.orderObserverOff.set(family, off);
+  }
+
+  private primeOrderSignature(family: AnatomyFamily): void {
+    if (this.orderSignatureByFamily.has(family)) return;
+    const signature = this.computeOrderSignature(family);
+    this.orderSignatureByFamily.set(family, signature);
+    this.orderVersionByFamily.set(family, 0);
+  }
+
+  private getOrderVersion(family: AnatomyFamily): number {
+    this.primeOrderSignature(family);
+    return this.orderVersionByFamily.get(family) ?? 0;
+  }
+
+  private emitOrderChangeIfNeeded(family: AnatomyFamily): void {
+    const prev = this.orderSignatureByFamily.get(family);
+    const next = this.computeOrderSignature(family);
+    if (typeof prev !== 'undefined' && prev === next) return;
+
+    this.orderSignatureByFamily.set(family, next);
+    const nextVersion = (this.orderVersionByFamily.get(family) ?? 0) + 1;
+    this.orderVersionByFamily.set(family, nextVersion);
+
+    const listeners = this.orderListeners.get(family);
+    if (!listeners || listeners.size === 0) return;
+    this.orderDispatch((ctx) => {
+      for (const listener of listeners) listener(ctx);
+    });
+  }
+
+  private computeOrderSignature(family: AnatomyFamily): string {
+    const domain = this.resolveCurrentDomain(family, false);
+    if (!domain.rootInstance) return 'missing-domain';
+    const ordered = this.sortClaims(domain.claims);
+    return ordered.map((claim) => `${claim.role}:${this.getIdentityId(claim.instance)}`).join('|');
+  }
+
+  private getIdentityId(value: unknown): number {
+    if (value && typeof value === 'object') {
+      const obj = value as object;
+      const existing = this.objectIds.get(obj);
+      if (existing) return existing;
+      const next = this.nextIdentityId++;
+      this.objectIds.set(obj, next);
+      return next;
+    }
+
+    if (this.primitiveIds.has(value)) {
+      return this.primitiveIds.get(value)!;
+    }
+    const next = this.nextIdentityId++;
+    this.primitiveIds.set(value, next);
+    return next;
+  }
+
+  private getObservedRootTarget(family: AnatomyFamily): AnatomyRootTarget | null {
+    const domain = this.resolveCurrentDomain(family, false);
+    if (!domain.rootInstance) return null;
+    const rootClaim = CENTER.getClaim(domain.rootInstance, family);
+    if (!rootClaim) return null;
+    return rootClaim.getRootTarget(rootClaim.instance);
+  }
+
+  private sortClaims(claims: ClaimRecord[]): ClaimRecord[] {
+    return claims
+      .map((claim, index) => ({ claim, index }))
+      .sort((left, right) => {
+        const cmp = this.compareClaims(left.claim, right.claim);
+        if (cmp !== 0) return cmp;
+        return left.index - right.index;
+      })
+      .map((entry) => entry.claim);
+  }
+
+  private compareClaims(a: ClaimRecord, b: ClaimRecord): number {
+    const aTarget = a.getRootTarget(a.instance);
+    const bTarget = b.getRootTarget(b.instance);
+    if (!aTarget || !bTarget || aTarget === bTarget) return 0;
+    if (typeof aTarget.compareDocumentPosition !== 'function') return 0;
+
+    const pos = aTarget.compareDocumentPosition(bTarget as AnatomyRootTarget);
+    if (pos & ORDER_FOLLOWING) return -1;
+    if (pos & ORDER_PRECEDING) return 1;
+    return 0;
   }
 
   private computeDiagnostics(family: AnatomyFamily): AnatomyDiagnostic[] {
@@ -546,5 +768,12 @@ export class AnatomyModuleImpl extends ModuleBase {
       throw anatomyError(ANATOMY_ERROR.CAP, `[Anatomy] host caps missing: prototype getter`);
     }
     return this.caps.get(ANATOMY_GET_PROTO_CAP) as AnatomyPrototypeGetter;
+  }
+
+  private getRootTargetGetter(): AnatomyRootTargetGetter {
+    if (!this.caps.has(ANATOMY_ROOT_TARGET_CAP)) {
+      return () => null;
+    }
+    return this.caps.get(ANATOMY_ROOT_TARGET_CAP) as AnatomyRootTargetGetter;
   }
 }

--- a/packages/modules/anatomy/src/types.ts
+++ b/packages/modules/anatomy/src/types.ts
@@ -2,9 +2,11 @@ import type {
   AnatomyClaimDecl,
   AnatomyFamily,
   AnatomyFamilyDecl,
+  AnatomyOrderView,
   AnatomyPartView,
   ModuleInstance,
   ModulePort,
+  Unsubscribe,
 } from '@proto.ui/core';
 
 export type AnatomyDiagnostic = {
@@ -17,6 +19,10 @@ export type AnatomyDiagnostic = {
   profile?: string;
 };
 
+export type AnatomyOrderCallbackCtx = unknown;
+export type AnatomyOrderCallbackDispatcher = (fn: (ctx: AnatomyOrderCallbackCtx) => void) => void;
+export type AnatomyOrderChangeCb = (ctx: AnatomyOrderCallbackCtx) => void;
+
 export type AnatomyFacade = {
   family(family: AnatomyFamily, decl: AnatomyFamilyDecl): void;
   claim(family: AnatomyFamily, decl: AnatomyClaimDecl): void;
@@ -24,10 +30,14 @@ export type AnatomyFacade = {
   has(family: AnatomyFamily, role: string): boolean;
   parts(family: AnatomyFamily): readonly AnatomyPartView[];
   partsOf(family: AnatomyFamily, role: string): readonly AnatomyPartView[];
+  order: AnatomyOrderView;
 };
 
 export type AnatomyPort = ModulePort & {
   getDiagnostics(): readonly AnatomyDiagnostic[];
+  order: AnatomyOrderView;
+  setOrderCallbackDispatcher(dispatch: AnatomyOrderCallbackDispatcher): void;
+  subscribeOrder(family: AnatomyFamily, cb: AnatomyOrderChangeCb): Unsubscribe;
 };
 
 export type AnatomyModule = ModuleInstance<AnatomyFacade> & {

--- a/packages/modules/anatomy/test/contract/anatomy-order.v0.contract.test.ts
+++ b/packages/modules/anatomy/test/contract/anatomy-order.v0.contract.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { createAnatomyFamily, type Prototype } from '@proto.ui/core';
+import { AnatomyModuleImpl } from '../../src/impl';
+import { makeCaps } from '../utils/fake-caps';
+
+function makeExposePort(record: Record<string, unknown> = {}) {
+  return {
+    get: (key: string) => record[key],
+    getAll: () => ({ ...record }),
+    has: (key: string) => Object.prototype.hasOwnProperty.call(record, key),
+    keys: () => Object.keys(record),
+  } as any;
+}
+
+function makeProto(hooks: string[] = []): Prototype<any> {
+  const proto: Prototype<any> = { name: `x-${hooks.join('-') || 'plain'}`, setup: () => {} };
+  Object.defineProperty(proto as any, '__asHooks', {
+    value: hooks.map((name) => ({ name, order: 0, privileged: true })),
+    configurable: true,
+  });
+  return proto;
+}
+
+describe('anatomy-module: order contract v0', () => {
+  it('ANATOMY-ORDER-MOD-0100: version starts at 0 and increments only when ordered signature changes', () => {
+    const family = createAnatomyFamily('contract-order-version');
+    const root = {};
+    const item = {};
+    let notifyObserver: (() => void) | null = null;
+
+    const rootCaps = makeCaps({
+      instance: root,
+      getParent: (instance) => (instance === item ? root : null),
+      getPrototype: () => makeProto([]),
+      getRootTarget: () => ({
+        compareDocumentPosition() {
+          return 0;
+        },
+      }),
+      orderObserver: (_target, notify) => {
+        notifyObserver = notify;
+        return () => {
+          notifyObserver = null;
+        };
+      },
+    });
+
+    const rootImpl = new AnatomyModuleImpl(rootCaps, 'root', makeExposePort());
+    const itemImpl = new AnatomyModuleImpl(
+      makeCaps({
+        instance: item,
+        getParent: (instance) => (instance === item ? root : null),
+        getPrototype: () => makeProto([]),
+        getRootTarget: () => ({
+          compareDocumentPosition() {
+            return 0;
+          },
+        }),
+      }),
+      'item',
+      makeExposePort()
+    );
+
+    rootImpl.family(family, {
+      roles: {
+        root: { cardinality: { min: 1, max: 1 } },
+        item: { cardinality: { min: 0, max: 10 } },
+      },
+    });
+    rootImpl.claim(family, { role: 'root' });
+
+    let calls = 0;
+    rootImpl.port.setOrderCallbackDispatcher((fn) => fn('ctx'));
+    rootImpl.port.subscribeOrder(family, () => {
+      calls++;
+    });
+
+    expect(rootImpl.port.order.version(family)).toBe(0);
+
+    notifyObserver?.();
+    expect(calls).toBe(0);
+    expect(rootImpl.port.order.version(family)).toBe(0);
+
+    itemImpl.claim(family, { role: 'item' });
+    notifyObserver?.();
+    expect(calls).toBe(1);
+    expect(rootImpl.port.order.version(family)).toBe(1);
+
+    notifyObserver?.();
+    expect(calls).toBe(1);
+    expect(rootImpl.port.order.version(family)).toBe(1);
+  });
+
+  it('ANATOMY-ORDER-MOD-0200: subscribeOrder callback is dispatched through configured callback dispatcher', () => {
+    const family = createAnatomyFamily('contract-order-dispatch');
+    const root = {};
+    const item = {};
+    let notifyObserver: (() => void) | null = null;
+
+    const rootImpl = new AnatomyModuleImpl(
+      makeCaps({
+        instance: root,
+        getParent: (instance) => (instance === item ? root : null),
+        getPrototype: () => makeProto([]),
+        getRootTarget: () => ({
+          compareDocumentPosition() {
+            return 0;
+          },
+        }),
+        orderObserver: (_target, notify) => {
+          notifyObserver = notify;
+          return () => {
+            notifyObserver = null;
+          };
+        },
+      }),
+      'root',
+      makeExposePort()
+    );
+    const itemImpl = new AnatomyModuleImpl(
+      makeCaps({
+        instance: item,
+        getParent: (instance) => (instance === item ? root : null),
+        getPrototype: () => makeProto([]),
+        getRootTarget: () => ({
+          compareDocumentPosition() {
+            return 0;
+          },
+        }),
+      }),
+      'item',
+      makeExposePort()
+    );
+
+    rootImpl.family(family, {
+      roles: {
+        root: { cardinality: { min: 1, max: 1 } },
+        item: { cardinality: { min: 0, max: 10 } },
+      },
+    });
+    rootImpl.claim(family, { role: 'root' });
+
+    let seen: unknown = null;
+    rootImpl.port.setOrderCallbackDispatcher((fn) => fn('callback-ctx'));
+    rootImpl.port.subscribeOrder(family, (ctx) => {
+      seen = ctx;
+    });
+
+    itemImpl.claim(family, { role: 'item' });
+    notifyObserver?.();
+
+    expect(seen).toBe('callback-ctx');
+  });
+});

--- a/packages/modules/anatomy/test/impl-spec.test.ts
+++ b/packages/modules/anatomy/test/impl-spec.test.ts
@@ -191,4 +191,141 @@ describe('AnatomyModuleImpl', () => {
     expect(diags.some((it) => it.code === 'ANATOMY_FAMILY_HOOK_REQUIRED')).toBe(true);
     expect(diags.some((it) => it.code === 'ANATOMY_FAMILY_RELATION')).toBe(true);
   });
+
+  it('provides ordered role views by host target position', () => {
+    const family = createAnatomyFamily('ordered-role-view');
+    const root = {};
+    const itemA = {};
+    const itemB = {};
+    const parentMap = new Map<any, any>([
+      [root, null],
+      [itemA, root],
+      [itemB, root],
+    ]);
+    const order = new Map<any, number>([
+      [root, 0],
+      [itemA, 2],
+      [itemB, 1],
+    ]);
+    const makeTarget = (instance: unknown) => ({
+      compareDocumentPosition(other: any) {
+        const a = order.get(instance) ?? 0;
+        const b = order.get(other.__instance) ?? 0;
+        if (a < b) return 4;
+        if (a > b) return 2;
+        return 0;
+      },
+      __instance: instance,
+    });
+
+    const rootCaps = makeCaps({
+      instance: root,
+      getParent: (instance) => parentMap.get(instance) ?? null,
+      getPrototype: () => makeProto([]),
+      getRootTarget: (instance) => makeTarget(instance),
+    });
+    const itemCapsA = makeCaps({
+      instance: itemA,
+      getParent: (instance) => parentMap.get(instance) ?? null,
+      getPrototype: () => makeProto([]),
+      getRootTarget: (instance) => makeTarget(instance),
+    });
+    const itemCapsB = makeCaps({
+      instance: itemB,
+      getParent: (instance) => parentMap.get(instance) ?? null,
+      getPrototype: () => makeProto([]),
+      getRootTarget: (instance) => makeTarget(instance),
+    });
+    const rootImpl = new AnatomyModuleImpl(rootCaps, 'root', makeExposePort());
+    const itemImplA = new AnatomyModuleImpl(itemCapsA, 'item-a', makeExposePort({ id: 'a' }));
+    const itemImplB = new AnatomyModuleImpl(itemCapsB, 'item-b', makeExposePort({ id: 'b' }));
+
+    rootImpl.family(family, {
+      roles: {
+        root: { cardinality: { min: 1, max: 1 } },
+        item: { cardinality: { min: 0, max: 10 } },
+      },
+    });
+    rootImpl.claim(family, { role: 'root' });
+    itemImplA.claim(family, { role: 'item' });
+    itemImplB.claim(family, { role: 'item' });
+
+    rootCaps.__sys.__setExecPhase('callback');
+    itemCapsA.__sys.__setExecPhase('callback');
+
+    const ordered = rootImpl.orderedPartsOf(family, 'item');
+    expect(ordered.map((part) => part.getExpose('id'))).toEqual(['b', 'a']);
+    expect(itemImplA.indexOfSelf(family, 'item')).toBe(1);
+    expect(itemImplA.prevOfSelf(family, 'item')?.getExpose('id')).toBe('b');
+    expect(itemImplA.nextOfSelf(family, 'item')).toBeNull();
+  });
+
+  it('dispatches order subscriptions through callback dispatcher', () => {
+    const family = createAnatomyFamily('ordered-subscribe');
+    const root = {};
+    const item = {};
+    const target = {
+      compareDocumentPosition() {
+        return 0;
+      },
+    };
+    let notifyObserver: (() => void) | null = null;
+    const caps = makeCaps({
+      instance: root,
+      getParent: (instance) => (instance === item ? root : null),
+      getPrototype: () => makeProto([]),
+      getRootTarget: () => target,
+      orderObserver: (_target, notify) => {
+        notifyObserver = notify;
+        return () => {
+          notifyObserver = null;
+        };
+      },
+    });
+    const impl = new AnatomyModuleImpl(caps, 'root', makeExposePort());
+    const itemImpl = new AnatomyModuleImpl(
+      makeCaps({
+        instance: item,
+        getParent: (instance) => (instance === item ? root : null),
+        getPrototype: () => makeProto([]),
+        getRootTarget: () => target,
+      }),
+      'item',
+      makeExposePort()
+    );
+
+    impl.family(family, {
+      roles: {
+        root: { cardinality: { min: 1, max: 1 } },
+        item: { cardinality: { min: 0, max: 10 } },
+      },
+    });
+    impl.claim(family, { role: 'root' });
+
+    let ctxSeen: unknown = null;
+    let calls = 0;
+    impl.port.setOrderCallbackDispatcher((fn) => fn('ctx'));
+    const off = impl.port.subscribeOrder(family, (ctx) => {
+      ctxSeen = ctx;
+      calls++;
+    });
+
+    expect(impl.port.order.version(family)).toBe(0);
+    notifyObserver?.();
+    expect(ctxSeen).toBeNull();
+    expect(calls).toBe(0);
+    expect(impl.port.order.version(family)).toBe(0);
+
+    itemImpl.claim(family, { role: 'item' });
+    notifyObserver?.();
+    expect(ctxSeen).toBe('ctx');
+    expect(calls).toBe(1);
+    expect(impl.port.order.version(family)).toBe(1);
+
+    notifyObserver?.();
+    expect(calls).toBe(1);
+    expect(impl.port.order.version(family)).toBe(1);
+
+    off();
+  });
 });

--- a/packages/modules/anatomy/test/utils/fake-caps.ts
+++ b/packages/modules/anatomy/test/utils/fake-caps.ts
@@ -2,7 +2,9 @@ import { SYS_CAP } from '@proto.ui/module-base';
 import {
   ANATOMY_GET_PROTO_CAP,
   ANATOMY_INSTANCE_TOKEN_CAP,
+  ANATOMY_ORDER_OBSERVER_CAP,
   ANATOMY_PARENT_CAP,
+  ANATOMY_ROOT_TARGET_CAP,
 } from '../../src/caps';
 
 type ExecPhase = 'setup' | 'render' | 'callback' | 'unknown';
@@ -44,6 +46,8 @@ export function makeCaps(args: {
   instance: unknown;
   getParent: (instance: unknown) => unknown | null;
   getPrototype: (instance: unknown) => any;
+  getRootTarget?: (instance: unknown) => unknown | null;
+  orderObserver?: (target: unknown, notify: () => void) => () => void;
 }) {
   let epoch = 0;
   const subs = new Set<(epoch: number) => void>();
@@ -54,6 +58,12 @@ export function makeCaps(args: {
   store.set(ANATOMY_INSTANCE_TOKEN_CAP.id, args.instance);
   store.set(ANATOMY_PARENT_CAP.id, args.getParent);
   store.set(ANATOMY_GET_PROTO_CAP.id, args.getPrototype);
+  if (args.getRootTarget) {
+    store.set(ANATOMY_ROOT_TARGET_CAP.id, args.getRootTarget);
+  }
+  if (args.orderObserver) {
+    store.set(ANATOMY_ORDER_OBSERVER_CAP.id, args.orderObserver);
+  }
 
   return {
     has(token: any) {

--- a/packages/prototypes/base/src/tools/as-collection-item.ts
+++ b/packages/prototypes/base/src/tools/as-collection-item.ts
@@ -1,0 +1,153 @@
+import { __AS_HOOK_PRIV_PORTS, defineAsHook } from '@proto.ui/core';
+import type {
+  AnatomyFamily,
+  ExposeMethod,
+  ExposeState,
+  RunHandle,
+  State,
+  PropsBaseType,
+} from '@proto.ui/core';
+import type { AnatomyPort } from '@proto.ui/module-anatomy';
+
+export type CollectionItemMeta = Record<string, unknown>;
+
+export type CollectionItemOptions<P extends PropsBaseType = any> = {
+  family: AnatomyFamily;
+  role?: string;
+  metaExposeKey?: string;
+  indexStateKey?: string;
+  totalStateKey?: string;
+  firstStateKey?: string;
+  lastStateKey?: string;
+  exposeIndexStateKey?: string;
+  exposeTotalStateKey?: string;
+  exposeFirstStateKey?: string;
+  exposeLastStateKey?: string;
+  exposeSnapshotMethodKey?: string;
+  getMeta?: (run: RunHandle<P>) => CollectionItemMeta;
+};
+
+export type CollectionItemSnapshot = Readonly<
+  CollectionItemMeta & {
+    index: number;
+    total: number;
+    first: boolean;
+    last: boolean;
+  }
+>;
+
+export type CollectionItemExposes = {
+  collectionIndex: ExposeState<number>;
+  collectionTotal: ExposeState<number>;
+  collectionFirst: ExposeState<boolean>;
+  collectionLast: ExposeState<boolean>;
+  getCollectionItem: ExposeMethod<() => CollectionItemSnapshot>;
+};
+
+export type CollectionItemHandles = {
+  collectionIndex: State<number>;
+  collectionTotal: State<number>;
+  collectionFirst: State<boolean>;
+  collectionLast: State<boolean>;
+};
+
+const DEFAULT_ROLE = 'item';
+const DEFAULT_META_EXPOSE_KEY = '__collectionItem';
+
+function getAnatomyPort(def: unknown): AnatomyPort {
+  const ports = (def as any)?.[__AS_HOOK_PRIV_PORTS] as Record<string, unknown> | undefined;
+  const anatomy = ports?.anatomy as AnatomyPort | undefined;
+  if (!anatomy?.order || typeof anatomy.subscribeOrder !== 'function') {
+    throw new Error('[AsHook:asCollectionItem] anatomy port unavailable.');
+  }
+  return anatomy;
+}
+
+export const asCollectionItem = defineAsHook<
+  any,
+  CollectionItemExposes,
+  CollectionItemHandles,
+  CollectionItemOptions<any>
+>({
+  name: 'asCollectionItem',
+  mode: 'once',
+  setup(def, options, api) {
+    const anatomy = getAnatomyPort(def);
+    const role = options.role ?? DEFAULT_ROLE;
+    const metaExposeKey = options.metaExposeKey ?? DEFAULT_META_EXPOSE_KEY;
+    const index = def.state.numberDiscrete(options.indexStateKey ?? 'collectionIndex', -1);
+    const total = def.state.numberDiscrete(options.totalStateKey ?? 'collectionTotal', 0);
+    const first = def.state.bool(options.firstStateKey ?? 'collectionFirst', false);
+    const last = def.state.bool(options.lastStateKey ?? 'collectionLast', false);
+
+    api.store.snapshot = {
+      index: -1,
+      total: 0,
+      first: false,
+      last: false,
+    } as CollectionItemSnapshot;
+    api.store.version = -1;
+
+    def.anatomy.claim(options.family, { role });
+
+    const sync = (run: RunHandle<any>, forceMeta = false) => {
+      const version = run.anatomy.order.version(options.family);
+      if (!forceMeta && api.store.version === version) return;
+      const nextIndex = run.anatomy.order.indexOfSelf(options.family, role);
+      const nextTotal = run.anatomy.order.partsOf(options.family, role).length;
+      const nextFirst = nextIndex === 0 && nextTotal > 0;
+      const nextLast = nextIndex >= 0 && nextIndex === nextTotal - 1;
+      const nextMeta = options.getMeta?.(run) ?? {};
+
+      index.set(nextIndex, 'reason: asCollectionItem.sync => index');
+      total.set(nextTotal, 'reason: asCollectionItem.sync => total');
+      first.set(nextFirst, 'reason: asCollectionItem.sync => first');
+      last.set(nextLast, 'reason: asCollectionItem.sync => last');
+      api.store.snapshot = {
+        ...nextMeta,
+        index: nextIndex,
+        total: nextTotal,
+        first: nextFirst,
+        last: nextLast,
+      } as CollectionItemSnapshot;
+      api.store.version = version;
+    };
+
+    def.expose.state(
+      (options.exposeIndexStateKey ?? 'collectionIndex') as keyof CollectionItemExposes & string,
+      index
+    );
+    def.expose.state(
+      (options.exposeTotalStateKey ?? 'collectionTotal') as keyof CollectionItemExposes & string,
+      total
+    );
+    def.expose.state(
+      (options.exposeFirstStateKey ?? 'collectionFirst') as keyof CollectionItemExposes & string,
+      first
+    );
+    def.expose.state(
+      (options.exposeLastStateKey ?? 'collectionLast') as keyof CollectionItemExposes & string,
+      last
+    );
+    def.expose.method(
+      (options.exposeSnapshotMethodKey ?? 'getCollectionItem') as keyof CollectionItemExposes &
+        string,
+      () => api.store.snapshot as CollectionItemSnapshot
+    );
+    def.expose.method(metaExposeKey as any, () => api.store.snapshot as CollectionItemSnapshot);
+
+    def.lifecycle.onMounted((run) => {
+      sync(run, true);
+      api.store.offOrder = anatomy.subscribeOrder(options.family, (ctx) => {
+        sync(ctx as RunHandle<any>);
+      });
+    });
+    def.lifecycle.onUpdated((run) => {
+      sync(run, true);
+    });
+    def.lifecycle.onUnmounted(() => {
+      (api.store.offOrder as (() => void) | undefined)?.();
+      api.store.offOrder = undefined;
+    });
+  },
+});

--- a/packages/prototypes/base/src/tools/as-collection.ts
+++ b/packages/prototypes/base/src/tools/as-collection.ts
@@ -1,0 +1,140 @@
+import { __AS_HOOK_PRIV_PORTS, defineAsHook } from '@proto.ui/core';
+import type { AnatomyFamily, ExposeMethod, ExposeState, RunHandle, State } from '@proto.ui/core';
+import type { AnatomyPort } from '@proto.ui/module-anatomy';
+
+export type CollectionItemSnapshot = Readonly<
+  Record<string, unknown> & {
+    index: number;
+    total: number;
+    first: boolean;
+    last: boolean;
+  }
+>;
+
+export type CollectionOptions = {
+  family: AnatomyFamily;
+  itemRole?: string;
+  rootRole?: string | false;
+  itemMetaExposeKey?: string;
+  countStateKey?: string;
+  exposeCountStateKey?: string;
+  exposeItemsMethodKey?: string;
+  exposeCountMethodKey?: string;
+};
+
+export type CollectionExposes = {
+  count: ExposeState<number>;
+  getCollectionItems: ExposeMethod<() => readonly CollectionItemSnapshot[]>;
+  getCollectionCount: ExposeMethod<() => number>;
+};
+
+export type CollectionHandles = {
+  count: State<number>;
+};
+
+const DEFAULT_ITEM_ROLE = 'item';
+const DEFAULT_ITEM_META_EXPOSE_KEY = '__collectionItem';
+
+function readItemSnapshot(part: { getExpose(key: string): unknown | null }, exposeKey: string) {
+  const value = part.getExpose(exposeKey);
+  if (!value) return {};
+  if (typeof value === 'function') {
+    const next = value();
+    return next && typeof next === 'object' ? next : {};
+  }
+  return typeof value === 'object' ? value : {};
+}
+
+function buildCollectionItems(
+  parts: readonly { getExpose(key: string): unknown | null }[],
+  itemMetaExposeKey: string
+): readonly CollectionItemSnapshot[] {
+  const total = parts.length;
+  return parts.map((part, index) => ({
+    ...readItemSnapshot(part, itemMetaExposeKey),
+    index,
+    total,
+    first: index === 0,
+    last: index === total - 1,
+  }));
+}
+
+function buildCollectionItemsFromRun(
+  run: RunHandle<any>,
+  family: AnatomyFamily,
+  itemRole: string,
+  itemMetaExposeKey: string
+): readonly CollectionItemSnapshot[] {
+  return buildCollectionItems(run.anatomy.order.partsOf(family, itemRole), itemMetaExposeKey);
+}
+
+function getAnatomyPort(def: unknown): AnatomyPort {
+  const ports = (def as any)?.[__AS_HOOK_PRIV_PORTS] as Record<string, unknown> | undefined;
+  const anatomy = ports?.anatomy as AnatomyPort | undefined;
+  if (!anatomy?.order) {
+    throw new Error('[AsHook:asCollection] anatomy port unavailable.');
+  }
+  return anatomy;
+}
+
+export const asCollection = defineAsHook<
+  any,
+  CollectionExposes,
+  CollectionHandles,
+  CollectionOptions
+>({
+  name: 'asCollection',
+  mode: 'once',
+  setup(def, options, api) {
+    const itemRole = options.itemRole ?? DEFAULT_ITEM_ROLE;
+    const rootRole = options.rootRole ?? false;
+    const itemMetaExposeKey = options.itemMetaExposeKey ?? DEFAULT_ITEM_META_EXPOSE_KEY;
+    const countStateKey = options.countStateKey ?? 'collectionCount';
+    const exposeCountStateKey = options.exposeCountStateKey ?? 'count';
+    const exposeItemsMethodKey = options.exposeItemsMethodKey ?? 'getCollectionItems';
+    const exposeCountMethodKey = options.exposeCountMethodKey ?? 'getCollectionCount';
+    const anatomy = getAnatomyPort(def);
+
+    if (rootRole) {
+      def.anatomy.claim(options.family, { role: rootRole });
+    }
+
+    const count = def.state.numberDiscrete(countStateKey, 0);
+    api.store.items = [] as readonly CollectionItemSnapshot[];
+    api.store.version = -1;
+
+    const sync = (run: RunHandle<any>) => {
+      const version = run.anatomy.order.version(options.family);
+      if (api.store.version === version) return;
+      const items = buildCollectionItemsFromRun(run, options.family, itemRole, itemMetaExposeKey);
+      api.store.items = items;
+      api.store.version = version;
+      count.set(items.length, 'reason: asCollection.sync => collection count');
+    };
+
+    def.expose.state(exposeCountStateKey as keyof CollectionExposes & string, count);
+    def.expose.method(exposeItemsMethodKey as keyof CollectionExposes & string, () => {
+      return buildCollectionItems(
+        anatomy.order.partsOf(options.family, itemRole),
+        itemMetaExposeKey
+      );
+    });
+    def.expose.method(exposeCountMethodKey as keyof CollectionExposes & string, () => {
+      return anatomy.order.partsOf(options.family, itemRole).length;
+    });
+
+    def.lifecycle.onMounted((run) => {
+      sync(run);
+      api.store.offOrder = anatomy.subscribeOrder(options.family, (ctx) => {
+        sync(ctx as RunHandle<any>);
+      });
+    });
+    def.lifecycle.onUpdated((run) => {
+      sync(run);
+    });
+    def.lifecycle.onUnmounted(() => {
+      (api.store.offOrder as (() => void) | undefined)?.();
+      api.store.offOrder = undefined;
+    });
+  },
+});

--- a/packages/prototypes/base/src/tools/index.ts
+++ b/packages/prototypes/base/src/tools/index.ts
@@ -1,4 +1,19 @@
 export { asEscapeKey } from './as-escape-key';
 export type { EscapeKeyOptions } from './as-escape-key';
+export { asCollection } from './as-collection';
+export type {
+  CollectionExposes,
+  CollectionHandles,
+  CollectionItemSnapshot as OrderedCollectionItemSnapshot,
+  CollectionOptions,
+} from './as-collection';
+export { asCollectionItem } from './as-collection-item';
+export type {
+  CollectionItemExposes,
+  CollectionItemHandles,
+  CollectionItemMeta,
+  CollectionItemOptions,
+  CollectionItemSnapshot,
+} from './as-collection-item';
 export { asOpenState } from './as-open-state';
 export type { OpenStateExposes, OpenStateHandles, OpenStateOptions } from './as-open-state';

--- a/packages/prototypes/base/test/as-collection.test.ts
+++ b/packages/prototypes/base/test/as-collection.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import { createAnatomyFamily, definePrototype, type Prototype } from '@proto.ui/core';
+import { executeWithHost, type RuntimeHost } from '@proto.ui/runtime';
+import { EXPOSE_SET_EXPOSES_CAP } from '@proto.ui/module-expose';
+import {
+  ANATOMY_GET_PROTO_CAP,
+  ANATOMY_INSTANCE_TOKEN_CAP,
+  ANATOMY_ORDER_OBSERVER_CAP,
+  ANATOMY_PARENT_CAP,
+  ANATOMY_ROOT_TARGET_CAP,
+} from '@proto.ui/module-anatomy';
+import { asCollection, asCollectionItem } from '../src/tools';
+
+type Target = {
+  id: string;
+  compareDocumentPosition(other: Target): number;
+};
+
+function createTarget(id: string, orderMap: Map<string, number>): Target {
+  return {
+    id,
+    compareDocumentPosition(other: Target) {
+      const a = orderMap.get(id) ?? 0;
+      const b = orderMap.get(other.id) ?? 0;
+      if (a < b) return 4;
+      if (a > b) return 2;
+      return 0;
+    },
+  };
+}
+
+function createHost(args: {
+  instance: Target;
+  getParent: (instance: unknown) => unknown | null;
+  getPrototype: (instance: unknown) => Prototype<any> | null;
+}) {
+  let exposes: Record<string, any> | null = null;
+  let orderNotify: (() => void) | null = null;
+
+  const host: RuntimeHost<any> = {
+    prototypeName: `host-${args.instance.id}`,
+    getRawProps: () => ({}),
+    commit(_children, signal) {
+      signal?.done();
+    },
+    schedule(task) {
+      task();
+    },
+    onRuntimeReady(wiring) {
+      wiring.attach('expose', [
+        [EXPOSE_SET_EXPOSES_CAP, (next: Record<string, unknown>) => (exposes = next)],
+      ]);
+      wiring.attach('anatomy', [
+        [ANATOMY_INSTANCE_TOKEN_CAP, args.instance],
+        [ANATOMY_PARENT_CAP, args.getParent],
+        [ANATOMY_GET_PROTO_CAP, args.getPrototype],
+        [ANATOMY_ROOT_TARGET_CAP, (instance: unknown) => instance as Target],
+        [
+          ANATOMY_ORDER_OBSERVER_CAP,
+          (_target: unknown, notify: () => void) => {
+            orderNotify = notify;
+            return () => {
+              orderNotify = null;
+            };
+          },
+        ],
+      ]);
+    },
+  };
+
+  return {
+    host,
+    getExposes() {
+      return exposes as Record<string, any>;
+    },
+    notifyOrderChange() {
+      orderNotify?.();
+    },
+  };
+}
+
+describe('prototypes/base: asCollection', () => {
+  it('provides live ordered collection snapshots and item indexes', () => {
+    const family = createAnatomyFamily('x-collection-family');
+    const orderMap = new Map<string, number>([
+      ['root', 0],
+      ['item-a', 2],
+      ['item-b', 1],
+    ]);
+    const rootTarget = createTarget('root', orderMap);
+    const itemATarget = createTarget('item-a', orderMap);
+    const itemBTarget = createTarget('item-b', orderMap);
+    const parents = new Map<unknown, unknown | null>([
+      [rootTarget, null],
+      [itemATarget, rootTarget],
+      [itemBTarget, rootTarget],
+    ]);
+
+    const Root = definePrototype({
+      name: 'x-collection-root',
+      setup(def) {
+        def.anatomy.family(family, {
+          roles: {
+            root: { cardinality: { min: 1, max: 1 } },
+            item: { cardinality: { min: 0, max: 10 } },
+          },
+        });
+        asCollection({ family, rootRole: 'root' });
+        return (r) => r.el('div', r.r.slot());
+      },
+    });
+
+    const Item = definePrototype<{ id?: string }>({
+      name: 'x-collection-item',
+      setup(def) {
+        def.props.define({
+          id: { type: 'string', empty: 'fallback' },
+        });
+        def.props.setDefaults({
+          id: '',
+        });
+        asCollectionItem({
+          family,
+          getMeta: (run) => ({ id: run.props.get().id ?? '' }),
+        });
+        return (r) => r.el('div', r.r.slot());
+      },
+    });
+
+    const getPrototype = (instance: unknown) => {
+      if (instance === rootTarget) return Root;
+      if (instance === itemATarget || instance === itemBTarget) return Item;
+      return null;
+    };
+
+    const rootCtx = createHost({
+      instance: rootTarget,
+      getParent: (instance) => parents.get(instance) ?? null,
+      getPrototype,
+    });
+    const itemACtx = createHost({
+      instance: itemATarget,
+      getParent: (instance) => parents.get(instance) ?? null,
+      getPrototype,
+    });
+    const itemBCtx = createHost({
+      instance: itemBTarget,
+      getParent: (instance) => parents.get(instance) ?? null,
+      getPrototype,
+    });
+
+    executeWithHost(Root as any, rootCtx.host as any);
+    const itemA = executeWithHost(
+      Item as any,
+      {
+        ...itemACtx.host,
+        getRawProps: () => ({ id: 'a' }),
+      } as any
+    );
+    executeWithHost(
+      Item as any,
+      {
+        ...itemBCtx.host,
+        getRawProps: () => ({ id: 'b' }),
+      } as any
+    );
+
+    rootCtx.notifyOrderChange();
+    itemACtx.notifyOrderChange();
+
+    const rootExposes = rootCtx.getExposes();
+    const itemAExposes = itemACtx.getExposes();
+
+    expect(rootExposes.getCollectionCount()).toBe(2);
+    expect(rootExposes.getCollectionItems()).toEqual([
+      { id: 'b', index: 0, total: 2, first: true, last: false },
+      { id: 'a', index: 1, total: 2, first: false, last: true },
+    ]);
+    expect(itemAExposes.collectionIndex.get()).toBe(1);
+    expect(itemAExposes.collectionTotal.get()).toBe(2);
+
+    orderMap.set('item-a', 1);
+    orderMap.set('item-b', 2);
+    rootCtx.notifyOrderChange();
+    itemACtx.notifyOrderChange();
+
+    expect(rootExposes.getCollectionItems()).toEqual([
+      { id: 'a', index: 0, total: 2, first: true, last: false },
+      { id: 'b', index: 1, total: 2, first: false, last: true },
+    ]);
+    expect(itemAExposes.collectionIndex.get()).toBe(0);
+  });
+});

--- a/packages/runtime/src/instance/instance.ts
+++ b/packages/runtime/src/instance/instance.ts
@@ -7,6 +7,7 @@ import { PropsModuleDef } from '@proto.ui/module-props';
 import { EventModuleDef } from '@proto.ui/module-event';
 import { ExposeModuleDef } from '@proto.ui/module-expose';
 import { AnatomyModuleDef } from '@proto.ui/module-anatomy';
+import type { AnatomyPort } from '@proto.ui/module-anatomy';
 import { ExposeStateModuleDef } from '@proto.ui/module-expose-state';
 import { ExposeStateWebModuleDef } from '@proto.ui/module-expose-state-web';
 import { RuleExposeStateWebModuleDef } from '@proto.ui/module-rule-expose-state-web';
@@ -108,6 +109,10 @@ export function createRuntimeInstance<P extends PropsBaseType>(
   );
   const contextPort = moduleHub.getPort<ContextPort>('context');
   contextPort?.setCallbackDispatcher?.((fn) => {
+    callbackScope.runNoSync(kernel.run, () => fn(kernel.run));
+  });
+  const anatomyPort = moduleHub.getPort<AnatomyPort>('anatomy');
+  anatomyPort?.setOrderCallbackDispatcher?.((fn) => {
     callbackScope.runNoSync(kernel.run, () => fn(kernel.run));
   });
 

--- a/packages/runtime/src/kernel/handles/run.ts
+++ b/packages/runtime/src/kernel/handles/run.ts
@@ -46,6 +46,32 @@ export const createRunHandle = <P extends PropsBaseType>(
         if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
         return anatomy.partsOf(family, role);
       },
+      order: {
+        version: (family) => {
+          if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
+          return anatomy.order.version(family);
+        },
+        parts: (family) => {
+          if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
+          return anatomy.order.parts(family);
+        },
+        partsOf: (family, role) => {
+          if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
+          return anatomy.order.partsOf(family, role);
+        },
+        indexOfSelf: (family, role) => {
+          if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
+          return anatomy.order.indexOfSelf(family, role);
+        },
+        prevOfSelf: (family, role) => {
+          if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
+          return anatomy.order.prevOfSelf(family, role);
+        },
+        nextOfSelf: (family, role) => {
+          if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
+          return anatomy.order.nextOfSelf(family, role);
+        },
+      },
     },
   };
 };

--- a/packages/runtime/src/kernel/kernel.ts
+++ b/packages/runtime/src/kernel/kernel.ts
@@ -10,6 +10,7 @@ import {
   TemplateChildren,
   __AS_HOOK_CURRENT_DEF,
   __AS_HOOK_PRIV_FACADES,
+  __AS_HOOK_PRIV_PORTS,
 } from '@proto.ui/core';
 import { PropsBaseType } from '@proto.ui/types';
 import {
@@ -74,6 +75,12 @@ export function createKernel<P extends PropsBaseType>(
   attachAsHookRuntime(def, st, proto, opt?.asHook);
   Object.defineProperty(def as any, __AS_HOOK_PRIV_FACADES, {
     value: modules.getFacades(),
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  Object.defineProperty(def as any, __AS_HOOK_PRIV_PORTS, {
+    value: modules.getPorts(),
     enumerable: false,
     configurable: false,
     writable: false,

--- a/packages/runtime/src/orchestrator/module-orchestrator/runtime-module-orchestrator.ts
+++ b/packages/runtime/src/orchestrator/module-orchestrator/runtime-module-orchestrator.ts
@@ -257,6 +257,10 @@ export class RuntimeModuleOrchestrator implements ModuleOrchestrator {
     return this.facades;
   }
 
+  getPorts(): Record<string, unknown> {
+    return this.ports;
+  }
+
   // -------------------------
   // runtime -> ports
   // -------------------------

--- a/packages/runtime/src/orchestrator/module-orchestrator/types.ts
+++ b/packages/runtime/src/orchestrator/module-orchestrator/types.ts
@@ -23,6 +23,7 @@ export type AnyModule = ModuleInstance<ModuleFacade> & {
 export interface ModuleOrchestratorFacadeView {
   /** runtime -> handles (facades are safe, stable, public) */
   getFacades(): Record<string, ModuleFacade>;
+  getPorts(): Record<string, unknown>;
 }
 
 export interface ModuleOrchestrator extends ModuleOrchestratorFacadeView {

--- a/packages/runtime/test/contract/anatomy.order.v0.contract.test.ts
+++ b/packages/runtime/test/contract/anatomy.order.v0.contract.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { createAnatomyFamily, definePrototype, type Prototype } from '@proto.ui/core';
+import type { RuntimeHost } from '../../src';
+import { executeWithHost } from '../../src';
+import {
+  ANATOMY_GET_PROTO_CAP,
+  ANATOMY_INSTANCE_TOKEN_CAP,
+  ANATOMY_PARENT_CAP,
+  ANATOMY_ROOT_TARGET_CAP,
+} from '@proto.ui/module-anatomy';
+
+type Target = {
+  id: string;
+  compareDocumentPosition(other: Target): number;
+};
+
+function createTarget(id: string, orderMap: Map<string, number>): Target {
+  return {
+    id,
+    compareDocumentPosition(other: Target) {
+      const a = orderMap.get(id) ?? 0;
+      const b = orderMap.get(other.id) ?? 0;
+      if (a < b) return 4;
+      if (a > b) return 2;
+      return 0;
+    },
+  };
+}
+
+function createHost(args: {
+  instance: Target;
+  getParent: (instance: unknown) => unknown | null;
+  getPrototype: (instance: unknown) => Prototype<any> | null;
+}) {
+  const host: RuntimeHost<any> = {
+    prototypeName: `host-${args.instance.id}`,
+    getRawProps: () => ({}),
+    commit(_children, signal) {
+      signal?.done();
+    },
+    schedule(task) {
+      task();
+    },
+    onRuntimeReady(wiring) {
+      wiring.attach('anatomy', [
+        [ANATOMY_INSTANCE_TOKEN_CAP, args.instance],
+        [ANATOMY_PARENT_CAP, args.getParent],
+        [ANATOMY_GET_PROTO_CAP, args.getPrototype],
+        [ANATOMY_ROOT_TARGET_CAP, (instance: unknown) => instance as Target],
+      ]);
+    },
+  };
+
+  return { host };
+}
+
+describe('runtime contract: anatomy.order (v0)', () => {
+  it('ANATOMY-ORDER-RT-0100: run.anatomy.order queries reflect host order and self adjacency', () => {
+    const family = createAnatomyFamily('rt-anatomy-order');
+    const orderMap = new Map<string, number>([
+      ['root', 0],
+      ['item-a', 2],
+      ['item-b', 1],
+    ]);
+    const rootTarget = createTarget('root', orderMap);
+    const itemATarget = createTarget('item-a', orderMap);
+    const itemBTarget = createTarget('item-b', orderMap);
+    const parents = new Map<unknown, unknown | null>([
+      [rootTarget, null],
+      [itemATarget, rootTarget],
+      [itemBTarget, rootTarget],
+    ]);
+
+    let orderedIds: unknown[] = [];
+    let version = -1;
+    let itemAIndex = -1;
+    let itemAPrevId: unknown = undefined;
+    let itemANextId: unknown = undefined;
+
+    const Root = definePrototype({
+      name: 'x-rt-anatomy-order-root',
+      setup(def) {
+        def.anatomy.family(family, {
+          roles: {
+            root: { cardinality: { min: 1, max: 1 } },
+            item: { cardinality: { min: 0, max: 10 } },
+          },
+        });
+        def.anatomy.claim(family, { role: 'root' });
+        def.lifecycle.onUpdated((run) => {
+          orderedIds = run.anatomy.order
+            .partsOf(family, 'item')
+            .map((part) => part.getExpose('id'));
+          version = run.anatomy.order.version(family);
+        });
+        return (r) => r.el('div', r.r.slot());
+      },
+    });
+
+    const Item = definePrototype({
+      name: 'x-rt-anatomy-order-item',
+      setup(def) {
+        def.anatomy.claim(family, { role: 'item' });
+        def.expose.value('id' as any, '');
+        def.lifecycle.onUpdated((run) => {
+          const prev = run.anatomy.order.prevOfSelf(family, 'item');
+          const next = run.anatomy.order.nextOfSelf(family, 'item');
+          if (
+            run.anatomy.order.indexOfSelf(family, 'item') >= 0 &&
+            run.anatomy.order.partsOf(family, 'item').length > 0
+          ) {
+            itemAIndex = run.anatomy.order.indexOfSelf(family, 'item');
+            itemAPrevId = prev?.getExpose('id');
+            itemANextId = next?.getExpose('id');
+          }
+        });
+        return (r) => r.el('div', r.r.slot());
+      },
+    });
+
+    const getPrototype = (instance: unknown) => {
+      if (instance === rootTarget) return Root;
+      if (instance === itemATarget || instance === itemBTarget) return Item;
+      return null;
+    };
+
+    const rootCtx = createHost({
+      instance: rootTarget,
+      getParent: (instance) => parents.get(instance) ?? null,
+      getPrototype,
+    });
+    const itemACtx = createHost({
+      instance: itemATarget,
+      getParent: (instance) => parents.get(instance) ?? null,
+      getPrototype,
+    });
+    const itemBCtx = createHost({
+      instance: itemBTarget,
+      getParent: (instance) => parents.get(instance) ?? null,
+      getPrototype,
+    });
+
+    const rootExec = executeWithHost(Root as any, rootCtx.host as any);
+    const itemAExec = executeWithHost(
+      definePrototype({
+        name: 'x-rt-anatomy-order-item-a',
+        setup(def) {
+          def.anatomy.claim(family, { role: 'item' });
+          def.expose.value('id' as any, 'a');
+          def.lifecycle.onUpdated((run) => {
+            itemAIndex = run.anatomy.order.indexOfSelf(family, 'item');
+            itemAPrevId = run.anatomy.order.prevOfSelf(family, 'item')?.getExpose('id');
+            itemANextId = run.anatomy.order.nextOfSelf(family, 'item')?.getExpose('id');
+          });
+          return (r) => r.el('div', r.r.slot());
+        },
+      }) as any,
+      itemACtx.host as any
+    );
+    executeWithHost(
+      definePrototype({
+        name: 'x-rt-anatomy-order-item-b',
+        setup(def) {
+          def.anatomy.claim(family, { role: 'item' });
+          def.expose.value('id' as any, 'b');
+          return (r) => r.el('div', r.r.slot());
+        },
+      }) as any,
+      itemBCtx.host as any
+    );
+
+    rootExec.controller.update();
+    itemAExec.controller.update();
+
+    expect(orderedIds).toEqual(['b', 'a']);
+    expect(version).toBe(0);
+    expect(itemAIndex).toBe(1);
+    expect(itemAPrevId).toBe('b');
+    expect(itemANextId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**中文 PR Comment**

本 PR 引入了 `anatomy.order` 以及建立在其上的最小 collection 语义核，目标是在不新增顶级 `collection` 运行时概念的前提下，为复合原型提供“真实元素顺序查询”和顺序变化信号。

主要改动：

- 在 `anatomy` 上新增 ordered host view 增强：
  - `run.anatomy.order.version(family)`
  - `run.anatomy.order.parts(family)`
  - `run.anatomy.order.partsOf(family, role)`
  - `run.anatomy.order.indexOfSelf(family, role)`
  - `run.anatomy.order.prevOfSelf(family, role)`
  - `run.anatomy.order.nextOfSelf(family, role)`
- `anatomy` module 新增顺序变化订阅能力：
  - `subscribeOrder(family, cb)`
  - `setOrderCallbackDispatcher(...)`
- `version` 不是简单的 observer 计数，而是基于 ordered signature 去重：
  - 初始为 `0`
  - 只有顺序签名真的变化才递增
  - observer 重复触发但顺序未变时不会递增或回调
- adapter 侧新增可选的 DOM order observer：
  - Web/React/Vue/Web Component 默认接入 `MutationObserver`
  - 仅在存在 order 订阅时按需启用，不是全局常驻开销
- base tools 新增：
  - `asCollection`
  - `asCollectionItem`
- 这两个 hook 当前只实现最小 ordered collection 能力：
  - ordered snapshot
  - count / index / first / last
  - observer 存在时的更及时同步
  - 没有 observer 时退化到 mounted/updated 语义
- Wiki 文档更新：
  - 明确 `anatomy.order` 是 anatomy 的有序宿主视图增强，不是新的一级 `collection` 概念
  - 明确 `asCollection` 是建立在 `anatomy.order` 之上的行为抽象

本 PR 还补充了契约测试：

- module contract:
  - `packages/modules/anatomy/test/contract/anatomy-order.v0.contract.test.ts`
- runtime contract:
  - `packages/runtime/test/contract/anatomy.order.v0.contract.test.ts`

希望 reviewer 重点关注：

- `anatomy.order` 作为 anatomy 增强而非独立一级概念，这个分层是否合理
- `version + subscribeOrder` 的语义是否足够稳定，能否作为后续 collection/selectable/listbox 等能力的底层信号
- DOM observer 采用 subtree `MutationObserver` 且按需启用，这个权衡是否合适
- `asCollection / asCollectionItem` 当前是否保持了“最小语义核”，没有过早混入 selection / roving focus / keyboard paging

后续方向暂时不在本 PR 内：

- `asSelectableCollection`
- collection keyboard policy
- 正式 Specifications 文档

**English PR Comment**

This PR introduces `anatomy.order` and a minimal collection semantic layer built on top of it. The goal is to support ordered host-view queries and order-change signals for compound prototypes without introducing a new top-level `collection` runtime concept.

Main changes:

- Added an ordered host-view enhancement under `anatomy`:
  - `run.anatomy.order.version(family)`
  - `run.anatomy.order.parts(family)`
  - `run.anatomy.order.partsOf(family, role)`
  - `run.anatomy.order.indexOfSelf(family, role)`
  - `run.anatomy.order.prevOfSelf(family, role)`
  - `run.anatomy.order.nextOfSelf(family, role)`
- Added order-change subscription support to the anatomy module:
  - `subscribeOrder(family, cb)`
  - `setOrderCallbackDispatcher(...)`
- `version` is not just an observer tick counter. It is deduped by ordered signature:
  - starts at `0`
  - increments only when the effective ordered signature changes
  - repeated observer notifications with unchanged order do not increment or dispatch
- Added an optional DOM order observer on the adapter side:
  - Web/React/Vue/Web Component now wire a `MutationObserver`-based implementation
  - it is enabled on demand only when there is an order subscription
- Added new base tools:
  - `asCollection`
  - `asCollectionItem`
- These hooks currently implement only a minimal ordered collection kernel:
  - ordered snapshot
  - count / index / first / last
  - more timely sync when an observer is available
  - fallback to mounted/updated semantics when no observer is available
- Updated Wiki docs:
  - clarified that `anatomy.order` is an ordered host-view enhancement of anatomy, not a new top-level `collection` concept
  - clarified that `asCollection` is a behavioral abstraction built on top of `anatomy.order`

This PR also adds contract tests:

- module contract:
  - `packages/modules/anatomy/test/contract/anatomy-order.v0.contract.test.ts`
- runtime contract:
  - `packages/runtime/test/contract/anatomy.order.v0.contract.test.ts`

Areas I’d like reviewers to focus on:

- whether the layering is correct: `anatomy.order` as an anatomy enhancement instead of an independent top-level concept
- whether `version + subscribeOrder` is stable enough to serve as the base signal for future collection/selectable/listbox capabilities
- whether the DOM observer tradeoff is acceptable: subtree `MutationObserver`, enabled only on demand
- whether `asCollection / asCollectionItem` still remain a minimal semantic kernel and do not prematurely absorb selection, roving focus, or keyboard paging

Out of scope for this PR:

- `asSelectableCollection`
- collection keyboard policy
- formal Specifications docs