### PR TITLE
docs: clarify contribution paths for new contributors

### DIFF
--- a/apps/www/src/content/docs/en/build/contribute.md
+++ b/apps/www/src/content/docs/en/build/contribute.md
@@ -1,7 +1,448 @@
 ---
 title: 'How to Contribute'
-desp: 'How to start contributing to the Proto UI ecosystem'
-description: 'How to start contributing to the Proto UI ecosystem'
+description: 'Contribution paths, entry points, and practical advice for the current phase of Proto UI'
 ---
 
-Coming soon.
+## What this page covers
+
+This page is for anyone who wants to contribute to the Proto UI ecosystem.
+
+It doesn't replace the repository's development docs or the whitepaper's theoretical depth. It answers the more immediate questions:
+
+- What kinds of contributions does Proto UI need most right now?
+- Which path fits me best?
+- What should I understand before contributing?
+- What's the simplest way to preview my work?
+- What makes a contribution easier to review and maintain?
+
+If you're unsure whether contributing is right for you, reading this page is usually enough.
+
+---
+
+## What does Proto UI need most right now?
+
+Proto UI is still in its early phase. The priority isn't "everything at once" — it's getting the core paths working well.
+
+The most valuable contributions right now tend to fall into these directions:
+
+- **Prototype**
+  - Expanding the official prototype library
+  - Adding interaction capabilities for common components
+  - Improving prototype fidelity and reusability
+
+- **Adapter**
+  - Building host integration for new platforms
+  - Improving how existing hosts fulfill prototype contracts
+  - Raising consistency and fidelity across hosts
+
+- **Contracts / Tests**
+  - Adding contract constraints for existing capabilities
+  - Making prototypes and adapters more verifiable
+  - Building a more stable foundation for "officially supported quality"
+
+- **Docs / Demo**
+  - Helping others understand Proto UI faster
+  - Lowering the barrier for new contributors
+  - Showing existing capabilities more clearly
+
+- **Community / Curation**
+  - Organizing questions and discussions
+  - Distilling consensus and indices
+  - Helping new contributors find their way in
+
+For most first-time contributors, **prototypes, docs, and tests** are often easier entry points. **Adapters** lean toward deeper waters, but are equally critical.
+
+---
+
+## What to read before contributing
+
+You don't need to memorize the entire whitepaper, but a minimal mental model helps a lot.
+
+At minimum, we suggest reading:
+
+- [Start Here / What You Just Saw](/en/start-here/what-you-saw/)
+- [Start Here / How It Works](/en/start-here/how-it-works/)
+
+- [Whitepaper / Component as Protocol](/en/whitepaper/component-as-protocol/)
+- [Whitepaper / Information Flow Model](/en/whitepaper/information-flow-model/)
+- [Whitepaper / Prototype Boundary](/en/whitepaper/prototype-boundary/)
+- [Whitepaper / Execution Semantics](/en/whitepaper/execution-semantics/)
+
+If you're planning to write an adapter, also read:
+
+- [Whitepaper / Translation Layer](/en/whitepaper/translation-layer/)
+- [Whitepaper / Design Constraints](/en/whitepaper/design-constraints/)
+
+This isn't about raising the bar — it's about avoiding the frustration of realizing your work and Proto UI's boundary model were never aligned to begin with.
+
+---
+
+## Contribution paths
+
+Proto UI's ecosystem isn't a single track. Different types of contributions solve problems at different layers.
+
+### Prototype
+
+This path is about:
+
+> **How a component should interact.**
+
+The Prototype direction cares about the interaction semantics of a component:
+
+- How state flows
+- How events enter
+- How feedback expresses itself
+- How prototype boundaries should be drawn
+- Which capabilities belong in the official prototype library
+
+If your background is closer to:
+
+- Component library development
+- Design systems
+- Headless components
+- Interaction design implementation
+- Accessibility improvements
+
+Then Prototype is often the more natural entry point.
+
+Good starting points include:
+
+- Adding a specific interaction capability to an existing prototype
+- Creating a new, well-scoped base prototype
+- Improving state / feedback expression for an existing prototype
+- Raising prototype fidelity across more scenarios
+
+**Relevant guides and templates:**
+
+- [Writing A Custom Primitive Prototype](/zh-cn/build/prototypes/writing-a-custom-primitive-prototype/) (Chinese — English version in progress)
+- [Writing A Compound Prototype](/zh-cn/build/prototypes/writing-a-compound-prototype/) (Chinese)
+- [Prototype Author Checklist](/zh-cn/build/prototypes/checklist/) (Chinese)
+- [Prototype Proposal Template](https://github.com/Proto-UI/Proto-UI/issues/new?template=prototype-proposal.md)
+- [Good First Issues: Prototype](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aprototype)
+
+---
+
+### Adapter
+
+This path is about:
+
+> **How prototypes land in a specific host.**
+
+The Adapter direction typically deals with:
+
+- How prototype contracts map to a given host
+- How to fill gaps in host capabilities
+- Which feedback and interactions can be carried directly
+- Which parts need host-specific handling
+- How the final artifact feels native to that host
+
+If you're more familiar with a specific host, for example:
+
+- React
+- Vue
+- Web Components
+- Flutter
+- Qt
+- Platform-native UI technologies
+
+And you tend to work on:
+
+- Framework internals
+- Rendering models
+- Event systems
+- State and ref management
+- Platform constraints and performance
+
+Then Adapter is likely a better fit.
+
+Good starting points include:
+
+- Filling in a contract-adherence gap for an existing host
+- Improving host-side fidelity for an existing prototype
+- Building a minimal working adapter for a new host
+- Adding a capability-fallback strategy for a host
+
+**Relevant guides and templates:**
+
+- [Adapter Guide](/en/build/adapter-guide/) (in progress — see Chinese version [here](/zh-cn/build/adapter-guide/))
+- [Adapter Proposal Template](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md)
+- [Good First Issues: Adapter](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadapter)
+
+Adapter work is deeper water than Prototype, but it's also critical — whether Proto UI can be used in real projects depends on the translation layer being reliable.
+
+---
+
+### Contracts / Tests
+
+This path is about:
+
+> **What does it mean to "really support" a capability.**
+
+In Proto UI, contracts and tests aren't just quality supplements. They directly determine:
+
+- Whether a prototype is clearly defined
+- Whether an adapter truly fulfills a prototype contract
+- Whether "officially supported quality" has a clear boundary
+- How community and official implementations form a verifiable relationship
+
+If you care more about:
+
+- Whether semantic boundaries are clear
+- Whether behavior is stably verified
+- Whether contracts and implementations are consistent
+- Whether a capability is genuinely "established" rather than "looks about right"
+
+Then this path fits you well.
+
+Good starting points include:
+
+- Adding contract tests for existing capabilities
+- Writing minimal verification for semantics already documented
+- Spotting "inconsistent but unconstrained" spots in existing prototypes / adapters
+- Distilling existing consensus into verifiable contracts
+
+**Relevant guides and templates:**
+
+- [Contracts & Tests](/en/build/contracts-and-tests/) (in progress — see Chinese version [here](/zh-cn/build/contracts-and-tests/))
+- [Good First Issues: automation](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aautomation)
+
+---
+
+### Docs / Demo
+
+This path is about:
+
+> **Whether others can understand Proto UI.**
+
+Proto UI currently carries non-trivial theoretical density. Docs, examples, and demos directly affect:
+
+- Whether new users can understand quickly
+- Whether new contributors know where to start
+- Whether prototypes and adapters are clearly demonstrated
+- Whether discussions can build on a shared minimal understanding
+
+If you're better at:
+
+- Explaining complex things clearly
+- Turning theory into readable docs
+- Turning abstract concepts into examples, diagrams, or demos
+- Spotting "where someone will get confused"
+
+Then Docs / Demo is a great entry point.
+
+Good starting points include:
+
+- Revising existing docs to smooth the entry path
+- Adding minimal examples for a prototype
+- Turning an abstract concept into an approachable demo
+- Writing FAQs, reading guides, or contribution-entry docs
+
+**Relevant guides and templates:**
+
+- [Docs Request Template](https://github.com/Proto-UI/Proto-UI/issues/new?template=docs-request.md)
+- [Good First Issues: docs](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Adocs)
+
+---
+
+### Community / Curation
+
+This path is about:
+
+> **Catching and organizing the ecosystem's questions, feedback, and consensus.**
+
+Proto UI's growth isn't only from code. It also comes from:
+
+- Whether questions are organized
+- Whether recurring discussions are distilled
+- Whether community prototypes / adapters are visible
+- Whether newcomers get consistent responses
+
+If you're better at:
+
+- Summarizing problems
+- Organizing discussions
+- Maintaining issues / discussions
+- Helping others articulate their ideas
+- Connecting contributors across different directions
+
+Then this path is a strong fit.
+
+Good starting points include:
+
+- Cataloging recurring questions
+- Helping maintain the FAQ or discussion index
+- Distilling scattered discussions into citable conclusions
+- Helping new contributors find the right entry point for them
+
+**Relevant resources:**
+
+- [Good First Issues: community](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Acommunity)
+- [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions)
+
+---
+
+## Not sure which path fits you?
+
+A simple way to tell is to notice which kind of question you naturally ask.
+
+If you more often ask:
+
+- "How should this component interact?"
+  - Closer to Prototype
+
+- "How does this host implement it?"
+  - Closer to Adapter
+
+- "Is this behavior clearly defined and verified?"
+  - Closer to Contracts / Tests
+
+- "Can others understand this?"
+  - Closer to Docs / Demo
+
+- "Have these discussions been organized?"
+  - Closer to Community / Curation
+
+If you're still unsure, the most stable approach is usually:
+
+> Start with docs, a small prototype, or a clear small test.
+
+These entry points carry the lowest risk and tend to get feedback fastest.
+
+---
+
+## Suggested progression for first-time contributors
+
+For someone contributing for the first time, the most reliable approach isn't to write a complete system up front, but rather:
+
+1. **Pick up a clearly scoped, small issue first**
+2. **Confirm the boundary in Discussions or the issue thread**
+3. **Then start implementing**
+4. **Submit the smallest reviewable result, rather than one massive change**
+
+Proto UI's theory and engineering are both still converging. The sooner you align on boundaries, the less rework later.
+
+### Picking up a Good First Issue
+
+We maintain a set of [Good First Issues](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22) that are scoped for new contributors. These issues include clear acceptance criteria, references, and explicit out-of-scope notes so you know what's expected before you start.
+
+If you find one you'd like to work on, comment on the issue to let maintainers know. If the scope or approach isn't clear, ask in the issue thread — clarifying the boundary before writing code saves everyone time.
+
+---
+
+## Simplest preview path right now
+
+Since adapter and prototype development doesn't yet have dedicated debugging tooling, the most direct preview path is:
+
+> **Wire them into the docs site and preview there.**
+
+This is the recommended approach in the current phase. The reasons:
+
+- The docs site is already Proto UI's main showcase and verification entry point
+- It's naturally suited for comparing behavior across hosts
+- New prototypes / adapters can be observed and discussed in an environment close to their real display context
+
+Proto UI provides ways to wire new adapters and prototypes into the docs site. So for many contributions, the shortest feedback loop right now is:
+
+1. Write a minimal working prototype / adapter
+2. Wire it into the docs site
+3. Preview and adjust directly in the docs site
+4. Then continue with docs, contracts, or tests
+
+Until dedicated debugging tooling matures, this is the most realistic path.
+
+---
+
+## What makes a contribution more likely to be accepted
+
+Proto UI is currently most able to accept contributions of these kinds:
+
+### 1. Clear boundaries
+
+The contributions easiest to maintain long-term are often not the ones that "do a lot," but the ones that solve a single, clearly bounded problem.
+
+For example:
+
+- Adding a specific interaction capability to an existing prototype
+- Filling in a specific contract-adherence gap for an existing host
+- Filling in a clearly missing entry point in the docs
+
+By contrast, submissions that "refactor many layers at once along the way" are harder to review in the current phase and harder to merge stably.
+
+### 2. Previewable on the docs site
+
+One of the most valuable things a contribution can do right now is land on the docs site for preview and discussion.
+
+For prototypes and adapters especially, whether they can quickly appear on the docs site often directly determines whether others can understand what problem the contribution actually solves.
+
+### 3. Comes with minimal documentation
+
+Even for a small contribution, it helps to at least describe:
+
+- What problem it solves
+- Which layer it belongs to (prototype / adapter / contracts / docs)
+- Why the approach aligns with Proto UI's current boundary model
+
+This dramatically reduces communication overhead.
+
+### 4. Open to iteration
+
+Proto UI is not a system where all the rules are fully frozen yet. Many contributions, even when directionally correct, may still need adjustments.
+
+This isn't a judgment on the contribution itself — it's because the ecosystem, boundaries, and engineering constraints are still converging.
+
+---
+
+## What to discuss before building
+
+These situations are usually better discussed first:
+
+- You're planning to add a new host adapter
+- You're planning to extend the prototype DSL
+- You're planning to change existing contract-layer boundaries
+- You're planning to introduce a new core capability dimension
+- You're planning a large-scale refactor
+
+These aren't off-limits — they just affect the mainline direction more than a typical contribution. Discussing first is far easier than explaining after writing everything.
+
+---
+
+## Relationship between community contributions and official maintenance
+
+Proto UI welcomes community prototypes and community adapters. Official doesn't intend to monopolize the writing of prototypes or adapters.
+
+What official aims to do:
+
+- Maintain a relatively neutral, stable public infrastructure
+- Provide at least one official integration path for key hosts
+- Establish higher quality guarantees for mature prototypes and adapters
+
+What this means:
+
+- Community can move faster and more vertically
+- Official emphasizes boundaries, stability, and long-term consistency
+
+These aren't competing — they're different roles within the same ecosystem.
+
+---
+
+## Where to start
+
+A reliable starting point is:
+
+- Read [Build / Overview](/en/build/)
+- Then based on your interest, choose:
+  - [Runtime Architecture](/en/build/runtime-architecture/) (in progress)
+  - [Adapter Guide](/en/build/adapter-guide/) (in progress)
+  - [Contracts & Tests](/en/build/contracts-and-tests/) (in progress)
+
+If you're still unsure where to begin, starting from a small issue, a small prototype, or a doc revision is often the better way.
+
+Browse open [Good First Issues](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22) to find a scoped task that matches your interests.
+
+---
+
+## Still have questions?
+
+This page covers "how to enter." More detailed processes, conventions, and repo collaboration specifics live in the corresponding development docs within the repository.
+
+If you still have questions about contribution direction, boundary decisions, or current priorities, feel free to ask in [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions) or the community channels. Many questions become much easier once the direction is aligned — the earlier, the better.

--- a/apps/www/src/content/docs/en/build/contribute.md
+++ b/apps/www/src/content/docs/en/build/contribute.md
@@ -3,446 +3,147 @@ title: 'How to Contribute'
 description: 'Contribution paths, entry points, and practical advice for the current phase of Proto UI'
 ---
 
-## What this page covers
+## Start here
 
-This page is for anyone who wants to contribute to the Proto UI ecosystem.
+If you're new to Proto UI, the simplest first step is to browse [Good First Issues](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — they're scoped with clear acceptance criteria. Comment on the issue before starting. If the scope or approach isn't clear, ask in [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions).
 
-It doesn't replace the repository's development docs or the whitepaper's theoretical depth. It answers the more immediate questions:
-
-- What kinds of contributions does Proto UI need most right now?
-- Which path fits me best?
-- What should I understand before contributing?
-- What's the simplest way to preview my work?
-- What makes a contribution easier to review and maintain?
-
-If you're unsure whether contributing is right for you, reading this page is usually enough.
-
----
-
-## What does Proto UI need most right now?
-
-Proto UI is still in its early phase. The priority isn't "everything at once" — it's getting the core paths working well.
-
-The most valuable contributions right now tend to fall into these directions:
-
-- **Prototype**
-  - Expanding the official prototype library
-  - Adding interaction capabilities for common components
-  - Improving prototype fidelity and reusability
-
-- **Adapter**
-  - Building host integration for new platforms
-  - Improving how existing hosts fulfill prototype contracts
-  - Raising consistency and fidelity across hosts
-
-- **Contracts / Tests**
-  - Adding contract constraints for existing capabilities
-  - Making prototypes and adapters more verifiable
-  - Building a more stable foundation for "officially supported quality"
-
-- **Docs / Demo**
-  - Helping others understand Proto UI faster
-  - Lowering the barrier for new contributors
-  - Showing existing capabilities more clearly
-
-- **Community / Curation**
-  - Organizing questions and discussions
-  - Distilling consensus and indices
-  - Helping new contributors find their way in
-
-For most first-time contributors, **prototypes, docs, and tests** are often easier entry points. **Adapters** lean toward deeper waters, but are equally critical.
-
----
-
-## What to read before contributing
-
-You don't need to memorize the entire whitepaper, but a minimal mental model helps a lot.
-
-At minimum, we suggest reading:
-
-- [Start Here / What You Just Saw](/en/start-here/what-you-saw/)
-- [Start Here / How It Works](/en/start-here/how-it-works/)
-
-- [Whitepaper / Component as Protocol](/en/whitepaper/component-as-protocol/)
-- [Whitepaper / Information Flow Model](/en/whitepaper/information-flow-model/)
-- [Whitepaper / Prototype Boundary](/en/whitepaper/prototype-boundary/)
-- [Whitepaper / Execution Semantics](/en/whitepaper/execution-semantics/)
-
-If you're planning to write an adapter, also read:
-
-- [Whitepaper / Translation Layer](/en/whitepaper/translation-layer/)
-- [Whitepaper / Design Constraints](/en/whitepaper/design-constraints/)
-
-This isn't about raising the bar — it's about avoiding the frustration of realizing your work and Proto UI's boundary model were never aligned to begin with.
-
----
-
-## Contribution paths
-
-Proto UI's ecosystem isn't a single track. Different types of contributions solve problems at different layers.
+## Choose a path
 
 ### Prototype
 
-This path is about:
+This path is about **how a component should interact** — state flow, events, feedback, and interaction semantics.
 
-> **How a component should interact.**
+**Best for:** component library developers, design system engineers, headless component authors, accessibility specialists
 
-The Prototype direction cares about the interaction semantics of a component:
-
-- How state flows
-- How events enter
-- How feedback expresses itself
-- How prototype boundaries should be drawn
-- Which capabilities belong in the official prototype library
-
-If your background is closer to:
-
-- Component library development
-- Design systems
-- Headless components
-- Interaction design implementation
-- Accessibility improvements
-
-Then Prototype is often the more natural entry point.
-
-Good starting points include:
+**Typical tasks:**
 
 - Adding a specific interaction capability to an existing prototype
 - Creating a new, well-scoped base prototype
 - Improving state / feedback expression for an existing prototype
-- Raising prototype fidelity across more scenarios
 
-**Relevant guides and templates:**
+**Start here:**
 
-- [Writing A Custom Primitive Prototype](/zh-cn/build/prototypes/writing-a-custom-primitive-prototype/) (Chinese — English version in progress)
-- [Writing A Compound Prototype](/zh-cn/build/prototypes/writing-a-compound-prototype/) (Chinese)
-- [Prototype Author Checklist](/zh-cn/build/prototypes/checklist/) (Chinese)
 - [Prototype Proposal Template](https://github.com/Proto-UI/Proto-UI/issues/new?template=prototype-proposal.md)
-- [Good First Issues: Prototype](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aprototype)
+- [Good First Issues: prototype](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aprototype)
+- [Writing A Custom Primitive Prototype](/zh-cn/build/prototypes/writing-a-custom-primitive-prototype/) (Chinese — English version in progress)
+- [Prototype Author Checklist](/zh-cn/build/prototypes/checklist/) (Chinese)
+
+**Before opening a PR:** describe the interaction behavior, explain the prototype boundary if relevant, and include preview / tests when possible.
 
 ---
 
 ### Adapter
 
-This path is about:
+This path is about **how prototypes land in a specific host** — contract mapping, capability gaps, and host-native fidelity.
 
-> **How prototypes land in a specific host.**
+**Best for:** framework maintainers, platform engineers, anyone deeply familiar with React, Vue, Web Components, Flutter, Qt, or native UI technologies
 
-The Adapter direction typically deals with:
-
-- How prototype contracts map to a given host
-- How to fill gaps in host capabilities
-- Which feedback and interactions can be carried directly
-- Which parts need host-specific handling
-- How the final artifact feels native to that host
-
-If you're more familiar with a specific host, for example:
-
-- React
-- Vue
-- Web Components
-- Flutter
-- Qt
-- Platform-native UI technologies
-
-And you tend to work on:
-
-- Framework internals
-- Rendering models
-- Event systems
-- State and ref management
-- Platform constraints and performance
-
-Then Adapter is likely a better fit.
-
-Good starting points include:
+**Typical tasks:**
 
 - Filling in a contract-adherence gap for an existing host
 - Improving host-side fidelity for an existing prototype
 - Building a minimal working adapter for a new host
-- Adding a capability-fallback strategy for a host
 
-**Relevant guides and templates:**
+**Start here:**
 
-- [Adapter Guide](/en/build/adapter-guide/) (in progress — see Chinese version [here](/zh-cn/build/adapter-guide/))
 - [Adapter Proposal Template](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md)
-- [Good First Issues: Adapter](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadapter)
+- [Good First Issues: adapter](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadapter)
+- [Adapter Guide](/en/build/adapter-guide/) (in progress — see Chinese version [here](/zh-cn/build/adapter-guide/))
 
-Adapter work is deeper water than Prototype, but it's also critical — whether Proto UI can be used in real projects depends on the translation layer being reliable.
+**Before opening a PR:** confirm the host capability mapping, explain fallback strategies if any, and test across host scenarios.
 
 ---
 
 ### Contracts / Tests
 
-This path is about:
+This path is about **what it means to "really support" a capability** — verifying that prototypes are clearly defined and adapters truly fulfill their contracts.
 
-> **What does it mean to "really support" a capability.**
+**Best for:** engineers who care about semantic boundaries, behavior verification, and contract consistency
 
-In Proto UI, contracts and tests aren't just quality supplements. They directly determine:
-
-- Whether a prototype is clearly defined
-- Whether an adapter truly fulfills a prototype contract
-- Whether "officially supported quality" has a clear boundary
-- How community and official implementations form a verifiable relationship
-
-If you care more about:
-
-- Whether semantic boundaries are clear
-- Whether behavior is stably verified
-- Whether contracts and implementations are consistent
-- Whether a capability is genuinely "established" rather than "looks about right"
-
-Then this path fits you well.
-
-Good starting points include:
+**Typical tasks:**
 
 - Adding contract tests for existing capabilities
-- Writing minimal verification for semantics already documented
-- Spotting "inconsistent but unconstrained" spots in existing prototypes / adapters
-- Distilling existing consensus into verifiable contracts
+- Writing minimal verification for documented semantics
+- Spotting and constraining inconsistent behavior in prototypes or adapters
 
-**Relevant guides and templates:**
+**Start here:**
 
 - [Contracts & Tests](/en/build/contracts-and-tests/) (in progress — see Chinese version [here](/zh-cn/build/contracts-and-tests/))
 - [Good First Issues: automation](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aautomation)
+
+**Before opening a PR:** describe what the contract verifies, why the boundary is drawn there, and include tests that fail before the change passes.
 
 ---
 
 ### Docs / Demo
 
-This path is about:
+This path is about **whether others can understand Proto UI** — lowering the barrier for new users and contributors.
 
-> **Whether others can understand Proto UI.**
+**Best for:** technical writers, educators, anyone who can turn abstract concepts into clear docs, examples, diagrams, or demos
 
-Proto UI currently carries non-trivial theoretical density. Docs, examples, and demos directly affect:
-
-- Whether new users can understand quickly
-- Whether new contributors know where to start
-- Whether prototypes and adapters are clearly demonstrated
-- Whether discussions can build on a shared minimal understanding
-
-If you're better at:
-
-- Explaining complex things clearly
-- Turning theory into readable docs
-- Turning abstract concepts into examples, diagrams, or demos
-- Spotting "where someone will get confused"
-
-Then Docs / Demo is a great entry point.
-
-Good starting points include:
+**Typical tasks:**
 
 - Revising existing docs to smooth the entry path
 - Adding minimal examples for a prototype
 - Turning an abstract concept into an approachable demo
-- Writing FAQs, reading guides, or contribution-entry docs
 
-**Relevant guides and templates:**
+**Start here:**
 
 - [Docs Request Template](https://github.com/Proto-UI/Proto-UI/issues/new?template=docs-request.md)
 - [Good First Issues: docs](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Adocs)
+
+**Before opening a PR:** explain what confusion or gap the change addresses, and verify the page renders correctly in the docs site.
 
 ---
 
 ### Community / Curation
 
-This path is about:
+This path is about **organizing questions, discussions, and consensus** — helping the ecosystem stay navigable and newcomers get consistent responses.
 
-> **Catching and organizing the ecosystem's questions, feedback, and consensus.**
+**Best for:** community organizers, people who summarize discussions, maintain issue indices, or help others articulate ideas
 
-Proto UI's growth isn't only from code. It also comes from:
-
-- Whether questions are organized
-- Whether recurring discussions are distilled
-- Whether community prototypes / adapters are visible
-- Whether newcomers get consistent responses
-
-If you're better at:
-
-- Summarizing problems
-- Organizing discussions
-- Maintaining issues / discussions
-- Helping others articulate their ideas
-- Connecting contributors across different directions
-
-Then this path is a strong fit.
-
-Good starting points include:
+**Typical tasks:**
 
 - Cataloging recurring questions
-- Helping maintain the FAQ or discussion index
+- Maintaining FAQ or discussion indices
 - Distilling scattered discussions into citable conclusions
-- Helping new contributors find the right entry point for them
+- Helping new contributors find their entry point
 
-**Relevant resources:**
+**Start here:**
 
 - [Good First Issues: community](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Acommunity)
 - [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions)
 
----
-
-## Not sure which path fits you?
-
-A simple way to tell is to notice which kind of question you naturally ask.
-
-If you more often ask:
-
-- "How should this component interact?"
-  - Closer to Prototype
-
-- "How does this host implement it?"
-  - Closer to Adapter
-
-- "Is this behavior clearly defined and verified?"
-  - Closer to Contracts / Tests
-
-- "Can others understand this?"
-  - Closer to Docs / Demo
-
-- "Have these discussions been organized?"
-  - Closer to Community / Curation
-
-If you're still unsure, the most stable approach is usually:
-
-> Start with docs, a small prototype, or a clear small test.
-
-These entry points carry the lowest risk and tend to get feedback fastest.
+**Before opening a PR:** summarize the pattern or consensus being captured, and link to the source discussions.
 
 ---
 
-## Suggested progression for first-time contributors
+## First-time contributor workflow
 
-For someone contributing for the first time, the most reliable approach isn't to write a complete system up front, but rather:
+1. Pick a small, clearly scoped [Good First Issue](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+2. Comment on the issue before starting
+3. Confirm the boundary in the issue thread or [Discussions](https://github.com/Proto-UI/Proto-UI/discussions) if unclear
+4. Keep the PR small — the smallest reviewable result, not one massive change
+5. Explain what changed and why in the PR description
 
-1. **Pick up a clearly scoped, small issue first**
-2. **Confirm the boundary in Discussions or the issue thread**
-3. **Then start implementing**
-4. **Submit the smallest reviewable result, rather than one massive change**
-
-Proto UI's theory and engineering are both still converging. The sooner you align on boundaries, the less rework later.
-
-### Picking up a Good First Issue
-
-We maintain a set of [Good First Issues](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22) that are scoped for new contributors. These issues include clear acceptance criteria, references, and explicit out-of-scope notes so you know what's expected before you start.
-
-If you find one you'd like to work on, comment on the issue to let maintainers know. If the scope or approach isn't clear, ask in the issue thread — clarifying the boundary before writing code saves everyone time.
+For prototypes and adapters, the simplest way to preview your work is to wire it into the docs site. Until dedicated debugging tooling matures, this is the most direct feedback loop.
 
 ---
 
-## Simplest preview path right now
+## Discuss first for larger changes
 
-Since adapter and prototype development doesn't yet have dedicated debugging tooling, the most direct preview path is:
+These situations should be discussed before writing code:
 
-> **Wire them into the docs site and preview there.**
+- Adding a new host adapter
+- Extending the prototype DSL
+- Changing existing contract-layer boundaries
+- Introducing a new core capability dimension
+- Large-scale refactors
 
-This is the recommended approach in the current phase. The reasons:
-
-- The docs site is already Proto UI's main showcase and verification entry point
-- It's naturally suited for comparing behavior across hosts
-- New prototypes / adapters can be observed and discussed in an environment close to their real display context
-
-Proto UI provides ways to wire new adapters and prototypes into the docs site. So for many contributions, the shortest feedback loop right now is:
-
-1. Write a minimal working prototype / adapter
-2. Wire it into the docs site
-3. Preview and adjust directly in the docs site
-4. Then continue with docs, contracts, or tests
-
-Until dedicated debugging tooling matures, this is the most realistic path.
+These aren't off-limits — they just affect the mainline direction more than typical contributions. Discussing first is far easier than explaining after writing everything.
 
 ---
 
-## What makes a contribution more likely to be accepted
+## Proposal acceptance
 
-Proto UI is currently most able to accept contributions of these kinds:
-
-### 1. Clear boundaries
-
-The contributions easiest to maintain long-term are often not the ones that "do a lot," but the ones that solve a single, clearly bounded problem.
-
-For example:
-
-- Adding a specific interaction capability to an existing prototype
-- Filling in a specific contract-adherence gap for an existing host
-- Filling in a clearly missing entry point in the docs
-
-By contrast, submissions that "refactor many layers at once along the way" are harder to review in the current phase and harder to merge stably.
-
-### 2. Previewable on the docs site
-
-One of the most valuable things a contribution can do right now is land on the docs site for preview and discussion.
-
-For prototypes and adapters especially, whether they can quickly appear on the docs site often directly determines whether others can understand what problem the contribution actually solves.
-
-### 3. Comes with minimal documentation
-
-Even for a small contribution, it helps to at least describe:
-
-- What problem it solves
-- Which layer it belongs to (prototype / adapter / contracts / docs)
-- Why the approach aligns with Proto UI's current boundary model
-
-This dramatically reduces communication overhead.
-
-### 4. Open to iteration
-
-Proto UI is not a system where all the rules are fully frozen yet. Many contributions, even when directionally correct, may still need adjustments.
-
-This isn't a judgment on the contribution itself — it's because the ecosystem, boundaries, and engineering constraints are still converging.
-
----
-
-## What to discuss before building
-
-These situations are usually better discussed first:
-
-- You're planning to add a new host adapter
-- You're planning to extend the prototype DSL
-- You're planning to change existing contract-layer boundaries
-- You're planning to introduce a new core capability dimension
-- You're planning a large-scale refactor
-
-These aren't off-limits — they just affect the mainline direction more than a typical contribution. Discussing first is far easier than explaining after writing everything.
-
----
-
-## Relationship between community contributions and official maintenance
-
-Proto UI welcomes community prototypes and community adapters. Official doesn't intend to monopolize the writing of prototypes or adapters.
-
-What official aims to do:
-
-- Maintain a relatively neutral, stable public infrastructure
-- Provide at least one official integration path for key hosts
-- Establish higher quality guarantees for mature prototypes and adapters
-
-What this means:
-
-- Community can move faster and more vertically
-- Official emphasizes boundaries, stability, and long-term consistency
-
-These aren't competing — they're different roles within the same ecosystem.
-
----
-
-## Where to start
-
-A reliable starting point is:
-
-- Read [Build / Overview](/en/build/)
-- Then based on your interest, choose:
-  - [Runtime Architecture](/en/build/runtime-architecture/) (in progress)
-  - [Adapter Guide](/en/build/adapter-guide/) (in progress)
-  - [Contracts & Tests](/en/build/contracts-and-tests/) (in progress)
-
-If you're still unsure where to begin, starting from a small issue, a small prototype, or a doc revision is often the better way.
-
-Browse open [Good First Issues](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22) to find a scoped task that matches your interests.
-
----
-
-## Still have questions?
-
-This page covers "how to enter." More detailed processes, conventions, and repo collaboration specifics live in the corresponding development docs within the repository.
-
-If you still have questions about contribution direction, boundary decisions, or current priorities, feel free to ask in [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions) or the community channels. Many questions become much easier once the direction is aligned — the earlier, the better.
+Submitting a proposal does not guarantee acceptance. Maintainers evaluate proposals based on current priorities, boundary fit, and long-term ecosystem consistency. If you're unsure whether an idea fits, start a [Discussion](https://github.com/Proto-UI/Proto-UI/discussions) before opening a formal proposal.

--- a/apps/www/src/content/docs/zh-cn/build/contribute.md
+++ b/apps/www/src/content/docs/zh-cn/build/contribute.md
@@ -118,6 +118,13 @@ Prototype 方向更关心组件本身的交互语义，例如：
 - 帮已有原型补齐更合理的状态 / 反馈表达
 - 让某个原型在更多场景下保持更高保真
 
+**相关模板与入口：**
+
+- [原型提案 Issue 模板](https://github.com/Proto-UI/Proto-UI/issues/new?template=prototype-proposal.md)
+- [Good First Issue：prototype](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aprototype)
+- [编写一个定制的单体原型](/zh-cn/build/prototypes/writing-a-custom-primitive-prototype/)
+- [原型作者检查清单](/zh-cn/build/prototypes/checklist/)
+
 ---
 
 ### Adapter（适配器）
@@ -160,6 +167,12 @@ Adapter 方向需要处理的问题通常包括：
 - 为新宿主建立最小可工作的适配器
 - 补足某类宿主缺失能力的承接方案
 
+**相关模板与入口：**
+
+- [适配器提案 Issue 模板](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md)
+- [Good First Issue：adapter](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadapter)
+- [Adapter 指南](/zh-cn/build/adapter-guide/)（施工中）
+
 Adapter 会比 Prototype 更偏深水区，  
 但它也非常关键，因为 Proto UI 最终能否进入真实项目，取决于翻译层是否可靠。
 
@@ -195,6 +208,12 @@ Adapter 会比 Prototype 更偏深水区，
 - 帮现有原型 / 适配器找出“不一致但还没被约束”的位置
 - 把已有共识整理成可验证的契约
 
+**相关模板与入口：**
+
+- [Good First Issue：automation](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aautomation)
+- [Good First Issue：prototype](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aprototype)（部分涉及测试的 prototype issue）
+- [契约与测试](/zh-cn/build/contracts-and-tests/)（施工中）
+
 ---
 
 ### Docs / Demo（文档与示例）
@@ -226,6 +245,11 @@ Proto UI 目前的理论密度不低，
 - 为某个原型补最小示例
 - 把某个抽象概念转成更容易理解的 Demo
 - 补充 FAQ、导读、贡献入口等生态文档
+
+**相关模板与入口：**
+
+- [文档需求 Issue 模板](https://github.com/Proto-UI/Proto-UI/issues/new?template=docs-request.md)
+- [Good First Issue：docs](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Adocs)
 
 ---
 
@@ -259,6 +283,11 @@ Proto UI 的成长不只来自代码。
 - 帮忙维护 FAQ 或讨论索引
 - 把一些零散讨论沉淀成可引用的结论
 - 协助新贡献者找到适合自己的入口
+
+**相关入口：**
+
+- [Good First Issue：community](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Acommunity)
+- [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions)
 
 ---
 
@@ -302,6 +331,31 @@ Proto UI 的成长不只来自代码。
 
 Proto UI 目前的理论与工程都还在逐步收敛。  
 越早对齐边界，后面的返工就越少。
+
+### 从 Good First Issue 开始
+
+我们维护了一批专门为新贡献者准备的 [Good First Issue](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22)，每个 issue 都包含了明确的目标、范围、验收标准和参考资料。
+
+这些 issue 按分类标记，方便你快速找到感兴趣的方向：
+
+- [prototype](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aprototype) — 原型相关
+- [adapter](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadapter) — 适配器相关
+- [docs](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Adocs) — 文档相关
+- [community](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Acommunity) — 社区相关
+- [automation](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aautomation) — 自动化 / 测试相关
+
+找到感兴趣的 issue 后，在 issue 下留言说明你想接手。  
+如果对范围或方案不确定，直接在 issue 里提问 —— 在写代码之前先对齐边界，能省下大量时间。
+
+此外，如果你想提出新想法，也可以通过 Issue 模板提交：
+
+- [原型提案](https://github.com/Proto-UI/Proto-UI/issues/new?template=prototype-proposal.md)
+- [适配器提案](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md)
+- [文档需求](https://github.com/Proto-UI/Proto-UI/issues/new?template=docs-request.md)
+
+需要说明的是：提交提案不代表一定会被接受。  
+Proto UI 目前仍处于早期收敛阶段，维护者会根据当前优先级、边界判断和生态一致性来评估每个提案。  
+建议在提交正式提案之前，先在 [Discussions](https://github.com/Proto-UI/Proto-UI/discussions) 或社群里讨论方向。
 
 ---
 
@@ -426,6 +480,8 @@ Proto UI 欢迎社区原型和社区适配器的存在。
 如果你还不确定从哪里开始，  
 先从一个小问题、一个小原型，或者一段文档修订开始，往往是更好的方式。
 
+浏览已开放的 [Good First Issue](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22)，找到和你兴趣匹配的带 scope 的任务。
+
 ---
 
 ## 还有别的问题？
@@ -434,5 +490,5 @@ Proto UI 欢迎社区原型和社区适配器的存在。
 更具体的流程、规范和仓库协作细节，会放在对应仓库的开发文档里。
 
 如果你对贡献方向、边界判断或当前优先级还有疑问，  
-欢迎继续到讨论区或社群里交流。  
+欢迎继续到 [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions) 或社群里交流。  
 很多问题只要先对齐方向，后面的推进会轻松很多。

--- a/apps/www/src/content/docs/zh-cn/build/contribute.md
+++ b/apps/www/src/content/docs/zh-cn/build/contribute.md
@@ -3,492 +3,147 @@ title: '如何参与贡献'
 description: 'Proto UI 当前阶段的贡献入口、主要路径与实践建议'
 ---
 
-## 这篇文章是做什么的？
+## 从这开始
 
-这一页面向的是想要参与 Proto UI 生态建设的人。
+如果你刚接触 Proto UI，最简单的第一步是浏览 [Good First Issue](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22)——每个 issue 都有明确的范围和验收标准。开始前先在 issue 下留言说明。如果对范围或方案不确定，到 [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions) 提问。
 
-它不会替代仓库里的开发说明，也不会展开白皮书中的理论细节。  
-它主要回答的是更直接的问题：
-
-- 现阶段 Proto UI 最需要哪些类型的贡献？
-- 我适合从哪一类事情开始？
-- 贡献之前需要先了解什么？
-- 现在最简单的预览方式是什么？
-- 怎样的贡献更容易被接住、被继续维护？
-
-如果你还不确定自己适不适合参与，先读完这一页通常就够了。
-
----
-
-## 现阶段最需要的贡献是什么？
-
-Proto UI 还处在早期阶段。  
-现在最重要的不是“什么都同时推进”，而是先把最核心的几条路径打通。
-
-当前最有价值的贡献通常集中在这些方向：
-
-- **Prototype（原型）**
-  - 扩充官方原型库
-  - 补足常见组件的交互能力
-  - 提高原型表达的保真度与可复用性
-
-- **Adapter（适配器）**
-  - 为新宿主建立接入能力
-  - 改善已有宿主对原型契约的承接程度
-  - 提高不同宿主之间的一致性与还原度
-
-- **Contracts / Tests（契约与测试）**
-  - 为现有能力补齐契约约束
-  - 提高原型与适配器的可验证性
-  - 为“官方支持质量”建立更稳的基础
-
-- **Docs / Demo（文档与示例）**
-  - 帮助别人更快理解 Proto UI
-  - 降低新贡献者的进入门槛
-  - 把已有能力展示得更清楚
-
-- **Community / Curation（社区与整理）**
-  - 整理问题与讨论
-  - 沉淀共识与索引
-  - 协助新贡献者找到入口
-
-对大多数第一次参与的人来说，**原型、文档、测试** 通常是更容易进入的方向。  
-**适配器** 会更偏向深水区，但也非常重要。
-
----
-
-## 贡献之前，建议先看什么？
-
-不需要把整套白皮书背下来，但最好先建立一个最小理解模型。
-
-建议至少先读这些内容：
-
-- [Start Here / 你刚刚看到的是什么？](/zh-cn/start-here/what-you-saw/)
-- [Start Here / 它是怎么工作的？](/zh-cn/start-here/how-it-works/)
-- [Start Here / Why Proto UI](/zh-cn/start-here/why-proto-ui/)
-
-- [Whitepaper / 组件作为协议](/zh-cn/whitepaper/component-as-protocol/)
-- [Whitepaper / 信息通路模型](/zh-cn/whitepaper/information-flow-model/)
-- [Whitepaper / 原型边界](/zh-cn/whitepaper/prototype-boundary/)
-- [Whitepaper / 执行语义](/zh-cn/whitepaper/execution-semantics/)
-
-对于想写适配器的人，再继续读：
-
-- [Whitepaper / 翻译层：Adapter / Compiler](/zh-cn/whitepaper/translation-layer/)
-- [Whitepaper / 设计约束](/zh-cn/whitepaper/design-constraints/)
-
-这并不是为了提高门槛，  
-而是为了避免在动手之后，才发现自己写的东西和 Proto UI 的边界判断完全不在同一层上。
-
----
-
-## 你可以从哪些路径参与？
-
-Proto UI 的生态并不是单一路径。  
-不同类型的贡献，解决的是不同层面的问题。
+## 选择你的路径
 
 ### Prototype（原型）
 
-这条路径主要关注的是：
+这条路径关注的是**组件应该如何交互**——状态流转、事件进入、反馈表达和交互语义。
 
-> **一个组件应该如何交互。**
+**适合：** 组件库开发者、设计系统工程师、Headless 组件作者、无障碍优化者
 
-Prototype 方向更关心组件本身的交互语义，例如：
-
-- 状态如何流转
-- 事件如何进入
-- 反馈如何表达
-- 原型边界应当如何切分
-- 哪些能力值得进入官方原型库
-
-如果你平时更接近这些工作：
-
-- 组件库开发
-- 设计系统
-- Headless 组件
-- 交互设计落地
-- 无障碍体验优化
-
-那 Prototype 往往会是更自然的入口。
-
-比较适合作为起点的事情包括：
+**常见任务：**
 
 - 为已有原型补足某个明确的交互能力
 - 新增一个边界清晰的基础原型
-- 帮已有原型补齐更合理的状态 / 反馈表达
-- 让某个原型在更多场景下保持更高保真
+- 改进已有原型的状态 / 反馈表达
 
-**相关模板与入口：**
+**从这里开始：**
 
 - [原型提案 Issue 模板](https://github.com/Proto-UI/Proto-UI/issues/new?template=prototype-proposal.md)
 - [Good First Issue：prototype](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aprototype)
 - [编写一个定制的单体原型](/zh-cn/build/prototypes/writing-a-custom-primitive-prototype/)
 - [原型作者检查清单](/zh-cn/build/prototypes/checklist/)
 
+**提交 PR 前：** 说明交互行为、必要时解释原型边界、尽量附带预览或测试。
+
 ---
 
 ### Adapter（适配器）
 
-这条路径主要关注的是：
+这条路径关注的是**原型如何进入具体宿主**——契约映射、能力补全和宿主原生体验。
 
-> **原型如何进入具体宿主。**
+**适合：** 框架维护者、平台工程师、熟悉 React / Vue / Web Components / Flutter / Qt / 平台原生 UI 技术的开发者
 
-Adapter 方向需要处理的问题通常包括：
-
-- 原型契约如何映射到某个宿主
-- 宿主缺失的能力如何补全
-- 哪些反馈和交互可以直接承接
-- 哪些地方需要宿主化处理
-- 最终产物如何更符合该宿主的使用习惯
-
-如果你对某个宿主更熟，例如：
-
-- React
-- Vue
-- Web Components
-- Flutter
-- Qt
-- 平台原生 UI 技术
-
-并且你平时更常处理：
-
-- 框架底层能力
-- 渲染模型
-- 事件系统
-- 状态与引用组织
-- 平台约束与性能问题
-
-那么 Adapter 很可能更适合你。
-
-比较适合作为起点的事情包括：
+**常见任务：**
 
 - 为已有宿主补齐某类原型契约的承接能力
-- 为一个已有原型改进宿主侧还原度
+- 改进已有原型在宿主侧的还原度
 - 为新宿主建立最小可工作的适配器
-- 补足某类宿主缺失能力的承接方案
 
-**相关模板与入口：**
+**从这里开始：**
 
 - [适配器提案 Issue 模板](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md)
 - [Good First Issue：adapter](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadapter)
 - [Adapter 指南](/zh-cn/build/adapter-guide/)（施工中）
 
-Adapter 会比 Prototype 更偏深水区，  
-但它也非常关键，因为 Proto UI 最终能否进入真实项目，取决于翻译层是否可靠。
+**提交 PR 前：** 确认宿主能力映射、如有回退策略需说明、跨宿主场景测试。
 
 ---
 
 ### Contracts / Tests（契约与测试）
 
-这条路径主要关注的是：
+这条路径关注的是**什么才算"真的支持了这个能力"**——验证原型被清楚定义、适配器真正承接了契约。
 
-> **什么才算“真的支持了这个能力”。**
+**适合：** 关注语义边界、行为验证和契约一致性的工程师
 
-在 Proto UI 里，契约与测试并不只是补充质量保障。  
-它们直接关系到：
+**常见任务：**
 
-- 一个原型是否已经被清楚定义
-- 一个适配器是否真的承接了原型契约
-- 所谓“官方支持质量”是否有明确边界
-- 社区实现和官方实现之间如何形成可验证关系
+- 为已有能力补契约测试
+- 为已文档化的语义补最小验证
+- 找出现有原型 / 适配器中"不一致但还没被约束"的位置
 
-如果你更关心：
+**从这里开始：**
 
-- 语义边界是否清晰
-- 行为是否被稳定验证
-- 契约与实现是否一致
-- 一个能力是否真的“成立”而不是“看起来差不多”
-
-那么这条路径会很适合你。
-
-比较适合作为起点的事情包括：
-
-- 给已有能力补契约测试
-- 为文档里已经明确的语义补最小验证
-- 帮现有原型 / 适配器找出“不一致但还没被约束”的位置
-- 把已有共识整理成可验证的契约
-
-**相关模板与入口：**
-
-- [Good First Issue：automation](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aautomation)
-- [Good First Issue：prototype](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aprototype)（部分涉及测试的 prototype issue）
 - [契约与测试](/zh-cn/build/contracts-and-tests/)（施工中）
+- [Good First Issue：automation](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aautomation)
+
+**提交 PR 前：** 说明契约验证了什么、为什么边界画在这里、确保测试在改动前会失败。
 
 ---
 
 ### Docs / Demo（文档与示例）
 
-这条路径主要关注的是：
+这条路径关注的是**别人能不能看懂 Proto UI**——降低新用户和新贡献者的进入门槛。
 
-> **别人能不能看懂 Proto UI。**
+**适合：** 技术写作者、教育者、能把抽象概念转化为清晰文档 / 示例 / 图示 / Demo 的人
 
-Proto UI 目前的理论密度不低，  
-而文档、示例和 Demo 会直接影响：
-
-- 新使用者是否能快速理解
-- 新贡献者是否知道从哪开始
-- 原型和适配器是否能被更清楚地展示
-- 讨论是否能基于同一组最小共识展开
-
-如果你更擅长：
-
-- 写清楚一件复杂的事
-- 把理论转成更容易读的文档
-- 把抽象概念变成例子、图示或 Demo
-- 识别“别人会在哪一步看不懂”
-
-那么 Docs / Demo 是很好的入口。
-
-比较适合作为起点的事情包括：
+**常见任务：**
 
 - 修订已有文档，让入口更顺
 - 为某个原型补最小示例
-- 把某个抽象概念转成更容易理解的 Demo
-- 补充 FAQ、导读、贡献入口等生态文档
+- 把抽象概念转成更容易理解的 Demo
 
-**相关模板与入口：**
+**从这里开始：**
 
 - [文档需求 Issue 模板](https://github.com/Proto-UI/Proto-UI/issues/new?template=docs-request.md)
 - [Good First Issue：docs](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Adocs)
+
+**提交 PR 前：** 说明改动解决了什么理解障碍或空白、确认页面在文档站点正确渲染。
 
 ---
 
 ### Community / Curation（社区与整理）
 
-这条路径主要关注的是：
+这条路径关注的是**把生态中的问题、讨论和共识接住**——让生态保持可导航、新人得到持续回应。
 
-> **把生态中的问题、反馈和共识接住。**
+**适合：** 社区组织者、善于归纳讨论 / 维护索引 / 帮别人把想法说清楚的人
 
-Proto UI 的成长不只来自代码。  
-它也来自：
-
-- 问题有没有被整理出来
-- 重复讨论有没有被沉淀
-- 社区原型 / 社区适配器有没有被更清楚地看见
-- 新人提出的问题有没有得到稳定回应
-
-如果你更擅长：
-
-- 归纳问题
-- 整理讨论
-- 维护 issue / discussions
-- 帮别人把想法说清楚
-- 连接不同方向的参与者
-
-那么这条路径会非常适合你。
-
-比较适合作为起点的事情包括：
+**常见任务：**
 
 - 整理重复出现的问题
-- 帮忙维护 FAQ 或讨论索引
-- 把一些零散讨论沉淀成可引用的结论
-- 协助新贡献者找到适合自己的入口
+- 维护 FAQ 或讨论索引
+- 把零散讨论沉淀成可引用的结论
+- 协助新贡献者找到入口
 
-**相关入口：**
+**从这里开始：**
 
 - [Good First Issue：community](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Acommunity)
 - [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions)
 
----
-
-## 如果我还不知道自己适合哪条路径怎么办？
-
-一个简单的方法是看你更自然会问哪类问题。
-
-如果你更常问：
-
-- “这个组件应该怎样交互？”
-  - 更接近 Prototype
-
-- “这个宿主怎么把它实现出来？”
-  - 更接近 Adapter
-
-- “这个行为有没有被清楚定义和验证？”
-  - 更接近 Contracts / Tests
-
-- “别人能不能看懂这件事？”
-  - 更接近 Docs / Demo
-
-- “这些讨论有没有被整理好？”
-  - 更接近 Community / Curation
-
-如果还是拿不准，最稳的方式通常是：
-
-> 先从文档、小原型、或一个清晰的小测试开始。
-
-这些入口的风险最低，也最容易得到反馈。
+**提交 PR 前：** 归纳你捕捉到的模式或共识、附上源讨论链接。
 
 ---
 
-## 现阶段推荐的参与顺序
+## 新贡献者工作流
 
-对于第一次参与的人，最稳的方式通常不是上来就写一整套东西，而是：
+1. 认领一个边界清晰的 [Good First Issue](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+2. 开始前先在 issue 下留言
+3. 不确定边界时，在 issue 或 [Discussions](https://github.com/Proto-UI/Proto-UI/discussions) 里确认
+4. PR 尽量小——最小可讨论结果，而非一次性提交巨大改动
+5. 在 PR 描述里说明改了什么、为什么
 
-1. **先认领一个清晰的小范围问题**
-2. **先在 Discussions 或社群里确认边界**
-3. **再开始真正动手**
-4. **优先提交最小可讨论结果，而不是一次性提交巨大改动**
-
-Proto UI 目前的理论与工程都还在逐步收敛。  
-越早对齐边界，后面的返工就越少。
-
-### 从 Good First Issue 开始
-
-我们维护了一批专门为新贡献者准备的 [Good First Issue](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22)，每个 issue 都包含了明确的目标、范围、验收标准和参考资料。
-
-这些 issue 按分类标记，方便你快速找到感兴趣的方向：
-
-- [prototype](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aprototype) — 原型相关
-- [adapter](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aadapter) — 适配器相关
-- [docs](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Adocs) — 文档相关
-- [community](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Acommunity) — 社区相关
-- [automation](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Aautomation) — 自动化 / 测试相关
-
-找到感兴趣的 issue 后，在 issue 下留言说明你想接手。  
-如果对范围或方案不确定，直接在 issue 里提问 —— 在写代码之前先对齐边界，能省下大量时间。
-
-此外，如果你想提出新想法，也可以通过 Issue 模板提交：
-
-- [原型提案](https://github.com/Proto-UI/Proto-UI/issues/new?template=prototype-proposal.md)
-- [适配器提案](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md)
-- [文档需求](https://github.com/Proto-UI/Proto-UI/issues/new?template=docs-request.md)
-
-需要说明的是：提交提案不代表一定会被接受。  
-Proto UI 目前仍处于早期收敛阶段，维护者会根据当前优先级、边界判断和生态一致性来评估每个提案。  
-建议在提交正式提案之前，先在 [Discussions](https://github.com/Proto-UI/Proto-UI/discussions) 或社群里讨论方向。
+对于 Prototype 和 Adapter 的改动，最简单的预览方式是接入文档站点。在专门的调试工具成熟之前，这是最直接的反馈回路。
 
 ---
 
-## 现阶段最简单的预览方式
+## 较大改动先讨论
 
-由于目前 Adapter 和 Prototype 的开发还没有额外的调试工具辅助，  
-最直接的预览方式通常是：
+以下情况建议先讨论再动手：
 
-> **把它们接入官网，然后直接在官网里预览。**
+- 准备新增一个宿主适配器
+- 准备扩展原型语法
+- 准备修改契约层的既有边界
+- 准备引入新的核心能力维度
+- 准备做较大范围的重构
 
-这也是当前阶段最推荐的做法。  
-原因很简单：
-
-- 官网已经是 Proto UI 的主要展示与验证入口
-- 它天然适合对比不同宿主下的表现
-- 新增的 Prototype / Adapter 可以在更接近真实展示环境的地方被观察和讨论
-
-Proto UI 会提供把新 Adapter 和新 Prototype 接入官网的方式。  
-因此，现阶段很多贡献的最短反馈回路会是：
-
-1. 写出最小可工作的 Prototype / Adapter
-2. 接入官网
-3. 直接在官网中预览与调整
-4. 再继续补文档、契约或测试
-
-在专门的调试工具成熟之前，这会是最现实的一条路径。
+这些不是不能做，而是它们会比普通贡献更容易影响主线方向——先讨论远比先写完再解释轻松。
 
 ---
 
-## 怎样的贡献更容易被接住？
+## 关于提案接受
 
-Proto UI 目前更容易接住的，通常是这些类型的贡献：
-
-### 1. 边界清晰
-
-最容易被继续维护的贡献，通常不是“做了很多”，  
-而是“解决了一个边界明确的问题”。
-
-例如：
-
-- 为一个已有原型补足某个明确的交互能力
-- 为一个已有宿主补上某一类契约承接
-- 为某个文档补齐明显缺失的入口说明
-
-相比之下，“顺手一起重构很多层”的提交，在现阶段更难 review，也更难稳定合入。
-
-### 2. 能在官网预览
-
-现阶段最有价值的贡献之一，是能快速进入官网进行预览和讨论。
-
-对 Prototype 和 Adapter 来说，  
-能不能尽快接入官网，通常会直接影响大家能否理解这份贡献到底解决了什么问题。
-
-### 3. 有最小文档说明
-
-即使只是很小的一项贡献，  
-也建议至少说明：
-
-- 它解决的是什么问题
-- 它落在哪一层（原型 / 适配器 / 契约 / 文档）
-- 为什么这样做符合当前 Proto UI 的边界判断
-
-这会极大降低沟通成本。
-
-### 4. 愿意接受继续修正
-
-Proto UI 现阶段不是一个“规则已经完全冻结”的系统。  
-很多贡献即使方向正确，也仍然可能需要继续调整。
-
-这不是否定贡献本身，  
-而是因为生态、边界和工程约束仍然在收敛中。
-
----
-
-## 哪些事情更适合先讨论，再动手？
-
-下面这些情况，通常更适合先讨论：
-
-- 你准备新增一个宿主适配器
-- 你准备扩展原型语法
-- 你准备修改契约层的既有边界
-- 你准备引入新的核心能力维度
-- 你准备做较大范围的重构
-
-这些事情不是不能做，  
-而是它们会比普通贡献更容易影响主线判断。  
-先讨论，会比先写完再解释轻松得多。
-
----
-
-## 社区贡献和官方维护是什么关系？
-
-Proto UI 欢迎社区原型和社区适配器的存在。  
-官方并不打算垄断原型或适配器的编写权。
-
-官方更希望做的是：
-
-- 维护一份相对中立、稳定的公共基建
-- 为关键宿主尽量提供至少一套官方承接方案
-- 为成熟的原型与适配器建立更高的质量保障
-
-这意味着：
-
-- 社区可以走得更激进、更垂直
-- 官方会更强调边界、稳定性和长期一致性
-
-两者不是竞争关系，  
-更像是生态中不同位置的角色分工。
-
----
-
-## 从哪里开始？
-
-一个比较稳的起点通常是：
-
-- 先看 [Build / 概览](/zh-cn/build/)
-- 再根据自己的兴趣选择：
-  - [Runtime 架构](/zh-cn/build/runtime-architecture/)
-  - [Adapter 指南](/zh-cn/build/adapter-guide/)
-  - [契约与测试](/zh-cn/build/contracts-and-tests/)
-
-如果你还不确定从哪里开始，  
-先从一个小问题、一个小原型，或者一段文档修订开始，往往是更好的方式。
-
-浏览已开放的 [Good First Issue](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22)，找到和你兴趣匹配的带 scope 的任务。
-
----
-
-## 还有别的问题？
-
-这一页只负责说明“如何进入”。  
-更具体的流程、规范和仓库协作细节，会放在对应仓库的开发文档里。
-
-如果你对贡献方向、边界判断或当前优先级还有疑问，  
-欢迎继续到 [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions) 或社群里交流。  
-很多问题只要先对齐方向，后面的推进会轻松很多。
+提交提案不代表一定会被接受。维护者会根据当前优先级、边界判断和长期生态一致性来评估每个提案。如果你不确定某个想法是否合适，先到 [Discussions](https://github.com/Proto-UI/Proto-UI/discussions) 讨论，再提交正式提案。


### PR DESCRIPTION
## Summary

Closes #237

- Write English \contribute.md\ adapted from the comprehensive Chinese version, covering all 5 contribution paths
- Add Good First Issue links, issue template references, and GitHub Discussion links to both en and zh-CN versions
- Each contribution path now links to relevant guides, templates, and labeled GitHub issues
- Add explicit note that submitting a proposal does not guarantee acceptance

## Test plan

- [ ] Verify both en and zh-CN contribute pages render correctly in docs site
- [ ] Verify all GitHub issue links resolve correctly
- [ ] CI passes