### PR TITLE
docs: add first-prototype and first-adapter contributor guides

### DIFF
--- a/apps/www/src/content/docs/en/build/first-adapter.md
+++ b/apps/www/src/content/docs/en/build/first-adapter.md
@@ -1,0 +1,180 @@
+---
+title: 'Your First Adapter'
+description: 'A step-by-step guide to writing your first Proto UI adapter.'
+---
+
+This guide walks you through creating a minimal Proto UI adapter — the bridge that lets prototypes run inside a specific host framework. If you've never written a Proto UI adapter, start here.
+
+## Before you start
+
+You should be comfortable with TypeScript and the host framework you're targeting (React, Vue, Web Components, etc.). You don't need to understand the full Proto UI architecture — this guide covers the minimum.
+
+An adapter's job is to answer three questions for every prototype:
+
+- How does it **mount** in this host?
+- How do **props** flow from host to prototype?
+- How do **events** flow from prototype to host?
+
+Before coding, read the [Adapter Proposal Template](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md) and open an issue. Adapters touch many prototypes, so alignment upfront saves time.
+
+## File structure
+
+Proto UI adapters live in `packages/adapters/<host>/`. A minimal adapter needs:
+
+```
+packages/adapters/<host>/
+  src/
+    adapt.ts          # core mapping logic
+    types.ts          # host-specific types
+    index.ts          # re-exports
+    runtime/
+      session.ts      # runtime session wiring
+      effects-port.ts # effects bridging
+```
+
+The simplest complete reference is [`packages/adapters/react/`](https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/react) — read through it before continuing.
+
+## Step 1: Claim an issue
+
+Find an adapter-scoped issue in the [issue tracker](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3Aadapter). Comment before starting. If no issue exists, create one using the [Adapter Proposal Template](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md).
+
+## Step 2: Set up the package
+
+Create `packages/adapters/<host>/` with a `package.json`:
+
+```json
+{
+  "name": "@proto.ui/<host>-adapter",
+  "private": true,
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@proto.ui/core": "workspace:*",
+    "@proto.ui/runtime": "workspace:*"
+  }
+}
+```
+
+## Step 3: Wire the host input
+
+Create `src/adapt.ts`. The adapter host needs three things from every host:
+
+```ts
+import type { Prototype, PropsBaseType } from '@proto.ui/core';
+import {
+  createAdapterHost,
+  type AdapterHostInput,
+  type AdapterHostHooks,
+} from '@proto.ui/adapters-base';
+
+function adaptPrototype<P extends PropsBaseType>(
+  proto: Prototype<P>,
+  hostInput: AdapterHostInput<P>,
+  hooks?: AdapterHostHooks<P>
+) {
+  return createAdapterHost(proto, hostInput, hooks);
+}
+```
+
+| Input         | Purpose                                             |
+| ------------- | --------------------------------------------------- |
+| `commit`      | Apply prototype output to host DOM / VDOM           |
+| `schedule`    | Schedule host-side updates (e.g. microtask / frame) |
+| `getRawProps` | Read raw props from the host layer                  |
+
+## Step 4: Implement commit
+
+`commit` receives the prototype's output and must translate it to host-native updates:
+
+```ts
+const hostInput: AdapterHostInput<MyProps> = {
+  commit(dom, ops) {
+    for (const op of ops) {
+      if (op.kind === 'attribute') {
+        dom.setAttribute(op.name, String(op.value));
+      } else if (op.kind === 'property') {
+        (dom as any)[op.name] = op.value;
+      } else if (op.kind === 'event') {
+        dom.addEventListener(op.name, op.handler);
+      }
+    }
+  },
+  schedule(fn) {
+    queueMicrotask(fn);
+  },
+  getRawProps() {
+    return rawProps;
+  },
+};
+```
+
+Look at [adapter-host.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/adapters/base/src/host/adapter-host.ts) for the full `AdapterHostInput` contract.
+
+## Step 5: Wire host lifecycle
+
+Use `AdapterHostHooks` to connect mount/unmount:
+
+```ts
+const hooks: AdapterHostHooks<MyProps> = {
+  onRuntimeReady(runtime) {
+    // Prototype runtime is ready — wire events, start interactions
+  },
+  onUnmountBegin(runtime) {
+    // Cleanup before unmount
+  },
+  afterUnmount() {
+    // Host-level teardown
+  },
+};
+```
+
+## Step 6: Register the adapter
+
+Add your adapter to `packages/adapters/<host>/src/index.ts`:
+
+```ts
+export { adaptPrototype } from './adapt';
+export type { HostSpecificTypes } from './types';
+```
+
+## Step 7: Test with contracts
+
+Create `packages/adapters/<host>/test/` with contract-driven tests. Adapters are validated by running existing prototype tests through the new host:
+
+```ts
+import { adaptPrototype } from '../src/adapt';
+import button from '@proto.ui/base/button';
+
+test('button renders via host', () => {
+  const session = adaptPrototype(button, mockHostInput);
+  expect(session.controller).toBeDefined();
+  session.dispose();
+});
+```
+
+At minimum, test: Button (simplest prototype), one compound prototype, and event routing.
+
+## Step 8: Wire into docs site
+
+Adapters are consumed through the docs site demo system. Register your adapter in the docs site adapter registry so prototypes can be previewed through your host.
+
+## Before opening a PR
+
+- [ ] All existing prototype tests pass through the new adapter
+- [ ] At least 3 prototypes render correctly (Button + 2 more)
+- [ ] Event routing works in both directions (host → proto, proto → host)
+- [ ] Cleanup doesn't leak (mount → unmount → remount works)
+- [ ] PR description links the proposal issue and explains capability mapping
+
+## Common pitfalls
+
+1. **Over-abstracting the host layer** — map prototypes to host, don't build a second framework. Keep the adapter thin.
+2. **Silent capability gaps** — if the host can't support a contract, document the gap explicitly rather than silently skipping it.
+3. **Forgetting teardown** — always call `session.dispose()` on unmount. Leaked sessions cause subtle bugs.
+4. **Mixing host concerns into prototypes** — the adapter translates, the prototype defines. Never put host-specific logic in a prototype.
+5. **Skipping contract tests** — contracts define what "correctly adapted" means. Without them, it's guesswork.
+
+## Next steps
+
+- [Adapter Guide](/en/build/adapter-guide/) — deeper reference (in progress)
+- [Contracts & Tests](/en/build/contracts-and-tests/) — how contract verification works
+- Existing adapters: [React](https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/react), [Vue](https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/vue), [Web Component](https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/web-component)

--- a/apps/www/src/content/docs/en/build/first-prototype.md
+++ b/apps/www/src/content/docs/en/build/first-prototype.md
@@ -1,0 +1,199 @@
+---
+title: 'Your First Prototype'
+description: 'A step-by-step guide to writing your first Proto UI prototype.'
+---
+
+This guide walks you through creating a complete Proto UI prototype — from setup to PR. If you have never written a Proto UI prototype before, start here.
+
+## Before you start
+
+You should be comfortable reading TypeScript. You do not need to understand the full Proto UI architecture — this guide covers the minimum.
+
+Pick a small, self-contained component for your first attempt. Good candidates: `badge`, `avatar`, `divider`, `label`. Avoid compound components (dropdown, dialog, tabs) until you have done a single-part prototype first.
+
+## How a prototype is structured
+
+A Proto UI prototype is a single file under `packages/prototypes/base/src/<name>/`. A minimal prototype needs only one file:
+
+```
+packages/prototypes/base/src/<name>/
+  <name>.ts       # setup + definePrototype + asHook
+  types.ts        # (optional) props / exposes types
+  index.ts        # re-exports
+```
+
+The simplest reference in the repo is [`button.ts`](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.ts) — read it before continuing.
+
+## Step 1: Claim an issue
+
+Find an open issue tagged `prototype` in the [issue tracker](https://github.com/Proto-UI/Proto-UI/issues). Comment to claim it before you start. If no suitable issue exists, open one describing what you plan to build.
+
+## Step 2: Create the source file
+
+Create `packages/prototypes/base/src/<name>/<name>.ts`. Start with this skeleton:
+
+```ts
+import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
+
+interface MyPrototypeProps {
+  disabled?: boolean;
+}
+
+type MyPrototypeExposes = {
+  disabled: import('@proto.ui/core').ExposeState<boolean>;
+};
+
+function setupMyPrototype(def: DefHandle<MyPrototypeProps, MyPrototypeExposes>): void {
+  // Step 3–6 go here
+}
+
+export const asMyPrototype = defineAsHook({
+  name: 'as-my-prototype',
+  mode: 'once',
+  setup: setupMyPrototype,
+});
+
+const myPrototype = definePrototype({
+  name: 'base-my-prototype',
+  setup: setupMyPrototype,
+});
+
+export default myPrototype;
+```
+
+## Step 3: Define props
+
+Use `def.props.define()` to declare what the Maker can pass in:
+
+```ts
+def.props.define({
+  disabled: { type: 'boolean', empty: 'fallback' },
+});
+def.props.setDefaults({ disabled: false });
+```
+
+## Step 4: Set up interaction state
+
+Use `def.state.fromInteraction()` for basic interaction states:
+
+```ts
+const hovered = def.state.fromInteraction('hovered');
+const focused = def.state.fromInteraction('focused');
+const pressed = def.state.fromInteraction('pressed');
+def.expose.state('hovered', hovered);
+def.expose.state('focused', focused);
+def.expose.state('pressed', pressed);
+```
+
+Or use `asButton()` for the full button interaction suite (hover, focus, press, click):
+
+```ts
+import { asButton } from '../button';
+// inside setup:
+asButton();
+```
+
+## Step 5: Handle events
+
+Bind to events with `def.event.on()`:
+
+```ts
+def.event.on('press.commit', (run) => {
+  if (run.props.get().disabled) return;
+  // handle the press
+});
+```
+
+Standard event names: `press.commit`, `pointer.enter`, `pointer.leave`, `native:focus`, `native:blur`.
+
+## Step 6: Expose state and methods
+
+Everything the outside world needs to read or call must be explicitly exposed:
+
+```ts
+def.expose.state('disabled', disabled);
+def.expose.method('focusSelf', (run) => () => {
+  // focus logic
+});
+```
+
+## Step 7: Register the prototype
+
+Add your prototype to `packages/prototypes/base/src/index.ts`:
+
+```ts
+export * from './<name>';
+export { default as myPrototype } from './<name>';
+```
+
+## Step 8: Write a test
+
+Create `packages/prototypes/base/test/<name>.test.ts`. Register your prototype as a web component for testing:
+
+```ts
+import { AdaptToWebComponent } from '@proto.ui/wc-adapter';
+import myPrototype from '../src/<name>/<name>';
+
+AdaptToWebComponent(myPrototype as any, { registerAs: 'wc-base-my-prototype' });
+```
+
+Write at least: a render test, a prop defaults test, and one interaction test.
+
+## Step 9: Add a demo
+
+Create `apps/www/src/content/docs/zh-cn/demo-base-<name>.demo.ts`:
+
+```ts
+export default {
+  type: 'demo',
+  root: {
+    kind: 'proto',
+    prototypeId: 'base-my-prototype',
+    className: 'px-3 py-1.5 rounded border',
+    children: ['Hello'],
+  },
+};
+```
+
+## Step 10: Add docs
+
+Create `apps/www/src/content/docs/en/ui-libraries/base/<name>.mdx` (and `zh-cn/` equivalent):
+
+```mdx
+---
+title: 'My Prototype'
+description: '...'
+---
+
+import PrototypePreviewer from '@/components/PrototypePreviewer/PrototypePreviewer.astro';
+
+<PrototypePreviewer
+  demoId="demo-base-<name>"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  hasCode={true}
+/>
+
+Description of what this prototype provides.
+```
+
+## Before opening a PR
+
+- [ ] Tests pass: run the test suite for your package
+- [ ] Type check passes
+- [ ] Demo renders in all three runtimes (wc, react, vue)
+- [ ] Both en and zh-cn docs are present (or explicitly skipped)
+- [ ] PR description links the issue and describes the interaction boundary
+
+## Common mistakes
+
+1. **Skipping `asHook`** — if your setup might be reused, always export `asHook` alongside the prototype.
+2. **Putting visual style in the prototype** — prototypes define interaction semantics, not CSS. Style belongs in the demo and the consuming app.
+3. **Over-engineering the first version** — start with the smallest useful surface. You can add `expose.method`, `context`, or `lifecycle` later.
+4. **Forgetting to register in `index.ts`** — the prototype won't be importable by consumers until re-exported.
+
+## Next steps
+
+- [Prototype author checklist](/zh-cn/build/prototypes/checklist/) — review before submitting
+- [Writing a compound prototype](/zh-cn/build/prototypes/writing-a-compound-prototype/) — when your component needs multiple parts
+- [Why you usually don't need a new prototype](/zh-cn/build/prototypes/when-not-to-write-a-new-prototype/) — before you start your second one

--- a/apps/www/src/content/docs/zh-cn/build/first-adapter.md
+++ b/apps/www/src/content/docs/zh-cn/build/first-adapter.md
@@ -1,0 +1,180 @@
+---
+title: '你的第一个适配器'
+description: '一份分步指南，带你完成第一个 Proto UI 适配器的编写。'
+---
+
+这份指南会带你走完一个最小 Proto UI 适配器的创建过程——适配器是让原型在特定宿主框架中运行的桥梁。如果你从未写过 Proto UI 适配器，从这里开始。
+
+## 开始之前
+
+你应该能熟练使用 TypeScript 和你目标宿主框架（React、Vue、Web Components 等）。不需要理解 Proto UI 的全部架构——这份指南只覆盖最小必要知识。
+
+适配器的核心工作是回答三个问题：
+
+- 原型如何在这个宿主中**挂载**？
+- **props** 如何从宿主流向原型？
+- **事件**如何从原型流向宿主？
+
+开始编码前，先阅读[适配器提案模板](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md)并创建 issue。适配器涉及大量原型，提前沟通能大幅节省时间。
+
+## 文件结构
+
+Proto UI 适配器放在 `packages/adapters/<host>/` 下。最小适配器需要：
+
+```
+packages/adapters/<host>/
+  src/
+    adapt.ts          # 核心映射逻辑
+    types.ts          # 宿主特定类型
+    index.ts          # 重导出
+    runtime/
+      session.ts      # 运行时会话接线
+      effects-port.ts # effects 桥接
+```
+
+最简单的完整参考是 [`packages/adapters/react/`](https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/react) ——继续之前先读一遍。
+
+## 第 1 步：认领 issue
+
+在 [issue tracker](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3Aadapter) 中找到标记为 `adapter` 的 issue。在开始之前评论认领。如果没有合适的 issue，使用[适配器提案模板](https://github.com/Proto-UI/Proto-UI/issues/new?template=adapter-proposal.md)新建一个。
+
+## 第 2 步：创建包
+
+创建 `packages/adapters/<host>/` 并添加 `package.json`：
+
+```json
+{
+  "name": "@proto.ui/<host>-adapter",
+  "private": true,
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@proto.ui/core": "workspace:*",
+    "@proto.ui/runtime": "workspace:*"
+  }
+}
+```
+
+## 第 3 步：接线宿主输入
+
+创建 `src/adapt.ts`。适配器宿主需要每个宿主提供三样东西：
+
+```ts
+import type { Prototype, PropsBaseType } from '@proto.ui/core';
+import {
+  createAdapterHost,
+  type AdapterHostInput,
+  type AdapterHostHooks,
+} from '@proto.ui/adapters-base';
+
+function adaptPrototype<P extends PropsBaseType>(
+  proto: Prototype<P>,
+  hostInput: AdapterHostInput<P>,
+  hooks?: AdapterHostHooks<P>
+) {
+  return createAdapterHost(proto, hostInput, hooks);
+}
+```
+
+| 输入          | 用途                                   |
+| ------------- | -------------------------------------- |
+| `commit`      | 将原型输出应用到宿主 DOM / VDOM        |
+| `schedule`    | 调度宿主端更新（如 microtask / frame） |
+| `getRawProps` | 从宿主层读取原始 props                 |
+
+## 第 4 步：实现 commit
+
+`commit` 接收原型输出并转换为宿主原生更新：
+
+```ts
+const hostInput: AdapterHostInput<MyProps> = {
+  commit(dom, ops) {
+    for (const op of ops) {
+      if (op.kind === 'attribute') {
+        dom.setAttribute(op.name, String(op.value));
+      } else if (op.kind === 'property') {
+        (dom as any)[op.name] = op.value;
+      } else if (op.kind === 'event') {
+        dom.addEventListener(op.name, op.handler);
+      }
+    }
+  },
+  schedule(fn) {
+    queueMicrotask(fn);
+  },
+  getRawProps() {
+    return rawProps;
+  },
+};
+```
+
+完整的 `AdapterHostInput` 合约见 [adapter-host.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/adapters/base/src/host/adapter-host.ts)。
+
+## 第 5 步：接线宿主生命周期
+
+用 `AdapterHostHooks` 连接挂载/卸载：
+
+```ts
+const hooks: AdapterHostHooks<MyProps> = {
+  onRuntimeReady(runtime) {
+    // 原型运行时已就绪——接线事件，启动交互
+  },
+  onUnmountBegin(runtime) {
+    // 卸载前的清理
+  },
+  afterUnmount() {
+    // 宿主层级的销毁
+  },
+};
+```
+
+## 第 6 步：注册适配器
+
+将适配器添加到 `packages/adapters/<host>/src/index.ts`：
+
+```ts
+export { adaptPrototype } from './adapt';
+export type { HostSpecificTypes } from './types';
+```
+
+## 第 7 步：用合约测试
+
+创建 `packages/adapters/<host>/test/` 并编写合约驱动的测试。适配器通过把已有原型测试跑在新宿主上来验证：
+
+```ts
+import { adaptPrototype } from '../src/adapt';
+import button from '@proto.ui/base/button';
+
+test('button renders via host', () => {
+  const session = adaptPrototype(button, mockHostInput);
+  expect(session.controller).toBeDefined();
+  session.dispose();
+});
+```
+
+至少测试：Button（最简单的原型）、一个复合原型、以及事件路由。
+
+## 第 8 步：接入文档站
+
+适配器通过文档站 demo 系统被消费。在文档站适配器注册表中注册你的适配器，使原型能通过你的宿主预览。
+
+## 提交 PR 之前
+
+- [ ] 所有已有原型测试在新适配器下通过
+- [ ] 至少 3 个原型正确渲染（Button + 2 个以上）
+- [ ] 事件路由双向正常（host → proto、proto → host）
+- [ ] 无泄漏（mount → unmount → remount 正常）
+- [ ] PR 描述链接了提案 issue 并说明了能力映射
+
+## 常见错误
+
+1. **过度抽象宿主层** ——把原型映射到宿主即可，不要造第二个框架。适配器应保持薄。
+2. **隐藏能力缺口** ——如果宿主无法支持某个合约，显式记录缺口，不要静默跳过。
+3. **忘记 teardown** ——卸载时务必调用 `session.dispose()`。泄漏的 session 会导致难以排查的问题。
+4. **把宿主关注点混入原型** ——适配器做翻译，原型做定义。绝对不要在原型中放宿主逻辑。
+5. **跳过合约测试** ——合约定义了"正确适配"的含义。没有合约测试就靠猜。
+
+## 下一步
+
+- [适配器指南](/zh-cn/build/adapter-guide/) ——更深入的参考（完善中）
+- [合约与测试](/zh-cn/build/contracts-and-tests/) ——合约验证的工作原理
+- 已有适配器：[React](https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/react)、[Vue](https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/vue)、[Web Component](https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/web-component)

--- a/apps/www/src/content/docs/zh-cn/build/first-prototype.md
+++ b/apps/www/src/content/docs/zh-cn/build/first-prototype.md
@@ -1,0 +1,199 @@
+---
+title: '你的第一个原型'
+description: '一份分步指南，带你完成第一个 Proto UI 原型的编写。'
+---
+
+这份指南会带你走完一个完整 Proto UI 原型的创建过程——从搭建到提交 PR。如果你从未写过 Proto UI 原型，从这里开始。
+
+## 开始之前
+
+你应该能熟练阅读 TypeScript，不需要理解 Proto UI 的全部架构——这份指南只覆盖最小必要知识。
+
+第一次尝试时，选一个小而独立的组件。推荐：`badge`、`avatar`、`divider`、`label`。避免复合组件（dropdown、dialog、tabs），先写好单个 part 的原型之后再说。
+
+## 一个原型的文件结构
+
+Proto UI 原型放在 `packages/prototypes/base/src/<name>/` 下。最小原型只需要一个文件：
+
+```
+packages/prototypes/base/src/<name>/
+  <name>.ts       # setup + definePrototype + asHook
+  types.ts        # （可选）props / exposes 类型
+  index.ts        # 重导出
+```
+
+仓库中最简单的参考是 [`button.ts`](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/src/button/button.ts) ——继续之前先读一遍。
+
+## 第 1 步：认领 issue
+
+在 [issue tracker](https://github.com/Proto-UI/Proto-UI/issues) 中找到标记为 `prototype` 的 issue。在开始之前评论认领。如果没有合适的 issue，新建一个描述你计划做什么。
+
+## 第 2 步：创建源文件
+
+创建 `packages/prototypes/base/src/<name>/<name>.ts`。从以下骨架开始：
+
+```ts
+import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
+
+interface MyPrototypeProps {
+  disabled?: boolean;
+}
+
+type MyPrototypeExposes = {
+  disabled: import('@proto.ui/core').ExposeState<boolean>;
+};
+
+function setupMyPrototype(def: DefHandle<MyPrototypeProps, MyPrototypeExposes>): void {
+  // 第 3–6 步写在这里
+}
+
+export const asMyPrototype = defineAsHook({
+  name: 'as-my-prototype',
+  mode: 'once',
+  setup: setupMyPrototype,
+});
+
+const myPrototype = definePrototype({
+  name: 'base-my-prototype',
+  setup: setupMyPrototype,
+});
+
+export default myPrototype;
+```
+
+## 第 3 步：定义 props
+
+使用 `def.props.define()` 声明 Maker 可以传入什么：
+
+```ts
+def.props.define({
+  disabled: { type: 'boolean', empty: 'fallback' },
+});
+def.props.setDefaults({ disabled: false });
+```
+
+## 第 4 步：建立交互状态
+
+使用 `def.state.fromInteraction()` 获取基础交互状态：
+
+```ts
+const hovered = def.state.fromInteraction('hovered');
+const focused = def.state.fromInteraction('focused');
+const pressed = def.state.fromInteraction('pressed');
+def.expose.state('hovered', hovered);
+def.expose.state('focused', focused);
+def.expose.state('pressed', pressed);
+```
+
+或者使用 `asButton()` 获取完整的按钮交互套件（hover、focus、press、click）：
+
+```ts
+import { asButton } from '../button';
+// 在 setup 内：
+asButton();
+```
+
+## 第 5 步：处理事件
+
+用 `def.event.on()` 绑定事件：
+
+```ts
+def.event.on('press.commit', (run) => {
+  if (run.props.get().disabled) return;
+  // 处理 press
+});
+```
+
+标准事件名：`press.commit`、`pointer.enter`、`pointer.leave`、`native:focus`、`native:blur`。
+
+## 第 6 步：暴露状态和方法
+
+外部需要读取或调用的所有内容都必须显式暴露：
+
+```ts
+def.expose.state('disabled', disabled);
+def.expose.method('focusSelf', (run) => () => {
+  // focus 逻辑
+});
+```
+
+## 第 7 步：注册原型
+
+将原型添加到 `packages/prototypes/base/src/index.ts`：
+
+```ts
+export * from './<name>';
+export { default as myPrototype } from './<name>';
+```
+
+## 第 8 步：编写测试
+
+创建 `packages/prototypes/base/test/<name>.test.ts`。将原型注册为 web component 以便测试：
+
+```ts
+import { AdaptToWebComponent } from '@proto.ui/wc-adapter';
+import myPrototype from '../src/<name>/<name>';
+
+AdaptToWebComponent(myPrototype as any, { registerAs: 'wc-base-my-prototype' });
+```
+
+至少写：一个渲染测试、一个 prop 默认值测试、一个交互测试。
+
+## 第 9 步：添加 demo
+
+创建 `apps/www/src/content/docs/zh-cn/demo-base-<name>.demo.ts`：
+
+```ts
+export default {
+  type: 'demo',
+  root: {
+    kind: 'proto',
+    prototypeId: 'base-my-prototype',
+    className: 'px-3 py-1.5 rounded border',
+    children: ['Hello'],
+  },
+};
+```
+
+## 第 10 步：添加文档
+
+创建 `apps/www/src/content/docs/en/ui-libraries/base/<name>.mdx`（以及 `zh-cn/` 对应文件）：
+
+```mdx
+---
+title: 'My Prototype'
+description: '...'
+---
+
+import PrototypePreviewer from '@/components/PrototypePreviewer/PrototypePreviewer.astro';
+
+<PrototypePreviewer
+  demoId="demo-base-<name>"
+  initialRuntime="wc"
+  runtimes={['wc', 'react', 'vue']}
+  hasCode={true}
+/>
+
+关于这个原型提供了什么的描述。
+```
+
+## 提交 PR 之前
+
+- [ ] 测试通过：运行你所在 package 的测试套件
+- [ ] 类型检查通过
+- [ ] Demo 在三种运行时（wc、react、vue）下均正常渲染
+- [ ] 中英文文档均已提供（或明确注明跳过）
+- [ ] PR 描述链接了 issue 并说明了交互边界
+
+## 常见错误
+
+1. **跳过 `asHook`** ——如果你的 setup 可能被复用，务必同时导出 `asHook` 和 prototype。
+2. **把视觉样式放进原型** ——原型定义的是交互语义，不是 CSS。样式属于 demo 和消费方应用。
+3. **第一个版本就过度设计** ——从最小的可用接口开始。`expose.method`、`context`、`lifecycle` 可以后续再加。
+4. **忘记在 `index.ts` 中注册** ——不重导出的话，消费者无法 import 你的原型。
+
+## 下一步
+
+- [原型作者检查清单](/zh-cn/build/prototypes/checklist/) ——提交前过一遍
+- [编写复合原型](/zh-cn/build/prototypes/writing-a-compound-prototype/) ——当你的组件需要多个 part
+- [为什么你通常不需要新写一个原型](/zh-cn/build/prototypes/when-not-to-write-a-new-prototype/) ——在你开始写第二个之前


### PR DESCRIPTION
## Summary
- Add irst-prototype.md (en/zh-cn): 10-step walkthrough from issue claim to PR (#235)
- Add irst-adapter.md (en/zh-cn): host wiring, lifecycle hooks, contract testing guide (#236)

Closes #235, closes #236