### PR TITLE
Feat/cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,21 +329,21 @@ jobs:
 
           # React facade per onboarding decision §4.5
           grep -q "createReactAdapter(React)" proto-ui/components/react/index.ts
-          grep -q "export const Button = adapt(shadcnButton)" proto-ui/components/react/index.ts
+          grep -q "export const ShadcnButton = adapt(shadcnButton)" proto-ui/components/react/index.ts
           grep -q "export const BaseButton = adapt(button)" proto-ui/components/react/index.ts
 
           # Vue facade
           grep -q "createVueAdapter(Vue)" proto-ui/components/vue/index.ts
-          grep -q "export const Button = adapt(shadcnButton)" proto-ui/components/vue/index.ts
+          grep -q "export const ShadcnButton = adapt(shadcnButton)" proto-ui/components/vue/index.ts
 
           # Web Component facade
           grep -q "AdaptToWebComponent(shadcnButton" proto-ui/components/wc/index.ts
 
           # Host-prefixed root re-export per onboarding decision §4.6
-          grep -q "Button as ReactButton" proto-ui/components/index.ts
+          grep -q "ShadcnButton as ReactShadcnButton" proto-ui/components/index.ts
           grep -q "BaseButton as ReactBaseButton" proto-ui/components/index.ts
-          grep -q "Button as VueButton" proto-ui/components/index.ts
-          grep -q "ButtonElement } from './wc'" proto-ui/components/index.ts
+          grep -q "ShadcnButton as VueShadcnButton" proto-ui/components/index.ts
+          grep -q "ShadcnButtonElement } from './wc'" proto-ui/components/index.ts
 
           # All adapter + prototype packages must actually be installed end-to-end
           test -d node_modules/@proto.ui/adapter-react

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -198,7 +198,7 @@ jobs:
           # which the commit+tag step downstream consumes. publish-single
           # is patch-only by contract; the script bumps patch unconditionally.
           TARGETS=$(echo "${{ inputs.only }}" | tr ',' ' ')
-          node scripts/release/bump-version.mjs -- $TARGETS
+          node scripts/release/bump-version.mjs --prefer-published -- $TARGETS
           node scripts/release/check-lockstep.mjs
 
       - name: Run Release Command

--- a/packages/adapters/vue/src/adapt.ts
+++ b/packages/adapters/vue/src/adapt.ts
@@ -28,12 +28,12 @@ export type VueRuntime = VueRenderRuntime & {
   defineComponent: (opt: any) => any;
   h: (type: any, props?: any, children?: any) => any;
   Teleport?: any;
-  ref: <T>(v: T) => { value: any };
-  shallowRef: <T>(v: T) => { value: any };
-  watch: (...args: any[]) => any;
+  ref: <T>(v: T) => { value: T };
+  shallowRef: <T>(v: T) => { value: T };
+  watch: (source: any, cb: (...args: any[]) => void | Promise<void>, options?: any) => unknown;
   onMounted: (cb: () => void) => void;
   onBeforeUnmount: (cb: () => void) => void;
-  nextTick: (...args: any[]) => Promise<any>;
+  nextTick: (fn?: () => void) => Promise<void>;
 };
 
 export type VueAdapterHandle = {

--- a/packages/adapters/vue/test/framework-contract.test.ts
+++ b/packages/adapters/vue/test/framework-contract.test.ts
@@ -65,10 +65,10 @@ describe('adapter-vue: framework contract', () => {
         return { type, props, children };
       },
       ref<T>(value: T) {
-        return { value: value as unknown };
+        return { value };
       },
       shallowRef<T>(value: T) {
-        return { value: value as unknown };
+        return { value };
       },
       watch: (() => () => {}) as VueStyleWatch,
       onMounted() {},

--- a/packages/adapters/web-component/src/feedback-style.ts
+++ b/packages/adapters/web-component/src/feedback-style.ts
@@ -2,6 +2,8 @@ import { mergeTwTokensV0 } from '@proto.ui/core';
 
 const KEY = '__proto_ui_applied_style_tokens_v0__';
 export const PUI_STYLE_ATTR = 'data-pui-style';
+const SETUP_STYLE_SOURCE = Symbol('proto-ui.setup-style');
+const ownedTokensByHost = new WeakMap<HTMLElement, Map<unknown, Set<string>>>();
 
 /**
  * v0 compatibility helper: map style tokens onto the Proto UI style attribute.
@@ -9,16 +11,15 @@ export const PUI_STYLE_ATTR = 'data-pui-style';
 export function applyStyleTokensToHost(el: HTMLElement, tokens: string[]) {
   const merged = mergeTwTokensV0(tokens).tokens;
   (el as any)[KEY] = merged;
-  setStyleAttribute(el, merged);
+  applyOwnedStyleTokens(el, SETUP_STYLE_SOURCE, merged);
 }
 
 export function applyFeedbackStyleTokensToHost(el: HTMLElement, tokens: string[]): () => void {
-  const previous = el.getAttribute(PUI_STYLE_ATTR);
-  setStyleAttribute(el, normalizeTokens(tokens));
+  const source = Symbol('proto-ui.feedback-style');
+  applyOwnedStyleTokens(el, source, tokens);
 
   return () => {
-    if (previous == null) el.removeAttribute(PUI_STYLE_ATTR);
-    else el.setAttribute(PUI_STYLE_ATTR, previous);
+    clearOwnedStyleTokens(el, source);
   };
 }
 
@@ -49,19 +50,20 @@ export function createOwnedTwTokenApplier(
   host: HTMLElement,
   hooks: { onChange?: () => void } = {}
 ): OwnedTokenApplier {
+  const source = Symbol('proto-ui.owned-style');
   let owned = new Set<string>();
 
   const apply = (nextTokens: string[]) => {
     const nextList = normalizeTokens(nextTokens);
     const nextSet = new Set<string>(nextList);
 
-    setStyleAttribute(host, nextList);
+    applyOwnedStyleTokens(host, source, nextList);
     owned = nextSet;
     hooks.onChange?.();
   };
 
   const clear = () => {
-    host.removeAttribute(PUI_STYLE_ATTR);
+    clearOwnedStyleTokens(host, source);
     owned = new Set<string>();
     hooks.onChange?.();
   };
@@ -89,4 +91,53 @@ function setStyleAttribute(el: HTMLElement, tokens: readonly string[]) {
   } else {
     el.removeAttribute(PUI_STYLE_ATTR);
   }
+}
+
+function applyOwnedStyleTokens(el: HTMLElement, source: unknown, tokens: readonly string[]) {
+  const owners = ownedTokensByHost.get(el) ?? new Map<unknown, Set<string>>();
+  const previouslyOwned = collectOwnedTokens(owners);
+  const normalized = new Set(normalizeTokens(tokens));
+  if (normalized.size > 0) owners.set(source, normalized);
+  else owners.delete(source);
+  ownedTokensByHost.set(el, owners);
+  rewriteStyleAttribute(el, owners, previouslyOwned);
+  if (owners.size === 0) ownedTokensByHost.delete(el);
+}
+
+function clearOwnedStyleTokens(el: HTMLElement, source: unknown) {
+  const owners = ownedTokensByHost.get(el);
+  if (!owners) return;
+  const previouslyOwned = collectOwnedTokens(owners);
+  owners.delete(source);
+  rewriteStyleAttribute(el, owners, previouslyOwned);
+  if (owners.size === 0) ownedTokensByHost.delete(el);
+}
+
+function collectOwnedTokens(owners: Map<unknown, Set<string>>) {
+  const out = new Set<string>();
+  for (const tokens of owners.values()) {
+    for (const token of tokens) out.add(token);
+  }
+  return out;
+}
+
+function rewriteStyleAttribute(
+  el: HTMLElement,
+  owners: Map<unknown, Set<string>>,
+  previouslyOwned: ReadonlySet<string>
+) {
+  const current = normalizeTokens((el.getAttribute(PUI_STYLE_ATTR) ?? '').split(/\s+/));
+  const external = current.filter((token) => !previouslyOwned.has(token));
+  const next = [...external];
+  const seen = new Set(next);
+
+  for (const tokens of owners.values()) {
+    for (const token of tokens) {
+      if (seen.has(token)) continue;
+      seen.add(token);
+      next.push(token);
+    }
+  }
+
+  setStyleAttribute(el, next);
 }

--- a/packages/adapters/web-component/test/feedback-style.test.ts
+++ b/packages/adapters/web-component/test/feedback-style.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { createOwnedTwTokenApplier } from '../src/feedback-style';
+import {
+  applyFeedbackStyleTokensToHost,
+  applyStyleTokensToHost,
+  createOwnedTwTokenApplier,
+} from '../src/feedback-style';
 
 describe('adapter-web-component: owned tw tokens applier', () => {
   it('apply adds tokens to data-pui-style and does not touch user classes', () => {
@@ -30,6 +34,58 @@ describe('adapter-web-component: owned tw tokens applier', () => {
 
     // user class preserved
     expect(host.classList.contains('user-a')).toBe(true);
+  });
+
+  it('preserves tokens owned by other internal sources when replacing or clearing', () => {
+    const host = document.createElement('div');
+    host.setAttribute('data-pui-style', 'external-token');
+
+    applyStyleTokensToHost(host, ['inline-flex', 'rounded-md']);
+    const clearFeedback = applyFeedbackStyleTokensToHost(host, ['opacity-50']);
+
+    expect(host.getAttribute('data-pui-style')?.split(/\s+/)).toEqual([
+      'external-token',
+      'inline-flex',
+      'rounded-md',
+      'opacity-50',
+    ]);
+
+    clearFeedback();
+
+    expect(host.getAttribute('data-pui-style')?.split(/\s+/)).toEqual([
+      'external-token',
+      'inline-flex',
+      'rounded-md',
+    ]);
+
+    applyStyleTokensToHost(host, ['inline-flex']);
+
+    expect(host.getAttribute('data-pui-style')?.split(/\s+/)).toEqual([
+      'external-token',
+      'inline-flex',
+    ]);
+  });
+
+  it('keeps duplicated tokens while another owner still owns them', () => {
+    const host = document.createElement('div');
+    const base = createOwnedTwTokenApplier(host);
+    const transient = createOwnedTwTokenApplier(host);
+
+    base.apply(['inline-flex', 'opacity-50']);
+    transient.apply(['opacity-50', 'bg-red-500']);
+
+    expect(host.getAttribute('data-pui-style')?.split(/\s+/)).toEqual([
+      'inline-flex',
+      'opacity-50',
+      'bg-red-500',
+    ]);
+
+    transient.clear();
+
+    expect(host.getAttribute('data-pui-style')?.split(/\s+/)).toEqual([
+      'inline-flex',
+      'opacity-50',
+    ]);
   });
 
   it('apply([]) clears all owned tokens', () => {

--- a/packages/cli/src/legacy/cli.ts
+++ b/packages/cli/src/legacy/cli.ts
@@ -59,7 +59,11 @@ export async function run(argv) {
     return;
   }
 
-  if (command === 'style' || command === 'tailwindcss') {
+  if (command === 'tailwindcss') {
+    throw new Error('The tailwindcss command has been removed. Use `proto-ui style` instead.');
+  }
+
+  if (command === 'style') {
     await runGenerateStyleCss(rest);
     return;
   }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -80,11 +80,41 @@ describe('@proto.ui/cli', () => {
 
     expect(tokensCss).toContain(`[data-pui-style~="bg-primary"]`);
     expect(tokensCss).not.toContain('@source');
+    expect(tokensCss).not.toContain('Unsupported Proto UI style tokens');
     expect(styleCss).toContain(`@import './shadcn-theme.css';`);
     expect(styleCss).toContain(`@import './proto-ui-tokens.generated.css';`);
     expect(themeCss).toContain('--pui-background');
     expect(themeCss).not.toContain('--background:');
     await expect(fs.stat(path.join(cwd, 'src/styles/shadcn-theme.css'))).resolves.toBeTruthy();
+  });
+
+  it('renders the official prototype token set without unsupported-token comments', async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'pui-cli-token-coverage-'));
+    const outFile = path.join(cwd, 'proto-ui-tokens.generated.css');
+
+    const result = runCli(process.cwd(), [
+      'tokens',
+      '--input',
+      'packages/prototypes',
+      '--out',
+      outFile,
+    ]);
+
+    expect(result.status).toBe(0);
+
+    const tokensCss = await fs.readFile(outFile, 'utf8');
+    expect(tokensCss).toContain(`[data-pui-style~="bg-primary"]`);
+    expect(tokensCss).toContain(`[data-pui-style~="rounded-md"]`);
+    expect(tokensCss).not.toContain('Unsupported Proto UI style tokens');
+  }, 30_000);
+
+  it('rejects the removed tailwindcss command with an explicit migration message', () => {
+    const result = runCli(process.cwd(), ['tailwindcss', '--out', './unused.css']);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'The tailwindcss command has been removed. Use `proto-ui style` instead.'
+    );
   });
 
   it('adds a React facade without installing packages when --no-install is used', async () => {

--- a/scripts/release/bump-version.mjs
+++ b/scripts/release/bump-version.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { findProtoPackages, getRoot } from './version-utils.mjs';
 
@@ -9,8 +10,25 @@ import { findProtoPackages, getRoot } from './version-utils.mjs';
 // from this script, which it intentionally is not.
 const args = process.argv.slice(2);
 const targets = [];
-for (const arg of args) {
+let preferPublished = false;
+let registry = '';
+let publishedVersionsFile = '';
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
   if (arg === '--') continue;
+  if (arg === '--prefer-published') {
+    preferPublished = true;
+    continue;
+  }
+  if (arg === '--registry') {
+    registry = args[++i] ?? '';
+    continue;
+  }
+  if (arg === '--published-versions-file') {
+    publishedVersionsFile = args[++i] ?? '';
+    preferPublished = true;
+    continue;
+  }
   targets.push(arg);
 }
 
@@ -39,7 +57,12 @@ for (const name of targets) {
     process.exit(1);
   }
   const [, major, minor, patch] = match;
-  const next = `${major}.${minor}.${Number(patch) + 1}`;
+  const localPatch = Number(patch);
+  const publishedPatch = preferPublished
+    ? highestPublishedPatch(name, major, minor, { registry, publishedVersionsFile })
+    : null;
+  const basePatch = Math.max(localPatch, publishedPatch ?? -1);
+  const next = `${major}.${minor}.${basePatch + 1}`;
   plan.push({ pkg, name, current, next });
 }
 
@@ -55,3 +78,41 @@ for (const entry of plan) {
 const summaryPath = join(getRoot(), 'release-bump.json');
 writeFileSync(summaryPath, `${JSON.stringify({ bumped }, null, 2)}\n`);
 console.log(`bump-version: wrote summary to ${summaryPath}`);
+
+function highestPublishedPatch(name, major, minor, options) {
+  const versions = loadPublishedVersions(name, options);
+  let highest = null;
+  for (const version of versions) {
+    const match = String(version).match(/^(\d+)\.(\d+)\.(\d+)$/);
+    if (!match) continue;
+    if (match[1] !== major || match[2] !== minor) continue;
+    const patch = Number(match[3]);
+    highest = highest == null ? patch : Math.max(highest, patch);
+  }
+  return highest;
+}
+
+function loadPublishedVersions(name, options) {
+  if (options.publishedVersionsFile) {
+    const data = JSON.parse(readFileSync(options.publishedVersionsFile, 'utf8'));
+    return data[name] ?? [];
+  }
+
+  const viewArgs = ['view', name, 'versions', '--json'];
+  if (options.registry) viewArgs.push('--registry', options.registry);
+  const result = spawnSync('npm', viewArgs, {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.status !== 0) {
+    const output = `${result.stderr}\n${result.stdout}`;
+    if (/E404|404 Not Found|not found/i.test(output)) return [];
+    console.error(`bump-version: failed to read published versions for ${name}`);
+    console.error(output.trim());
+    process.exit(1);
+  }
+
+  const parsed = JSON.parse(result.stdout || '[]');
+  return Array.isArray(parsed) ? parsed : [parsed];
+}

--- a/scripts/release/test/bump-version.test.mjs
+++ b/scripts/release/test/bump-version.test.mjs
@@ -70,6 +70,33 @@ test('bumps multiple packages by patch', () => {
   }
 });
 
+test('prefers the highest published patch in the same minor when requested', () => {
+  const root = makeFixture({
+    version: '0.1.0',
+    packages: [{ relPath: 'cli', name: '@proto.ui/cli', version: '0.1.1' }],
+  });
+  try {
+    const versionsPath = join(root, 'published-versions.json');
+    writeFileSync(
+      versionsPath,
+      `${JSON.stringify({ '@proto.ui/cli': ['0.1.0', '0.1.2', '0.2.0'] }, null, 2)}\n`
+    );
+
+    const result = runBump(root, [
+      '--prefer-published',
+      '--published-versions-file',
+      versionsPath,
+      '--',
+      '@proto.ui/cli',
+    ]);
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(readManifestVersion(root, 'cli'), '0.1.3');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('writes release-bump.json summary in cwd', () => {
   const root = makeFixture({
     version: '0.1.0',


### PR DESCRIPTION
## Summary

Fix `publish-single` release jobs so they do not try to republish an npm version that already exists.

## What Changed

- Updated the `publish-single` workflow to patch-bump against published npm versions, not only the local package version.
- Added `--prefer-published` support to `scripts/release/bump-version.mjs`.
- When enabled, the bump script now:
  - reads published versions from npm,
  - finds the highest published patch in the same major/minor line,
  - bumps to the next available patch.
- Added regression coverage for the case where local `@proto.ui/cli` is `0.1.1` but npm already has `0.1.2`.

## Why

The previous workflow bumped only from the local manifest version. If a previous publish succeeded but the release commit/tag did not land, rerunning `publish-single` could try to publish the same version again.

In the observed failure, npm already had `@proto.ui/cli@0.1.2`, but the workflow still attempted to publish `0.1.2`.

With this change, the same scenario bumps to `0.1.3` instead.

## Verification

```sh
corepack pnpm@10.32.1 exec node --test scripts/release/test/*.test.mjs
corepack pnpm@10.32.1 exec prettier --check .github/workflows/release-packages.yml scripts/release/bump-version.mjs scripts/release/test/bump-version.test.mjs
```