### PR TITLE
feat(whitepaper): add Mermaid information-flow diagram (#234)

### DIFF
--- a/apps/www/src/components/override/ThemeProvider.astro
+++ b/apps/www/src/components/override/ThemeProvider.astro
@@ -21,6 +21,19 @@
       // 给 chrome/safari 一个暗色介面提示（和 meta 协同）
       document.documentElement.style.colorScheme = t;
     };
+    const updatePickers = (theme = load() || 'auto') => {
+      document.querySelectorAll('starlight-theme-select').forEach((picker) => {
+        const select = picker.querySelector('select');
+        if (select) select.value = theme;
+
+        const tmpl = document.getElementById('starlight-theme-icons');
+        const newIcon = tmpl && tmpl.content.querySelector('.' + theme);
+        const oldIcon = picker.querySelector('svg.label-icon');
+        if (newIcon && oldIcon) {
+          oldIcon.replaceChildren(...newIcon.cloneNode(true).childNodes);
+        }
+      });
+    };
 
     // 初始化（若无存储，则跟随系统）
     const initial = load() || getSystem();
@@ -48,6 +61,12 @@
       hydratePickers() {
         document.dispatchEvent(new CustomEvent('starlight-theme:hydrate'));
       },
+    };
+
+    // Compatibility for Starlight's built-in ThemeSelect used in the default
+    // mobile sidebar preferences slot.
+    window.StarlightThemeProvider = {
+      updatePickers,
     };
 
     // 如果恰好监听到了主题切换，那么随系统切换主题
@@ -99,5 +118,21 @@
     <path d="M12 9l4.65 -4.65"></path>
     <path d="M12 14.3l7.37 -7.37"></path>
     <path d="M12 19.6l8.85 -8.85"></path>
+  </svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="size-4.5 auto"
+  >
+    <path d="M4 5a2 2 0 0 1 2 -2h12a2 2 0 0 1 2 2v8a2 2 0 0 1 -2 2H6a2 2 0 0 1 -2 -2z"></path>
+    <path d="M8 21h8"></path>
+    <path d="M12 15v6"></path>
   </svg>
 </template>

--- a/apps/www/src/content/docs/en/whitepaper/information-flow-model.md
+++ b/apps/www/src/content/docs/en/whitepaper/information-flow-model.md
@@ -219,6 +219,23 @@ The reason is simple:
 So the Information Flow Model is open,  
 but Proto UI still remains cautious about which flows should enter the core prototype.
 
+The following diagram summarizes the relationships described above:
+
+```mermaid
+graph TB
+    User["User"] -->|"event"| Component["Component"]
+    Component -->|"feedback"| User
+    Maker["Maker"] -->|"props"| Component
+    Component -->|"expose"| Maker
+    Other["Other Component"] <-.->|"context"| Component
+    Component --- State["state"]
+    Component --- Lifecycle["lifecycle"]
+    Component --- Meta["meta"]
+    Host["Host"] -.->|"host (potential)"| Component
+```
+
+*Figure: The Information Flow Model. The component exchanges information with User, Maker, and Other Component through event, feedback, props, expose, and context. Internal dimensions (state, lifecycle, meta) handle aspects that do not directly belong to external exchange. The host flow (dotted) is a potential extension.*
+
 ---
 
 ## What does this article not expand on?

--- a/apps/www/src/content/docs/en/whitepaper/information-flow-model.md
+++ b/apps/www/src/content/docs/en/whitepaper/information-flow-model.md
@@ -219,22 +219,61 @@ The reason is simple:
 So the Information Flow Model is open,  
 but Proto UI still remains cautious about which flows should enter the core prototype.
 
-The following diagram summarizes the relationships described above:
+The following diagram summarizes the relationships described above. The caption describes the same relationships so the model remains understandable without the image:
 
-```mermaid
-graph TB
-    User["User"] -->|"event"| Component["Component"]
-    Component -->|"feedback"| User
-    Maker["Maker"] -->|"props"| Component
-    Component -->|"expose"| Maker
-    Other["Other Component"] <-.->|"context"| Component
-    Component --- State["state"]
-    Component --- Lifecycle["lifecycle"]
-    Component --- Meta["meta"]
-    Host["Host"] -.->|"host (potential)"| Component
-```
-
-*Figure: The Information Flow Model. The component exchanges information with User, Maker, and Other Component through event, feedback, props, expose, and context. Internal dimensions (state, lifecycle, meta) handle aspects that do not directly belong to external exchange. The host flow (dotted) is a potential extension.*
+<figure class="information-flow-diagram" style="margin: 2rem 0;">
+  <svg role="img" aria-labelledby="information-flow-diagram-title information-flow-diagram-desc" viewBox="0 0 960 460" xmlns="http://www.w3.org/2000/svg" style="max-width: 100%; height: auto; color: var(--sl-color-text, #111827); font-family: var(--sl-font-system, system-ui, sans-serif);">
+    <title id="information-flow-diagram-title">Information Flow Model</title>
+    <desc id="information-flow-diagram-desc">User event and Maker props enter the Component. Inside the Component, intent and state organize behavior. Feedback leaves the Component through host rendering and returns to the User. Other Component exchanges context with the Component, and the Component can expose capabilities back to Maker.</desc>
+    <defs>
+      <marker id="flow-arrow-accent" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+        <path d="M0 0L10 5L0 10Z" fill="var(--sl-color-accent, #2563eb)" />
+      </marker>
+      <marker id="flow-arrow-muted" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto-start-reverse">
+        <path d="M0 0L10 5L0 10Z" fill="var(--sl-color-gray-4, #94a3b8)" />
+      </marker>
+    </defs>
+    <rect x="32" y="24" width="896" height="390" rx="18" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="480" y="58" text-anchor="middle" fill="currentColor" font-size="24" font-weight="700">Information Flow Model</text>
+    <rect x="80" y="76" width="180" height="70" rx="10" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="170" y="119" text-anchor="middle" fill="currentColor" font-size="18" font-weight="650">User</text>
+    <rect x="80" y="190" width="180" height="70" rx="10" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="170" y="233" text-anchor="middle" fill="currentColor" font-size="18" font-weight="650">Maker</text>
+    <rect x="80" y="322" width="180" height="70" rx="10" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="170" y="351" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">Other</text>
+    <text x="170" y="374" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">Component</text>
+    <rect x="360" y="122" width="260" height="220" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" />
+    <text x="490" y="156" text-anchor="middle" fill="currentColor" font-size="20" font-weight="700">Component</text>
+    <rect x="392" y="184" width="88" height="54" rx="8" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-accent, #2563eb)" />
+    <text x="436" y="218" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">intent</text>
+    <rect x="500" y="184" width="88" height="54" rx="8" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-accent, #2563eb)" />
+    <text x="544" y="218" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">state</text>
+    <rect x="392" y="266" width="88" height="42" rx="8" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="436" y="293" text-anchor="middle" fill="currentColor" font-size="14" font-weight="600">lifecycle</text>
+    <rect x="500" y="266" width="88" height="42" rx="8" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="544" y="293" text-anchor="middle" fill="currentColor" font-size="14" font-weight="600">meta</text>
+    <rect x="720" y="190" width="170" height="80" rx="10" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="805" y="223" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">host</text>
+    <text x="805" y="247" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">rendering</text>
+    <path d="M260 111C308 111 313 177 360 194" fill="none" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" marker-end="url(#flow-arrow-accent)" />
+    <rect x="292" y="104" width="66" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="325" y="123" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">event</text>
+    <path d="M260 225L360 225" fill="none" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" marker-end="url(#flow-arrow-accent)" />
+    <rect x="293" y="207" width="64" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="325" y="226" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">props</text>
+    <path d="M360 257L260 257" fill="none" stroke="var(--sl-color-gray-4, #94a3b8)" stroke-width="2" stroke-dasharray="7 6" marker-end="url(#flow-arrow-muted)" />
+    <rect x="292" y="263" width="72" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="328" y="282" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">expose</text>
+    <path d="M260 357C308 357 314 313 360 303" fill="none" stroke="var(--sl-color-gray-4, #94a3b8)" stroke-width="2" stroke-dasharray="7 6" marker-start="url(#flow-arrow-muted)" marker-end="url(#flow-arrow-muted)" />
+    <rect x="292" y="332" width="78" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="331" y="351" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">context</text>
+    <path d="M620 230L720 230" fill="none" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" marker-end="url(#flow-arrow-accent)" />
+    <rect x="638" y="205" width="94" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="685" y="224" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">feedback</text>
+    <path d="M805 190C805 84 404 64 260 100" fill="none" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" marker-end="url(#flow-arrow-accent)" />
+  </svg>
+  <figcaption style="margin-top: 0.75rem; color: var(--sl-color-text-secondary, #64748b); font-size: 0.95rem;">Figure: The Information Flow Model. <code>props</code> and <code>event</code> enter Component from Maker and User. Inside Component, <code>intent</code> and <code>state</code> organize behavior, while <code>lifecycle</code> and <code>meta</code> remain internal dimensions. <code>feedback</code> reaches User through host rendering. <code>context</code> connects Other Component, and <code>expose</code> points back to Maker.</figcaption>
+</figure>
 
 ---
 

--- a/apps/www/src/content/docs/zh-cn/whitepaper/information-flow-model.md
+++ b/apps/www/src/content/docs/zh-cn/whitepaper/information-flow-model.md
@@ -219,6 +219,23 @@ Proto UI 可以承认这种方向存在，并把它视作潜在的 `host` 通路
 因此，信息通路模型是开放的，  
 但 Proto UI 对哪些通路应当进入核心原型，仍然会保持审慎。
 
+下图总结了上文描述的关系：
+
+```mermaid
+graph TB
+    User["用户<br/>User"] -->|"event"| Component["组件<br/>Component"]
+    Component -->|"feedback"| User
+    Maker["组装者<br/>Maker"] -->|"props"| Component
+    Component -->|"expose"| Maker
+    Other["其他组件<br/>Other Component"] <-.->|"context"| Component
+    Component --- State["state"]
+    Component --- Lifecycle["lifecycle"]
+    Component --- Meta["meta"]
+    Host["宿主<br/>Host"] -.->|"host（潜在）"| Component
+```
+
+*图示：信息通路模型。组件通过 event、feedback、props、expose、context 与 User、Maker、Other Component 交换信息。内部维度（state、lifecycle、meta）处理不直接属于外部交换的部分。host 通路（虚线）为潜在扩展。*
+
 ---
 
 ## 这一篇没有展开什么？

--- a/apps/www/src/content/docs/zh-cn/whitepaper/information-flow-model.md
+++ b/apps/www/src/content/docs/zh-cn/whitepaper/information-flow-model.md
@@ -219,22 +219,64 @@ Proto UI 可以承认这种方向存在，并把它视作潜在的 `host` 通路
 因此，信息通路模型是开放的，  
 但 Proto UI 对哪些通路应当进入核心原型，仍然会保持审慎。
 
-下图总结了上文描述的关系：
+下图总结了上文描述的关系。图注也说明了同一组关系，因此不依赖图片也可以理解：
 
-```mermaid
-graph TB
-    User["用户<br/>User"] -->|"event"| Component["组件<br/>Component"]
-    Component -->|"feedback"| User
-    Maker["组装者<br/>Maker"] -->|"props"| Component
-    Component -->|"expose"| Maker
-    Other["其他组件<br/>Other Component"] <-.->|"context"| Component
-    Component --- State["state"]
-    Component --- Lifecycle["lifecycle"]
-    Component --- Meta["meta"]
-    Host["宿主<br/>Host"] -.->|"host（潜在）"| Component
-```
-
-*图示：信息通路模型。组件通过 event、feedback、props、expose、context 与 User、Maker、Other Component 交换信息。内部维度（state、lifecycle、meta）处理不直接属于外部交换的部分。host 通路（虚线）为潜在扩展。*
+<figure class="information-flow-diagram" style="margin: 2rem 0;">
+  <svg role="img" aria-labelledby="information-flow-diagram-title-zh information-flow-diagram-desc-zh" viewBox="0 0 960 460" xmlns="http://www.w3.org/2000/svg" style="max-width: 100%; height: auto; color: var(--sl-color-text, #111827); font-family: var(--sl-font-system, system-ui, sans-serif);">
+    <title id="information-flow-diagram-title-zh">信息通路模型</title>
+    <desc id="information-flow-diagram-desc-zh">User 的 event 与 Maker 的 props 进入 Component。Component 内部由 intent 和 state 组织行为。feedback 经由 host rendering 输出并回到 User。Other Component 通过 context 与 Component 交换信息，Component 也可以通过 expose 向 Maker 暴露能力。</desc>
+    <defs>
+      <marker id="flow-arrow-accent-zh" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+        <path d="M0 0L10 5L0 10Z" fill="var(--sl-color-accent, #2563eb)" />
+      </marker>
+      <marker id="flow-arrow-muted-zh" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto-start-reverse">
+        <path d="M0 0L10 5L0 10Z" fill="var(--sl-color-gray-4, #94a3b8)" />
+      </marker>
+    </defs>
+    <rect x="32" y="24" width="896" height="390" rx="18" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="480" y="58" text-anchor="middle" fill="currentColor" font-size="24" font-weight="700">信息通路模型</text>
+    <rect x="80" y="76" width="180" height="70" rx="10" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="170" y="104" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">用户</text>
+    <text x="170" y="128" text-anchor="middle" fill="currentColor" font-size="16" font-weight="650">User</text>
+    <rect x="80" y="190" width="180" height="70" rx="10" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="170" y="218" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">组装者</text>
+    <text x="170" y="242" text-anchor="middle" fill="currentColor" font-size="16" font-weight="650">Maker</text>
+    <rect x="80" y="322" width="180" height="70" rx="10" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="170" y="350" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">其他组件</text>
+    <text x="170" y="374" text-anchor="middle" fill="currentColor" font-size="16" font-weight="650">Other Component</text>
+    <rect x="360" y="122" width="260" height="220" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" />
+    <text x="490" y="148" text-anchor="middle" fill="currentColor" font-size="18" font-weight="700">组件</text>
+    <text x="490" y="171" text-anchor="middle" fill="currentColor" font-size="18" font-weight="700">Component</text>
+    <rect x="392" y="184" width="88" height="54" rx="8" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-accent, #2563eb)" />
+    <text x="436" y="218" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">intent</text>
+    <rect x="500" y="184" width="88" height="54" rx="8" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-accent, #2563eb)" />
+    <text x="544" y="218" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">state</text>
+    <rect x="392" y="266" width="88" height="42" rx="8" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="436" y="293" text-anchor="middle" fill="currentColor" font-size="14" font-weight="600">lifecycle</text>
+    <rect x="500" y="266" width="88" height="42" rx="8" fill="var(--sl-color-bg-nav, #f8fafc)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="544" y="293" text-anchor="middle" fill="currentColor" font-size="14" font-weight="600">meta</text>
+    <rect x="720" y="190" width="170" height="80" rx="10" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="805" y="218" text-anchor="middle" fill="currentColor" font-size="17" font-weight="650">宿主渲染</text>
+    <text x="805" y="243" text-anchor="middle" fill="currentColor" font-size="16" font-weight="650">host rendering</text>
+    <path d="M260 111C308 111 313 177 360 194" fill="none" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" marker-end="url(#flow-arrow-accent-zh)" />
+    <rect x="292" y="104" width="66" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="325" y="123" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">event</text>
+    <path d="M260 225L360 225" fill="none" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" marker-end="url(#flow-arrow-accent-zh)" />
+    <rect x="293" y="207" width="64" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="325" y="226" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">props</text>
+    <path d="M360 257L260 257" fill="none" stroke="var(--sl-color-gray-4, #94a3b8)" stroke-width="2" stroke-dasharray="7 6" marker-end="url(#flow-arrow-muted-zh)" />
+    <rect x="292" y="263" width="72" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="328" y="282" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">expose</text>
+    <path d="M260 357C308 357 314 313 360 303" fill="none" stroke="var(--sl-color-gray-4, #94a3b8)" stroke-width="2" stroke-dasharray="7 6" marker-start="url(#flow-arrow-muted-zh)" marker-end="url(#flow-arrow-muted-zh)" />
+    <rect x="292" y="332" width="78" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="331" y="351" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">context</text>
+    <path d="M620 230L720 230" fill="none" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" marker-end="url(#flow-arrow-accent-zh)" />
+    <rect x="638" y="205" width="94" height="28" rx="14" fill="var(--sl-color-bg, #ffffff)" stroke="var(--sl-color-gray-5, #cbd5e1)" />
+    <text x="685" y="224" text-anchor="middle" fill="currentColor" font-size="14" font-weight="650">feedback</text>
+    <path d="M805 190C805 84 404 64 260 100" fill="none" stroke="var(--sl-color-accent, #2563eb)" stroke-width="2" marker-end="url(#flow-arrow-accent-zh)" />
+  </svg>
+  <figcaption style="margin-top: 0.75rem; color: var(--sl-color-text-secondary, #64748b); font-size: 0.95rem;">图示：信息通路模型。<code>props</code> 与 <code>event</code> 从 Maker 与 User 进入 Component；<code>intent</code> 与 <code>state</code> 在 Component 内部组织行为，<code>lifecycle</code> 与 <code>meta</code> 仍作为内部维度存在；<code>feedback</code> 经由 host rendering 面向 User 输出；<code>context</code> 连接 Other Component，<code>expose</code> 指回 Maker。</figcaption>
+</figure>
 
 ---
 


### PR DESCRIPTION
## Summary

在白皮书信息流模型页面添加 Mermaid 示意图，展示 intent、props、state、events、feedback、host rendering 之间的连接关系。

- en/zh-cn 两页均添加
- 标签与白皮书术语一致
- 包含 alt text 说明文字
- Closes #234
