### PR TITLE
feat(docs): add inline concept cards for terminology

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -2,10 +2,12 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import starlight from '@astrojs/starlight';
+import remarkDirective from 'remark-directive';
 
 import tailwindcss from '@tailwindcss/vite';
 import { fileURLToPath } from 'node:url';
 import { rehypeEnhancedImage } from './src/utils/rehype-enhanced-image.js';
+import { remarkConceptDirective } from './src/utils/remark-concept-directive.js';
 
 const inProgressBadge = {
   text: { en: 'WIP', 'zh-CN': '施工中' },
@@ -485,6 +487,7 @@ export default defineConfig({
     mdx(),
   ],
   markdown: {
+    remarkPlugins: [remarkDirective, remarkConceptDirective],
     rehypePlugins: [rehypeEnhancedImage],
   },
   vite: {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -35,6 +35,7 @@
     "sharp": "^0.34.2",
     "shiki": "^3.22.0",
     "tailwindcss": "^4.1.11",
+    "remark-directive": "^4.0.0",
     "unist-util-visit": "^5.0.0",
     "vue": "^3.5.13"
   },

--- a/apps/www/src/components/override/PageFrame.astro
+++ b/apps/www/src/components/override/PageFrame.astro
@@ -1,6 +1,7 @@
 ---
 import MobileMenuToggle from '@astrojs/starlight/components/MobileMenuToggle.astro';
 import '../../styles/global.css';
+import conceptScriptUrl from '../../scripts/proto-concept.ts?url';
 
 const { hasSidebar } = Astro.locals.starlightRoute;
 ---
@@ -8,6 +9,7 @@ const { hasSidebar } = Astro.locals.starlightRoute;
 <div
   class="bg-background text-foreground group/body overscroll-none font-sans antialiased [--footer-height:calc(var(--spacing)*14)] [--header-height:calc(var(--spacing)*14)] xl:[--footer-height:calc(var(--spacing)*24)]"
 >
+  <script is:inline type="module" src={conceptScriptUrl}></script>
   <div class="bg-background container-wrapper flex flex-1 flex-col px-2">
     <header class="bg-background sticky top-0 z-50 w-full"><slot name="header" /></header>
     <div

--- a/apps/www/src/content/docs/zh-cn/specifications/introduction.md
+++ b/apps/www/src/content/docs/zh-cn/specifications/introduction.md
@@ -10,6 +10,14 @@ description: '如何阅读规范'
 - 规范文与白皮书、工程文档分别有什么分工。
 - 这一章应该如何阅读、如何查阅、如何引用。
 
+## 概念速览卡（Concept Card）
+
+当你在正文里第一次遇到 Proto UI 的专有术语时，可以用行内概念卡做“就地解释”，不跳转、不打断阅读节奏。
+
+示例：:concept[host]、:concept[adapter]、:concept[prototype]
+
+你也可以覆盖摘要（用于临时补充或语境化解释）：:concept[host]{summary="这里的 host 指你选择的技术载体/运行环境。"}
+
 ## 这一章不负责什么？
 
 写作提示：

--- a/apps/www/src/data/concepts.ts
+++ b/apps/www/src/data/concepts.ts
@@ -1,0 +1,42 @@
+export type ConceptLocale = 'zh-cn' | 'en';
+
+export type ConceptEntry = {
+  slug: string;
+  term: Record<ConceptLocale, string>;
+  summary: Record<ConceptLocale, string>;
+  href?: string;
+};
+
+export const concepts: ConceptEntry[] = [
+  {
+    slug: 'host',
+    term: { 'zh-cn': 'host', en: 'host' },
+    summary: {
+      'zh-cn':
+        'Proto UI 的依赖环境：泛指框架技术、平台技术、硬件设备等。限制极少，几乎可运行于任何 HCI 技术体系之上。',
+      en: 'The environment Proto UI depends on (frameworks, platforms, hardware, etc.). Constraints are intentionally minimal.',
+    },
+  },
+  {
+    slug: 'adapter',
+    term: { 'zh-cn': 'adapter', en: 'adapter' },
+    summary: {
+      'zh-cn':
+        '把 Proto UI 的协议能力翻译到具体技术载体（某个 host）上的“适配层”。它负责把抽象能力落地为真实的运行时行为。',
+      en: 'A translation layer that maps Proto UI capabilities onto a specific host, turning abstractions into real runtime behavior.',
+    },
+  },
+  {
+    slug: 'prototype',
+    term: { 'zh-cn': 'prototype', en: 'prototype' },
+    summary: {
+      'zh-cn':
+        'Proto UI 中的交互主体单元：以协议的方式描述结构、状态、事件与反馈等能力，并可被 adapter/运行时解释与执行。',
+      en: 'An interaction subject described as a protocol (structure, state, events, feedback, etc.), interpretable by adapters/runtimes.',
+    },
+  },
+];
+
+export function getConcept(slug: string): ConceptEntry | undefined {
+  return concepts.find((c) => c.slug === slug);
+}

--- a/apps/www/src/scripts/proto-concept.ts
+++ b/apps/www/src/scripts/proto-concept.ts
@@ -1,0 +1,127 @@
+import { getConcept, type ConceptLocale } from '../data/concepts';
+
+function detectLocale(): ConceptLocale {
+  const path = typeof window !== 'undefined' ? window.location.pathname : '';
+  return path.startsWith('/en/') ? 'en' : 'zh-cn';
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+class ProtoConceptElement extends HTMLElement {
+  #instanceId = `proto-concept-${Math.random().toString(36).slice(2, 10)}`;
+  #cleanup: (() => void) | null = null;
+
+  connectedCallback() {
+    const locale = detectLocale();
+
+    const slug = (this.getAttribute('slug') || '').trim();
+    const overrideSummary = (this.getAttribute('summary') || '').trim();
+    const overrideHref = (this.getAttribute('href') || '').trim();
+    const labelFromContent = (this.textContent || '').trim();
+
+    const entry = slug ? getConcept(slug) : undefined;
+    const termLabel = labelFromContent || entry?.term[locale] || slug || 'concept';
+    const summary = overrideSummary || entry?.summary[locale] || '';
+    const href = overrideHref || entry?.href || '';
+
+    // Avoid double-hydration.
+    if (this.dataset.hydrated === 'true') return;
+    this.dataset.hydrated = 'true';
+
+    const root = document.createElement('span');
+    root.className = 'proto-concept';
+    root.dataset.protoConcept = '';
+    root.id = this.#instanceId;
+
+    root.innerHTML = `
+      <button
+        class="proto-concept__trigger"
+        type="button"
+        aria-expanded="false"
+        aria-controls="${this.#instanceId}-card"
+      >${escapeHtml(termLabel)}</button>
+      <span class="proto-concept__card" role="note" id="${this.#instanceId}-card">
+        <span class="proto-concept__eyebrow">${locale === 'zh-cn' ? '概念' : 'Concept'}</span>
+        <span class="proto-concept__title">${escapeHtml(entry?.term[locale] || termLabel)}</span>
+        ${summary ? `<span class="proto-concept__summary">${escapeHtml(summary)}</span>` : ''}
+        <span class="proto-concept__actions">
+          <button class="proto-concept__action proto-concept__close" type="button">
+            ${locale === 'zh-cn' ? '关闭' : 'Close'}
+          </button>
+          ${
+            href
+              ? `<a class="proto-concept__action proto-concept__link" href="${escapeHtml(href)}">${
+                  locale === 'zh-cn' ? '了解更多' : 'Learn more'
+                }</a>`
+              : ''
+          }
+        </span>
+      </span>
+    `;
+
+    this.replaceWith(root);
+
+    const trigger = root.querySelector('.proto-concept__trigger');
+    const close = root.querySelector('.proto-concept__close');
+    if (!(trigger instanceof HTMLButtonElement)) return;
+
+    const setPinned = (next: boolean) => {
+      root.dataset.pinned = next ? 'true' : 'false';
+      trigger.setAttribute('aria-expanded', next ? 'true' : 'false');
+    };
+
+    const supportsHover =
+      window.matchMedia?.('(hover: hover) and (pointer: fine)')?.matches ?? false;
+    const onEnter = () => {
+      if (supportsHover) root.dataset.hovering = 'true';
+    };
+    const onLeave = () => {
+      if (supportsHover) root.dataset.hovering = 'false';
+    };
+
+    trigger.addEventListener('click', () => {
+      const pinned = root.dataset.pinned === 'true';
+      setPinned(!pinned);
+    });
+
+    if (close instanceof HTMLButtonElement) {
+      close.addEventListener('click', () => setPinned(false));
+    }
+
+    root.addEventListener('pointerenter', onEnter);
+    root.addEventListener('pointerleave', onLeave);
+
+    const onDocClick = (event: MouseEvent) => {
+      if (!root.contains(event.target as Node)) setPinned(false);
+    };
+    const onKeydown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setPinned(false);
+    };
+
+    document.addEventListener('click', onDocClick);
+    root.addEventListener('keydown', onKeydown);
+
+    this.#cleanup = () => {
+      document.removeEventListener('click', onDocClick);
+      root.removeEventListener('keydown', onKeydown);
+      root.removeEventListener('pointerenter', onEnter);
+      root.removeEventListener('pointerleave', onLeave);
+    };
+  }
+
+  disconnectedCallback() {
+    this.#cleanup?.();
+    this.#cleanup = null;
+  }
+}
+
+if (!customElements.get('proto-concept')) {
+  customElements.define('proto-concept', ProtoConceptElement);
+}

--- a/apps/www/src/styles/global.css
+++ b/apps/www/src/styles/global.css
@@ -4,6 +4,162 @@
 @import './sidebar.css';
 @import './right-sidebar.css';
 
+.proto-concept {
+  position: relative;
+  display: inline-flex;
+  vertical-align: baseline;
+}
+
+.proto-concept__trigger {
+  appearance: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: none;
+  font: inherit;
+  line-height: inherit;
+  cursor: pointer;
+  color: var(--color-foreground);
+  border-bottom: 1px dashed color-mix(in oklab, var(--color-primary) 60%, transparent);
+  background: linear-gradient(
+      to top,
+      color-mix(in oklab, var(--color-primary) 10%, transparent) 0%,
+      color-mix(in oklab, var(--color-primary) 10%, transparent) 100%
+    )
+    0 100% / 100% 0.45em no-repeat;
+  transition:
+    border-color 180ms ease,
+    background-size 180ms ease,
+    color 180ms ease;
+}
+
+.proto-concept__trigger:hover,
+.proto-concept__trigger:focus-visible {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+  background-size: 100% 0.8em;
+  outline: none;
+}
+
+.proto-concept__card {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 0.7rem);
+  z-index: 40;
+  width: min(20rem, calc(100vw - 2rem));
+  min-width: 16rem;
+  translate: -50% 0.35rem;
+  border: 1px solid color-mix(in oklab, var(--color-border) 88%, transparent);
+  border-radius: 1rem;
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--color-background) 92%, white 8%),
+    color-mix(in oklab, var(--color-background) 98%, black 2%)
+  );
+  box-shadow:
+    0 18px 40px rgba(15, 23, 42, 0.12),
+    0 2px 10px rgba(15, 23, 42, 0.08);
+  padding: 0.9rem 1rem 0.95rem;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 180ms ease,
+    translate 180ms ease;
+}
+
+[data-theme='dark'] .proto-concept__card {
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--color-background) 88%, white 4%),
+    color-mix(in oklab, var(--color-background) 94%, black 6%)
+  );
+  box-shadow:
+    0 18px 40px rgba(0, 0, 0, 0.4),
+    0 2px 10px rgba(0, 0, 0, 0.28);
+}
+
+.proto-concept[data-hovering='true'] .proto-concept__card,
+.proto-concept:focus-within .proto-concept__card,
+.proto-concept[data-pinned='true'] .proto-concept__card {
+  opacity: 1;
+  pointer-events: auto;
+  translate: -50% 0;
+}
+
+.proto-concept__eyebrow {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--color-muted-foreground);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.proto-concept__title {
+  display: block;
+  color: var(--color-foreground);
+  font-size: 0.98rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.proto-concept__summary {
+  display: block;
+  margin-top: 0.45rem;
+  color: var(--color-muted-foreground);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.proto-concept__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.proto-concept__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.9rem;
+  border-radius: 999px;
+  padding: 0 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.proto-concept__close {
+  appearance: none;
+  border: 1px solid color-mix(in oklab, var(--color-border) 86%, transparent);
+  background: color-mix(in oklab, var(--color-muted) 72%, transparent);
+  color: var(--color-foreground);
+  cursor: pointer;
+}
+
+.proto-concept__link {
+  color: var(--color-primary);
+  background: color-mix(in oklab, var(--color-primary) 12%, transparent);
+}
+
+@media (max-width: 640px) {
+  .proto-concept__card {
+    left: 0;
+    min-width: min(16rem, calc(100vw - 2rem));
+    width: min(18rem, calc(100vw - 2rem));
+    translate: 0 0.35rem;
+  }
+
+  .proto-concept[data-hovering='true'] .proto-concept__card,
+  .proto-concept:focus-within .proto-concept__card,
+  .proto-concept[data-pinned='true'] .proto-concept__card {
+    translate: 0 0;
+  }
+}
+
 .container-wrapper {
   width: 100%;
   padding-inline: calc(var(--spacing) * 4);

--- a/apps/www/src/utils/remark-concept-directive.js
+++ b/apps/www/src/utils/remark-concept-directive.js
@@ -1,0 +1,38 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Markdown 用法（行内）：
+ *   :concept[host]
+ *   :concept[Host]{slug="host"}
+ *   :concept[host]{summary="..."}  // 可选覆盖
+ */
+export function remarkConceptDirective() {
+  return (tree) => {
+    visit(tree, (node) => {
+      if (!node || typeof node !== 'object') return;
+      if (node.type !== 'textDirective') return;
+      if (node.name !== 'concept') return;
+
+      const attributes =
+        node.attributes && typeof node.attributes === 'object' ? node.attributes : {};
+      const labelText =
+        Array.isArray(node.children) && node.children.length
+          ? node.children.map((c) => (c && c.type === 'text' ? c.value : '')).join('')
+          : '';
+
+      const slug = (attributes.slug || labelText || '').toString().trim();
+      if (!slug) return;
+
+      const summary = (attributes.summary || '').toString().trim();
+      const href = (attributes.href || '').toString().trim();
+
+      node.data ||= {};
+      node.data.hName = 'proto-concept';
+      node.data.hProperties = {
+        slug,
+        ...(summary ? { summary } : null),
+        ...(href ? { href } : null),
+      };
+    });
+  };
+}


### PR DESCRIPTION
## 背景 / Why
Proto UI 文档中存在大量协议级/哲学级术语，频繁出现但解释成本高。
本 PR 引入“行内概念速览卡（Concept Card）”，在不跳转、不打断阅读的前提下，让读者可随时查看术语简释，提升 onboarding 体验。

## 做了什么 / What
- 支持在 Markdown 中用行内语法声明概念卡：`:concept[host]`
  - 可选覆盖：`:concept[host]{summary="..."}`、`:concept[host]{href="/..."}`
- 新增轻量概念数据源（可扩展）：`host` / `adapter` / `prototype`
- 桌面端 hover 展示；触屏/鼠标点击固定展开（tap-to-reveal），不发生页面跳转
- 支持关闭：Close 按钮、点外关闭、`Escape` 关闭
- 样式与 Starlight 主题变量对齐（暗色/亮色兼容），信息优先级低于正文

## 实现方式 / How
- remark 指令解析：`remark-directive` + 自定义 `remarkConceptDirective`
- 自定义元素：`<proto-concept slug="...">`（由 Markdown 指令生成）
- 全站注入交互脚本：在 `PageFrame` 加载 `proto-concept` 脚本
- 样式：集中在全局样式中（避免引入重依赖）

## 改动文件 / Files
- `apps/www/astro.config.mjs`
- `apps/www/package.json`（新增依赖 `remark-directive`）
- `apps/www/src/utils/remark-concept-directive.js`
- `apps/www/src/data/concepts.ts`
- `apps/www/src/scripts/proto-concept.ts`
- `apps/www/src/components/override/PageFrame.astro`
- `apps/www/src/styles/global.css`
- `apps/www/src/content/docs/zh-cn/specifications/introduction.md`（示例用法）

## 测试 / Test plan
- [x] 在文档页中确认 `:concept[host]` 渲染为可交互概念卡
- [x] 桌面端 hover 可展示卡片；移开后隐藏
- [x] 触屏/点击：点击触发展开；再次点击/点外/Esc/Close 可关闭
- [x] 不发生页面跳转（非 anchor 导航）
- [x] 亮色/暗色主题下样式可读、不过度抢占正文注意力