### PR TITLE
fix: align release workflow with npm trusted publishing

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -91,7 +91,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
 
       - name: Setup pnpm (corepack)
         run: |
@@ -127,6 +126,32 @@ jobs:
 
       - name: Install
         run: corepack pnpm@"${PROTO_PNPM_VERSION}" install --frozen-lockfile
+
+      - name: Verify npm trusted publishing runtime
+        if: ${{ inputs.mode == 'publish-all' || inputs.mode == 'publish-single' }}
+        run: |
+          set -euo pipefail
+
+          npm install -g npm@11
+          NPM_VERSION=$(npm --version)
+          echo "npm=${NPM_VERSION}"
+
+          node --input-type=module - "$NPM_VERSION" <<'NODE'
+          const version = process.argv[2];
+          const [major, minor, patch] = version.split('.').map((part) => Number(part));
+          if (
+            !Number.isInteger(major) ||
+            major < 11 ||
+            (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))
+          ) {
+            throw new Error(`npm trusted publishing requires npm >= 11.5.1; got ${version}`);
+          }
+          NODE
+
+          if [[ -n "${NODE_AUTH_TOKEN:-}" || -n "${NPM_TOKEN:-}" ]]; then
+            echo "OIDC publish must not use NODE_AUTH_TOKEN or NPM_TOKEN."
+            exit 1
+          fi
 
       - name: Validate Publish Branch
         if: ${{ inputs.mode == 'publish-all' || inputs.mode == 'publish-single' }}
@@ -206,9 +231,8 @@ jobs:
               node scripts/release/publish.mjs --dry-run "${ARGS[@]}"
               ;;
             publish-all)
-              # OIDC: no NODE_AUTH_TOKEN, no NPM_TOKEN. npm CLI auto-detects
-              # ACTIONS_ID_TOKEN_REQUEST_URL/_TOKEN and exchanges for a
-              # short-lived publish credential (with provenance).
+              # OIDC: npm CLI auto-detects ACTIONS_ID_TOKEN_REQUEST_URL/_TOKEN
+              # and exchanges them for short-lived publish credentials.
               node scripts/release/publish.mjs --publish "${ARGS[@]}"
               ;;
             publish-single)

--- a/packages/adapters/base/package.json
+++ b/packages/adapters/base/package.json
@@ -17,14 +17,14 @@
   },
   "description": "Base package for building Proto UI adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/adapters/base",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/base",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/adapters/base"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/adapters/react/package.json
+++ b/packages/adapters/react/package.json
@@ -34,14 +34,14 @@
   },
   "description": "Translates Proto UI prototypes into React component functions for use with Proto UI adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/adapters/react",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/react",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/adapters/react"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/adapters/vue/package.json
+++ b/packages/adapters/vue/package.json
@@ -34,14 +34,14 @@
   },
   "description": "Translates Proto UI prototypes into Vue component functions for use with Proto UI adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/adapters/vue",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/vue",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/adapters/vue"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/adapters/web-component/package.json
+++ b/packages/adapters/web-component/package.json
@@ -35,14 +35,14 @@
   },
   "description": "Translates Proto UI prototypes into Web Components component functions for use with Proto UI adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/adapters/web-component",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/adapters/web-component",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/adapters/web-component"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,14 +18,14 @@
   },
   "description": "Proto UI command line tooling for initialization, component facade generation, and style presets.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/cli",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/cli",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,14 +18,14 @@
   },
   "description": "Proto UI core syntax and protocol primitives.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/core",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/core",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/core"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -17,14 +17,14 @@
   },
   "description": "Proto UI built-in author-facing hooks powered by the runtime bridge.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/hooks",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/hooks",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/hooks"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/anatomy/package.json
+++ b/packages/modules/anatomy/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides anatomy capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/anatomy",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/anatomy",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/anatomy"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/as-trigger/package.json
+++ b/packages/modules/as-trigger/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides as-trigger capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/as-trigger",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/as-trigger",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/as-trigger"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/base/package.json
+++ b/packages/modules/base/package.json
@@ -14,14 +14,14 @@
   },
   "description": "Base package for building Proto UI modules.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/base",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/base",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/base"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/boundary/package.json
+++ b/packages/modules/boundary/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides interaction-boundary capability.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/boundary",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/boundary",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/boundary"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/context/package.json
+++ b/packages/modules/context/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides context capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/context",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/context",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/context"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/event/package.json
+++ b/packages/modules/event/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides event capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/event",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/event",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/event"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/expose-state-web/package.json
+++ b/packages/modules/expose-state-web/package.json
@@ -17,14 +17,14 @@
   },
   "description": "Proto UI module that provides web state expose capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/expose-state-web",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/expose-state-web",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/expose-state-web"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/expose-state/package.json
+++ b/packages/modules/expose-state/package.json
@@ -18,14 +18,14 @@
   },
   "description": "Proto UI module that provides state expose capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/expose-state",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/expose-state",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/expose-state"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/expose/package.json
+++ b/packages/modules/expose/package.json
@@ -15,14 +15,14 @@
   },
   "description": "Proto UI module that provides expose capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/expose",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/expose",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/expose"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/feedback/package.json
+++ b/packages/modules/feedback/package.json
@@ -15,14 +15,14 @@
   },
   "description": "Proto UI module that provides feedback capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/feedback",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/feedback",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/feedback"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/focus/package.json
+++ b/packages/modules/focus/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides focus capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/focus",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/focus",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/focus"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/hit-participation/package.json
+++ b/packages/modules/hit-participation/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides hit-participation capability.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/hit-participation",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/hit-participation",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/hit-participation"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/overlay/package.json
+++ b/packages/modules/overlay/package.json
@@ -17,14 +17,14 @@
   },
   "description": "Proto UI module that provides overlay capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/overlay",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/overlay",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/overlay"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/presence/package.json
+++ b/packages/modules/presence/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides structural presence governance for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/presence",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/presence",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/presence"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/props/package.json
+++ b/packages/modules/props/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides props capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/props",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/props",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/props"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/rule-expose-state-web/package.json
+++ b/packages/modules/rule-expose-state-web/package.json
@@ -19,14 +19,14 @@
   },
   "description": "Proto UI module that provides rule-based web state expose capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/rule-expose-state-web",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/rule-expose-state-web",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/rule-expose-state-web"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/rule-meta/package.json
+++ b/packages/modules/rule-meta/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides rule metadata capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/rule-meta",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/rule-meta",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/rule-meta"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/rule/package.json
+++ b/packages/modules/rule/package.json
@@ -20,14 +20,14 @@
   },
   "description": "Proto UI module that provides rule capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/rule",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/rule",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/rule"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/state-accessibility/package.json
+++ b/packages/modules/state-accessibility/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides state accessibility capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/state-accessibility",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/state-accessibility",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/state-accessibility"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/state-interaction/package.json
+++ b/packages/modules/state-interaction/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides state interaction capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/state-interaction",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/state-interaction",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/state-interaction"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/state/package.json
+++ b/packages/modules/state/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides state capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/state",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/state",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/state"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/modules/test-sys/package.json
+++ b/packages/modules/test-sys/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Proto UI module that provides test system capability for adapters.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/modules/test-sys",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/test-sys",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/modules/test-sys"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prototypes/base/package.json
+++ b/packages/prototypes/base/package.json
@@ -23,14 +23,14 @@
   },
   "description": "Base Proto UI prototype library for reusable interaction prototypes.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/prototypes/base",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/prototypes/base"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prototypes/lucide/package.json
+++ b/packages/prototypes/lucide/package.json
@@ -45,14 +45,14 @@
   },
   "description": "Lucide-based Proto UI icon prototype library and svg render helpers.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/prototypes/lucide",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/lucide",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/prototypes/lucide"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/prototypes/shadcn/package.json
+++ b/packages/prototypes/shadcn/package.json
@@ -21,14 +21,14 @@
   },
   "description": "shadcn-style Proto UI prototype library for adapter-driven components.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/prototypes/shadcn",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/shadcn",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/prototypes/shadcn"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -38,14 +38,14 @@
   },
   "description": "Proto UI runtime that executes prototypes under the Proto UI contracts.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/runtime",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/runtime",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/runtime"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,14 +16,14 @@
   },
   "description": "Shared type definitions for Proto UI packages.",
   "license": "MIT",
-  "homepage": "https://github.com/guangliang2019/Prototype-UI/tree/main/packages/types",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/types",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guangliang2019/Prototype-UI.git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
     "directory": "packages/types"
   },
   "bugs": {
-    "url": "https://github.com/guangliang2019/Prototype-UI/issues"
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/release/sync-metadata.mjs
+++ b/scripts/release/sync-metadata.mjs
@@ -2,10 +2,10 @@ import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { ROOT_DIR, getAllPackages } from './lib.mjs';
 
-const REPO_URL = 'https://github.com/guangliang2019/Prototype-UI';
-const REPO_GIT_URL = 'git+https://github.com/guangliang2019/Prototype-UI.git';
-const BUGS_URL = 'https://github.com/guangliang2019/Prototype-UI/issues';
-const RELEASE_VERSION = '0.0.1';
+const REPO_URL = 'https://github.com/Proto-UI/Proto-UI';
+const REPO_GIT_URL = 'git+https://github.com/Proto-UI/Proto-UI.git';
+const BUGS_URL = 'https://github.com/Proto-UI/Proto-UI/issues';
+const RELEASE_VERSION = readFileSync(join(ROOT_DIR, 'VERSION'), 'utf8').trim();
 
 const PACKAGE_RULES = {
   '@proto.ui/core': {
@@ -66,6 +66,14 @@ const PACKAGE_RULES = {
   '@proto.ui/adapter-react': adapterRule('React'),
   '@proto.ui/adapter-vue': adapterRule('Vue'),
   '@proto.ui/adapter-web-component': adapterRule('Web Components'),
+  '@proto.ui/cli': {
+    description:
+      'Proto UI command line tooling for initialization, component facade generation, and style presets.',
+    kind: 'cli',
+    purpose:
+      'Provides command line tooling for initializing Proto UI workspaces and generating framework integration assets.',
+    role: 'CLI package used by applications and maintainers to scaffold Proto UI configuration and generated files.',
+  },
   '@proto.ui/prototypes-base': {
     description: 'Base Proto UI prototype library for reusable interaction prototypes.',
     kind: 'prototype-lib',
@@ -152,6 +160,7 @@ function buildKeywords(pkg, rule) {
   }
   if (rule.kind === 'module' || rule.kind === 'module-base') keywords.add('module');
   if (rule.kind === 'adapter' || rule.kind === 'adapter-base') keywords.add('adapter');
+  if (rule.kind === 'cli') keywords.add('cli');
   if (rule.kind === 'prototype-lib') keywords.add('prototype-library');
   if (rule.target) keywords.add(String(rule.target).toLowerCase().replace(/\s+/g, '-'));
   if (rule.style) keywords.add(String(rule.style).toLowerCase().replace(/\s+/g, '-'));


### PR DESCRIPTION
## Summary

Fix the release workflow to use npm Trusted Publishing through GitHub Actions OIDC instead of token-based npm publishing.

## Changes

- Removed `registry-url` from `actions/setup-node` so the workflow no longer creates a token-style npm config.
- Added a publish-mode runtime guard that installs `npm@11`, verifies `npm >= 11.5.1`, and fails if `NODE_AUTH_TOKEN` or `NPM_TOKEN` is present.
- Updated release workflow comments to reflect the actual OIDC publish path.
- Updated all `@proto.ui/*` package metadata to point to `Proto-UI/Proto-UI`, matching the npm trusted publisher configuration.
- Fixed `scripts/release/sync-metadata.mjs` so it reads the release version from `VERSION` and includes metadata rules for `@proto.ui/cli`.

## Root Cause

The release workflow claimed to use OIDC trusted publishing, but `actions/setup-node` was still configured with `registry-url`, and the failed job had `NODE_AUTH_TOKEN` in the environment. That made the publish path behave like token-based npm publishing instead of a clean OIDC trusted-publishing flow.

The package metadata also still referenced the old GitHub repository, while npm trusted publisher settings are configured for `Proto-UI/Proto-UI`.

## Validation

- Parsed `.github/workflows/release-packages.yml` successfully.
- Ran `node scripts/release/check-lockstep.mjs`.
- Ran `corepack pnpm@10.32.1 -s release:stage -- --only @proto.ui/cli`.
