### PR TITLE
fix: publish workspace dependencies as package ranges

### DIFF
--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -338,6 +338,7 @@ export function stagePackage(pkg, options) {
     maxPublishRetries = 2,
     retryDelayMs = 15000,
     publishSequenceIndex = 0,
+    packageVersions = new Map(),
   } = options;
   const stageDir = join(outDir, sanitizePackageName(pkg.name));
   const npmCacheDir = join(tmpdir(), 'proto-ui-npm-cache');
@@ -380,7 +381,7 @@ export function stagePackage(pkg, options) {
   });
 
   const buildErrors = collectNonEmptyLines(`${buildResult.stdout}\n${buildResult.stderr}`);
-  const manifest = createPublishManifest(pkg, { version, access });
+  const manifest = createPublishManifest(pkg, { version, access, packageVersions });
   writeFileSync(join(stageDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
   writeSupportingFiles(pkg, stageDir);
 
@@ -508,7 +509,7 @@ export function stagePackage(pkg, options) {
 }
 
 export function createPublishManifest(pkg, options) {
-  const { version, access } = options;
+  const { version, access, packageVersions = new Map() } = options;
   const manifest = JSON.parse(JSON.stringify(pkg.manifest));
 
   delete manifest.private;
@@ -548,12 +549,18 @@ export function createPublishManifest(pkg, options) {
     if (!manifest[field]) continue;
     for (const [name, depVersion] of Object.entries(manifest[field])) {
       if (String(depVersion).startsWith('workspace:')) {
-        manifest[field][name] = version ?? pkg.version;
+        manifest[field][name] = toPublishedWorkspaceRange(
+          packageVersions.get(name) ?? version ?? pkg.version
+        );
       }
     }
   }
 
   return manifest;
+}
+
+function toPublishedWorkspaceRange(version) {
+  return `^${version}`;
 }
 
 function rewriteManifestField(manifest, field) {

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -78,6 +78,9 @@ const selected = selectPackages(packages, {
   launchGovernance,
 });
 const ordered = topoSortPackages(selected);
+const packageVersions = new Map(
+  packages.map((pkg) => [pkg.name, args.version ?? pkg.manifest.version ?? pkg.version])
+);
 
 if (ordered.length === 0) {
   console.error('No packages selected.');
@@ -113,6 +116,7 @@ const results = [];
 for (const [index, pkg] of ordered.entries()) {
   const result = stagePackage(pkg, {
     ...args,
+    packageVersions,
     publishSequenceIndex: index,
   });
   results.push(result);

--- a/scripts/release/test/publish-manifest.test.mjs
+++ b/scripts/release/test/publish-manifest.test.mjs
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createPublishManifest } from '../lib.mjs';
+
+test('workspace dependencies use their own package versions when publishing a single package', () => {
+  const manifest = createPublishManifest(
+    {
+      name: '@proto.ui/adapter-react',
+      version: '0.1.1',
+      manifest: {
+        name: '@proto.ui/adapter-react',
+        version: '0.1.1',
+        type: 'module',
+        dependencies: {
+          '@proto.ui/core': 'workspace:*',
+          '@proto.ui/runtime': 'workspace:*',
+        },
+        peerDependencies: {
+          '@proto.ui/types': 'workspace:*',
+        },
+        exports: {
+          '.': {
+            types: './src/index.ts',
+            default: './src/index.ts',
+          },
+        },
+      },
+    },
+    {
+      access: 'public',
+      packageVersions: new Map([
+        ['@proto.ui/adapter-react', '0.1.1'],
+        ['@proto.ui/core', '0.1.0'],
+        ['@proto.ui/runtime', '0.1.0'],
+        ['@proto.ui/types', '0.1.0'],
+      ]),
+    }
+  );
+
+  assert.equal(manifest.version, '0.1.1');
+  assert.equal(manifest.dependencies['@proto.ui/core'], '^0.1.0');
+  assert.equal(manifest.dependencies['@proto.ui/runtime'], '^0.1.0');
+  assert.equal(manifest.peerDependencies['@proto.ui/types'], '^0.1.0');
+});


### PR DESCRIPTION
## Summary

Fix release CI behavior for `publish-single`.

## What Changed

- `publish-single` now avoids republishing an already published npm version.
  - The bump step can read published npm versions.
  - It bumps from the highest published patch in the same major/minor line when needed.
  - Example: local `@proto.ui/cli@0.1.1` + npm already has `0.1.2` => next publish uses `0.1.3`.

- Published manifests now rewrite `workspace:*` dependencies to the dependency package’s own version range.
  - Before: publishing `@proto.ui/adapter-react@0.1.1` rewrote all internal deps to `0.1.1`.
  - After: internal deps use their actual package versions, e.g. `^0.1.0`.
  - This prevents published packages from depending on internal package versions that were never published.

## Why

Two release failures were possible in `publish-single`:

1. A previous publish could succeed but the release commit/tag might not land, causing a rerun to attempt the same npm version again.
2. A single bumped package could publish with incorrect internal dependency versions, pointing at non-existent package versions.

## Verification

```sh
corepack pnpm@10.32.1 exec node --test scripts/release/test/*.test.mjs
corepack pnpm@10.32.1 exec prettier --check .github/workflows/release-packages.yml scripts/release/bump-version.mjs scripts/release/lib.mjs scripts/release/publish.mjs scripts/release/test/bump-version.test.mjs scripts/release/test/publish-manifest.test.mjs
