### PR TITLE
feat: add base Checkbox prototype

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -184,6 +184,11 @@ export default defineConfig({
                   translations: { en: 'Select', 'zh-CN': 'Select' },
                   slug: 'ui-libraries/base/select',
                 },
+                {
+                  label: 'Checkbox',
+                  translations: { en: 'Checkbox', 'zh-CN': 'Checkbox' },
+                  slug: 'ui-libraries/base/checkbox',
+                },
               ],
             },
             {

--- a/apps/www/src/components/PrototypePreviewer/prototype-modules.ts
+++ b/apps/www/src/components/PrototypePreviewer/prototype-modules.ts
@@ -71,6 +71,14 @@ const manualPrototypeModules: Record<string, PrototypeModuleLoader> = {
     const mod = await import('../../../../../packages/prototypes/base/src/hover-card/content');
     registerPrototype('base-hover-card-content', mod.default);
   },
+  'base-checkbox-root': async () => {
+    const mod = await import('../../../../../packages/prototypes/base/src/checkbox/root');
+    registerPrototype('base-checkbox-root', mod.default);
+  },
+  'base-checkbox-indicator': async () => {
+    const mod = await import('../../../../../packages/prototypes/base/src/checkbox/indicator');
+    registerPrototype('base-checkbox-indicator', mod.default);
+  },
   'base-transition': async () => {
     const mod = await import('../../../../../packages/prototypes/base/src/transition/transition');
     registerPrototype('base-transition', mod.default);

--- a/apps/www/src/content/docs/demo_components/base-checkbox/baseCheckboxCode.ts
+++ b/apps/www/src/content/docs/demo_components/base-checkbox/baseCheckboxCode.ts
@@ -1,0 +1,59 @@
+import { formatCode } from '@/utils/conversionUtils';
+import type { RuntimeId } from '@/components/PrototypePreviewer/runtimes/registry';
+
+export const codeMap: Record<RuntimeId, Record<string, string>> = {
+  wc: {
+    'demo-base-checkbox': formatCode(`
+<wc-base-checkbox-root class="flex items-center gap-2">
+  <wc-base-checkbox-indicator class="flex h-5 w-5 items-center justify-center rounded border">
+    <svg class="h-3 w-3" viewBox="0 0 12 12" fill="none">
+      <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" />
+    </svg>
+  </wc-base-checkbox-indicator>
+  <span>Accept terms</span>
+</wc-base-checkbox-root>
+    `),
+  },
+  react: {
+    'demo-base-checkbox': formatCode(`
+import {
+  BaseCheckboxRoot,
+  BaseCheckboxIndicator,
+} from '@prototype-libs/base';
+
+export function DemoBaseCheckbox() {
+  return (
+    <BaseCheckboxRoot className="flex items-center gap-2">
+      <BaseCheckboxIndicator className="flex h-5 w-5 items-center justify-center rounded border">
+        <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none">
+          <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" strokeWidth={1.5} />
+        </svg>
+      </BaseCheckboxIndicator>
+      <span>Accept terms</span>
+    </BaseCheckboxRoot>
+  );
+}
+    `),
+  },
+  vue: {
+    'demo-base-checkbox': formatCode(`
+<script setup lang="ts">
+import {
+  BaseCheckboxRoot,
+  BaseCheckboxIndicator,
+} from '@prototype-libs/base';
+</script>
+
+<template>
+  <BaseCheckboxRoot class="flex items-center gap-2">
+    <BaseCheckboxIndicator class="flex h-5 w-5 items-center justify-center rounded border">
+      <svg class="h-3 w-3" viewBox="0 0 12 12" fill="none">
+        <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" />
+      </svg>
+    </BaseCheckboxIndicator>
+    <span>Accept terms</span>
+  </BaseCheckboxRoot>
+</template>
+    `),
+  },
+};

--- a/apps/www/src/content/docs/demo_components/base-checkbox/baseCheckboxCode.ts
+++ b/apps/www/src/content/docs/demo_components/base-checkbox/baseCheckboxCode.ts
@@ -5,7 +5,7 @@ export const codeMap: Record<RuntimeId, Record<string, string>> = {
   wc: {
     'demo-base-checkbox': formatCode(`
 <wc-base-checkbox-root class="flex items-center gap-2">
-  <wc-base-checkbox-indicator class="flex h-5 w-5 items-center justify-center rounded border">
+  <wc-base-checkbox-indicator class="flex h-5 w-5 items-center justify-center rounded-[4px] border">
     <svg class="h-3 w-3" viewBox="0 0 12 12" fill="none">
       <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" />
     </svg>
@@ -24,7 +24,7 @@ import {
 export function DemoBaseCheckbox() {
   return (
     <BaseCheckboxRoot className="flex items-center gap-2">
-      <BaseCheckboxIndicator className="flex h-5 w-5 items-center justify-center rounded border">
+      <BaseCheckboxIndicator className="flex h-5 w-5 items-center justify-center rounded-[4px] border">
         <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none">
           <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" strokeWidth={1.5} />
         </svg>
@@ -46,7 +46,7 @@ import {
 
 <template>
   <BaseCheckboxRoot class="flex items-center gap-2">
-    <BaseCheckboxIndicator class="flex h-5 w-5 items-center justify-center rounded border">
+    <BaseCheckboxIndicator class="flex h-5 w-5 items-center justify-center rounded-[4px] border">
       <svg class="h-3 w-3" viewBox="0 0 12 12" fill="none">
         <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" />
       </svg>

--- a/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox.demo.ts
+++ b/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox.demo.ts
@@ -1,0 +1,94 @@
+export default {
+  type: 'demo',
+  root: {
+    kind: 'box',
+    className: 'flex flex-col gap-4',
+    children: [
+      {
+        kind: 'box',
+        className: 'flex items-center gap-2',
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'base-checkbox-root',
+            children: [
+              {
+                kind: 'proto',
+                prototypeId: 'base-checkbox-indicator',
+                className: 'flex h-5 w-5 items-center justify-center rounded border',
+                children: [
+                  '<svg class="h-3 w-3" viewBox="0 0 12 12" fill="none"><path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" /></svg>',
+                ],
+              },
+              'Unchecked',
+            ],
+          },
+        ],
+      },
+      {
+        kind: 'box',
+        className: 'flex items-center gap-2',
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'base-checkbox-root',
+            props: { defaultChecked: true },
+            children: [
+              {
+                kind: 'proto',
+                prototypeId: 'base-checkbox-indicator',
+                className: 'flex h-5 w-5 items-center justify-center rounded border',
+                children: [
+                  '<svg class="h-3 w-3" viewBox="0 0 12 12" fill="none"><path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" /></svg>',
+                ],
+              },
+              'Checked',
+            ],
+          },
+        ],
+      },
+      {
+        kind: 'box',
+        className: 'flex items-center gap-2',
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'base-checkbox-root',
+            props: { defaultIndeterminate: true },
+            children: [
+              {
+                kind: 'proto',
+                prototypeId: 'base-checkbox-indicator',
+                className: 'flex h-5 w-5 items-center justify-center rounded border',
+                children: ['—'],
+              },
+              'Indeterminate',
+            ],
+          },
+        ],
+      },
+      {
+        kind: 'box',
+        className: 'flex items-center gap-2',
+        children: [
+          {
+            kind: 'proto',
+            prototypeId: 'base-checkbox-root',
+            props: { disabled: true },
+            children: [
+              {
+                kind: 'proto',
+                prototypeId: 'base-checkbox-indicator',
+                className: 'flex h-5 w-5 items-center justify-center rounded border opacity-50',
+                children: [
+                  '<svg class="h-3 w-3" viewBox="0 0 12 12" fill="none"><path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" /></svg>',
+                ],
+              },
+              'Disabled',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox.demo.ts
+++ b/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox.demo.ts
@@ -1,94 +1,110 @@
-export default {
-  type: 'demo',
-  root: {
-    kind: 'box',
-    className: 'flex flex-col gap-4',
+const indicatorClass =
+  'group relative grid h-5 w-5 place-items-center rounded border border-slate-400 text-white ' +
+  'data-[checked]:border-blue-600 data-[checked]:bg-blue-600 ' +
+  'data-[indeterminate]:border-blue-600 data-[indeterminate]:bg-blue-600';
+
+const checkMark = {
+  kind: 'box',
+  className: 'h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100',
+};
+
+const indeterminateMark = {
+  kind: 'box',
+  className:
+    'absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100',
+};
+
+function checkboxRow({
+  ref,
+  label,
+  props,
+}: {
+  ref: string;
+  label: string;
+  props?: Record<string, unknown>;
+}) {
+  return {
+    kind: 'proto',
+    prototypeId: 'base-checkbox-root',
+    ref,
+    className:
+      'inline-flex min-h-8 cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1 text-sm ' +
+      'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+    props,
     children: [
       {
-        kind: 'box',
-        className: 'flex items-center gap-2',
-        children: [
-          {
-            kind: 'proto',
-            prototypeId: 'base-checkbox-root',
-            children: [
-              {
-                kind: 'proto',
-                prototypeId: 'base-checkbox-indicator',
-                className: 'flex h-5 w-5 items-center justify-center rounded border',
-                children: [
-                  '<svg class="h-3 w-3" viewBox="0 0 12 12" fill="none"><path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" /></svg>',
-                ],
-              },
-              'Unchecked',
-            ],
-          },
-        ],
+        kind: 'proto',
+        prototypeId: 'base-checkbox-indicator',
+        className: indicatorClass,
+        children: [checkMark, indeterminateMark],
       },
       {
         kind: 'box',
-        className: 'flex items-center gap-2',
+        className: 'flex flex-col gap-0.5',
         children: [
+          label,
           {
-            kind: 'proto',
-            prototypeId: 'base-checkbox-root',
-            props: { defaultChecked: true },
-            children: [
-              {
-                kind: 'proto',
-                prototypeId: 'base-checkbox-indicator',
-                className: 'flex h-5 w-5 items-center justify-center rounded border',
-                children: [
-                  '<svg class="h-3 w-3" viewBox="0 0 12 12" fill="none"><path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" /></svg>',
-                ],
-              },
-              'Checked',
-            ],
-          },
-        ],
-      },
-      {
-        kind: 'box',
-        className: 'flex items-center gap-2',
-        children: [
-          {
-            kind: 'proto',
-            prototypeId: 'base-checkbox-root',
-            props: { defaultIndeterminate: true },
-            children: [
-              {
-                kind: 'proto',
-                prototypeId: 'base-checkbox-indicator',
-                className: 'flex h-5 w-5 items-center justify-center rounded border',
-                children: ['—'],
-              },
-              'Indeterminate',
-            ],
-          },
-        ],
-      },
-      {
-        kind: 'box',
-        className: 'flex items-center gap-2',
-        children: [
-          {
-            kind: 'proto',
-            prototypeId: 'base-checkbox-root',
-            props: { disabled: true },
-            children: [
-              {
-                kind: 'proto',
-                prototypeId: 'base-checkbox-indicator',
-                className: 'flex h-5 w-5 items-center justify-center rounded border opacity-50',
-                children: [
-                  '<svg class="h-3 w-3" viewBox="0 0 12 12" fill="none"><path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" /></svg>',
-                ],
-              },
-              'Disabled',
-            ],
+            kind: 'box',
+            ref: `${ref}-status`,
+            className: 'text-xs text-slate-500',
+            children: ['checked: false, indeterminate: false'],
           },
         ],
       },
     ],
+  };
+}
+
+export default {
+  type: 'demo',
+  root: {
+    kind: 'box',
+    className: 'flex flex-col items-start gap-3',
+    children: [
+      checkboxRow({ ref: 'unchecked', label: 'Unchecked' }),
+      checkboxRow({ ref: 'checked', label: 'Checked', props: { defaultChecked: true } }),
+      checkboxRow({
+        ref: 'indeterminate',
+        label: 'Indeterminate',
+        props: { defaultIndeterminate: true },
+      }),
+      checkboxRow({ ref: 'disabled', label: 'Disabled', props: { disabled: true } }),
+    ],
+  },
+  setup({ refs, api }: any) {
+    const roots = ['unchecked', 'checked', 'indeterminate', 'disabled'];
+
+    const update = (ref: string) => {
+      const exposes = api.getExposes(ref) as any;
+      const status = refs[`${ref}-status`];
+      if (!exposes || !status) return;
+      const checked = !!exposes.checked?.get?.();
+      const indeterminate = !!exposes.indeterminate?.get?.();
+      status.textContent = `checked: ${checked}, indeterminate: ${indeterminate}`;
+    };
+
+    const updateSoon = (ref: string) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => update(ref)));
+    };
+
+    roots.forEach(update);
+
+    const cleanups = roots.flatMap((ref) => {
+      const root = refs[ref];
+      if (!root) return [];
+      const listener = () => updateSoon(ref);
+      root.addEventListener('click', listener);
+      root.addEventListener('checkedChange', listener);
+      root.addEventListener('indeterminateChange', listener);
+      return [
+        () => root.removeEventListener('click', listener),
+        () => root.removeEventListener('checkedChange', listener),
+        () => root.removeEventListener('indeterminateChange', listener),
+      ];
+    });
+
+    return () => {
+      cleanups.forEach((cleanup) => cleanup());
+    };
   },
 };

--- a/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox.demo.ts
+++ b/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox.demo.ts
@@ -1,5 +1,5 @@
 const indicatorClass =
-  'group relative grid h-5 w-5 place-items-center rounded border border-slate-400 text-white ' +
+  'group relative grid h-5 w-5 place-items-center rounded-[4px] border border-slate-400 text-white ' +
   'data-[checked]:border-blue-600 data-[checked]:bg-blue-600 ' +
   'data-[indeterminate]:border-blue-600 data-[indeterminate]:bg-blue-600';
 

--- a/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox.demo.ts
+++ b/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox.demo.ts
@@ -73,37 +73,75 @@ export default {
   },
   setup({ refs, api }: any) {
     const roots = ['unchecked', 'checked', 'indeterminate', 'disabled'];
+    const cleanups: Array<() => void> = [];
+    const subscribed = new Set<string>();
+    const timers: ReturnType<typeof setTimeout>[] = [];
 
     const update = (ref: string) => {
       const exposes = api.getExposes(ref) as any;
       const status = refs[`${ref}-status`];
-      if (!exposes || !status) return;
+      if (!exposes || !status) return false;
       const checked = !!exposes.checked?.get?.();
       const indeterminate = !!exposes.indeterminate?.get?.();
       status.textContent = `checked: ${checked}, indeterminate: ${indeterminate}`;
+      return true;
     };
 
     const updateSoon = (ref: string) => {
       requestAnimationFrame(() => requestAnimationFrame(() => update(ref)));
     };
 
-    roots.forEach(update);
+    const bindState = (ref: string) => {
+      if (subscribed.has(ref)) return true;
+      const exposes = api.getExposes(ref) as any;
+      if (!exposes) return false;
 
-    const cleanups = roots.flatMap((ref) => {
+      const listener = () => updateSoon(ref);
+      for (const key of ['checked', 'indeterminate']) {
+        const handle = exposes[key];
+        if (!handle || typeof handle.subscribe !== 'function') continue;
+        const off = handle.subscribe(listener);
+        cleanups.push(() => {
+          if (typeof handle.unsubscribe === 'function') handle.unsubscribe(off);
+          else if (typeof off === 'function') off();
+        });
+      }
+
+      subscribed.add(ref);
+      update(ref);
+      return true;
+    };
+
+    const syncAll = (attempt = 0) => {
+      roots.forEach((ref) => {
+        bindState(ref);
+        update(ref);
+      });
+
+      if (subscribed.size === roots.length || attempt >= 6) return;
+
+      const timer = setTimeout(() => syncAll(attempt + 1), 50 * (attempt + 1));
+      timers.push(timer);
+    };
+
+    requestAnimationFrame(() => requestAnimationFrame(() => syncAll()));
+
+    roots.forEach((ref) => {
       const root = refs[ref];
-      if (!root) return [];
+      if (!root) return;
       const listener = () => updateSoon(ref);
       root.addEventListener('click', listener);
       root.addEventListener('checkedChange', listener);
       root.addEventListener('indeterminateChange', listener);
-      return [
+      cleanups.push(
         () => root.removeEventListener('click', listener),
         () => root.removeEventListener('checkedChange', listener),
-        () => root.removeEventListener('indeterminateChange', listener),
-      ];
+        () => root.removeEventListener('indeterminateChange', listener)
+      );
     });
 
     return () => {
+      timers.forEach((timer) => clearTimeout(timer));
       cleanups.forEach((cleanup) => cleanup());
     };
   },

--- a/apps/www/src/content/docs/en/ui-libraries/base/checkbox.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/checkbox.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Checkbox'
+desp: 'Checkbox'
+description: 'Checkbox base prototype'
+---
+
+import PrototypePreviewer from '@/components/PrototypePreviewer/PrototypePreviewer.astro';
+
+The Checkbox base prototype provides checked, unchecked, disabled, and indeterminate interactions built on the Toggle semantics.
+
+<div>
+  <PrototypePreviewer
+    demoId="demo-base-checkbox"
+    initialRuntime="wc"
+    runtimes={['wc', 'react', 'vue']}
+    hasCode={true}
+  />
+</div>

--- a/apps/www/src/content/docs/en/ui-libraries/base/checkbox.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/checkbox.mdx
@@ -16,3 +16,22 @@ The Checkbox base prototype provides checked, unchecked, disabled, and indetermi
     hasCode={true}
   />
 </div>
+
+## Anatomy
+
+The Checkbox is split into two parts connected through the anatomy system:
+
+- **Root** (`base-checkbox-root`) — manages toggle state (`checked`, `checkedChange`), disabled, and indeterminate. The root extends Toggle semantics, adding `indeterminate` as a custom boolean state.
+- **Indicator** (`base-checkbox-indicator`) — reads the root's `checked` and `indeterminate` states through anatomy runtime access and exposes them for rendering. It does not manage state independently.
+
+The root and indicator are linked via the `base-checkbox` anatomy family, with a `contains` relation (root → indicator).
+
+## Indeterminate behavior
+
+When `indeterminate` is `true`, pressing the checkbox:
+
+1. Clears `indeterminate` to `false`
+2. Emits `checkedChange` with `checked: true`
+3. Emits `indeterminateChange` with `indeterminate: false`
+
+If you control the `indeterminate` prop externally, listen for `indeterminateChange` to sync your state.

--- a/apps/www/src/content/docs/en/ui-libraries/base/checkbox.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/checkbox.mdx
@@ -6,32 +6,37 @@ description: 'Checkbox base prototype'
 
 import PrototypePreviewer from '@/components/PrototypePreviewer/PrototypePreviewer.astro';
 
-The Checkbox base prototype provides checked, unchecked, disabled, and indeterminate interactions built on the Toggle semantics.
+The Checkbox base prototype provides checked, unchecked, disabled, and indeterminate interactions on top of Toggle semantics.
 
 <div>
   <PrototypePreviewer
     demoId="demo-base-checkbox"
     initialRuntime="wc"
-    runtimes={['wc', 'react', 'vue']}
+    runtimes={['wc']}
     hasCode={true}
   />
 </div>
 
 ## Anatomy
 
-The Checkbox is split into two parts connected through the anatomy system:
+Checkbox is split into root and indicator parts connected through the anatomy system.
 
-- **Root** (`base-checkbox-root`) — manages toggle state (`checked`, `checkedChange`), disabled, and indeterminate. The root extends Toggle semantics, adding `indeterminate` as a custom boolean state.
-- **Indicator** (`base-checkbox-indicator`) — reads the root's `checked` and `indeterminate` states through anatomy runtime access and exposes them for rendering. It does not manage state independently.
+- **Root** (`base-checkbox-root`) manages Toggle state (`checked`, `checkedChange`), disabled behavior, and the additional `indeterminate` state.
+- **Indicator** (`base-checkbox-indicator`) reads the root `checked` and `indeterminate` states through anatomy runtime access and reflects them for rendering. It does not own checkbox state.
 
-The root and indicator are linked via the `base-checkbox` anatomy family, with a `contains` relation (root → indicator).
+The `base-checkbox` anatomy family uses a `contains` relation from root to indicator. A checkbox is expected to have at least one indicator, and may have more than one indicator when multiple visual surfaces need the same indicator semantics.
 
-## Indeterminate behavior
+In the Web Components preview runtime, prototype IDs are registered with a `wc-` tag prefix: `wc-base-checkbox-root` and `wc-base-checkbox-indicator`.
 
-When `indeterminate` is `true`, pressing the checkbox:
+## Indeterminate Behavior
 
-1. Clears `indeterminate` to `false`
-2. Emits `checkedChange` with `checked: true`
-3. Emits `indeterminateChange` with `indeterminate: false`
+`indeterminate` may be uncontrolled via `defaultIndeterminate` or controlled via `indeterminate`.
 
-If you control the `indeterminate` prop externally, listen for `indeterminateChange` to sync your state.
+When an enabled indeterminate checkbox is pressed:
+
+1. `checked` follows the normal `asToggle()` checked behavior and emits `checkedChange`.
+2. The root requests `indeterminate: false` by emitting `indeterminateChange`.
+3. If `indeterminate` is uncontrolled, the root also clears its internal indeterminate state.
+4. If `indeterminate` is controlled, the external owner must handle `indeterminateChange` and pass `indeterminate={false}` back in.
+
+Disabled checkboxes do not change checked or indeterminate state on press.

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/checkbox.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/checkbox.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Checkbox'
+desp: 'Checkbox'
+description: 'Checkbox 基础原型'
+---
+
+import PrototypePreviewer from '@/components/PrototypePreviewer/PrototypePreviewer.astro';
+
+Checkbox 基础原型在 Toggle 语义之上提供了 checked、unchecked、disabled 和 indeterminate 交互能力。
+
+<div>
+  <PrototypePreviewer
+    demoId="demo-base-checkbox"
+    initialRuntime="wc"
+    runtimes={['wc', 'react', 'vue']}
+    hasCode={true}
+  />
+</div>

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/checkbox.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/checkbox.mdx
@@ -16,3 +16,22 @@ Checkbox 基础原型在 Toggle 语义之上提供了 checked、unchecked、disa
     hasCode={true}
   />
 </div>
+
+## 结构
+
+Checkbox 通过 anatomy 系统拆分为两个部分：
+
+- **Root** (`base-checkbox-root`) — 管理 toggle 状态（`checked`、`checkedChange`）、disabled 以及 indeterminate。Root 扩展了 Toggle 语义，将 `indeterminate` 添加为自定义布尔状态。
+- **Indicator** (`base-checkbox-indicator`) — 通过 anatomy 运行时访问读取 root 的 `checked` 和 `indeterminate` 状态，并暴露给渲染层。它不独立管理状态。
+
+Root 和 Indicator 通过 `base-checkbox` anatomy 族关联，关系为 contains（root → indicator）。
+
+## Indeterminate 行为
+
+当 `indeterminate` 为 `true` 时，点击 checkbox 会：
+
+1. 将 `indeterminate` 清除为 `false`
+2. 发出 `checkedChange`，携带 `checked: true`
+3. 发出 `indeterminateChange`，携带 `indeterminate: false`
+
+如果你在外部通过 prop 控制 `indeterminate`，请监听 `indeterminateChange` 来同步你的状态。

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/checkbox.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/checkbox.mdx
@@ -6,32 +6,37 @@ description: 'Checkbox 基础原型'
 
 import PrototypePreviewer from '@/components/PrototypePreviewer/PrototypePreviewer.astro';
 
-Checkbox 基础原型在 Toggle 语义之上提供了 checked、unchecked、disabled 和 indeterminate 交互能力。
+Checkbox 基础原型在 Toggle 语义之上提供 checked、unchecked、disabled 和 indeterminate 交互能力。
 
 <div>
   <PrototypePreviewer
     demoId="demo-base-checkbox"
     initialRuntime="wc"
-    runtimes={['wc', 'react', 'vue']}
+    runtimes={['wc']}
     hasCode={true}
   />
 </div>
 
 ## 结构
 
-Checkbox 通过 anatomy 系统拆分为两个部分：
+Checkbox 通过 anatomy 系统拆分为 root 和 indicator 两个部分。
 
-- **Root** (`base-checkbox-root`) — 管理 toggle 状态（`checked`、`checkedChange`）、disabled 以及 indeterminate。Root 扩展了 Toggle 语义，将 `indeterminate` 添加为自定义布尔状态。
-- **Indicator** (`base-checkbox-indicator`) — 通过 anatomy 运行时访问读取 root 的 `checked` 和 `indeterminate` 状态，并暴露给渲染层。它不独立管理状态。
+- **Root** (`base-checkbox-root`) 管理 Toggle 状态（`checked`、`checkedChange`）、disabled 行为以及额外的 `indeterminate` 状态。
+- **Indicator** (`base-checkbox-indicator`) 通过 anatomy 运行时访问读取 root 的 `checked` 和 `indeterminate` 状态，并将这些状态反映给渲染层。它不独立拥有 checkbox 状态。
 
-Root 和 Indicator 通过 `base-checkbox` anatomy 族关联，关系为 contains（root → indicator）。
+`base-checkbox` anatomy family 使用 root 到 indicator 的 `contains` 关系。Checkbox 预期至少有一个 indicator；当多个视觉区域需要表达同一份 indicator 语义时，也允许存在多个 indicator。
+
+在 Web Components 预览运行时中，prototype ID 会注册为带 `wc-` 前缀的标签：`wc-base-checkbox-root` 和 `wc-base-checkbox-indicator`。
 
 ## Indeterminate 行为
 
-当 `indeterminate` 为 `true` 时，点击 checkbox 会：
+`indeterminate` 可以通过 `defaultIndeterminate` 作为非受控状态使用，也可以通过 `indeterminate` 作为受控状态使用。
 
-1. 将 `indeterminate` 清除为 `false`
-2. 发出 `checkedChange`，携带 `checked: true`
-3. 发出 `indeterminateChange`，携带 `indeterminate: false`
+当启用状态下的 indeterminate checkbox 被按下时：
 
-如果你在外部通过 prop 控制 `indeterminate`，请监听 `indeterminateChange` 来同步你的状态。
+1. `checked` 遵循正常的 `asToggle()` checked 行为，并发出 `checkedChange`。
+2. Root 通过 `indeterminateChange` 请求将 `indeterminate` 清为 `false`。
+3. 如果 `indeterminate` 是非受控状态，root 会同时清除内部 indeterminate 状态。
+4. 如果 `indeterminate` 是受控状态，外部 owner 需要处理 `indeterminateChange`，并重新传入 `indeterminate={false}`。
+
+Disabled checkbox 在按下时不会改变 checked 或 indeterminate 状态。

--- a/packages/prototypes/base/src/checkbox/index.ts
+++ b/packages/prototypes/base/src/checkbox/index.ts
@@ -1,0 +1,14 @@
+export type {
+  CheckboxRootProps,
+  CheckboxRootExposes,
+  CheckboxRootStateHandles,
+  CheckboxRootAsHookContract,
+  CheckboxIndicatorProps,
+  CheckboxIndicatorExposes,
+  CheckboxIndicatorStateHandles,
+  CheckboxIndicatorAsHookContract,
+} from './types';
+
+export { CHECKBOX_FAMILY } from './shared';
+export { asCheckboxRoot, default as checkboxRoot } from './root';
+export { asCheckboxIndicator, default as checkboxIndicator } from './indicator';

--- a/packages/prototypes/base/src/checkbox/indicator.ts
+++ b/packages/prototypes/base/src/checkbox/indicator.ts
@@ -1,0 +1,125 @@
+import {
+  defineAsHook,
+  definePrototype,
+  type AnatomyPartView,
+  type DefHandle,
+  type RunHandle,
+} from '@proto.ui/core';
+import { CHECKBOX_FAMILY } from './shared';
+import type {
+  CheckboxIndicatorAsHookContract,
+  CheckboxIndicatorExposes,
+  CheckboxIndicatorProps,
+} from './types';
+
+function setupCheckboxIndicator(
+  def: DefHandle<CheckboxIndicatorProps, CheckboxIndicatorExposes>
+): void {
+  def.anatomy.claim(CHECKBOX_FAMILY, { role: 'indicator' });
+  const checked = def.state.fromAccessibility('checked');
+  const indeterminate = def.state.bool('indeterminate', false);
+
+  let rootPart: AnatomyPartView | null = null;
+  let rootCheckedOff: (() => void) | null = null;
+  let rootIndeterminateOff: (() => void) | null = null;
+
+  def.expose.state('checked', checked);
+  def.expose.state('indeterminate', indeterminate);
+
+  def.expose.method('isChecked', () => {
+    const rootChecked = rootPart?.getExpose('checked') as { get?: () => boolean } | null;
+    if (!rootChecked || typeof rootChecked.get !== 'function') return null;
+    return rootChecked.get();
+  });
+
+  def.expose.method('isIndeterminate', () => {
+    const rootIndeterminate = rootPart?.getExpose('indeterminate') as {
+      get?: () => boolean;
+    } | null;
+    if (!rootIndeterminate || typeof rootIndeterminate.get !== 'function') return null;
+    return rootIndeterminate.get();
+  });
+
+  const syncRoot = (run: RunHandle<CheckboxIndicatorProps>) => {
+    rootCheckedOff?.();
+    rootCheckedOff = null;
+    rootIndeterminateOff?.();
+    rootIndeterminateOff = null;
+
+    rootPart = run.anatomy.partsOf(CHECKBOX_FAMILY, 'root')[0] ?? null;
+
+    const rootChecked = rootPart?.getExpose('checked') as {
+      get?: () => boolean;
+      subscribe?: (cb: (e: { next: boolean }) => void) => () => void;
+      unsubscribe?: (off: () => void) => void;
+    } | null;
+    checked.set(!!rootChecked?.get?.(), 'reason: checkbox indicator sync => checked');
+    if (rootChecked && typeof rootChecked.subscribe === 'function') {
+      const off = rootChecked.subscribe((e) => {
+        checked.set(!!e.next, 'reason: checkbox indicator root checked subscription');
+      });
+      rootCheckedOff = () => {
+        if (typeof rootChecked.unsubscribe === 'function') {
+          rootChecked.unsubscribe(off);
+          return;
+        }
+        off();
+      };
+    }
+
+    const rootIndeterminate = rootPart?.getExpose('indeterminate') as {
+      get?: () => boolean;
+      subscribe?: (cb: (e: { next: boolean }) => void) => () => void;
+      unsubscribe?: (off: () => void) => void;
+    } | null;
+    indeterminate.set(
+      !!rootIndeterminate?.get?.(),
+      'reason: checkbox indicator sync => indeterminate'
+    );
+    if (rootIndeterminate && typeof rootIndeterminate.subscribe === 'function') {
+      const off = rootIndeterminate.subscribe((e) => {
+        indeterminate.set(!!e.next, 'reason: checkbox indicator root indeterminate subscription');
+      });
+      rootIndeterminateOff = () => {
+        if (typeof rootIndeterminate.unsubscribe === 'function') {
+          rootIndeterminate.unsubscribe(off);
+          return;
+        }
+        off();
+      };
+    }
+  };
+
+  def.lifecycle.onMounted((run) => {
+    syncRoot(run);
+  });
+
+  def.lifecycle.onUpdated((run) => {
+    syncRoot(run);
+  });
+
+  def.lifecycle.onUnmounted(() => {
+    rootCheckedOff?.();
+    rootCheckedOff = null;
+    rootIndeterminateOff?.();
+    rootIndeterminateOff = null;
+    rootPart = null;
+  });
+}
+
+export const asCheckboxIndicator = defineAsHook<
+  CheckboxIndicatorProps,
+  CheckboxIndicatorExposes,
+  CheckboxIndicatorAsHookContract
+>({
+  name: 'as-checkbox-indicator',
+  mode: 'once',
+  setup: setupCheckboxIndicator,
+});
+
+const checkboxIndicator = definePrototype({
+  name: 'base-checkbox-indicator',
+  setup: setupCheckboxIndicator,
+});
+
+export default checkboxIndicator;

--- a/packages/prototypes/base/src/checkbox/indicator.ts
+++ b/packages/prototypes/base/src/checkbox/indicator.ts
@@ -5,7 +5,7 @@ import {
   type DefHandle,
   type RunHandle,
 } from '@proto.ui/core';
-import { CHECKBOX_FAMILY } from './shared';
+import { CHECKBOX_CONTEXT, CHECKBOX_FAMILY } from './shared';
 import type {
   CheckboxIndicatorAsHookContract,
   CheckboxIndicatorExposes,
@@ -19,9 +19,15 @@ function setupCheckboxIndicator(
   const checked = def.state.fromAccessibility('checked');
   const indeterminate = def.state.bool('indeterminate', false);
 
+  def.context.subscribe(CHECKBOX_CONTEXT, (_run, next) => {
+    checked.set(!!next.checked, 'reason: checkbox indicator context checked sync');
+    indeterminate.set(
+      !!next.indeterminate,
+      'reason: checkbox indicator context indeterminate sync'
+    );
+  });
+
   let rootPart: AnatomyPartView | null = null;
-  let rootCheckedOff: (() => void) | null = null;
-  let rootIndeterminateOff: (() => void) | null = null;
 
   def.expose.state('checked', checked);
   def.expose.state('indeterminate', indeterminate);
@@ -41,53 +47,11 @@ function setupCheckboxIndicator(
   });
 
   const syncRoot = (run: RunHandle<CheckboxIndicatorProps>) => {
-    rootCheckedOff?.();
-    rootCheckedOff = null;
-    rootIndeterminateOff?.();
-    rootIndeterminateOff = null;
-
     rootPart = run.anatomy.partsOf(CHECKBOX_FAMILY, 'root')[0] ?? null;
+    const ctx = run.context.read(CHECKBOX_CONTEXT);
 
-    const rootChecked = rootPart?.getExpose('checked') as {
-      get?: () => boolean;
-      subscribe?: (cb: (e: { next: boolean }) => void) => () => void;
-      unsubscribe?: (off: () => void) => void;
-    } | null;
-    checked.set(!!rootChecked?.get?.(), 'reason: checkbox indicator sync => checked');
-    if (rootChecked && typeof rootChecked.subscribe === 'function') {
-      const off = rootChecked.subscribe((e) => {
-        checked.set(!!e.next, 'reason: checkbox indicator root checked subscription');
-      });
-      rootCheckedOff = () => {
-        if (typeof rootChecked.unsubscribe === 'function') {
-          rootChecked.unsubscribe(off);
-          return;
-        }
-        off();
-      };
-    }
-
-    const rootIndeterminate = rootPart?.getExpose('indeterminate') as {
-      get?: () => boolean;
-      subscribe?: (cb: (e: { next: boolean }) => void) => () => void;
-      unsubscribe?: (off: () => void) => void;
-    } | null;
-    indeterminate.set(
-      !!rootIndeterminate?.get?.(),
-      'reason: checkbox indicator sync => indeterminate'
-    );
-    if (rootIndeterminate && typeof rootIndeterminate.subscribe === 'function') {
-      const off = rootIndeterminate.subscribe((e) => {
-        indeterminate.set(!!e.next, 'reason: checkbox indicator root indeterminate subscription');
-      });
-      rootIndeterminateOff = () => {
-        if (typeof rootIndeterminate.unsubscribe === 'function') {
-          rootIndeterminate.unsubscribe(off);
-          return;
-        }
-        off();
-      };
-    }
+    checked.set(!!ctx.checked, 'reason: checkbox indicator sync => checked');
+    indeterminate.set(!!ctx.indeterminate, 'reason: checkbox indicator sync => indeterminate');
   };
 
   def.lifecycle.onMounted((run) => {
@@ -99,10 +63,6 @@ function setupCheckboxIndicator(
   });
 
   def.lifecycle.onUnmounted(() => {
-    rootCheckedOff?.();
-    rootCheckedOff = null;
-    rootIndeterminateOff?.();
-    rootIndeterminateOff = null;
     rootPart = null;
   });
 }

--- a/packages/prototypes/base/src/checkbox/root.ts
+++ b/packages/prototypes/base/src/checkbox/root.ts
@@ -1,0 +1,72 @@
+import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
+import { asToggle } from '../toggle';
+import { CHECKBOX_FAMILY } from './shared';
+import type { CheckboxRootAsHookContract, CheckboxRootExposes, CheckboxRootProps } from './types';
+
+function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes>): void {
+  def.anatomy.claim(CHECKBOX_FAMILY, { role: 'root' });
+
+  def.props.define({
+    checked: { type: 'boolean', empty: 'fallback' },
+    defaultChecked: { type: 'boolean', empty: 'fallback' },
+    disabled: { type: 'boolean', empty: 'fallback' },
+    indeterminate: { type: 'boolean', empty: 'fallback' },
+    defaultIndeterminate: { type: 'boolean', empty: 'fallback' },
+  });
+  def.props.setDefaults({
+    defaultChecked: false,
+    disabled: false,
+    defaultIndeterminate: false,
+  });
+
+  asToggle();
+
+  const indeterminate = def.state.bool('indeterminate', false);
+  def.expose.state('indeterminate', indeterminate);
+
+  let controlledIndeterminate = false;
+
+  def.lifecycle.onCreated((run) => {
+    controlledIndeterminate = run.props.isProvided('indeterminate');
+    indeterminate.set(
+      controlledIndeterminate
+        ? !!run.props.get().indeterminate
+        : !!run.props.get().defaultIndeterminate,
+      'reason: lifecycle.onCreated => initialize indeterminate'
+    );
+  });
+
+  def.props.watch(['indeterminate'], (run, next) => {
+    controlledIndeterminate = run.props.isProvided('indeterminate');
+    if (!controlledIndeterminate) return;
+    indeterminate.set(
+      !!next.indeterminate,
+      'reason: props.watch(indeterminate) => controlled sync'
+    );
+  });
+
+  def.event.on('press.commit', (run) => {
+    if (indeterminate.get()) {
+      indeterminate.set(false, 'reason: press.commit => clear indeterminate');
+      run.event.emit('checkedChange', { checked: true });
+      return;
+    }
+  });
+}
+
+export const asCheckboxRoot = defineAsHook<
+  CheckboxRootProps,
+  CheckboxRootExposes,
+  CheckboxRootAsHookContract
+>({
+  name: 'as-checkbox-root',
+  mode: 'once',
+  setup: setupCheckboxRoot,
+});
+
+const checkboxRoot = definePrototype({
+  name: 'base-checkbox-root',
+  setup: setupCheckboxRoot,
+});
+
+export default checkboxRoot;

--- a/packages/prototypes/base/src/checkbox/root.ts
+++ b/packages/prototypes/base/src/checkbox/root.ts
@@ -49,6 +49,7 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
     if (indeterminate.get()) {
       indeterminate.set(false, 'reason: press.commit => clear indeterminate');
       run.event.emit('checkedChange', { checked: true });
+      run.event.emit('indeterminateChange', { indeterminate: false });
       return;
     }
   });

--- a/packages/prototypes/base/src/checkbox/root.ts
+++ b/packages/prototypes/base/src/checkbox/root.ts
@@ -21,6 +21,8 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
 
   asToggle();
 
+  def.expose.event('indeterminateChange', { payload: 'json' });
+
   const indeterminate = def.state.bool('indeterminate', false);
   def.expose.state('indeterminate', indeterminate);
 

--- a/packages/prototypes/base/src/checkbox/root.ts
+++ b/packages/prototypes/base/src/checkbox/root.ts
@@ -1,6 +1,6 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { asToggle } from '../toggle';
-import { CHECKBOX_FAMILY } from './shared';
+import { CHECKBOX_CONTEXT, CHECKBOX_FAMILY } from './shared';
 import type { CheckboxRootAsHookContract, CheckboxRootExposes, CheckboxRootProps } from './types';
 
 function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes>): void {
@@ -20,6 +20,12 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
   });
 
   asToggle();
+  const checked = def.state.fromAccessibility('checked');
+  const updateContext = def.context.provide(CHECKBOX_CONTEXT, {
+    checked: false,
+    indeterminate: false,
+    disabled: false,
+  });
 
   def.expose.event('indeterminateChange', { payload: 'json' });
 
@@ -27,6 +33,14 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
   def.expose.state('indeterminate', indeterminate);
 
   let controlledIndeterminate = false;
+
+  const publishContext = (run: any) => {
+    updateContext({
+      checked: !!checked.get(),
+      indeterminate: !!indeterminate.get(),
+      disabled: !!run.props.get().disabled,
+    });
+  };
 
   def.lifecycle.onCreated((run) => {
     controlledIndeterminate = run.props.isProvided('indeterminate');
@@ -36,15 +50,23 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
         : !!run.props.get().defaultIndeterminate,
       'reason: lifecycle.onCreated => initialize indeterminate'
     );
+    publishContext(run);
   });
 
-  def.props.watch(['indeterminate'], (run, next) => {
+  def.props.watch(['indeterminate', 'disabled'], (run, next) => {
     controlledIndeterminate = run.props.isProvided('indeterminate');
-    if (!controlledIndeterminate) return;
-    indeterminate.set(
-      !!next.indeterminate,
-      'reason: props.watch(indeterminate) => controlled sync'
-    );
+    if (controlledIndeterminate) {
+      indeterminate.set(
+        !!next.indeterminate,
+        'reason: props.watch(indeterminate) => controlled sync'
+      );
+    }
+    publishContext(run);
+  });
+
+  checked.watch((run, event) => {
+    if (event.type === 'disconnect') return;
+    publishContext(run);
   });
 
   def.event.on('press.commit', (run) => {
@@ -54,6 +76,7 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
         indeterminate.set(false, 'reason: press.commit => clear indeterminate');
       }
       run.event.emit('indeterminateChange', { indeterminate: false });
+      publishContext(run);
     }
   });
 }

--- a/packages/prototypes/base/src/checkbox/root.ts
+++ b/packages/prototypes/base/src/checkbox/root.ts
@@ -48,11 +48,12 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
   });
 
   def.event.on('press.commit', (run) => {
+    if (run.props.get().disabled) return;
     if (indeterminate.get()) {
-      indeterminate.set(false, 'reason: press.commit => clear indeterminate');
-      run.event.emit('checkedChange', { checked: true });
+      if (!controlledIndeterminate) {
+        indeterminate.set(false, 'reason: press.commit => clear indeterminate');
+      }
       run.event.emit('indeterminateChange', { indeterminate: false });
-      return;
     }
   });
 }

--- a/packages/prototypes/base/src/checkbox/shared.ts
+++ b/packages/prototypes/base/src/checkbox/shared.ts
@@ -1,0 +1,9 @@
+import { createAnatomyFamily } from '@proto.ui/core';
+
+export const CHECKBOX_FAMILY = createAnatomyFamily('base-checkbox', {
+  roles: {
+    root: { cardinality: { min: 1, max: 1 } },
+    indicator: { cardinality: { min: 0, max: 1 } },
+  },
+  relations: [{ kind: 'contains', parent: 'root', child: 'indicator' }],
+});

--- a/packages/prototypes/base/src/checkbox/shared.ts
+++ b/packages/prototypes/base/src/checkbox/shared.ts
@@ -1,4 +1,11 @@
 import { createAnatomyFamily } from '@proto.ui/core';
+import type { ContextKey } from '@proto.ui/types';
+
+export type CheckboxContextValue = {
+  checked: boolean;
+  indeterminate: boolean;
+  disabled: boolean;
+};
 
 export const CHECKBOX_FAMILY = createAnatomyFamily('base-checkbox', {
   roles: {
@@ -7,3 +14,8 @@ export const CHECKBOX_FAMILY = createAnatomyFamily('base-checkbox', {
   },
   relations: [{ kind: 'contains', parent: 'root', child: 'indicator' }],
 });
+
+export const CHECKBOX_CONTEXT = {
+  __brand: 'ContextKey',
+  debugName: 'base-checkbox',
+} as ContextKey<CheckboxContextValue>;

--- a/packages/prototypes/base/src/checkbox/shared.ts
+++ b/packages/prototypes/base/src/checkbox/shared.ts
@@ -3,7 +3,7 @@ import { createAnatomyFamily } from '@proto.ui/core';
 export const CHECKBOX_FAMILY = createAnatomyFamily('base-checkbox', {
   roles: {
     root: { cardinality: { min: 1, max: 1 } },
-    indicator: { cardinality: { min: 0, max: 1 } },
+    indicator: { cardinality: { min: 1, max: 100 } },
   },
   relations: [{ kind: 'contains', parent: 'root', child: 'indicator' }],
 });

--- a/packages/prototypes/base/src/checkbox/types.ts
+++ b/packages/prototypes/base/src/checkbox/types.ts
@@ -1,0 +1,42 @@
+import { ExposeMethod, ExposeState, State } from '@proto.ui/core';
+import type {
+  ToggleAsHookContract,
+  ToggleExposes,
+  ToggleProps,
+  ToggleStateHandles,
+} from '../toggle/types';
+
+export interface CheckboxRootProps extends ToggleProps {
+  indeterminate?: boolean;
+  defaultIndeterminate?: boolean;
+}
+
+export type CheckboxRootExposes = ToggleExposes & {
+  indeterminate: ExposeState<boolean>;
+};
+
+export type CheckboxRootStateHandles = ToggleStateHandles & {
+  indeterminate: State<boolean>;
+};
+
+export type CheckboxRootAsHookContract = ToggleAsHookContract & {
+  state: { indeterminate: State<boolean> };
+};
+
+export interface CheckboxIndicatorProps {}
+
+export type CheckboxIndicatorExposes = {
+  checked: ExposeState<boolean>;
+  indeterminate: ExposeState<boolean>;
+  isChecked: ExposeMethod<() => boolean | null>;
+  isIndeterminate: ExposeMethod<() => boolean | null>;
+};
+
+export type CheckboxIndicatorStateHandles = {
+  checked: State<boolean>;
+  indeterminate: State<boolean>;
+};
+
+export type CheckboxIndicatorAsHookContract = {
+  state: CheckboxIndicatorStateHandles;
+};

--- a/packages/prototypes/base/src/checkbox/types.ts
+++ b/packages/prototypes/base/src/checkbox/types.ts
@@ -1,4 +1,4 @@
-import { ExposeMethod, ExposeState, State } from '@proto.ui/core';
+import { ExposeEvent, ExposeMethod, ExposeState, State } from '@proto.ui/core';
 import type {
   ToggleAsHookContract,
   ToggleExposes,
@@ -13,6 +13,7 @@ export interface CheckboxRootProps extends ToggleProps {
 
 export type CheckboxRootExposes = ToggleExposes & {
   indeterminate: ExposeState<boolean>;
+  indeterminateChange: ExposeEvent<{ indeterminate: boolean }>;
 };
 
 export type CheckboxRootStateHandles = ToggleStateHandles & {
@@ -21,6 +22,7 @@ export type CheckboxRootStateHandles = ToggleStateHandles & {
 
 export type CheckboxRootAsHookContract = ToggleAsHookContract & {
   state: { indeterminate: State<boolean> };
+  event: { indeterminateChange: { indeterminate: boolean } };
 };
 
 export interface CheckboxIndicatorProps {}

--- a/packages/prototypes/base/src/index.ts
+++ b/packages/prototypes/base/src/index.ts
@@ -6,6 +6,7 @@ export { default as toggle } from './toggle';
 export * from './transition';
 export { default as transition } from './transition';
 export * from './switch';
+export * from './checkbox';
 export * from './tabs';
 export * from './dropdown';
 export * from './select';

--- a/packages/prototypes/base/test/checkbox.test.ts
+++ b/packages/prototypes/base/test/checkbox.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
+import { checkboxRoot, checkboxIndicator } from '../src/checkbox';
+
+AdaptToWebComponent(checkboxRoot as any);
+AdaptToWebComponent(checkboxIndicator as any);
+
+describe('prototypes/base: checkbox', () => {
+  it('checkbox-root reuses toggle semantics for checked state and checkedChange', async () => {
+    const root = document.createElement('base-checkbox-root') as any;
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = root.getExposes() as any;
+    expect(exposes.checked.get()).toBe(false);
+
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(exposes.checked.get()).toBe(true);
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-root supports indeterminate state', async () => {
+    const root = document.createElement('base-checkbox-root') as any;
+    setElementProps(root, { defaultIndeterminate: true });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = root.getExposes() as any;
+    expect(exposes.indeterminate.get()).toBe(true);
+    expect(exposes.checked.get()).toBe(false);
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-root clears indeterminate on press.commit', async () => {
+    const root = document.createElement('base-checkbox-root') as any;
+    setElementProps(root, { defaultIndeterminate: true });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = root.getExposes() as any;
+    expect(exposes.indeterminate.get()).toBe(true);
+
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(exposes.indeterminate.get()).toBe(false);
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-indicator reads root checked and indeterminate through anatomy', async () => {
+    const root = document.createElement('base-checkbox-root') as any;
+    const indicator = document.createElement('base-checkbox-indicator') as any;
+    setElementProps(root, { defaultIndeterminate: true });
+    root.appendChild(indicator);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const indicatorExposes = indicator.getExposes();
+
+    expect(indicatorExposes.isChecked()).toBe(false);
+    expect(indicatorExposes.isIndeterminate()).toBe(true);
+
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(indicatorExposes.isChecked()).toBe(true);
+    expect(indicatorExposes.isIndeterminate()).toBe(false);
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('disabled checkbox-root suppresses checked changes', async () => {
+    const root = document.createElement('base-checkbox-root') as any;
+    setElementProps(root, { disabled: true });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = root.getExposes() as any;
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(exposes.checked.get()).toBe(false);
+    root.remove();
+    await Promise.resolve();
+  });
+});

--- a/packages/prototypes/base/test/checkbox.test.ts
+++ b/packages/prototypes/base/test/checkbox.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
 import { checkboxRoot, checkboxIndicator } from '../src/checkbox';
 
-AdaptToWebComponent(checkboxRoot as any);
-AdaptToWebComponent(checkboxIndicator as any);
+AdaptToWebComponent(checkboxRoot as any, { registerAs: 'wc-base-checkbox-root' });
+AdaptToWebComponent(checkboxIndicator as any, { registerAs: 'wc-base-checkbox-indicator' });
 
 describe('prototypes/base: checkbox', () => {
   it('checkbox-root reuses toggle semantics for checked state and checkedChange', async () => {
-    const root = document.createElement('base-checkbox-root') as any;
+    const root = document.createElement('wc-base-checkbox-root') as any;
     document.body.appendChild(root);
 
     await Promise.resolve();
@@ -24,7 +24,7 @@ describe('prototypes/base: checkbox', () => {
   });
 
   it('checkbox-root supports indeterminate state', async () => {
-    const root = document.createElement('base-checkbox-root') as any;
+    const root = document.createElement('wc-base-checkbox-root') as any;
     setElementProps(root, { defaultIndeterminate: true });
     document.body.appendChild(root);
 
@@ -40,7 +40,7 @@ describe('prototypes/base: checkbox', () => {
   });
 
   it('checkbox-root clears indeterminate on press.commit', async () => {
-    const root = document.createElement('base-checkbox-root') as any;
+    const root = document.createElement('wc-base-checkbox-root') as any;
     setElementProps(root, { defaultIndeterminate: true });
     document.body.appendChild(root);
 
@@ -58,8 +58,8 @@ describe('prototypes/base: checkbox', () => {
   });
 
   it('checkbox-indicator reads root checked and indeterminate through anatomy', async () => {
-    const root = document.createElement('base-checkbox-root') as any;
-    const indicator = document.createElement('base-checkbox-indicator') as any;
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    const indicator = document.createElement('wc-base-checkbox-indicator') as any;
     setElementProps(root, { defaultIndeterminate: true });
     root.appendChild(indicator);
     document.body.appendChild(root);
@@ -81,7 +81,7 @@ describe('prototypes/base: checkbox', () => {
   });
 
   it('disabled checkbox-root suppresses checked changes', async () => {
-    const root = document.createElement('base-checkbox-root') as any;
+    const root = document.createElement('wc-base-checkbox-root') as any;
     setElementProps(root, { disabled: true });
     document.body.appendChild(root);
 

--- a/packages/prototypes/base/test/checkbox.test.ts
+++ b/packages/prototypes/base/test/checkbox.test.ts
@@ -39,9 +39,13 @@ describe('prototypes/base: checkbox', () => {
     await Promise.resolve();
   });
 
-  it('checkbox-root clears indeterminate on press.commit', async () => {
+  it('checkbox-root clears uncontrolled indeterminate on press.commit', async () => {
     const root = document.createElement('wc-base-checkbox-root') as any;
     setElementProps(root, { defaultIndeterminate: true });
+    const events: Array<{ indeterminate: boolean }> = [];
+    root.addEventListener('indeterminateChange', (event: Event) => {
+      events.push((event as CustomEvent).detail);
+    });
     document.body.appendChild(root);
 
     await Promise.resolve();
@@ -52,6 +56,55 @@ describe('prototypes/base: checkbox', () => {
 
     root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
+    expect(exposes.indeterminate.get()).toBe(false);
+    expect(events).toEqual([{ indeterminate: false }]);
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-root keeps controlled indeterminate stable and emits indeterminateChange', async () => {
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    setElementProps(root, { indeterminate: true });
+    const events: Array<{ indeterminate: boolean }> = [];
+    root.addEventListener('indeterminateChange', (event: Event) => {
+      events.push((event as CustomEvent).detail);
+    });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = root.getExposes() as any;
+    expect(exposes.indeterminate.get()).toBe(true);
+
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(exposes.indeterminate.get()).toBe(true);
+    expect(events).toEqual([{ indeterminate: false }]);
+
+    setElementProps(root, { indeterminate: false });
+    await Promise.resolve();
+
+    expect(exposes.indeterminate.get()).toBe(false);
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-root reuses toggle checked semantics when clearing indeterminate', async () => {
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    setElementProps(root, { defaultChecked: true, defaultIndeterminate: true });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = root.getExposes() as any;
+    expect(exposes.checked.get()).toBe(true);
+    expect(exposes.indeterminate.get()).toBe(true);
+
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(exposes.checked.get()).toBe(false);
     expect(exposes.indeterminate.get()).toBe(false);
     root.remove();
     await Promise.resolve();
@@ -92,6 +145,27 @@ describe('prototypes/base: checkbox', () => {
     root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(exposes.checked.get()).toBe(false);
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('disabled checkbox-root suppresses indeterminate clearing', async () => {
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    setElementProps(root, { disabled: true, defaultIndeterminate: true });
+    const events: Array<{ indeterminate: boolean }> = [];
+    root.addEventListener('indeterminateChange', (event: Event) => {
+      events.push((event as CustomEvent).detail);
+    });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = root.getExposes() as any;
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(exposes.indeterminate.get()).toBe(true);
+    expect(events).toEqual([]);
     root.remove();
     await Promise.resolve();
   });

--- a/packages/prototypes/base/test/checkbox.test.ts
+++ b/packages/prototypes/base/test/checkbox.test.ts
@@ -124,10 +124,36 @@ describe('prototypes/base: checkbox', () => {
 
     expect(indicatorExposes.isChecked()).toBe(false);
     expect(indicatorExposes.isIndeterminate()).toBe(true);
+    expect(indicatorExposes.checked.get()).toBe(false);
+    expect(indicatorExposes.indeterminate.get()).toBe(true);
 
     root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(indicatorExposes.isChecked()).toBe(true);
     expect(indicatorExposes.isIndeterminate()).toBe(false);
+    expect(indicatorExposes.checked.get()).toBe(true);
+    expect(indicatorExposes.indeterminate.get()).toBe(false);
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-indicator syncs controlled indeterminate prop changes from root', async () => {
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    const indicator = document.createElement('wc-base-checkbox-indicator') as any;
+    setElementProps(root, { indeterminate: true });
+    root.appendChild(indicator);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const indicatorExposes = indicator.getExposes();
+    expect(indicatorExposes.indeterminate.get()).toBe(true);
+
+    setElementProps(root, { indeterminate: false });
+    await Promise.resolve();
+
+    expect(indicatorExposes.indeterminate.get()).toBe(false);
 
     root.remove();
     await Promise.resolve();


### PR DESCRIPTION
## Summary

Closes #222

- Add base Checkbox prototype with checked/unchecked/disabled/indeterminate states
- Checkbox root extends Toggle semantics, adding indeterminate as a custom boolean state
- Checkbox indicator reads root checked and indeterminate states via anatomy runtime access
- Press on an indeterminate checkbox clears indeterminate
- 5 unit tests covering toggle semantics, indeterminate state, disabled suppression, and indicator anatomy sync
- Docs pages (en/zh-cn) with PrototypePreviewer demos

## Test plan

- [ ] 5 unit tests pass (checkbox.test.ts)
- [ ] Type check passes
- [ ] Docs site renders Checkbox page correctly with live preview
- [ ] CI passes