### PR TITLE
feat(workspace): Props Contacts

### DIFF
--- a/apps/workspace/PHASE-PLAN.zh-CN.md
+++ b/apps/workspace/PHASE-PLAN.zh-CN.md
@@ -44,6 +44,9 @@ Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和
 - `C-PROPS-0002`：Props API surface
   - 已通过 `T-PROPS-0010` 固定 `def.props` / `run.props` 的最小 API surface 与阶段边界。
   - 不再承接 render commit 调度语义；该断口转移到 `C-PROPS-0014` 与未来 core runtime/update 契约。
+- `C-PROPS-0014`：runtime `applyRawProps` boundary
+  - 已通过 `T-PROPS-0011` 映射到 runtime props integration 与 run props wiring 测试。
+  - 只声明 `applyRawProps` 可以更新 Props channel、触发 watcher，但不得隐式 render commit；`run.update()` 与 render commit 的正向调度规则保留为 core runtime/update 断口。
 
 这个阶段证明了 Workspace 的核心链路可以工作：
 
@@ -92,14 +95,14 @@ Contract -> Criteria -> T entity -> shared fixture / conformance harness -> modu
 
 | 优先级 | 契约 | 判断 | 计划 |
 | --- | --- | --- | --- |
-| P0 | `C-PROPS-0014` applyRawProps updates the props channel without implicit render commit | 当前仍是 draft/deferred，且牵涉 runtime update / render commit 的上游契约。 | 先判断是否需要拆出 `C-CORE-RUNTIME-*` 或 `C-CORE-UPDATE-*`，再决定 0014 是否保留为 Props-specific refinement。 |
 | P1 | `C-PROPS-0005` Setup-time prop declarations are mergeable plans | 高层 mergeable plan 契约仍需要与 `0006/0007/0010` 对齐。 | 回扫 criteria，确保它只表达“可合并计划”的上层语义，不重复写具体 merge rules。 |
 | P1 | `C-CORE-SYNTAX-0001` / `C-CORE-SYNTAX-0002` | `def handle` 与 `run handle` 仍为 draft，但 Props 已经大量依赖它们。 | 后续应补核心语法测试或至少补 cross-reference，避免 Props 契约承担过多 core 语义。 |
+| P1 | Core runtime/update contract | `run.update()` 与 render commit 是不同层级的 API，目前只在 Props 0014 留了断口。 | 后续新建 core runtime/update 契约，承接主动更新与 commit 调度的正向语义。 |
 
 暂缓推进或需要回收的项：
 
 - `C-PROPS-0001`：偏哲学/通路身份，更多作为上游引用，不适合作为测试链路主线。
-- `C-PROPS-0002/0003/0004/0006/0007/0008/0009/0010/0011/0012/0013`：已进入 active，但后续仍需要跟随实现变更回扫 wording 与 coverage。
+- `C-PROPS-0002/0003/0004/0006/0007/0008/0009/0010/0011/0012/0013/0014`：已进入 active，但后续仍需要跟随实现变更回扫 wording 与 coverage。
 - `C-CORE-VALUE-0001`：`null` canonical empty value 仍为 draft；它是 Props 多条契约的上游，应在 Props 回扫后补强。
 
 交付物：
@@ -151,5 +154,5 @@ Contract -> Criteria -> T entity -> shared fixture / conformance harness -> modu
 - 回看所有 `C-PROPS-*` 的边界是否仍然合理。
 - 将“范围过大”的 `C-PROPS` 拆分或降级为上游/总契约。
 - 将暂缓项保留为明确 open question 或 deferred tag，避免 draft 堆积后遗失上下文。
-- 优先处理 `C-PROPS-0014`：它决定 props update 与 render commit 的 runtime/core 边界。
+- 优先处理 `C-PROPS-0005` 与 core syntax/update 断口：`0005` 是 Props declaration mergeable plans 的高层语义，core update contract 则承接 `run.update()` 与 render commit 的正向规则。
 - 同步补强 `C-CORE-SYNTAX-0001/0002` 与 `C-CORE-VALUE-0001`，避免 Props 契约继续承载过多核心语法和核心 value 语义。

--- a/apps/workspace/PHASE-PLAN.zh-CN.md
+++ b/apps/workspace/PHASE-PLAN.zh-CN.md
@@ -41,6 +41,9 @@ Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和
 - `C-PROPS-0006` / `C-PROPS-0007` / `C-PROPS-0010`：declaration descriptor shape、merge safety 与 failed merge atomicity
   - 已通过 `T-PROPS-0003`、`T-PROPS-0004` 映射到 define merge module tests。
   - 保留断口：`validator` 作为函数型 descriptor 字段是否属于 portable Props declaration 仍需后续讨论。
+- `C-PROPS-0002`：Props API surface
+  - 已通过 `T-PROPS-0010` 固定 `def.props` / `run.props` 的最小 API surface 与阶段边界。
+  - 不再承接 render commit 调度语义；该断口转移到 `C-PROPS-0014` 与未来 core runtime/update 契约。
 
 这个阶段证明了 Workspace 的核心链路可以工作：
 
@@ -89,7 +92,6 @@ Contract -> Criteria -> T entity -> shared fixture / conformance harness -> modu
 
 | 优先级 | 契约 | 判断 | 计划 |
 | --- | --- | --- | --- |
-| P0 | `C-PROPS-0002` Props defines setup-time declaration and runtime access surfaces | API surface 总契约仍是 draft；其子契约已经补齐不少，可以开始回收边界。 | 回看 `0005/0008/0011/0012/0013/0014` 后，决定哪些 API shape 写入 `0002`，哪些只作为子契约细化。 |
 | P0 | `C-PROPS-0014` applyRawProps updates the props channel without implicit render commit | 当前仍是 draft/deferred，且牵涉 runtime update / render commit 的上游契约。 | 先判断是否需要拆出 `C-CORE-RUNTIME-*` 或 `C-CORE-UPDATE-*`，再决定 0014 是否保留为 Props-specific refinement。 |
 | P1 | `C-PROPS-0005` Setup-time prop declarations are mergeable plans | 高层 mergeable plan 契约仍需要与 `0006/0007/0010` 对齐。 | 回扫 criteria，确保它只表达“可合并计划”的上层语义，不重复写具体 merge rules。 |
 | P1 | `C-CORE-SYNTAX-0001` / `C-CORE-SYNTAX-0002` | `def handle` 与 `run handle` 仍为 draft，但 Props 已经大量依赖它们。 | 后续应补核心语法测试或至少补 cross-reference，避免 Props 契约承担过多 core 语义。 |
@@ -97,7 +99,7 @@ Contract -> Criteria -> T entity -> shared fixture / conformance harness -> modu
 暂缓推进或需要回收的项：
 
 - `C-PROPS-0001`：偏哲学/通路身份，更多作为上游引用，不适合作为测试链路主线。
-- `C-PROPS-0003/0004/0006/0007/0008/0009/0010/0011/0012/0013`：已进入 active，但后续仍需要跟随实现变更回扫 wording 与 coverage。
+- `C-PROPS-0002/0003/0004/0006/0007/0008/0009/0010/0011/0012/0013`：已进入 active，但后续仍需要跟随实现变更回扫 wording 与 coverage。
 - `C-CORE-VALUE-0001`：`null` canonical empty value 仍为 draft；它是 Props 多条契约的上游，应在 Props 回扫后补强。
 
 交付物：
@@ -149,5 +151,5 @@ Contract -> Criteria -> T entity -> shared fixture / conformance harness -> modu
 - 回看所有 `C-PROPS-*` 的边界是否仍然合理。
 - 将“范围过大”的 `C-PROPS` 拆分或降级为上游/总契约。
 - 将暂缓项保留为明确 open question 或 deferred tag，避免 draft 堆积后遗失上下文。
-- 优先处理 `C-PROPS-0002` 与 `C-PROPS-0014`：前者决定 Props API surface 的总边界，后者决定 props update 与 render commit 的 runtime/core 边界。
+- 优先处理 `C-PROPS-0014`：它决定 props update 与 render commit 的 runtime/core 边界。
 - 同步补强 `C-CORE-SYNTAX-0001/0002` 与 `C-CORE-VALUE-0001`，避免 Props 契约继续承载过多核心语法和核心 value 语义。

--- a/apps/workspace/PHASE-PLAN.zh-CN.md
+++ b/apps/workspace/PHASE-PLAN.zh-CN.md
@@ -1,6 +1,6 @@
 # Proto UI Workspace 阶段性目标
 
-> 当前版本：2026-05-17 更新
+> 当前版本：2026-05-18 更新
 
 Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和测试，而是先打通一条真实可用的治理链路：
 
@@ -23,7 +23,7 @@ Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和
 
 ## 当前进展
 
-截至 2026-05-17，第一条 Props 契约测试链路已经跑通：
+截至 2026-05-18，Props 契约测试链路已经从单契约闭环扩展到几个小域：
 
 - `C-PROPS-0003`：Props values must be JSON values
   - 已通过 `T-PROPS-0001` 建立 JSON value boundary fixture。
@@ -32,6 +32,15 @@ Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和
   - 已通过 `T-PROPS-0005` 拆出 criteria-level cases。
   - 已落到 module focused test、runtime props wiring/integration，以及 React、Vue、Web Component adapter conformance 测试。
   - 保留断口：`resolved snapshot` 的深层语义只读更适合未来静态分析检查，v0 runtime 目前只验证浅层不可变。
+- `C-PROPS-0004` / `C-PROPS-0009`：per-key state classification 与 fallback resolution
+  - 已通过 `T-PROPS-0002`、`T-PROPS-0006` 建立 criteria-level mapping。
+  - 已落到 focused module tests，并保留历史测试作为 supporting coverage。
+- `C-PROPS-0011` / `C-PROPS-0012` / `C-PROPS-0013`：resolved watcher、raw escape hatch 与 watcher-time `run handle` binding
+  - 已通过 `T-PROPS-0007`、`T-PROPS-0008`、`T-PROPS-0009` 映射到 module/runtime 测试。
+  - `C-PROPS-0013` 已被重新定位为 `C-CORE-SYNTAX-0002` 的 Props-specific refinement。
+- `C-PROPS-0006` / `C-PROPS-0007` / `C-PROPS-0010`：declaration descriptor shape、merge safety 与 failed merge atomicity
+  - 已通过 `T-PROPS-0003`、`T-PROPS-0004` 映射到 define merge module tests。
+  - 保留断口：`validator` 作为函数型 descriptor 字段是否属于 portable Props declaration 仍需后续讨论。
 
 这个阶段证明了 Workspace 的核心链路可以工作：
 
@@ -61,7 +70,7 @@ Contract -> Criteria -> T entity -> shared fixture / conformance harness -> modu
 - 至少 1 个 `T-*` 不再只是占位，而是指向真实测试
 - Workspace 能看出哪些 criteria 已覆盖、哪些未覆盖
 
-当前判断：Phase 1 已完成，可以进入小域闭环。
+当前判断：Phase 1 已完成；Phase 2 已经覆盖 value boundary、resolution/fallback、watch/raw 和 define/merge 的主要可测链路。
 
 ## Phase 2：Props 小域闭环
 
@@ -80,21 +89,16 @@ Contract -> Criteria -> T entity -> shared fixture / conformance harness -> modu
 
 | 优先级 | 契约 | 判断 | 计划 |
 | --- | --- | --- | --- |
-| P0 | `C-PROPS-0009` Empty and invalid prop values resolve through deterministic fallback | 边界清晰，已有 `T-PROPS-0006` 占位和 `resolve-fallback` module 测试；与 `C-PROPS-0008` 已形成测试链路衔接。 | 下一条主线。先补 statement/criteria，再写实 `T-PROPS-0006`，最后补 module focused coverage 与必要 adapter/runtime exercises。 |
-| P0.5 | `C-PROPS-0004` Prop semantic state is classified per key | 是 `0009` 的前置语义，边界清晰，但独立测试价值主要体现在 `0009` 的输入分类中。 | 可在推进 `0009` 时顺手补 criteria，并让 `T-PROPS-0002` 记录分类覆盖；不必单独拉成一条长主线。 |
-| P1 | `C-PROPS-0011` Resolved props watchers observe resolved snapshot changes | watch 行为边界相对清晰，已有 `watch-resolved` 与 runtime integration 测试基础。 | 在 fallback 小域后推进。需要先补 criteria，再整理 `T-*`，尤其明确 hydration、Object.is、watchAll/watch(keys)、调用顺序。 |
-| P1 | `C-PROPS-0006` Prop declaration descriptors have constrained shape | setup-time descriptor 边界清晰，已有 define JSON boundary 和 shape/merge 相关测试基础。 | 适合作为 define 小域起点。需要把 descriptor shape 细节补进 criteria。 |
-| P2 | `C-PROPS-0007` Prop declaration merge preserves evolution safety | 可测试，但具体“breaking narrowing / widening traceable”的边界需要再次确认。 | 等 `0006` criteria 稳定后推进。 |
-| P2 | `C-PROPS-0010` Failed declaration merge must not partially apply | 边界清晰，适合测试 atomicity，但依赖 `0007` 的冲突定义。 | 跟随 `0007`，不单独提前。 |
+| P0 | `C-PROPS-0002` Props defines setup-time declaration and runtime access surfaces | API surface 总契约仍是 draft；其子契约已经补齐不少，可以开始回收边界。 | 回看 `0005/0008/0011/0012/0013/0014` 后，决定哪些 API shape 写入 `0002`，哪些只作为子契约细化。 |
+| P0 | `C-PROPS-0014` applyRawProps updates the props channel without implicit render commit | 当前仍是 draft/deferred，且牵涉 runtime update / render commit 的上游契约。 | 先判断是否需要拆出 `C-CORE-RUNTIME-*` 或 `C-CORE-UPDATE-*`，再决定 0014 是否保留为 Props-specific refinement。 |
+| P1 | `C-PROPS-0005` Setup-time prop declarations are mergeable plans | 高层 mergeable plan 契约仍需要与 `0006/0007/0010` 对齐。 | 回扫 criteria，确保它只表达“可合并计划”的上层语义，不重复写具体 merge rules。 |
+| P1 | `C-CORE-SYNTAX-0001` / `C-CORE-SYNTAX-0002` | `def handle` 与 `run handle` 仍为 draft，但 Props 已经大量依赖它们。 | 后续应补核心语法测试或至少补 cross-reference，避免 Props 契约承担过多 core 语义。 |
 
-暂缓推进：
+暂缓推进或需要回收的项：
 
 - `C-PROPS-0001`：偏哲学/通路身份，更多作为上游引用，不适合作为测试链路主线。
-- `C-PROPS-0002`：API surface 总契约，范围较大，应由 `0005`、`0008`、`0011`、`0012`、`0014` 等子契约反向收敛后再回修。
-- `C-PROPS-0005`：mergeable plans 的高层判断，需要和 `0006/0007/0010` 一起过。
-- `C-PROPS-0012`：raw escape hatch 可测，但属于非推荐 API，优先级低于 resolved/fallback/watch 主链路。
-- `C-PROPS-0013`：watcher callback `run handle` 绑定已有 runtime 测试基础，但依赖 `0011/0012` 的 watcher 语义稳定。
-- `C-PROPS-0014`：`applyRawProps` 与 render commit 的关系更接近 runtime/core update 契约，需要先明确是否拆出更上游的 runtime contract。
+- `C-PROPS-0003/0004/0006/0007/0008/0009/0010/0011/0012/0013`：已进入 active，但后续仍需要跟随实现变更回扫 wording 与 coverage。
+- `C-CORE-VALUE-0001`：`null` canonical empty value 仍为 draft；它是 Props 多条契约的上游，应在 Props 回扫后补强。
 
 交付物：
 
@@ -140,17 +144,10 @@ Contract -> Criteria -> T entity -> shared fixture / conformance harness -> modu
 
 ## 下一步
 
-从 `C-PROPS-0009` 开始：
-
-1. 补全 `C-PROPS-0009` 的 `statement` 和 criteria。
-2. 同步补一份轻量的 `C-PROPS-0004` criteria，作为 `0009` 的输入分类前置。
-3. 将 `T-PROPS-0006` 写实，拆出 missing、provided-empty、invalid、fallback order、prevValid、`empty="error"` 等 cases。
-4. 对照现有 `packages/modules/props/test/contract/resolve-fallback.v0.contract.test.ts`，将可确认的实现状态标为 passing。
-5. 检查是否需要新的 focused module test，避免历史测试过宽导致 coverage 难以阅读。
-6. 再判断 adapter/runtime 是否只作为 exercises，还是需要建立独立 conformance harness。
-
-完成 `0009` 后，进入一次回扫：
+进入一次 Props 回扫：
 
 - 回看所有 `C-PROPS-*` 的边界是否仍然合理。
 - 将“范围过大”的 `C-PROPS` 拆分或降级为上游/总契约。
 - 将暂缓项保留为明确 open question 或 deferred tag，避免 draft 堆积后遗失上下文。
+- 优先处理 `C-PROPS-0002` 与 `C-PROPS-0014`：前者决定 Props API surface 的总边界，后者决定 props update 与 render commit 的 runtime/core 边界。
+- 同步补强 `C-CORE-SYNTAX-0001/0002` 与 `C-CORE-VALUE-0001`，避免 Props 契约继续承载过多核心语法和核心 value 语义。

--- a/apps/workspace/PHASE-PLAN.zh-CN.md
+++ b/apps/workspace/PHASE-PLAN.zh-CN.md
@@ -1,6 +1,6 @@
 # Proto UI Workspace 阶段性目标
 
-> 当前版本：2026-05-11 草案
+> 当前版本：2026-05-17 更新
 
 Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和测试，而是先打通一条真实可用的治理链路：
 
@@ -21,14 +21,32 @@ Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和
 - 某个 Props 行为调整会影响哪些契约、测试、module 和 adapter 能力？
 - 哪些断口阻塞了契约从 draft 进入 active？
 
+## 当前进展
+
+截至 2026-05-17，第一条 Props 契约测试链路已经跑通：
+
+- `C-PROPS-0003`：Props values must be JSON values
+  - 已通过 `T-PROPS-0001` 建立 JSON value boundary fixture。
+  - 已落到 module resolved/define 测试，以及 React、Vue、Web Component adapter conformance 测试。
+- `C-PROPS-0008`：Runtime props resolution produces a declared-key resolved snapshot
+  - 已通过 `T-PROPS-0005` 拆出 criteria-level cases。
+  - 已落到 module focused test、runtime props wiring/integration，以及 React、Vue、Web Component adapter conformance 测试。
+  - 保留断口：`resolved snapshot` 的深层语义只读更适合未来静态分析检查，v0 runtime 目前只验证浅层不可变。
+
+这个阶段证明了 Workspace 的核心链路可以工作：
+
+```text
+Contract -> Criteria -> T entity -> shared fixture / conformance harness -> module/runtime/adapter tests
+```
+
 ## Phase 1：单契约闭环
 
 目标：选 1-2 条边界清晰的 Props 契约，把契约到测试的最小链路跑通。
 
-建议起点：
+已完成起点：
 
 - `C-PROPS-0003`：Props values must be JSON values
-- 备选：`C-PROPS-0008`：Runtime props resolution produces a declared-key resolved snapshot
+- `C-PROPS-0008`：Runtime props resolution produces a declared-key resolved snapshot
 
 交付物：
 
@@ -43,6 +61,8 @@ Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和
 - 至少 1 个 `T-*` 不再只是占位，而是指向真实测试
 - Workspace 能看出哪些 criteria 已覆盖、哪些未覆盖
 
+当前判断：Phase 1 已完成，可以进入小域闭环。
+
 ## Phase 2：Props 小域闭环
 
 目标：扩展到一个小型 Props 语义域，而不是整个 Props 系统。
@@ -53,6 +73,28 @@ Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和
 - resolution：declared key、raw/resolved、null normalization
 - fallback：missing、empty、invalid、prevValid
 - watch：watchAll、watch(keys)、Object.is、hydration
+
+### 下一批候选筛选
+
+优先选择边界明确、可测试、已有工程落点或可复用 conformance harness 的契约。
+
+| 优先级 | 契约 | 判断 | 计划 |
+| --- | --- | --- | --- |
+| P0 | `C-PROPS-0009` Empty and invalid prop values resolve through deterministic fallback | 边界清晰，已有 `T-PROPS-0006` 占位和 `resolve-fallback` module 测试；与 `C-PROPS-0008` 已形成测试链路衔接。 | 下一条主线。先补 statement/criteria，再写实 `T-PROPS-0006`，最后补 module focused coverage 与必要 adapter/runtime exercises。 |
+| P0.5 | `C-PROPS-0004` Prop semantic state is classified per key | 是 `0009` 的前置语义，边界清晰，但独立测试价值主要体现在 `0009` 的输入分类中。 | 可在推进 `0009` 时顺手补 criteria，并让 `T-PROPS-0002` 记录分类覆盖；不必单独拉成一条长主线。 |
+| P1 | `C-PROPS-0011` Resolved props watchers observe resolved snapshot changes | watch 行为边界相对清晰，已有 `watch-resolved` 与 runtime integration 测试基础。 | 在 fallback 小域后推进。需要先补 criteria，再整理 `T-*`，尤其明确 hydration、Object.is、watchAll/watch(keys)、调用顺序。 |
+| P1 | `C-PROPS-0006` Prop declaration descriptors have constrained shape | setup-time descriptor 边界清晰，已有 define JSON boundary 和 shape/merge 相关测试基础。 | 适合作为 define 小域起点。需要把 descriptor shape 细节补进 criteria。 |
+| P2 | `C-PROPS-0007` Prop declaration merge preserves evolution safety | 可测试，但具体“breaking narrowing / widening traceable”的边界需要再次确认。 | 等 `0006` criteria 稳定后推进。 |
+| P2 | `C-PROPS-0010` Failed declaration merge must not partially apply | 边界清晰，适合测试 atomicity，但依赖 `0007` 的冲突定义。 | 跟随 `0007`，不单独提前。 |
+
+暂缓推进：
+
+- `C-PROPS-0001`：偏哲学/通路身份，更多作为上游引用，不适合作为测试链路主线。
+- `C-PROPS-0002`：API surface 总契约，范围较大，应由 `0005`、`0008`、`0011`、`0012`、`0014` 等子契约反向收敛后再回修。
+- `C-PROPS-0005`：mergeable plans 的高层判断，需要和 `0006/0007/0010` 一起过。
+- `C-PROPS-0012`：raw escape hatch 可测，但属于非推荐 API，优先级低于 resolved/fallback/watch 主链路。
+- `C-PROPS-0013`：watcher callback `run handle` 绑定已有 runtime 测试基础，但依赖 `0011/0012` 的 watcher 语义稳定。
+- `C-PROPS-0014`：`applyRawProps` 与 render commit 的关系更接近 runtime/core update 契约，需要先明确是否拆出更上游的 runtime contract。
 
 交付物：
 
@@ -98,10 +140,17 @@ Workspace 的近期目标不是完整录入 Proto UI 的全部哲学、契约和
 
 ## 下一步
 
-从 `C-PROPS-0003` 开始：
+从 `C-PROPS-0009` 开始：
 
-1. 补全该契约的 `statement` 和 criteria。
-2. 查找现有 module / adapter / runtime 测试。
-3. 将真实测试映射到 `T-PROPS-0001`。
-4. 为测试实体补充覆盖状态和缺口。
-5. 让 Workspace UI 展示 criteria coverage。
+1. 补全 `C-PROPS-0009` 的 `statement` 和 criteria。
+2. 同步补一份轻量的 `C-PROPS-0004` criteria，作为 `0009` 的输入分类前置。
+3. 将 `T-PROPS-0006` 写实，拆出 missing、provided-empty、invalid、fallback order、prevValid、`empty="error"` 等 cases。
+4. 对照现有 `packages/modules/props/test/contract/resolve-fallback.v0.contract.test.ts`，将可确认的实现状态标为 passing。
+5. 检查是否需要新的 focused module test，避免历史测试过宽导致 coverage 难以阅读。
+6. 再判断 adapter/runtime 是否只作为 exercises，还是需要建立独立 conformance harness。
+
+完成 `0009` 后，进入一次回扫：
+
+- 回看所有 `C-PROPS-*` 的边界是否仍然合理。
+- 将“范围过大”的 `C-PROPS` 拆分或降级为上游/总契约。
+- 将暂缓项保留为明确 open question 或 deferred tag，避免 draft 堆积后遗失上下文。

--- a/apps/workspace/src/main.tsx
+++ b/apps/workspace/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, useEffect, useMemo, useState } from 'react';
+import { StrictMode, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import {
@@ -362,7 +362,7 @@ function WorkspaceView(props: {
                   onClick={() => props.onSelectEntity(entity.id)}
                 >
                   <strong>{entity.id}</strong>
-                  <span>{entity.title}</span>
+                  <span>{renderInlineText(entity.title)}</span>
                   {entity.openQuestions.length > 0 ? <em>{entity.openQuestions.length}</em> : null}
                 </button>
               ))}
@@ -431,7 +431,7 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
     <section className="panel entity-panel">
       <div className="panel-heading">
         <p className="eyebrow">{entity.type}</p>
-        <h2>{entity.title}</h2>
+        <h2>{renderInlineText(entity.title)}</h2>
       </div>
       <dl className="entity-meta">
         <div>
@@ -447,11 +447,11 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
           <dd>{entity.since}</dd>
         </div>
       </dl>
-      {entity.summary ? <p className="summary">{entity.summary}</p> : null}
+      {entity.summary ? <p className="summary">{renderInlineText(entity.summary)}</p> : null}
       {entity.statement ? (
         <section className="detail-section">
           <h3>{props.t.statement}</h3>
-          <p>{formatLocalizedText(entity.statement, props.locale)}</p>
+          <p>{renderLocalizedText(entity.statement, props.locale)}</p>
         </section>
       ) : null}
       {entity.criteria.length > 0 ? (
@@ -461,11 +461,11 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
             {entity.criteria.map((criterion) => (
               <article className="criterion-row" key={criterion.id}>
                 <strong>{criterion.id}</strong>
-                <p>{formatLocalizedText(criterion.text, props.locale)}</p>
+                <p>{renderLocalizedText(criterion.text, props.locale)}</p>
                 {criterion.rationale ? (
                   <p className="rationale">
                     <span>{props.t.rationale}: </span>
-                    {formatLocalizedText(criterion.rationale, props.locale)}
+                    {renderLocalizedText(criterion.rationale, props.locale)}
                   </p>
                 ) : null}
               </article>
@@ -480,10 +480,10 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
             {entity.openQuestions.map((question) => (
               <article className="issue-row" key={question.id}>
                 <p className="issue-file">{question.id}</p>
-                <p>{formatLocalizedText(question.question, props.locale)}</p>
+                <p>{renderLocalizedText(question.question, props.locale)}</p>
                 {question.context ? (
                   <p className="issue-context">
-                    {formatLocalizedText(question.context, props.locale)}
+                    {renderLocalizedText(question.context, props.locale)}
                   </p>
                 ) : null}
                 {question.blocks.length > 0 ? (
@@ -795,7 +795,7 @@ function OpenQuestionsPanel(props: {
                 {entity.id}
               </button>
               <p className="issue-file">{question.id}</p>
-              <p>{formatLocalizedText(question.question, props.locale)}</p>
+              <p>{renderLocalizedText(question.question, props.locale)}</p>
               {question.blocks.length > 0 ? (
                 <p className="blocked-items">
                   {props.t.blocks}: {question.blocks.join(', ')}
@@ -858,6 +858,25 @@ function formatLocalizedText(
   }
 
   return value.en ?? value['zh-CN'] ?? '';
+}
+
+function renderLocalizedText(
+  value: string | { en?: string | undefined; 'zh-CN'?: string | undefined },
+  locale: Locale
+): ReactNode {
+  return renderInlineText(formatLocalizedText(value, locale));
+}
+
+function renderInlineText(value: string): ReactNode {
+  const parts = value.split(/(`[^`]+`)/g);
+
+  return parts.map((part, index) => {
+    if (part.startsWith('`') && part.endsWith('`') && part.length > 2) {
+      return <code key={index}>{part.slice(1, -1)}</code>;
+    }
+
+    return part;
+  });
 }
 
 function createGraphLayout(graph: SpecGraph): Map<string, { x: number; y: number }> {

--- a/apps/workspace/src/main.tsx
+++ b/apps/workspace/src/main.tsx
@@ -39,9 +39,30 @@ const UI_TEXT = {
     blocks: 'Blocks',
     covers: 'Covers',
     consumes: 'Consumes',
+    exercises: 'Exercises',
     expectation: 'Expectation',
     implementationStatus: 'Implementation Status',
     note: 'Note',
+    notes: 'Notes',
+    path: 'Path',
+    required: 'Required',
+    optional: 'Optional',
+    implementationKinds: {
+      fixture: 'Fixture',
+      'module-test': 'Module Test',
+      'adapter-test': 'Adapter Test',
+      'runtime-test': 'Runtime Test',
+      'workspace-check': 'Workspace Check',
+    },
+    implementationStatuses: {
+      missing: 'Missing',
+      planned: 'Planned',
+      active: 'Active',
+      passing: 'Passing',
+      failing: 'Failing',
+      'needs-review': 'Needs Review',
+      skipped: 'Skipped',
+    },
     relationships: 'Relationships',
     relationKinds: {
       relates: 'Relates',
@@ -100,9 +121,30 @@ const UI_TEXT = {
     blocks: '阻塞项',
     covers: '覆盖',
     consumes: '消费',
+    exercises: '演练',
     expectation: '预期',
     implementationStatus: '落点状态',
     note: '备注',
+    notes: '备注',
+    path: '路径',
+    required: '必需',
+    optional: '可选',
+    implementationKinds: {
+      fixture: '共享 Fixture',
+      'module-test': 'Module 测试',
+      'adapter-test': 'Adapter 测试',
+      'runtime-test': 'Runtime 测试',
+      'workspace-check': 'Workspace 校验',
+    },
+    implementationStatuses: {
+      missing: '缺失',
+      planned: '计划中',
+      active: '已启用',
+      passing: '通过',
+      failing: '失败',
+      'needs-review': '待复核',
+      skipped: '跳过',
+    },
     relationships: '实体关系',
     relationKinds: {
       relates: '关联',
@@ -480,18 +522,49 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
       {entity.implementations.length > 0 ? (
         <section className="detail-section">
           <h3>{props.t.implementations}</h3>
-          <div className="issue-list compact">
+          <div className="implementation-list">
             {entity.implementations.map((implementation) => (
-              <article className="issue-row" key={implementation.id}>
-                <p className="issue-file">{implementation.id}</p>
-                <p>
-                  {implementation.kind} / {props.t.implementationStatus}: {implementation.status}
-                </p>
-                {implementation.path ? <p>{implementation.path}</p> : null}
-                {implementation.consumesCases.length > 0 ? (
-                  <p className="blocked-items">
-                    {props.t.consumes}: {implementation.consumesCases.join(', ')}
+              <article
+                className={`implementation-card status-${implementation.status}`}
+                key={implementation.id}
+              >
+                <div className="implementation-header">
+                  <strong>{implementation.id}</strong>
+                  <div className="implementation-tags">
+                    <span className="kind-badge">
+                      {props.t.implementationKinds[implementation.kind]}
+                    </span>
+                    <span className={`status-badge status-${implementation.status}`}>
+                      {props.t.implementationStatuses[implementation.status]}
+                    </span>
+                    <span className={implementation.required ? 'required-badge' : 'optional-badge'}>
+                      {implementation.required ? props.t.required : props.t.optional}
+                    </span>
+                  </div>
+                </div>
+                {implementation.path ? (
+                  <p className="implementation-path">
+                    <span>{props.t.path}</span>
+                    <code>{implementation.path}</code>
                   </p>
+                ) : null}
+                <ImplementationChipGroup
+                  label={props.t.consumes}
+                  values={implementation.consumesCases}
+                />
+                <ImplementationChipGroup
+                  label={props.t.exercises}
+                  values={implementation.exercises}
+                />
+                {implementation.notes.length > 0 ? (
+                  <div className="implementation-notes">
+                    <span>{props.t.notes}</span>
+                    <ul>
+                      {implementation.notes.map((note) => (
+                        <li key={note}>{note}</li>
+                      ))}
+                    </ul>
+                  </div>
                 ) : null}
               </article>
             ))}
@@ -509,6 +582,21 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
         ))}
       </section>
     </section>
+  );
+}
+
+function ImplementationChipGroup(props: { label: string; values: string[] }) {
+  if (props.values.length === 0) return null;
+
+  return (
+    <div className="implementation-chip-group">
+      <span>{props.label}</span>
+      <div>
+        {props.values.map((value) => (
+          <code key={value}>{value}</code>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/apps/workspace/src/main.tsx
+++ b/apps/workspace/src/main.tsx
@@ -42,6 +42,9 @@ const UI_TEXT = {
     exercises: 'Exercises',
     expectation: 'Expectation',
     implementationStatus: 'Implementation Status',
+    primary: 'Primary',
+    supporting: 'Supporting',
+    coveredBy: 'Covered By',
     note: 'Note',
     notes: 'Notes',
     path: 'Path',
@@ -124,6 +127,9 @@ const UI_TEXT = {
     exercises: '演练',
     expectation: '预期',
     implementationStatus: '落点状态',
+    primary: '主落点',
+    supporting: '辅助落点',
+    coveredBy: '覆盖落点',
     note: '备注',
     notes: '备注',
     path: '路径',
@@ -426,6 +432,11 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
   }
 
   const entity = props.entity;
+  const caseImplementations = getCaseImplementations(entity);
+  const sortedImplementations = [...entity.implementations].sort((a, b) => {
+    if (a.required !== b.required) return a.required ? -1 : 1;
+    return a.id.localeCompare(b.id);
+  });
 
   return (
     <section className="panel entity-panel">
@@ -503,16 +514,30 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
             {entity.cases.map((testCase) => (
               <article className="criterion-row" key={testCase.id}>
                 <strong>{testCase.id}</strong>
-                <p>{testCase.title}</p>
+                <p>{renderInlineText(testCase.title)}</p>
                 <p className="rationale">
                   <span>{props.t.expectation}: </span>
-                  {testCase.expectation}
+                  {renderInlineText(testCase.expectation)}
                 </p>
                 {testCase.covers.length > 0 ? (
                   <p className="rationale">
                     <span>{props.t.covers}: </span>
                     {testCase.covers.join(', ')}
                   </p>
+                ) : null}
+                {(caseImplementations.get(testCase.id) ?? []).length > 0 ? (
+                  <CaseCoverageList
+                    label={props.t.coveredBy}
+                    implementations={caseImplementations.get(testCase.id) ?? []}
+                    t={props.t}
+                  />
+                ) : null}
+                {testCase.notes.length > 0 ? (
+                  <ul className="case-notes">
+                    {testCase.notes.map((note) => (
+                      <li key={note}>{renderInlineText(note)}</li>
+                    ))}
+                  </ul>
                 ) : null}
               </article>
             ))}
@@ -523,9 +548,11 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
         <section className="detail-section">
           <h3>{props.t.implementations}</h3>
           <div className="implementation-list">
-            {entity.implementations.map((implementation) => (
+            {sortedImplementations.map((implementation) => (
               <article
-                className={`implementation-card status-${implementation.status}`}
+                className={`implementation-card status-${implementation.status} ${
+                  implementation.required ? 'is-primary' : 'is-supporting'
+                }`}
                 key={implementation.id}
               >
                 <div className="implementation-header">
@@ -537,8 +564,10 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
                     <span className={`status-badge status-${implementation.status}`}>
                       {props.t.implementationStatuses[implementation.status]}
                     </span>
-                    <span className={implementation.required ? 'required-badge' : 'optional-badge'}>
-                      {implementation.required ? props.t.required : props.t.optional}
+                    <span
+                      className={implementation.required ? 'primary-badge' : 'supporting-badge'}
+                    >
+                      {implementation.required ? props.t.primary : props.t.supporting}
                     </span>
                   </div>
                 </div>
@@ -561,7 +590,7 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
                     <span>{props.t.notes}</span>
                     <ul>
                       {implementation.notes.map((note) => (
-                        <li key={note}>{note}</li>
+                        <li key={note}>{renderInlineText(note)}</li>
                       ))}
                     </ul>
                   </div>
@@ -585,6 +614,30 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
   );
 }
 
+function CaseCoverageList(props: {
+  label: string;
+  implementations: SpecEntity['implementations'];
+  t: UiText;
+}) {
+  return (
+    <div className="case-coverage">
+      <span>{props.label}</span>
+      <div>
+        {props.implementations.map((implementation) => (
+          <span
+            className={`coverage-chip ${implementation.required ? 'is-primary' : 'is-supporting'}`}
+            key={implementation.id}
+          >
+            <code>{implementation.id}</code>
+            <small>{props.t.implementationStatuses[implementation.status]}</small>
+            <small>{implementation.required ? props.t.primary : props.t.supporting}</small>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function ImplementationChipGroup(props: { label: string; values: string[] }) {
   if (props.values.length === 0) return null;
 
@@ -598,6 +651,28 @@ function ImplementationChipGroup(props: { label: string; values: string[] }) {
       </div>
     </div>
   );
+}
+
+function getCaseImplementations(entity: SpecEntity): Map<string, SpecEntity['implementations']> {
+  const caseImplementations = new Map<string, SpecEntity['implementations']>();
+
+  for (const implementation of entity.implementations) {
+    for (const caseId of implementation.consumesCases) {
+      const implementations = caseImplementations.get(caseId) ?? [];
+      implementations.push(implementation);
+      caseImplementations.set(caseId, implementations);
+    }
+  }
+
+  for (const [caseId, implementations] of caseImplementations) {
+    implementations.sort((a, b) => {
+      if (a.required !== b.required) return a.required ? -1 : 1;
+      return a.id.localeCompare(b.id);
+    });
+    caseImplementations.set(caseId, implementations);
+  }
+
+  return caseImplementations;
 }
 
 function RelationList(props: { title: string; relations: SpecEntity['relates'] }) {

--- a/apps/workspace/src/main.tsx
+++ b/apps/workspace/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { StrictMode, useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import {
@@ -22,6 +22,8 @@ const UI_TEXT = {
     from: 'From',
     to: 'To',
     navLabel: 'Spec entities',
+    quickJump: 'Jump',
+    scope: 'Scope',
     entities: 'Entities',
     graphNodes: 'Graph Nodes',
     graphEdges: 'Graph Edges',
@@ -107,6 +109,8 @@ const UI_TEXT = {
     from: '起始版本',
     to: '目标版本',
     navLabel: 'Spec 实体',
+    quickJump: '跳转',
+    scope: '族',
     entities: '实体',
     graphNodes: '图节点',
     graphEdges: '图关系',
@@ -223,7 +227,7 @@ function App() {
         if (!active) return;
 
         setLoadState({ status: 'ready', dataset });
-        setSelectedId(dataset.entities[0]?.id ?? null);
+        setSelectedId(getEntityIdFromLocation(dataset.entities) ?? dataset.entities[0]?.id ?? null);
         setFromVersion(dataset.versions[0] ?? dataset.latestVersion);
         setToVersion(dataset.latestVersion);
       })
@@ -238,6 +242,29 @@ function App() {
     return () => {
       active = false;
     };
+  }, []);
+
+  useEffect(() => {
+    if (loadState.status !== 'ready') return;
+
+    const syncSelectedIdFromLocation = () => {
+      const routeId = getEntityIdFromLocation(loadState.dataset.entities);
+      if (routeId) setSelectedId(routeId);
+    };
+
+    window.addEventListener('hashchange', syncSelectedIdFromLocation);
+    window.addEventListener('popstate', syncSelectedIdFromLocation);
+    syncSelectedIdFromLocation();
+
+    return () => {
+      window.removeEventListener('hashchange', syncSelectedIdFromLocation);
+      window.removeEventListener('popstate', syncSelectedIdFromLocation);
+    };
+  }, [loadState]);
+
+  const handleSelectEntity = useCallback((id: string) => {
+    setSelectedId(id);
+    writeEntityRoute(id);
   }, []);
 
   if (loadState.status === 'loading') return <main className="status-page">{t.loading}</main>;
@@ -263,7 +290,7 @@ function App() {
       t={t}
       fromVersion={fromVersion}
       toVersion={toVersion}
-      onSelectEntity={setSelectedId}
+      onSelectEntity={handleSelectEntity}
       onSelectLocale={setLocale}
       onSelectFromVersion={setFromVersion}
       onSelectToVersion={setToVersion}
@@ -291,6 +318,29 @@ function WorkspaceView(props: {
     () => groupEntitiesByType(props.snapshot.entities),
     [props.snapshot.entities]
   );
+  const typeSummaries = useMemo(
+    () =>
+      getOrderedEntityTypes(entityGroups).map((type) => ({
+        type,
+        entities: entityGroups[type] ?? [],
+      })),
+    [entityGroups]
+  );
+  const [expandedScopes, setExpandedScopes] = useState<Set<string>>(new Set());
+  const selectedEntity = props.selectedEntity;
+
+  useEffect(() => {
+    if (!selectedEntity) return;
+
+    const scopeKey = getEntityScopeKey(selectedEntity);
+    setExpandedScopes((previous) => {
+      if (previous.has(scopeKey)) return previous;
+      const next = new Set(previous);
+      next.add(scopeKey);
+      return next;
+    });
+  }, [selectedEntity]);
+
   const criteriaCount = props.snapshot.entities.reduce(
     (count, entity) => count + entity.criteria.length,
     0
@@ -299,6 +349,14 @@ function WorkspaceView(props: {
     (count, entity) => count + entity.openQuestions.length,
     0
   );
+  const toggleScope = (scopeKey: string) => {
+    setExpandedScopes((previous) => {
+      const next = new Set(previous);
+      if (next.has(scopeKey)) next.delete(scopeKey);
+      else next.add(scopeKey);
+      return next;
+    });
+  };
 
   return (
     <main className="workspace-shell">
@@ -353,25 +411,69 @@ function WorkspaceView(props: {
           </label>
         </div>
 
+        <div className="entity-jumpbar" aria-label={props.t.quickJump}>
+          {typeSummaries.map(({ type, entities }) => (
+            <button
+              className={selectedEntity?.type === type ? 'active' : ''}
+              key={type}
+              title={props.t.entityTypes[type] ?? type}
+              type="button"
+              onClick={() => scrollEntityTypeIntoView(type)}
+            >
+              <span>{getEntityTypePrefix(type)}</span>
+              <small>{entities.length}</small>
+            </button>
+          ))}
+        </div>
+
         <nav className="entity-nav" aria-label={props.t.navLabel}>
-          {Object.entries(entityGroups).map(([type, entities]) => (
-            <section key={type}>
+          {typeSummaries.map(({ type, entities }) => (
+            <section id={getEntityTypeSectionId(type)} key={type}>
               <h2>
-                {props.t.entityTypes[type as SpecEntity['type']] ?? type}
+                {props.t.entityTypes[type] ?? type}
                 <span>{entities.length}</span>
               </h2>
-              {entities.map((entity) => (
-                <button
-                  className={entity.id === props.selectedId ? 'entity-link active' : 'entity-link'}
-                  key={entity.id}
-                  type="button"
-                  onClick={() => props.onSelectEntity(entity.id)}
-                >
-                  <strong>{entity.id}</strong>
-                  <span>{renderInlineText(entity.title)}</span>
-                  {entity.openQuestions.length > 0 ? <em>{entity.openQuestions.length}</em> : null}
-                </button>
-              ))}
+              {groupEntitiesByScope(entities).map((scope) => {
+                const scopeKey = getScopeKey(type, scope.name);
+                const expanded = expandedScopes.has(scopeKey);
+                const selectedInScope = scope.entities.some(
+                  (entity) => entity.id === props.selectedId
+                );
+
+                return (
+                  <div className="entity-scope" key={scopeKey}>
+                    <button
+                      aria-expanded={expanded}
+                      className={`scope-toggle ${selectedInScope ? 'active' : ''}`}
+                      type="button"
+                      onClick={() => toggleScope(scopeKey)}
+                    >
+                      <span>{scope.name}</span>
+                      <small>{scope.entities.length}</small>
+                    </button>
+                    {expanded ? (
+                      <div className="scope-entities">
+                        {scope.entities.map((entity) => (
+                          <button
+                            className={
+                              entity.id === props.selectedId ? 'entity-link active' : 'entity-link'
+                            }
+                            key={entity.id}
+                            type="button"
+                            onClick={() => props.onSelectEntity(entity.id)}
+                          >
+                            <strong>{entity.id}</strong>
+                            <span>{renderInlineText(entity.title)}</span>
+                            {entity.openQuestions.length > 0 ? (
+                              <em>{entity.openQuestions.length}</em>
+                            ) : null}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                );
+              })}
             </section>
           ))}
         </nav>
@@ -399,7 +501,9 @@ function WorkspaceView(props: {
           <EntityInspector entity={props.selectedEntity} locale={props.locale} t={props.t} />
           <DiffPanel diff={props.diff} t={props.t} />
           <GraphPanel
+            entities={props.snapshot.entities}
             graph={props.graph}
+            locale={props.locale}
             selectedId={props.selectedId}
             t={props.t}
             onSelectEntity={props.onSelectEntity}
@@ -746,13 +850,28 @@ function DiffColumn(props: { title: string; entities: SpecEntity[]; emptyLabel: 
 }
 
 function GraphPanel(props: {
+  entities: SpecEntity[];
   graph: SpecGraph;
+  locale: Locale;
   selectedId: string | null;
   t: UiText;
   onSelectEntity(id: string): void;
 }) {
-  const layout = useMemo(() => createGraphLayout(props.graph), [props.graph]);
-  const highlightedIds = getHighlightedGraphIds(props.graph, props.selectedId);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const visibleGraph = useMemo(
+    () => getVisibleGraphProjection(props.graph, props.selectedId),
+    [props.graph, props.selectedId]
+  );
+  const layout = useMemo(
+    () => createGraphLayout(visibleGraph, props.selectedId),
+    [visibleGraph, props.selectedId]
+  );
+  const entityById = useMemo(
+    () => new Map(props.entities.map((entity) => [entity.id, entity])),
+    [props.entities]
+  );
+  const hoveredEntity = hoveredNodeId ? (entityById.get(hoveredNodeId) ?? null) : null;
+  const hoveredPoint = hoveredNodeId ? (layout.get(hoveredNodeId) ?? null) : null;
 
   return (
     <section className="panel graph-panel">
@@ -761,14 +880,15 @@ function GraphPanel(props: {
         <h2>{props.t.graphProjection}</h2>
       </div>
       <div className="graph-canvas" aria-label={props.t.graphProjection}>
-        {props.graph.edges.length === 0 ? (
+        {visibleGraph.edges.length === 0 ? (
           <p className="empty">{props.t.noActiveEdges}</p>
         ) : (
-          <svg role="img" viewBox="0 0 720 520">
+          <svg role="img" viewBox="0 0 820 580">
             <defs>
               <marker
                 id="arrowhead"
                 markerHeight="6"
+                markerUnits="userSpaceOnUse"
                 markerWidth="8"
                 orient="auto"
                 refX="7"
@@ -778,39 +898,54 @@ function GraphPanel(props: {
               </marker>
             </defs>
             <g className="graph-edges">
-              {props.graph.edges.map((edge) => {
+              {visibleGraph.edges.map((edge) => {
                 const from = layout.get(edge.from);
                 const to = layout.get(edge.to);
                 if (!from || !to) return null;
-                const active =
+                const clipped = getClippedEdge(
+                  from,
+                  to,
+                  getGraphNodeRadius(edge.from, props.selectedId),
+                  getGraphNodeRadius(edge.to, props.selectedId)
+                );
+                const direct =
                   props.selectedId === null ||
                   edge.from === props.selectedId ||
                   edge.to === props.selectedId;
 
                 return (
-                  <g className={active ? 'active' : ''} key={edge.id}>
-                    <line markerEnd="url(#arrowhead)" x1={from.x} y1={from.y} x2={to.x} y2={to.y} />
-                    <text x={(from.x + to.x) / 2} y={(from.y + to.y) / 2}>
-                      {edge.kind}
+                  <g className={direct ? 'direct' : 'context'} key={edge.id}>
+                    <line
+                      markerEnd="url(#arrowhead)"
+                      x1={clipped.x1}
+                      y1={clipped.y1}
+                      x2={clipped.x2}
+                      y2={clipped.y2}
+                    />
+                    <text x={(clipped.x1 + clipped.x2) / 2} y={(clipped.y1 + clipped.y2) / 2}>
+                      {props.t.relationKinds[edge.kind]}
                     </text>
                   </g>
                 );
               })}
             </g>
             <g className="graph-nodes">
-              {props.graph.nodes.map((node) => {
+              {visibleGraph.nodes.map((node) => {
                 const point = layout.get(node.id);
                 if (!point) return null;
-                const active = highlightedIds.has(node.id);
 
                 return (
                   <g
-                    className={`graph-node type-${node.type} ${active ? 'active' : ''}`}
+                    className={`graph-node type-${node.type} active`}
                     key={node.id}
                     role="button"
                     tabIndex={0}
                     transform={`translate(${point.x} ${point.y})`}
                     onClick={() => props.onSelectEntity(node.id)}
+                    onFocus={() => setHoveredNodeId(node.id)}
+                    onBlur={() => setHoveredNodeId(null)}
+                    onMouseEnter={() => setHoveredNodeId(node.id)}
+                    onMouseLeave={() => setHoveredNodeId(null)}
                     onKeyDown={(event) => {
                       if (event.key === 'Enter' || event.key === ' ') {
                         event.preventDefault();
@@ -818,7 +953,7 @@ function GraphPanel(props: {
                       }
                     }}
                   >
-                    <circle r={node.id === props.selectedId ? 28 : 22} />
+                    <circle r={getGraphNodeRadius(node.id, props.selectedId)} />
                     <title>{node.id}</title>
                     <text>{compactSpecId(node.id)}</text>
                   </g>
@@ -827,18 +962,69 @@ function GraphPanel(props: {
             </g>
           </svg>
         )}
+        {hoveredEntity && hoveredPoint ? (
+          <GraphHoverCard
+            entity={hoveredEntity}
+            locale={props.locale}
+            point={hoveredPoint}
+            t={props.t}
+          />
+        ) : null}
       </div>
       <div className="edge-list">
-        {props.graph.edges.slice(0, 12).map((edge) => (
+        {visibleGraph.edges.slice(0, 12).map((edge) => (
           <div className="edge-row" key={edge.id}>
             <span>{edge.from}</span>
-            <strong>{edge.kind}</strong>
+            <strong>{props.t.relationKinds[edge.kind]}</strong>
             <span>{edge.to}</span>
           </div>
         ))}
       </div>
     </section>
   );
+}
+
+function GraphHoverCard(props: {
+  entity: SpecEntity;
+  locale: Locale;
+  point: { x: number; y: number };
+  t: UiText;
+}) {
+  const placement = props.point.y < 140 ? 'below' : 'above';
+  const description = getGraphHoverDescription(props.entity, props.locale);
+
+  return (
+    <div
+      className={`graph-hover-card is-${placement}`}
+      style={{
+        left: `${(props.point.x / 820) * 100}%`,
+        top: `${(props.point.y / 580) * 100}%`,
+      }}
+    >
+      <strong>{props.entity.id}</strong>
+      <p className="graph-hover-title">{renderInlineText(props.entity.title)}</p>
+      {description ? <p>{renderInlineText(description)}</p> : null}
+      <div>
+        <span>
+          {props.t.criteria}: {props.entity.criteria.length}
+        </span>
+        <span>
+          {props.t.cases}: {props.entity.cases.length}
+        </span>
+        <span>
+          {props.t.openQuestions}: {props.entity.openQuestions.length}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function getGraphHoverDescription(entity: SpecEntity, locale: Locale): string {
+  if (entity.statement) {
+    return formatLocalizedText(entity.statement, locale);
+  }
+
+  return entity.summary ?? '';
 }
 
 function OpenQuestionsPanel(props: {
@@ -922,6 +1108,39 @@ function groupEntitiesByType(entities: SpecEntity[]): Record<string, SpecEntity[
   }, {});
 }
 
+function getVisibleGraphProjection(graph: SpecGraph, selectedId: string | null): SpecGraph {
+  if (!selectedId) return graph;
+
+  const visibleIds = getHighlightedGraphIds(graph, selectedId);
+  const visibleNodes = graph.nodes.filter((node) => visibleIds.has(node.id));
+  const visibleEdges = graph.edges.filter(
+    (edge) => visibleIds.has(edge.from) && visibleIds.has(edge.to)
+  );
+
+  return {
+    nodes: visibleNodes,
+    edges: visibleEdges,
+  };
+}
+
+function groupEntitiesByScope(
+  entities: SpecEntity[]
+): Array<{ name: string; entities: SpecEntity[] }> {
+  const groups = entities.reduce<Record<string, SpecEntity[]>>((result, entity) => {
+    const scope = getSpecScope(entity.id);
+    result[scope] ??= [];
+    result[scope].push(entity);
+    return result;
+  }, {});
+
+  return Object.entries(groups)
+    .map(([name, scopeEntities]) => ({
+      name,
+      entities: [...scopeEntities].sort((a, b) => a.id.localeCompare(b.id)),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
 function formatLocalizedText(
   value: string | { en?: string | undefined; 'zh-CN'?: string | undefined },
   locale: Locale
@@ -954,12 +1173,11 @@ function renderInlineText(value: string): ReactNode {
   });
 }
 
-function createGraphLayout(graph: SpecGraph): Map<string, { x: number; y: number }> {
-  const center = { x: 360, y: 260 };
-  const radiusX = 270;
-  const radiusY = 185;
-  const byType = groupGraphNodesByType(graph.nodes);
-  const typeOrder = Object.keys(byType).sort();
+function createGraphLayout(
+  graph: SpecGraph,
+  selectedId: string | null
+): Map<string, { x: number; y: number }> {
+  const center = { x: 410, y: 280 };
   const layout = new Map<string, { x: number; y: number }>();
 
   if (graph.nodes.length === 1) {
@@ -967,30 +1185,149 @@ function createGraphLayout(graph: SpecGraph): Map<string, { x: number; y: number
     return layout;
   }
 
-  let cursor = 0;
+  const nodeIds = new Set(graph.nodes.map((node) => node.id));
 
-  for (const type of typeOrder) {
-    const nodes = byType[type];
+  if (selectedId && nodeIds.has(selectedId)) {
+    const incoming = new Set<string>();
+    const outgoing = new Set<string>();
 
-    for (const node of nodes) {
-      const angle = (cursor / graph.nodes.length) * Math.PI * 2 - Math.PI / 2;
-      layout.set(node.id, {
-        x: center.x + Math.cos(angle) * radiusX,
-        y: center.y + Math.sin(angle) * radiusY,
-      });
-      cursor += 1;
+    for (const edge of graph.edges) {
+      if (edge.to === selectedId && edge.from !== selectedId) incoming.add(edge.from);
+      if (edge.from === selectedId && edge.to !== selectedId) outgoing.add(edge.to);
     }
+
+    const bidirectional = [...incoming].filter((id) => outgoing.has(id)).sort();
+    const left = [...incoming].filter((id) => !outgoing.has(id)).sort();
+    const right = [...outgoing].filter((id) => !incoming.has(id)).sort();
+
+    layout.set(selectedId, center);
+    placeVerticalGraphGroup(layout, left, 140, 110, 450);
+    placeVerticalGraphGroup(layout, right, 680, 110, 450);
+    placeHorizontalGraphGroup(layout, bidirectional, 250, 570, 84);
+
+    const placed = new Set(layout.keys());
+    const context = graph.nodes
+      .filter((node) => !placed.has(node.id))
+      .sort((a, b) => compareGraphNodes(a, b));
+    placeContextGraphNodes(layout, context, placed);
+
+    return layout;
   }
+
+  const levels = createRelationLevels(graph);
+  const levelsByValue = new Map<number, SpecGraph['nodes']>();
+
+  for (const node of [...graph.nodes].sort(compareGraphNodes)) {
+    const level = levels.get(node.id) ?? 0;
+    const nodes = levelsByValue.get(level) ?? [];
+    nodes.push(node);
+    levelsByValue.set(level, nodes);
+  }
+
+  const orderedLevels = [...levelsByValue.keys()].sort((a, b) => a - b);
+  const maxLevelIndex = Math.max(orderedLevels.length - 1, 1);
+
+  orderedLevels.forEach((level, levelIndex) => {
+    const nodes = levelsByValue.get(level) ?? [];
+    const x = 90 + (levelIndex / maxLevelIndex) * 640;
+    placeVerticalGraphGroup(
+      layout,
+      nodes.map((node) => node.id),
+      x,
+      70,
+      510
+    );
+  });
 
   return layout;
 }
 
-function groupGraphNodesByType(nodes: SpecGraph['nodes']): Record<string, SpecGraph['nodes']> {
-  return nodes.reduce<Record<string, SpecGraph['nodes']>>((groups, node) => {
-    groups[node.type] ??= [];
-    groups[node.type].push(node);
-    return groups;
-  }, {});
+function createRelationLevels(graph: SpecGraph): Map<string, number> {
+  const levels = new Map(graph.nodes.map((node) => [node.id, 0]));
+  const ids = new Set(graph.nodes.map((node) => node.id));
+
+  for (let index = 0; index < graph.nodes.length; index += 1) {
+    let changed = false;
+
+    for (const edge of graph.edges) {
+      if (!ids.has(edge.from) || !ids.has(edge.to)) continue;
+      const nextLevel = Math.min((levels.get(edge.from) ?? 0) + 1, 6);
+      if (nextLevel > (levels.get(edge.to) ?? 0)) {
+        levels.set(edge.to, nextLevel);
+        changed = true;
+      }
+    }
+
+    if (!changed) break;
+  }
+
+  return levels;
+}
+
+function placeVerticalGraphGroup(
+  layout: Map<string, { x: number; y: number }>,
+  ids: string[],
+  x: number,
+  minY: number,
+  maxY: number
+) {
+  if (ids.length === 0) return;
+  if (ids.length === 1) {
+    layout.set(ids[0], { x, y: (minY + maxY) / 2 });
+    return;
+  }
+
+  const step = (maxY - minY) / (ids.length - 1);
+  ids.forEach((id, index) => {
+    layout.set(id, { x, y: minY + step * index });
+  });
+}
+
+function placeHorizontalGraphGroup(
+  layout: Map<string, { x: number; y: number }>,
+  ids: string[],
+  minX: number,
+  maxX: number,
+  y: number
+) {
+  if (ids.length === 0) return;
+  if (ids.length === 1) {
+    layout.set(ids[0], { x: (minX + maxX) / 2, y });
+    return;
+  }
+
+  const step = (maxX - minX) / (ids.length - 1);
+  ids.forEach((id, index) => {
+    layout.set(id, { x: minX + step * index, y });
+  });
+}
+
+function placeContextGraphNodes(
+  layout: Map<string, { x: number; y: number }>,
+  nodes: SpecGraph['nodes'],
+  placed: Set<string>
+) {
+  const columns = 9;
+  const startX = 70;
+  const gapX = 85;
+  const startY = 520;
+  const gapY = 32;
+
+  nodes.forEach((node, index) => {
+    if (placed.has(node.id)) return;
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    layout.set(node.id, {
+      x: startX + column * gapX,
+      y: startY + row * gapY,
+    });
+  });
+}
+
+function compareGraphNodes(a: SpecGraph['nodes'][number], b: SpecGraph['nodes'][number]) {
+  const typeDiff = getEntityTypeOrder(a.type) - getEntityTypeOrder(b.type);
+  if (typeDiff !== 0) return typeDiff;
+  return a.id.localeCompare(b.id);
 }
 
 function getHighlightedGraphIds(graph: SpecGraph, selectedId: string | null): Set<string> {
@@ -1011,6 +1348,107 @@ function compactSpecId(id: string): string {
   if (parts.length <= 3) return id;
 
   return `${parts[0]}-${parts.at(-2)}-${parts.at(-1)}`;
+}
+
+function getClippedEdge(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  fromRadius: number,
+  toRadius: number
+): { x1: number; y1: number; x2: number; y2: number } {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const length = Math.hypot(dx, dy);
+
+  if (length === 0) return { x1: from.x, y1: from.y, x2: to.x, y2: to.y };
+
+  const ux = dx / length;
+  const uy = dy / length;
+  const endPadding = toRadius + 8;
+
+  return {
+    x1: from.x + ux * fromRadius,
+    y1: from.y + uy * fromRadius,
+    x2: to.x - ux * endPadding,
+    y2: to.y - uy * endPadding,
+  };
+}
+
+function getGraphNodeRadius(id: string, selectedId: string | null): number {
+  return id === selectedId ? 28 : 22;
+}
+
+function getEntityTypePrefix(type: SpecEntity['type']): string {
+  const prefixes: Record<SpecEntity['type'], string> = {
+    contract: 'C',
+    module: 'M',
+    decision: 'D',
+    'host-cap': 'HC',
+    test: 'T',
+    version: 'V',
+    knowledge: 'K',
+  };
+
+  return prefixes[type];
+}
+
+function getOrderedEntityTypes(groups: Record<string, SpecEntity[]>): Array<SpecEntity['type']> {
+  return (Object.keys(groups) as Array<SpecEntity['type']>).sort(
+    (a, b) => getEntityTypeOrder(a) - getEntityTypeOrder(b)
+  );
+}
+
+function getEntityTypeOrder(type: SpecEntity['type']): number {
+  const order: Record<SpecEntity['type'], number> = {
+    contract: 0,
+    test: 1,
+    module: 2,
+    knowledge: 3,
+    decision: 4,
+    'host-cap': 5,
+    version: 6,
+  };
+
+  return order[type] ?? 99;
+}
+
+function getSpecScope(id: string): string {
+  const parts = id.split('-');
+  if (parts.length <= 2) return id;
+  return parts.slice(0, -1).join('-');
+}
+
+function getScopeKey(type: SpecEntity['type'], scope: string): string {
+  return `${type}:${scope}`;
+}
+
+function getEntityScopeKey(entity: SpecEntity): string {
+  return getScopeKey(entity.type, getSpecScope(entity.id));
+}
+
+function getEntityTypeSectionId(type: SpecEntity['type']): string {
+  return `entity-section-${type}`;
+}
+
+function scrollEntityTypeIntoView(type: SpecEntity['type']) {
+  document.getElementById(getEntityTypeSectionId(type))?.scrollIntoView({
+    block: 'start',
+    behavior: 'smooth',
+  });
+}
+
+function getEntityIdFromLocation(entities: SpecEntity[]): string | null {
+  const match = window.location.hash.match(/^#\/entities\/([^/?#]+)$/);
+  if (!match) return null;
+
+  const id = decodeURIComponent(match[1]);
+  return entities.some((entity) => entity.id === id) ? id : null;
+}
+
+function writeEntityRoute(id: string) {
+  const nextHash = `#/entities/${encodeURIComponent(id)}`;
+  if (window.location.hash === nextHash) return;
+  window.history.pushState(null, '', nextHash);
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/apps/workspace/src/styles.css
+++ b/apps/workspace/src/styles.css
@@ -363,6 +363,166 @@ h1 {
   font-weight: 700;
 }
 
+.implementation-list {
+  display: grid;
+  gap: 12px;
+}
+
+.implementation-card {
+  display: grid;
+  gap: 10px;
+  border: 1px solid #cfdad5;
+  border-left: 4px solid #7f9389;
+  border-radius: 8px;
+  background: #fbfcfa;
+  padding: 12px;
+}
+
+.implementation-card.status-passing,
+.implementation-card.status-active {
+  border-left-color: #2f7d58;
+}
+
+.implementation-card.status-missing,
+.implementation-card.status-failing {
+  border-left-color: #b84a3b;
+}
+
+.implementation-card.status-planned,
+.implementation-card.status-needs-review {
+  border-left-color: #9b6b1f;
+}
+
+.implementation-card.status-skipped {
+  border-left-color: #7a8180;
+}
+
+.implementation-header {
+  display: grid;
+  gap: 8px;
+}
+
+.implementation-header strong {
+  color: #26342e;
+  font-size: 13px;
+}
+
+.implementation-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.kind-badge,
+.status-badge,
+.required-badge,
+.optional-badge {
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 11px;
+  font-weight: 800;
+  line-height: 1.4;
+}
+
+.kind-badge {
+  background: #e8eff0;
+  color: #38505a;
+}
+
+.status-badge {
+  background: #edf1ef;
+  color: #40504a;
+}
+
+.status-badge.status-passing,
+.status-badge.status-active {
+  background: #e5f4ec;
+  color: #236847;
+}
+
+.status-badge.status-missing,
+.status-badge.status-failing {
+  background: #f9e8e4;
+  color: #963a2e;
+}
+
+.status-badge.status-planned,
+.status-badge.status-needs-review {
+  background: #fff1d6;
+  color: #7d5115;
+}
+
+.status-badge.status-skipped {
+  background: #eceeed;
+  color: #596260;
+}
+
+.required-badge {
+  background: #eef4f0;
+  color: #2d624a;
+}
+
+.optional-badge {
+  background: #f0f2f1;
+  color: #66736d;
+}
+
+.implementation-path,
+.implementation-chip-group,
+.implementation-notes {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+}
+
+.implementation-path span,
+.implementation-chip-group > span,
+.implementation-notes > span {
+  color: #607068;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.implementation-path code {
+  overflow-wrap: anywhere;
+  border: 1px solid #dfe6e2;
+  border-radius: 6px;
+  background: #f4f7f5;
+  color: #2f3f38;
+  padding: 7px 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.implementation-chip-group div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.implementation-chip-group code {
+  border: 1px solid #d8e2dd;
+  border-radius: 6px;
+  background: #f6f9f7;
+  color: #40504a;
+  padding: 4px 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+}
+
+.implementation-notes ul {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding-left: 18px;
+}
+
+.implementation-notes li {
+  color: #43524b;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .relation-list {
   display: flex;
   flex-wrap: wrap;

--- a/apps/workspace/src/styles.css
+++ b/apps/workspace/src/styles.css
@@ -330,6 +330,19 @@ h1 {
   line-height: 1.55;
 }
 
+.summary code,
+.detail-section p code,
+.issue-row p code {
+  border: 1px solid #d7e0db;
+  border-radius: 5px;
+  background: #f1f5f3;
+  color: #1f352b;
+  padding: 1px 5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92em;
+  font-weight: 700;
+}
+
 .criteria-list {
   display: grid;
   gap: 10px;

--- a/apps/workspace/src/styles.css
+++ b/apps/workspace/src/styles.css
@@ -376,6 +376,71 @@ h1 {
   font-weight: 700;
 }
 
+.case-coverage {
+  display: grid;
+  gap: 6px;
+  margin-top: 9px;
+}
+
+.case-coverage > span {
+  color: #44524b;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.case-coverage > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.coverage-chip {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  align-items: center;
+  border: 1px solid #d8e2dd;
+  border-radius: 6px;
+  background: #fbfcfa;
+  padding: 5px 6px;
+}
+
+.coverage-chip.is-primary {
+  border-color: #b8d5c5;
+  background: #eef7f2;
+}
+
+.coverage-chip.is-supporting {
+  border-style: dashed;
+  color: #5e6e66;
+}
+
+.coverage-chip code {
+  color: #2f3f38;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.coverage-chip small {
+  color: #607068;
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.case-notes {
+  display: grid;
+  gap: 4px;
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.case-notes li {
+  color: #617069;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .implementation-list {
   display: grid;
   gap: 12px;
@@ -389,6 +454,15 @@ h1 {
   border-radius: 8px;
   background: #fbfcfa;
   padding: 12px;
+}
+
+.implementation-card.is-primary {
+  background: #fbfefc;
+}
+
+.implementation-card.is-supporting {
+  border-style: dashed;
+  background: #f7f9f8;
 }
 
 .implementation-card.status-passing,
@@ -429,7 +503,9 @@ h1 {
 .kind-badge,
 .status-badge,
 .required-badge,
-.optional-badge {
+.optional-badge,
+.primary-badge,
+.supporting-badge {
   border-radius: 999px;
   padding: 3px 8px;
   font-size: 11px;
@@ -475,9 +551,19 @@ h1 {
   color: #2d624a;
 }
 
+.primary-badge {
+  background: #dff3e8;
+  color: #1e6945;
+}
+
 .optional-badge {
   background: #f0f2f1;
   color: #66736d;
+}
+
+.supporting-badge {
+  background: #eef1f0;
+  color: #5f6f67;
 }
 
 .implementation-path,

--- a/apps/workspace/src/styles.css
+++ b/apps/workspace/src/styles.css
@@ -138,17 +138,57 @@ h1 {
   padding: 8px 10px;
 }
 
+.entity-jumpbar {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.entity-jumpbar button {
+  display: grid;
+  min-width: 0;
+  border: 1px solid #d0dad4;
+  border-radius: 6px;
+  background: #f7faf8;
+  color: #4b5a53;
+  cursor: pointer;
+  padding: 6px 4px;
+  text-align: center;
+}
+
+.entity-jumpbar button:hover,
+.entity-jumpbar button.active {
+  border-color: #8ba99a;
+  background: #eef6f1;
+  color: #1e3f31;
+}
+
+.entity-jumpbar span {
+  font-size: 12px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.entity-jumpbar small {
+  margin-top: 3px;
+  color: #75857d;
+  font-size: 10px;
+  font-weight: 800;
+}
+
 .entity-nav {
   display: grid;
-  gap: 22px;
+  gap: 18px;
   min-height: 0;
   overflow: auto;
   padding-right: 4px;
+  scroll-behavior: smooth;
 }
 
 .entity-nav section {
   display: grid;
   gap: 8px;
+  scroll-margin-top: 16px;
 }
 
 .entity-nav h2 {
@@ -165,6 +205,65 @@ h1 {
   color: #7b8982;
 }
 
+.entity-scope {
+  display: grid;
+  gap: 6px;
+}
+
+.scope-toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border: 1px solid #dde5e0;
+  border-radius: 6px;
+  background: #f7faf8;
+  color: #4a5a52;
+  cursor: pointer;
+  padding: 7px 9px;
+  text-align: left;
+}
+
+.scope-toggle:hover,
+.scope-toggle.active {
+  border-color: #b8c9c0;
+  background: #eef4f0;
+}
+
+.scope-toggle span {
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 900;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.scope-toggle span::before {
+  content: '▸';
+  margin-right: 6px;
+  color: #7a8c83;
+}
+
+.scope-toggle[aria-expanded='true'] span::before {
+  content: '▾';
+}
+
+.scope-toggle small {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: #e8efeb;
+  color: #617069;
+  padding: 1px 6px;
+  font-size: 11px;
+  font-weight: 900;
+}
+
+.scope-entities {
+  display: grid;
+  gap: 6px;
+}
+
 .entity-link {
   position: relative;
   display: grid;
@@ -174,7 +273,7 @@ h1 {
   border-radius: 8px;
   background: transparent;
   color: #1e2924;
-  padding: 10px;
+  padding: 9px 10px;
   text-align: left;
 }
 
@@ -185,13 +284,13 @@ h1 {
 }
 
 .entity-link strong {
-  font-size: 13px;
+  font-size: 12px;
 }
 
 .entity-link span {
   padding-right: 24px;
   color: #5b6862;
-  font-size: 13px;
+  font-size: 12px;
 }
 
 .entity-link em {
@@ -697,8 +796,9 @@ h1 {
 }
 
 .graph-canvas {
+  position: relative;
   margin-top: 18px;
-  overflow: hidden;
+  overflow: visible;
   border: 1px solid #e1e5e1;
   border-radius: 6px;
   background: #f8faf8;
@@ -707,7 +807,7 @@ h1 {
 .graph-canvas svg {
   display: block;
   width: 100%;
-  min-height: 360px;
+  min-height: 380px;
 }
 
 .graph-canvas marker path {
@@ -716,7 +816,7 @@ h1 {
 
 .graph-edges line {
   stroke: #c8d2cc;
-  stroke-width: 1.3;
+  stroke-width: 1.5;
 }
 
 .graph-edges text {
@@ -728,13 +828,22 @@ h1 {
   stroke-width: 4px;
 }
 
-.graph-edges .active line {
+.graph-edges .direct line {
   stroke: #517564;
-  stroke-width: 1.8;
+  stroke-width: 2;
 }
 
-.graph-edges .active text {
+.graph-edges .direct text {
   opacity: 1;
+}
+
+.graph-edges .context {
+  opacity: 0.28;
+}
+
+.graph-edges .context line {
+  stroke: #7c8b84;
+  stroke-width: 1.2;
 }
 
 .graph-node {
@@ -775,6 +884,64 @@ h1 {
 
 .graph-node.type-decision circle {
   stroke: #3f6f9b;
+}
+
+.graph-hover-card {
+  position: absolute;
+  z-index: 2;
+  display: grid;
+  width: min(280px, calc(100% - 24px));
+  gap: 8px;
+  border: 1px solid #b9c9c1;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 12px 28px rgb(28 44 36 / 18%);
+  color: #21302a;
+  padding: 12px;
+  pointer-events: none;
+  transform: translate(-50%, calc(-100% - 16px));
+}
+
+.graph-hover-card.is-below {
+  transform: translate(-50%, 34px);
+}
+
+.graph-hover-card strong {
+  color: #1f3029;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.graph-hover-card p {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  color: #4b5b53;
+  font-size: 12px;
+  -webkit-line-clamp: 3;
+  line-height: 1.45;
+}
+
+.graph-hover-card .graph-hover-title {
+  color: #718077;
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.graph-hover-card div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.graph-hover-card span {
+  border-radius: 999px;
+  background: #edf4f0;
+  color: #456155;
+  padding: 3px 7px;
+  font-size: 11px;
+  font-weight: 800;
 }
 
 .work-panel,
@@ -845,6 +1012,10 @@ h1 {
 
   .entity-nav {
     max-height: 420px;
+  }
+
+  .entity-jumpbar {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .topbar,

--- a/internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
+++ b/internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
@@ -40,7 +40,7 @@ Props 值必须是 **JSON value**，即 JSON 能够表达的可移植数据：
 - **missing**：raw 中不存在该 key
 - **provided-empty**：raw 中存在该 key，值为 `null` 或 `undefined`
 - **provided-non-empty**：raw 中存在该 key，且值非 `null/undefined`
-- **invalid**：provided-non-empty 且不满足校验（type/enum/range/validator）
+- **invalid**：provided-non-empty 且不满足校验（type/options/range/validator）
 
 ### 3.2 规范空值
 
@@ -53,8 +53,10 @@ Props 值必须是 **JSON value**，即 JSON 能够表达的可移植数据：
 
 ### 4.1 形状约束
 
-- `type` 必须为 `any | boolean | string | number | object`
+- `type` 必须为 `any | boolean | string | number | object | enum`
 - `empty` 只能是 `accept | fallback | error`
+- `type: "enum"` 时 `options` 必填，且必须是非空 string 数组
+- 非 `type: "enum"` 不得提供 `options`
 - `range.min/max` 必须是 number
 
 ### 4.2 合并规则（同 key）
@@ -64,7 +66,7 @@ Props 值必须是 **JSON value**，即 JSON 能够表达的可移植数据：
   - 变严格（accept → fallback → error）→ error
   - 变宽松 → warning，但**保持原有更严格**（行为不放松）
   - omit → 不改变
-- **enum**：
+- **enum options**：
   - incoming 是子集 → error
   - incoming 是超集 → warning
   - 相等 → ok

--- a/internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
+++ b/internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
@@ -130,7 +130,7 @@ Props 值必须是 **JSON value**，即 JSON 能够表达的可移植数据：
 
 - diff 使用 `Object.is`
 - 首次 applyRaw（hydration）不触发
-- watchAll 先于 watch(keys) 触发
+- watchAll 与 watch(keys) 共享注册顺序
 
 ### 6.2 Raw Watch
 

--- a/internal/contracts/props/base-text/01.define-merge.v0.zh-CN.md
+++ b/internal/contracts/props/base-text/01.define-merge.v0.zh-CN.md
@@ -11,6 +11,7 @@
 
 - **Base**：系统中已存在的声明
 - **Incoming**：本次 `define()` 提供的新声明
+- **Enum options**：`type: "enum"` 声明上的可选值集合，字段名为 `options`
 - **Diagnostic**：本次合并产生的警告或错误
   - error：`define()` 必须抛错，且**不产生任何变更**
   - warning：合并成功但需记录
@@ -21,8 +22,10 @@
 
 对每个 incoming prop：
 
-- `type` 必须为 `any | boolean | string | number | object`
+- `type` 必须为 `any | boolean | string | number | object | enum`
 - 若显式提供 `empty`，只能是 `accept | fallback | error`
+- 若 `type: "enum"`，`options` 必须是非空 string 数组
+- 若 `type` 不是 `"enum"`，不得提供 `options`
 - 若提供 `range`：`min/max` 必须是 number
 
 以上校验失败必须 **error**。
@@ -48,15 +51,15 @@ accept < fallback < error
 - Incoming 更宽松 → **warning**，但**保留原有更严格**
 - Incoming omit → 不影响 base
 
-### 3.3 enum
+### 3.3 enum options
 
-- Incoming 是 Base 的**子集** → **error**
-- Incoming 是 Base 的**超集** → **warning**
+- Incoming `options` 是 Base `options` 的**子集** → **error**
+- Incoming `options` 是 Base `options` 的**超集** → **warning**
 - 相等 → ok
-- Base 无 enum 且 Incoming 有 → ok
+- Base 无 `options` 且 Incoming 有 → ok
 - Incoming omit → 保留 Base
 
-> v0 enum 比较使用 `String(...)` 语义。
+> v0 enum options 仅支持 string，比较使用 string 精确相等语义。
 
 ### 3.4 range
 
@@ -84,7 +87,7 @@ accept < fallback < error
 - 合并失败必须原子性：**任一 error，整个 define 不生效**
 - 合并成功：
   - `type` 保持 base
-  - `empty/enum/range/validator/default` 按上述规则合并
+  - `empty/options/range/validator/default` 按上述规则合并
   - 其他字段按 object spread 合并
 
 ---

--- a/internal/contracts/props/base-text/02.resolve-fallback.v0.zh-CN.md
+++ b/internal/contracts/props/base-text/02.resolve-fallback.v0.zh-CN.md
@@ -11,7 +11,7 @@
 - **missing**：raw 中不存在该 key
 - **provided-empty**：raw 中存在该 key，值为 `null` 或 `undefined`
 - **provided-non-empty**：raw 中存在且非 `null/undefined`
-- **invalid**：provided-non-empty，但不满足校验（type/enum/range/validator）
+- **invalid**：provided-non-empty，但不满足校验（type/options/range/validator）
 
 ---
 
@@ -84,9 +84,10 @@
   - string → `typeof v === "string"`
   - number → `typeof v === "number" && !Number.isNaN(v)`
   - object → `typeof v === "object"`
+  - enum → `typeof v === "string" && options.includes(v)`
   - any → 总是通过
 
-- enum/range/validator 失败 → invalid
+- options/range/validator 失败 → invalid
 
 ---
 

--- a/internal/contracts/props/base-text/03.watch-resolved.v0.zh-CN.md
+++ b/internal/contracts/props/base-text/03.watch-resolved.v0.zh-CN.md
@@ -60,8 +60,7 @@
 
 在一次触发性 `applyRaw(...)` 中：
 
-1. `watchAll` 按注册顺序评估与触发
-2. `watch(keys)` 按注册顺序评估与触发
+- 匹配的 `watchAll` 与 `watch(keys)` callback 共享 setup 阶段注册顺序
 
 ---
 

--- a/internal/contracts/props/base-text/05.runtime-integration.v0.zh-CN.md
+++ b/internal/contracts/props/base-text/05.runtime-integration.v0.zh-CN.md
@@ -48,8 +48,8 @@
 
 在一次 watcher-firing 的 raw 应用中：
 
-1. raw watchers（rawAll → raw(keys)，保持注册顺序）
-2. resolved watchers（watchAll → watch(keys)，保持注册顺序）
+1. raw watchers（rawAll → raw(keys)，同组内保持注册顺序）
+2. resolved watchers（`watchAll` 与 `watch(keys)` 共享注册顺序）
 
 ---
 

--- a/internal/contracts/props/runtime-integration.v0.md
+++ b/internal/contracts/props/runtime-integration.v0.md
@@ -48,8 +48,8 @@ Behavioral alignment:
 
 On a watcher-firing raw application:
 
-1. raw watchers (rawAll → raw(keys), registration order preserved)
-2. resolved watchers (watchAll → watch(keys), registration order preserved)
+1. raw watchers (rawAll → raw(keys), registration order preserved within each group)
+2. resolved watchers (`watchAll` and `watch(keys)` share registration order)
 
 ---
 

--- a/internal/contracts/props/watch-resolved.v0.md
+++ b/internal/contracts/props/watch-resolved.v0.md
@@ -63,8 +63,7 @@ Callback:
 
 For a watcher-firing `applyRaw(...)`:
 
-1. `watchAll` callbacks (registration order)
-2. `watch(keys)` callbacks (registration order)
+- matching `watchAll` and `watch(keys)` callbacks run in shared registration order
 
 ---
 

--- a/internal/contracts/types/props.specmap.v0.type-test.ts
+++ b/internal/contracts/types/props.specmap.v0.type-test.ts
@@ -8,6 +8,25 @@ type P = { disabled: boolean | null; count: number };
   count: { type: 'number' },
 }) satisfies PropsSpecMap<P>;
 
+type PEnum = { mode: 'primary' | 'secondary' };
+
+// ✅ enum props use state-style string options
+({
+  mode: { type: 'enum', options: ['primary', 'secondary'] as const },
+}) satisfies PropsSpecMap<PEnum>;
+
+// ❌ enum options are required
+({
+  // @ts-expect-error type:"enum" requires options
+  mode: { type: 'enum' },
+}) satisfies PropsSpecMap<PEnum>;
+
+// ❌ legacy enum descriptor field is no longer part of PropsSpecMap
+({
+  // @ts-expect-error use type:"enum" with options instead
+  mode: { type: 'string', enum: ['primary', 'secondary'] as const },
+}) satisfies PropsSpecMap<PEnum>;
+
 // ❌ empty:"accept" requires null in declared type
 type P2 = { disabled: boolean; count: number };
 

--- a/packages/adapters/base/test-utils/props-json-value-boundary.ts
+++ b/packages/adapters/base/test-utils/props-json-value-boundary.ts
@@ -94,6 +94,10 @@ function lastObservation(
   return undefined;
 }
 
+function latestObservation(observations: BoundaryObservation[]): BoundaryObservation | undefined {
+  return observations[observations.length - 1];
+}
+
 export function describeAdapterPropsJsonValueBoundaryConformance(
   harness: AdapterPropsBoundaryHarness
 ) {
@@ -111,7 +115,7 @@ export function describeAdapterPropsJsonValueBoundaryConformance(
         const mounted = await harness.mount(proto, { value });
 
         try {
-          expectBoundaryObservation(observations.at(-1), value, testCase);
+          expectBoundaryObservation(latestObservation(observations), value, testCase);
         } finally {
           await mounted.unmount();
         }

--- a/packages/adapters/base/test-utils/props-json-value-boundary.ts
+++ b/packages/adapters/base/test-utils/props-json-value-boundary.ts
@@ -1,0 +1,142 @@
+import { definePrototype, type Prototype, type RunHandle } from '@proto.ui/core';
+import { JSON_PROPS_VALUE_BOUNDARY_CASES } from '@proto.ui/spec-fixtures/props/json-value-boundary';
+import { describe, expect, it } from 'vitest';
+
+const FALLBACK_VALUE = 'adapter-fallback-value';
+
+type BoundaryObservation = {
+  phase: 'mounted' | 'updated';
+  resolvedValue: unknown;
+  rawValue: unknown;
+  provided: boolean;
+};
+
+export type AdapterPropsBoundaryMounted = {
+  updateProps(nextProps: Record<string, unknown>): void | Promise<void>;
+  unmount(): void | Promise<void>;
+};
+
+export type AdapterPropsBoundaryHarness = {
+  adapterName: string;
+  mount(
+    proto: Prototype<any>,
+    props: Record<string, unknown>
+  ): AdapterPropsBoundaryMounted | Promise<AdapterPropsBoundaryMounted>;
+};
+
+function isPortableValueCase(testCase: (typeof JSON_PROPS_VALUE_BOUNDARY_CASES)[number]): boolean {
+  return testCase.expectation === 'accepted-as-portable';
+}
+
+function createBoundaryPrototype(args: {
+  name: string;
+  acceptNull: boolean;
+  observations: BoundaryObservation[];
+}) {
+  const { name, acceptNull, observations } = args;
+
+  return definePrototype<{ value: unknown }>({
+    name,
+    setup(def) {
+      def.props.define({
+        value: {
+          type: 'any',
+          default: FALLBACK_VALUE,
+          empty: acceptNull ? 'accept' : 'fallback',
+        },
+      });
+
+      const observe = (phase: BoundaryObservation['phase'], run: RunHandle<{ value: unknown }>) => {
+        observations.push({
+          phase,
+          resolvedValue: run.props.get().value,
+          rawValue: run.props.getRaw().value,
+          provided: run.props.isProvided('value'),
+        });
+      };
+
+      def.lifecycle.onMounted((run) => observe('mounted', run));
+      def.lifecycle.onUpdated((run) => observe('updated', run));
+
+      return (renderer) => [renderer.el('div', `${name}:ready`)];
+    },
+  });
+}
+
+function expectBoundaryObservation(
+  observation: BoundaryObservation | undefined,
+  value: unknown,
+  testCase: (typeof JSON_PROPS_VALUE_BOUNDARY_CASES)[number]
+) {
+  expect(observation, `${testCase.id} should produce an adapter observation`).toBeDefined();
+  expect(observation?.provided).toBe(true);
+
+  if (isPortableValueCase(testCase)) {
+    expect(observation?.resolvedValue).toEqual(value);
+    return;
+  }
+
+  expect(observation?.resolvedValue).toBe(FALLBACK_VALUE);
+
+  if (testCase.expectation === 'raw-observable-but-not-portable') {
+    expect(observation?.rawValue).toBe(value);
+  }
+}
+
+function lastObservation(
+  observations: BoundaryObservation[],
+  phase: BoundaryObservation['phase']
+): BoundaryObservation | undefined {
+  for (let index = observations.length - 1; index >= 0; index -= 1) {
+    const observation = observations[index];
+    if (observation?.phase === phase) return observation;
+  }
+  return undefined;
+}
+
+export function describeAdapterPropsJsonValueBoundaryConformance(
+  harness: AdapterPropsBoundaryHarness
+) {
+  describe(`${harness.adapterName}: adapter props JSON value boundary conformance`, () => {
+    for (const testCase of JSON_PROPS_VALUE_BOUNDARY_CASES) {
+      it(`${testCase.id}: passes host props through mount without expanding resolved props semantics`, async () => {
+        const value = testCase.createValue();
+        const observations: BoundaryObservation[] = [];
+        const proto = createBoundaryPrototype({
+          name: `${harness.adapterName}-props-json-value-boundary-mount-${testCase.id}`,
+          acceptNull: testCase.id === 'json-primitive-null',
+          observations,
+        });
+
+        const mounted = await harness.mount(proto, { value });
+
+        try {
+          expectBoundaryObservation(observations.at(-1), value, testCase);
+        } finally {
+          await mounted.unmount();
+        }
+      });
+
+      it(`${testCase.id}: passes host props through update without expanding resolved props semantics`, async () => {
+        const value = testCase.createValue();
+        const observations: BoundaryObservation[] = [];
+        const proto = createBoundaryPrototype({
+          name: `${harness.adapterName}-props-json-value-boundary-update-${testCase.id}`,
+          acceptNull: testCase.id === 'json-primitive-null',
+          observations,
+        });
+
+        const mounted = await harness.mount(proto, {});
+
+        try {
+          await mounted.updateProps({ value });
+
+          const updateObservation = lastObservation(observations, 'updated');
+          expectBoundaryObservation(updateObservation, value, testCase);
+        } finally {
+          await mounted.unmount();
+        }
+      });
+    }
+  });
+}

--- a/packages/adapters/base/test-utils/resolved-snapshot-shape.ts
+++ b/packages/adapters/base/test-utils/resolved-snapshot-shape.ts
@@ -1,0 +1,225 @@
+import { definePrototype, type Prototype, type RunHandle } from '@proto.ui/core';
+import { describe, expect, it } from 'vitest';
+
+type SnapshotPhase = 'mounted' | 'updated';
+
+type SnapshotObservation = {
+  phase: SnapshotPhase;
+  resolved: Record<string, unknown>;
+  raw: Record<string, unknown>;
+  provided: Record<string, boolean>;
+};
+
+export type AdapterResolvedSnapshotMounted = {
+  updateProps(nextProps: Record<string, unknown>): void | Promise<void>;
+  unmount(): void | Promise<void>;
+};
+
+export type AdapterResolvedSnapshotHarness = {
+  adapterName: string;
+  mount(
+    proto: Prototype<any>,
+    props: Record<string, unknown>
+  ): AdapterResolvedSnapshotMounted | Promise<AdapterResolvedSnapshotMounted>;
+};
+
+function latestObservation(
+  observations: SnapshotObservation[],
+  phase?: SnapshotPhase
+): SnapshotObservation | undefined {
+  for (let index = observations.length - 1; index >= 0; index -= 1) {
+    const observation = observations[index];
+    if (!phase || observation?.phase === phase) return observation;
+  }
+  return undefined;
+}
+
+function observeProps(
+  phase: SnapshotPhase,
+  run: RunHandle<any>,
+  keys: string[],
+  observations: SnapshotObservation[]
+) {
+  const resolved = run.props.get() as Record<string, unknown>;
+  const raw = run.props.getRaw() as Record<string, unknown>;
+
+  observations.push({
+    phase,
+    resolved,
+    raw,
+    provided: Object.fromEntries(keys.map((key) => [key, run.props.isProvided(key)])),
+  });
+}
+
+function createObservedPrototype(args: {
+  name: string;
+  props: Record<string, unknown>;
+  providedKeys: string[];
+  observations: SnapshotObservation[];
+}) {
+  const { name, props, providedKeys, observations } = args;
+
+  return definePrototype<any>({
+    name,
+    setup(def) {
+      def.props.define(props as any);
+
+      const observe = (phase: SnapshotPhase, run: RunHandle<any>) => {
+        observeProps(phase, run, providedKeys, observations);
+      };
+
+      def.lifecycle.onMounted((run) => observe('mounted', run));
+      def.lifecycle.onUpdated((run) => observe('updated', run));
+
+      return (renderer) => [renderer.el('div', `${name}:ready`)];
+    },
+  });
+}
+
+export function describeAdapterResolvedSnapshotShapeConformance(
+  harness: AdapterResolvedSnapshotHarness
+) {
+  describe(`${harness.adapterName}: adapter resolved props snapshot shape conformance`, () => {
+    it('mount path preserves declared-key resolved snapshot shape', async () => {
+      const observations: SnapshotObservation[] = [];
+      const proto = createObservedPrototype({
+        name: `${harness.adapterName}-resolved-snapshot-declared-keys`,
+        props: {
+          present: { type: 'number' },
+          missingWithDefault: { type: 'string', default: 'fallback' },
+          missingEmpty: { type: 'boolean' },
+        },
+        providedKeys: ['present', 'missingWithDefault', 'missingEmpty'],
+        observations,
+      });
+
+      const mounted = await harness.mount(proto, { present: 1 });
+
+      try {
+        const observation = latestObservation(observations);
+
+        expect(observation?.resolved).toEqual({
+          present: 1,
+          missingWithDefault: 'fallback',
+          missingEmpty: null,
+        });
+        expect(observation?.provided).toEqual({
+          present: true,
+          missingWithDefault: false,
+          missingEmpty: false,
+        });
+      } finally {
+        await mounted.unmount();
+      }
+    });
+
+    it('update path excludes undeclared raw keys from resolved props', async () => {
+      const observations: SnapshotObservation[] = [];
+      const proto = createObservedPrototype({
+        name: `${harness.adapterName}-resolved-snapshot-undeclared-keys`,
+        props: {
+          declared: { type: 'number' },
+        },
+        providedKeys: ['declared', 'extra'],
+        observations,
+      });
+
+      const mounted = await harness.mount(proto, { declared: 1 });
+
+      try {
+        await mounted.updateProps({ declared: 2, extra: 9 });
+
+        const observation = latestObservation(observations, 'updated');
+
+        expect(observation?.resolved).toEqual({ declared: 2 });
+        expect(observation?.resolved).not.toHaveProperty('extra');
+        expect(observation?.raw).toEqual({ declared: 2, extra: 9 });
+        expect(observation?.provided).toEqual({ declared: true, extra: true });
+      } finally {
+        await mounted.unmount();
+      }
+    });
+
+    it('update path resolves each key independently', async () => {
+      const observations: SnapshotObservation[] = [];
+      const proto = createObservedPrototype({
+        name: `${harness.adapterName}-resolved-snapshot-key-granularity`,
+        props: {
+          valid: { type: 'number' },
+          missing: { type: 'string', default: 'missing-fallback' },
+          empty: { type: 'number', empty: 'accept' },
+          invalid: { type: 'boolean', default: true },
+        },
+        providedKeys: ['valid', 'missing', 'empty', 'invalid'],
+        observations,
+      });
+
+      const mounted = await harness.mount(proto, {
+        valid: 1,
+        missing: 'initial',
+        empty: 2,
+        invalid: false,
+      });
+
+      try {
+        await mounted.updateProps({
+          valid: 42,
+          empty: null,
+          invalid: 'not-boolean',
+        });
+
+        const observation = latestObservation(observations, 'updated');
+
+        expect(observation?.resolved).toEqual({
+          valid: 42,
+          missing: 'initial',
+          empty: null,
+          invalid: false,
+        });
+      } finally {
+        await mounted.unmount();
+      }
+    });
+
+    it('update path does not expose undefined and normalizes empty values to null', async () => {
+      const observations: SnapshotObservation[] = [];
+      const proto = createObservedPrototype({
+        name: `${harness.adapterName}-resolved-snapshot-empty-normalization`,
+        props: {
+          missing: { type: 'string' },
+          providedUndefined: { type: 'number', empty: 'accept' },
+          providedNull: { type: 'boolean', empty: 'accept' },
+        },
+        providedKeys: ['missing', 'providedUndefined', 'providedNull'],
+        observations,
+      });
+
+      const mounted = await harness.mount(proto, {
+        providedUndefined: 1,
+        providedNull: true,
+      });
+
+      try {
+        await mounted.updateProps({
+          providedUndefined: undefined,
+          providedNull: null,
+        });
+
+        const observation = latestObservation(observations, 'updated');
+
+        expect(observation?.resolved).toEqual({
+          missing: null,
+          providedUndefined: null,
+          providedNull: null,
+        });
+        expect(Object.values(observation?.resolved ?? {})).not.toContain(undefined);
+        expect(observation?.raw).toEqual({
+          providedUndefined: null,
+          providedNull: null,
+        });
+      } finally {
+        await mounted.unmount();
+      }
+    });
+  });
+}

--- a/packages/adapters/react/test/contract/props-json-value-boundary.v0.contract.test.ts
+++ b/packages/adapters/react/test/contract/props-json-value-boundary.v0.contract.test.ts
@@ -1,0 +1,18 @@
+import { describeAdapterPropsJsonValueBoundaryConformance } from '../../../base/test-utils/props-json-value-boundary';
+import { createMountedReactAdapter } from '../utils/fake-react';
+
+describeAdapterPropsJsonValueBoundaryConformance({
+  adapterName: 'adapter-react',
+  mount(proto, props) {
+    const mounted = createMountedReactAdapter(proto, props);
+
+    return {
+      updateProps(nextProps) {
+        mounted.update(nextProps);
+      },
+      unmount() {
+        mounted.unmount();
+      },
+    };
+  },
+});

--- a/packages/adapters/react/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+++ b/packages/adapters/react/test/contract/resolved-snapshot-shape.v0.contract.test.ts
@@ -1,0 +1,18 @@
+import { describeAdapterResolvedSnapshotShapeConformance } from '../../../base/test-utils/resolved-snapshot-shape';
+import { createMountedReactAdapter } from '../utils/fake-react';
+
+describeAdapterResolvedSnapshotShapeConformance({
+  adapterName: 'adapter-react',
+  mount(proto, props) {
+    const mounted = createMountedReactAdapter(proto, props);
+
+    return {
+      updateProps(nextProps) {
+        mounted.update(nextProps);
+      },
+      unmount() {
+        mounted.unmount();
+      },
+    };
+  },
+});

--- a/packages/adapters/vue/test/contract/props-json-value-boundary.v0.contract.test.ts
+++ b/packages/adapters/vue/test/contract/props-json-value-boundary.v0.contract.test.ts
@@ -1,0 +1,40 @@
+import { describeAdapterPropsJsonValueBoundaryConformance } from '../../../base/test-utils/props-json-value-boundary';
+import { createVueAdapter } from '../../src/adapt';
+import { flushVue, VueAny } from '../utils/vue';
+
+describeAdapterPropsJsonValueBoundaryConformance({
+  adapterName: 'adapter-vue',
+  async mount(proto, props) {
+    const adapter = createVueAdapter(VueAny);
+    const Component = adapter(proto);
+    const host = document.createElement('div');
+    const state = VueAny.reactive({ ...props });
+
+    document.body.appendChild(host);
+
+    const Root = VueAny.defineComponent({
+      setup() {
+        return () => VueAny.h(Component, { ...state });
+      },
+    });
+
+    const app = VueAny.createApp(Root);
+    app.mount(host);
+    await flushVue();
+
+    return {
+      async updateProps(nextProps) {
+        for (const key of Object.keys(state)) {
+          if (!(key in nextProps)) delete state[key];
+        }
+        Object.assign(state, nextProps);
+        await flushVue();
+      },
+      async unmount() {
+        app.unmount();
+        await flushVue();
+        host.remove();
+      },
+    };
+  },
+});

--- a/packages/adapters/vue/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+++ b/packages/adapters/vue/test/contract/resolved-snapshot-shape.v0.contract.test.ts
@@ -1,0 +1,40 @@
+import { describeAdapterResolvedSnapshotShapeConformance } from '../../../base/test-utils/resolved-snapshot-shape';
+import { createVueAdapter } from '../../src/adapt';
+import { flushVue, VueAny } from '../utils/vue';
+
+describeAdapterResolvedSnapshotShapeConformance({
+  adapterName: 'adapter-vue',
+  async mount(proto, props) {
+    const adapter = createVueAdapter(VueAny);
+    const Component = adapter(proto);
+    const host = document.createElement('div');
+    const state = VueAny.reactive({ ...props });
+
+    document.body.appendChild(host);
+
+    const Root = VueAny.defineComponent({
+      setup() {
+        return () => VueAny.h(Component, { ...state });
+      },
+    });
+
+    const app = VueAny.createApp(Root);
+    app.mount(host);
+    await flushVue();
+
+    return {
+      async updateProps(nextProps) {
+        for (const key of Object.keys(state)) {
+          if (!(key in nextProps)) delete state[key];
+        }
+        Object.assign(state, nextProps);
+        await flushVue();
+      },
+      async unmount() {
+        app.unmount();
+        await flushVue();
+        host.remove();
+      },
+    };
+  },
+});

--- a/packages/adapters/web-component/test/contract/props-json-value-boundary.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/props-json-value-boundary.v0.contract.test.ts
@@ -1,0 +1,43 @@
+import { describeAdapterPropsJsonValueBoundaryConformance } from '../../../base/test-utils/props-json-value-boundary';
+import { AdaptToWebComponent } from '../../src/adapt';
+import { setElementProps } from '../../src/props';
+
+async function flushWebComponentAdapter() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describeAdapterPropsJsonValueBoundaryConformance({
+  adapterName: 'adapter-web-component',
+  async mount(proto, props) {
+    const tagName = proto.name;
+    const Ctor = AdaptToWebComponent(proto, {
+      register: false,
+      registerAs: tagName,
+    });
+
+    if (!customElements.get(tagName)) {
+      customElements.define(tagName, Ctor);
+    }
+
+    const el = document.createElement(tagName) as HTMLElement & {
+      update?: () => void;
+    };
+
+    setElementProps(el, props);
+    document.body.appendChild(el);
+    await flushWebComponentAdapter();
+
+    return {
+      async updateProps(nextProps) {
+        setElementProps(el, nextProps);
+        el.update?.();
+        await flushWebComponentAdapter();
+      },
+      async unmount() {
+        el.remove();
+        await flushWebComponentAdapter();
+      },
+    };
+  },
+});

--- a/packages/adapters/web-component/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/resolved-snapshot-shape.v0.contract.test.ts
@@ -1,0 +1,43 @@
+import { describeAdapterResolvedSnapshotShapeConformance } from '../../../base/test-utils/resolved-snapshot-shape';
+import { AdaptToWebComponent } from '../../src/adapt';
+import { setElementProps } from '../../src/props';
+
+async function flushWebComponentAdapter() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describeAdapterResolvedSnapshotShapeConformance({
+  adapterName: 'adapter-web-component',
+  async mount(proto, props) {
+    const tagName = proto.name;
+    const Ctor = AdaptToWebComponent(proto, {
+      register: false,
+      registerAs: tagName,
+    });
+
+    if (!customElements.get(tagName)) {
+      customElements.define(tagName, Ctor);
+    }
+
+    const el = document.createElement(tagName) as HTMLElement & {
+      update?: () => void;
+    };
+
+    setElementProps(el, props);
+    document.body.appendChild(el);
+    await flushWebComponentAdapter();
+
+    return {
+      async updateProps(nextProps) {
+        setElementProps(el, nextProps);
+        el.update?.();
+        await flushWebComponentAdapter();
+      },
+      async unmount() {
+        el.remove();
+        await flushWebComponentAdapter();
+      },
+    };
+  },
+});

--- a/packages/hooks/src/as-transition.ts
+++ b/packages/hooks/src/as-transition.ts
@@ -46,9 +46,9 @@ export function asTransition(options?: TransitionOptions): TransitionHandles {
     enterDuration: { type: 'number', empty: 'fallback' },
     leaveDuration: { type: 'number', empty: 'fallback' },
     interrupt: {
-      type: 'string',
+      type: 'enum',
       empty: 'fallback',
-      enum: ['reverse', 'wait', 'immediate'],
+      options: ['reverse', 'wait', 'immediate'],
     },
   });
 

--- a/packages/modules/props/src/impl.ts
+++ b/packages/modules/props/src/impl.ts
@@ -52,8 +52,10 @@ export class PropsModuleImpl<P extends PropsBaseType> extends ModuleBase {
   private readonly declaredKeys: Set<string> = new Set();
 
   // watchers (setup-only registration)
-  private watch: Array<{ keys: string[]; cb: PropsWatchCb<P>; active: boolean }> = [];
-  private watchAll: Array<{ cb: PropsWatchCb<P>; active: boolean }> = [];
+  private resolvedWatchSeq = 0;
+  private watch: Array<{ order: number; keys: string[]; cb: PropsWatchCb<P>; active: boolean }> =
+    [];
+  private watchAll: Array<{ order: number; cb: PropsWatchCb<P>; active: boolean }> = [];
   private watchRaw: Array<{
     keys: string[];
     cb: RawWatchCb<P & PropsBaseType>;
@@ -119,7 +121,7 @@ export class PropsModuleImpl<P extends PropsBaseType> extends ModuleBase {
       }
     }
 
-    const entry = { keys: [...(keys as any)], cb, active: true };
+    const entry = { order: this.resolvedWatchSeq++, keys: [...(keys as any)], cb, active: true };
     this.watch.push(entry);
     return () => {
       entry.active = false;
@@ -128,7 +130,7 @@ export class PropsModuleImpl<P extends PropsBaseType> extends ModuleBase {
 
   watchAllKeys(cb: PropsWatchCb<P>): () => void {
     this.guardSetupOnly('def.props.watchAll');
-    const entry = { cb, active: true };
+    const entry = { order: this.resolvedWatchSeq++, cb, active: true };
     this.watchAll.push(entry);
     return () => {
       entry.active = false;
@@ -274,7 +276,9 @@ export class PropsModuleImpl<P extends PropsBaseType> extends ModuleBase {
       });
     }
 
-    // resolved watchers: all first, then keyed (registration order preserved within group)
+    // resolved watchers: watchAll and keyed watchers share registration order.
+    const resolvedTasks: Array<{ order: number; task: PropsWatchTask<P> }> = [];
+
     for (const w of this.watchAll) {
       if (!w.active) continue;
       if (changedAllResolved.length === 0) continue;
@@ -282,12 +286,15 @@ export class PropsModuleImpl<P extends PropsBaseType> extends ModuleBase {
         changedKeysAll: changedAllResolved as any,
         changedKeysMatched: changedAllResolved as any,
       };
-      tasks.push({
-        kind: 'resolved',
-        cb: w.cb as any,
-        next: nextResolved as any,
-        prev: prevResolved as any,
-        info: info as any,
+      resolvedTasks.push({
+        order: w.order,
+        task: {
+          kind: 'resolved',
+          cb: w.cb as any,
+          next: nextResolved as any,
+          prev: prevResolved as any,
+          info: info as any,
+        },
       });
     }
 
@@ -300,14 +307,20 @@ export class PropsModuleImpl<P extends PropsBaseType> extends ModuleBase {
         changedKeysAll: changedAllResolved as any,
         changedKeysMatched: matched as any,
       };
-      tasks.push({
-        kind: 'resolved',
-        cb: w.cb as any,
-        next: nextResolved as any,
-        prev: prevResolved as any,
-        info: info as any,
+      resolvedTasks.push({
+        order: w.order,
+        task: {
+          kind: 'resolved',
+          cb: w.cb as any,
+          next: nextResolved as any,
+          prev: prevResolved as any,
+          info: info as any,
+        },
       });
     }
+
+    resolvedTasks.sort((a, b) => a.order - b.order);
+    for (const { task } of resolvedTasks) tasks.push(task);
 
     return tasks;
   }

--- a/packages/modules/props/src/kernel/kernel.ts
+++ b/packages/modules/props/src/kernel/kernel.ts
@@ -313,6 +313,12 @@ export class PropsKernel<P extends PropsBaseType> {
       case 'string':
         if (typeof v !== 'string') return { ok: false };
         break;
+      case 'enum':
+        if (typeof v !== 'string') return { ok: false };
+        if (!Array.isArray((decl as any).options) || !(decl as any).options.includes(v)) {
+          return { ok: false };
+        }
+        break;
       case 'number':
         if (typeof v !== 'number' || Number.isNaN(v)) return { ok: false };
         break;
@@ -322,11 +328,6 @@ export class PropsKernel<P extends PropsBaseType> {
       case 'any':
       default:
         break;
-    }
-
-    if ((decl as any).enum) {
-      const set = new Set((decl as any).enum.map(String));
-      if (!set.has(String(v))) return { ok: false };
     }
 
     if ((decl as any).range) {

--- a/packages/modules/props/src/kernel/kernel.ts
+++ b/packages/modules/props/src/kernel/kernel.ts
@@ -70,6 +70,7 @@ export class PropsKernel<P extends PropsBaseType> {
         .filter((d: PropsKernelDiag) => d.level === 'error')
         .map((d: PropsKernelDiag) => (d.key ? `${d.key}: ${d.message}` : d.message))
         .join('; ');
+      // Merge conflicts are transaction-level blocking errors: do not assign specs or persist warnings from the failed merge.
       throw new Error(`[Props] define merge error: ${msg}`);
     }
     for (const d of diags) {

--- a/packages/modules/props/src/kernel/merge.ts
+++ b/packages/modules/props/src/kernel/merge.ts
@@ -34,20 +34,31 @@ function isValidEmptyBehavior(x: any): x is EmptyBehavior {
 }
 
 function isValidPropType(x: any): x is PropType {
-  return x === 'any' || x === 'boolean' || x === 'string' || x === 'number' || x === 'object';
+  return (
+    x === 'any' ||
+    x === 'boolean' ||
+    x === 'string' ||
+    x === 'number' ||
+    x === 'object' ||
+    x === 'enum'
+  );
 }
 
-function isSupersetEnum(next?: readonly any[], prev?: readonly any[]) {
+function isValidOptions(x: any): x is readonly string[] {
+  return Array.isArray(x) && x.length > 0 && x.every((option) => typeof option === 'string');
+}
+
+function isSupersetOptions(next?: readonly string[], prev?: readonly string[]) {
   if (!prev || prev.length === 0) return true;
   if (!next) return false;
-  const set = new Set(next.map(String));
-  return prev.every((x) => set.has(String(x)));
+  const set = new Set(next);
+  return prev.every((x) => set.has(x));
 }
 
 /**
  * NOTE:
  * The current merge strategy is "incoming must not be stricter".
- * - enum: incoming must be a superset of prev (or equal), else error.
+ * - options: incoming must be a superset of prev (or equal), else error.
  * - range: incoming must be wider/equal (or omit), else error.
  */
 function rangeWider(next?: { min?: number; max?: number }, prev?: { min?: number; max?: number }) {
@@ -98,7 +109,34 @@ export function mergeSpecs<A extends PropsBaseType, B extends PropsBaseType>(
       diags.push({
         level: 'error',
         key,
-        message: `type must be one of \"any\" | \"boolean\" | \"string\" | \"number\" | \"object\"`,
+        message: `type must be one of \"any\" | \"boolean\" | \"string\" | \"number\" | \"object\" | \"enum\"`,
+      });
+      continue;
+    }
+
+    if ((next as any).type === 'enum' && !isValidOptions((next as any).options)) {
+      diags.push({
+        level: 'error',
+        key,
+        message: `enum props require non-empty string options`,
+      });
+      continue;
+    }
+
+    if ((next as any).type !== 'enum' && hasOwn(next as any, 'options')) {
+      diags.push({
+        level: 'error',
+        key,
+        message: `options are only allowed for type "enum"`,
+      });
+      continue;
+    }
+
+    if (hasOwn(next as any, 'enum')) {
+      diags.push({
+        level: 'error',
+        key,
+        message: `enum descriptor field is deprecated; use type "enum" with options`,
       });
       continue;
     }
@@ -204,30 +242,30 @@ export function mergeSpecs<A extends PropsBaseType, B extends PropsBaseType>(
     }
 
     // -----------------------------
-    // enum:
+    // enum options:
     // - require incoming to be superset/equal, else error
     // - if widened => warning
     // -----------------------------
-    if ((prev as any).enum || (next as any).enum) {
-      const prevEnum = (prev as any).enum as readonly any[] | undefined;
-      const nextEnum = (next as any).enum as readonly any[] | undefined;
+    if ((prev as any).options || (next as any).options) {
+      const prevOptions = (prev as any).options as readonly string[] | undefined;
+      const nextOptions = (next as any).options as readonly string[] | undefined;
 
-      if (!isSupersetEnum(nextEnum, prevEnum)) {
+      if (!isSupersetOptions(nextOptions, prevOptions)) {
         diags.push({
           level: 'error',
           key,
-          message: `enum becomes stricter (subset)`,
+          message: `enum options become stricter (subset)`,
         });
         continue;
       }
 
       // warn if next strictly wider than prev
       // (i.e. prev is not a superset of next)
-      if (!isSupersetEnum(prevEnum, nextEnum)) {
+      if (!isSupersetOptions(prevOptions, nextOptions)) {
         diags.push({
           level: 'warning',
           key,
-          message: `enum widened (superset)`,
+          message: `enum options widened (superset)`,
         });
       }
     }
@@ -330,7 +368,7 @@ export function mergeSpecs<A extends PropsBaseType, B extends PropsBaseType>(
 
       // enforced merges
       empty: mergedEmpty,
-      enum: (next as any).enum ?? (prev as any).enum,
+      options: (next as any).options ?? (prev as any).options,
       range: (next as any).range ?? (prev as any).range,
       validator: (prev as any).validator ?? (next as any).validator,
     };

--- a/packages/modules/props/src/kernel/types.ts
+++ b/packages/modules/props/src/kernel/types.ts
@@ -8,7 +8,7 @@ export type PropsResolveMeta<P extends PropsBaseType> = {
   /** raw 里 provided 但值是 null/undefined（不等于 invalid） */
   emptyKeys: Array<keyof P & string>;
 
-  /** raw 里 provided 且 non-empty，但不满足 spec（type/enum/range/validator） */
+  /** raw 里 provided 且 non-empty，但不满足 spec（type/options/range/validator） */
   invalidKeys: Array<keyof P & string>;
 
   /** resolved 值来自 defaults stack / spec.default / canonical null，而不是 raw 直通 */

--- a/packages/modules/props/test/contract/define-merge.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/define-merge.v0.contract.test.ts
@@ -212,28 +212,32 @@ describe('props: define merge semantics (v0)', () => {
     expect(k1.getDiagnostics()).toEqual(k2.getDiagnostics());
   });
 
-  it('PROP-V0-1800: define merge failure is atomic (observable behavior unchanged; warnings not partially added)', () => {
-    type P = { a: number };
+  it('PROP-V0-1800: define merge conflict blocks the whole batch without partial behavior or warnings', () => {
+    type P = { a: number; b: number };
     const pm = new PropsKernel<P>();
 
     pm.define({
-      a: { type: 'number', range: { min: 0, max: 10 }, default: 1 },
+      a: { type: 'number', empty: 'error', default: 1 },
+      b: { type: 'number', range: { min: 0, max: 10 }, default: 5 },
     } satisfies PropsSpecMap<P>);
 
-    pm.applyRaw({});
+    pm.applyRaw({ a: 2, b: 5 });
     const beforeValue = pm.get().a;
     const beforeWarn = warnings(pm).length;
 
-    // incompatible range => throw
+    // Same incoming batch first produces a warning for `a`, then a blocking conflict for `b`.
     expect(() =>
-      pm.define({ a: { type: 'number', range: { min: 100, max: 200 } } } as any)
+      pm.define({
+        a: { type: 'number', empty: 'accept' },
+        b: { type: 'number', range: { min: 100, max: 200 } },
+      } as any)
     ).toThrow(/define merge error/i);
 
-    // behavior unchanged
-    pm.applyRaw({});
+    // Behavior is unchanged: `a` did not become empty-accepting after the failed batch.
+    pm.applyRaw({ a: null, b: 5 });
     expect(pm.get().a).toBe(beforeValue);
 
-    // warnings should not grow due to failed merge (atomic)
+    // Warnings from the failed transaction are not recorded.
     expect(warnings(pm).length).toBe(beforeWarn);
   });
 });

--- a/packages/modules/props/test/contract/define-merge.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/define-merge.v0.contract.test.ts
@@ -20,6 +20,24 @@ describe('props: define merge semantics (v0)', () => {
         a: { type: 'number', range: { min: 'bad' } },
       } as any)
     ).toThrow();
+
+    expect(() =>
+      pm.define({
+        mode: { type: 'enum' },
+      } as any)
+    ).toThrow(/options/i);
+
+    expect(() =>
+      pm.define({
+        label: { type: 'string', options: ['a'] },
+      } as any)
+    ).toThrow(/options/i);
+
+    expect(() =>
+      pm.define({
+        legacy: { type: 'string', enum: ['a'] },
+      } as any)
+    ).toThrow(/enum descriptor field/i);
   });
 
   it('PROP-V0-1100: merge type mismatch MUST throw', () => {
@@ -68,26 +86,26 @@ describe('props: define merge semantics (v0)', () => {
     expect(pm3.get().x).toBe(7);
   });
 
-  it('PROP-V0-1300: merge enum: intersect; widening warns; incompatible throws', () => {
+  it('PROP-V0-1300: merge enum options: intersect; widening warns; incompatible throws', () => {
     type P = { mode: string };
     const pm = new PropsKernel<P>();
 
     pm.define({
-      mode: { type: 'string', enum: ['a', 'b', 'c'] as const, default: 'a' },
+      mode: { type: 'enum', options: ['a', 'b', 'c'] as const, default: 'a' },
     } satisfies PropsSpecMap<P>);
 
     // widening => warn (intersection stays the same, but we can't read spec; just check warning exists)
     pm.define({
-      mode: { type: 'string', enum: ['a', 'b', 'c', 'd'] as const },
+      mode: { type: 'enum', options: ['a', 'b', 'c', 'd'] as const },
     } satisfies PropsSpecMap<P>);
     expect(warnings(pm).length).toBeGreaterThan(0);
 
     // incompatible => throw (no intersection)
     const pm2 = new PropsKernel<P>();
     pm2.define({
-      mode: { type: 'string', enum: ['a', 'b'] as const },
+      mode: { type: 'enum', options: ['a', 'b'] as const },
     } satisfies PropsSpecMap<P>);
-    expect(() => pm2.define({ mode: { type: 'string', enum: ['c'] as const } } as any)).toThrow(
+    expect(() => pm2.define({ mode: { type: 'enum', options: ['c'] as const } } as any)).toThrow(
       /define merge error/i
     );
   });
@@ -174,11 +192,11 @@ describe('props: define merge semantics (v0)', () => {
       a: { type: 'number', range: { min: 0, max: 10 }, default: 1 },
     } as any);
     k1.define({
-      b: { type: 'string', enum: ['x', 'y'] as const, default: 'x' },
+      b: { type: 'enum', options: ['x', 'y'] as const, default: 'x' },
     } as any);
 
     k2.define({
-      b: { type: 'string', enum: ['x', 'y'] as const, default: 'x' },
+      b: { type: 'enum', options: ['x', 'y'] as const, default: 'x' },
     } as any);
     k2.define({
       a: { type: 'number', range: { min: 0, max: 10 }, default: 1 },

--- a/packages/modules/props/test/contract/fallback-resolution.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/fallback-resolution.v0.contract.test.ts
@@ -4,7 +4,7 @@ import { PropsKernel } from '../../src/kernel/kernel';
 
 describe('props: fallback resolution (T-PROPS-0006)', () => {
   it('T-PROPS-0006-CASE-MISSING-FALLBACK / C-PROPS-0009-A: missing input enters fallback chain', () => {
-    const pm = new PropsKernel<{ value: number }>();
+    const pm = new PropsKernel<{ value: number | null }>();
 
     pm.define({
       value: { type: 'number', default: 1 },
@@ -47,7 +47,7 @@ describe('props: fallback resolution (T-PROPS-0006)', () => {
   });
 
   it('T-PROPS-0006-CASE-INVALID-FALLBACK / C-PROPS-0009-D: invalid non-empty input enters fallback chain', () => {
-    const pm = new PropsKernel<{ value: number }>();
+    const pm = new PropsKernel<{ value: number | null }>();
 
     pm.define({
       value: { type: 'number', default: 1, empty: 'accept' },

--- a/packages/modules/props/test/contract/fallback-resolution.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/fallback-resolution.v0.contract.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import { PropsKernel } from '../../src/kernel/kernel';
+
+describe('props: fallback resolution (T-PROPS-0006)', () => {
+  it('T-PROPS-0006-CASE-MISSING-FALLBACK / C-PROPS-0009-A: missing input enters fallback chain', () => {
+    const pm = new PropsKernel<{ value: number }>();
+
+    pm.define({
+      value: { type: 'number', default: 1 },
+    });
+
+    pm.applyRaw({});
+
+    expect(pm.isProvided('value')).toBe(false);
+    expect(pm.get()).toEqual({ value: 1 });
+  });
+
+  it('T-PROPS-0006-CASE-EMPTY-ACCEPT / C-PROPS-0009-B: empty accept resolves to null and does not update prevValid', () => {
+    const pm = new PropsKernel<{ value: number | null }>();
+
+    pm.define({
+      value: { type: 'number', default: 1, empty: 'accept' },
+    });
+
+    pm.applyRaw({ value: 2 });
+    expect(pm.get()).toEqual({ value: 2 });
+
+    pm.applyRaw({ value: null });
+    expect(pm.get()).toEqual({ value: null });
+
+    pm.applyRaw({});
+    expect(pm.get()).toEqual({ value: 2 });
+  });
+
+  it('T-PROPS-0006-CASE-EMPTY-FALLBACK / C-PROPS-0009-C: empty fallback enters fallback chain', () => {
+    const pm = new PropsKernel<{ value: number }>();
+
+    pm.define({
+      value: { type: 'number', default: 1, empty: 'fallback' },
+    });
+
+    pm.applyRaw({ value: null });
+
+    expect(pm.isProvided('value')).toBe(true);
+    expect(pm.get()).toEqual({ value: 1 });
+  });
+
+  it('T-PROPS-0006-CASE-INVALID-FALLBACK / C-PROPS-0009-D: invalid non-empty input enters fallback chain', () => {
+    const pm = new PropsKernel<{ value: number }>();
+
+    pm.define({
+      value: { type: 'number', default: 1, empty: 'accept' },
+    });
+
+    pm.applyRaw({ value: 'not-number' });
+
+    expect(pm.isProvided('value')).toBe(true);
+    expect(pm.get()).toEqual({ value: 1 });
+  });
+
+  it('T-PROPS-0006-CASE-FALLBACK-ORDER / C-PROPS-0009-E: fallback order is prevValid, setDefaults, declaration default, then null', () => {
+    const prevValid = new PropsKernel<{ value: number }>();
+    prevValid.define({
+      value: { type: 'number', default: 1 },
+    });
+    prevValid.setDefaults({ value: 9 });
+    prevValid.applyRaw({ value: 2 });
+    prevValid.applyRaw({});
+    expect(prevValid.get()).toEqual({ value: 2 });
+
+    const setDefaults = new PropsKernel<{ value: number }>();
+    setDefaults.define({
+      value: { type: 'number', default: 1 },
+    });
+    setDefaults.setDefaults({ value: 9 });
+    setDefaults.applyRaw({});
+    expect(setDefaults.get()).toEqual({ value: 9 });
+
+    const declarationDefault = new PropsKernel<{ value: number }>();
+    declarationDefault.define({
+      value: { type: 'number', default: 1 },
+    });
+    declarationDefault.applyRaw({});
+    expect(declarationDefault.get()).toEqual({ value: 1 });
+
+    const terminalNull = new PropsKernel<{ value: number }>();
+    terminalNull.define({
+      value: { type: 'number' },
+    });
+    terminalNull.applyRaw({});
+    expect(terminalNull.get()).toEqual({ value: null });
+  });
+
+  it('T-PROPS-0006-CASE-FALLBACK-TO-NULL / C-PROPS-0009-F: default fallback may end in null as canonical empty result', () => {
+    const pm = new PropsKernel<{ value: number }>();
+
+    pm.define({
+      value: { type: 'number' },
+    });
+
+    pm.applyRaw({});
+
+    expect(pm.get()).toEqual({ value: null });
+  });
+
+  it('T-PROPS-0006-CASE-EMPTY-ERROR / C-PROPS-0009-G: empty error requires a non-empty fallback or throws', () => {
+    const noFallback = new PropsKernel<{ value: number }>();
+    noFallback.define({
+      value: { type: 'number', empty: 'error' },
+    });
+
+    expect(() => noFallback.applyRaw({})).toThrow(/empty="error"|missing/i);
+    expect(() => noFallback.applyRaw({ value: null })).toThrow(/empty="error"/i);
+
+    const withPrevValid = new PropsKernel<{ value: number }>();
+    withPrevValid.define({
+      value: { type: 'number', empty: 'error' },
+    });
+    withPrevValid.applyRaw({ value: 2 });
+    withPrevValid.applyRaw({});
+
+    expect(withPrevValid.get()).toEqual({ value: 2 });
+  });
+
+  it('T-PROPS-0006-CASE-PREV-VALID-NON-EMPTY / C-PROPS-0009-H: prevValid stores only non-empty valid values', () => {
+    const pm = new PropsKernel<{ value: number | null }>();
+
+    pm.define({
+      value: { type: 'number', default: 1, empty: 'accept' },
+    });
+
+    pm.applyRaw({ value: null });
+    expect(pm.get()).toEqual({ value: null });
+
+    pm.applyRaw({});
+
+    expect(pm.get()).toEqual({ value: 1 });
+  });
+});

--- a/packages/modules/props/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/resolved-snapshot-shape.v0.contract.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { PropsKernel } from '../../src/kernel/kernel';
+
+describe('props: resolved snapshot shape (T-PROPS-0005)', () => {
+  it('contains every declared prop key even when raw input omits them', () => {
+    const pm = new PropsKernel<{
+      present: number;
+      missingWithDefault: string;
+      missingEmpty: boolean;
+    }>();
+
+    pm.define({
+      present: { type: 'number' },
+      missingWithDefault: { type: 'string', default: 'fallback' },
+      missingEmpty: { type: 'boolean' },
+    });
+
+    pm.applyRaw({ present: 1 });
+
+    expect(pm.get()).toEqual({
+      present: 1,
+      missingWithDefault: 'fallback',
+      missingEmpty: null,
+    });
+    expect(Object.keys(pm.get()).sort()).toEqual(['missingEmpty', 'missingWithDefault', 'present']);
+  });
+
+  it('excludes undeclared raw prop keys from resolved props while preserving them in raw props', () => {
+    const pm = new PropsKernel<{ declared: number }>();
+
+    pm.define({
+      declared: { type: 'number' },
+    });
+
+    pm.applyRaw({ declared: 1, extra: 2 });
+
+    expect(pm.get()).toEqual({ declared: 1 });
+    expect(pm.get()).not.toHaveProperty('extra');
+    expect(pm.getRaw()).toEqual({ declared: 1, extra: 2 });
+  });
+
+  it('resolves each key independently when other keys are missing, empty, or invalid', () => {
+    const pm = new PropsKernel<{
+      valid: number;
+      missing: string;
+      empty: number | null;
+      invalid: boolean;
+    }>();
+
+    pm.define({
+      valid: { type: 'number' },
+      missing: { type: 'string', default: 'missing-fallback' },
+      empty: { type: 'number', empty: 'accept' },
+      invalid: { type: 'boolean', default: true },
+    });
+
+    pm.applyRaw({
+      valid: 42,
+      empty: null,
+      invalid: 'not-boolean',
+    });
+
+    expect(pm.get()).toEqual({
+      valid: 42,
+      missing: 'missing-fallback',
+      empty: null,
+      invalid: true,
+    });
+  });
+
+  it('never exposes undefined and uses null as the canonical empty resolved value', () => {
+    const pm = new PropsKernel<{
+      missing: string;
+      providedUndefined: number | null;
+      providedNull: boolean | null;
+    }>();
+
+    pm.define({
+      missing: { type: 'string' },
+      providedUndefined: { type: 'number', empty: 'accept' },
+      providedNull: { type: 'boolean', empty: 'accept' },
+    });
+
+    pm.applyRaw({
+      providedUndefined: undefined,
+      providedNull: null,
+    });
+
+    expect(pm.get()).toEqual({
+      missing: null,
+      providedUndefined: null,
+      providedNull: null,
+    });
+    expect(Object.values(pm.get())).not.toContain(undefined);
+    expect(pm.getRaw()).toEqual({
+      providedUndefined: null,
+      providedNull: null,
+    });
+  });
+
+  it('returns a shallowly immutable resolved snapshot', () => {
+    const pm = new PropsKernel<{ value: number; nested: { count: number } }>();
+
+    pm.define({
+      value: { type: 'number' },
+      nested: { type: 'object' },
+    });
+
+    pm.applyRaw({
+      value: 1,
+      nested: { count: 1 },
+    });
+
+    const snapshot = pm.get();
+
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(() => {
+      (snapshot as { value: number }).value = 2;
+    }).toThrow();
+    expect(pm.get().value).toBe(1);
+  });
+});

--- a/packages/modules/props/test/contract/resolved-watchers.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/resolved-watchers.v0.contract.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ProtoPhase } from '@proto.ui/core';
+import type { PropsSpecMap } from '@proto.ui/types';
+
+import { PropsModuleImpl } from '../../src/impl';
+
+function createModule<P extends Record<string, any>>() {
+  const caps = {
+    onChange: (_fn: (epoch: number) => void) => {},
+    has: (_k: string) => false,
+    get: (_k: string) => undefined,
+  } as any;
+
+  return new PropsModuleImpl<P>(caps, 'test-proto');
+}
+
+function drain(mod: PropsModuleImpl<any>) {
+  return mod.consumeTasks();
+}
+
+function executeResolvedTasks(mod: PropsModuleImpl<any>) {
+  const tasks = drain(mod).filter((task) => task.kind === 'resolved');
+  const run = { kind: 'run' } as any;
+
+  for (const task of tasks) {
+    task.cb(run, task.next, task.prev, task.info);
+  }
+
+  return tasks;
+}
+
+describe('props: resolved watchers (T-PROPS-0007)', () => {
+  it('T-PROPS-0007-CASE-REGISTRATION-SURFACE / C-PROPS-0011-A,F: registration is setup-only and declared-key scoped', () => {
+    type P = { value: number };
+
+    const beforeDefine = createModule<P>();
+    expect(() => beforeDefine.watchKeys(['value'], () => {})).toThrow(/define/i);
+
+    const pm = createModule<P>();
+    pm.define({ value: { type: 'number' } } satisfies PropsSpecMap<P>);
+
+    expect(() => pm.watchKeys([], () => {})).toThrow(/non-empty/i);
+    expect(() => pm.watchKeys(['unknown'] as any, () => {})).toThrow(/undeclared/i);
+
+    const unsubscribeAll = pm.watchAllKeys(() => {});
+    const unsubscribeKeyed = pm.watchKeys(['value'], () => {});
+    expect(typeof unsubscribeAll).toBe('function');
+    expect(typeof unsubscribeKeyed).toBe('function');
+
+    const runtime = createModule<P>();
+    runtime.define({ value: { type: 'number' } } satisfies PropsSpecMap<P>);
+    runtime.onProtoPhase('mounted' satisfies ProtoPhase);
+
+    expect(() => runtime.watchAllKeys(() => {})).toThrow(/illegal phase/i);
+    expect(() => runtime.watchKeys(['value'], () => {})).toThrow(/illegal phase/i);
+  });
+
+  it('T-PROPS-0007-CASE-HYDRATION-SKIP / C-PROPS-0011-B: hydration does not trigger resolved watchers', () => {
+    type P = { value: number };
+    const pm = createModule<P>();
+    pm.define({ value: { type: 'number' } } satisfies PropsSpecMap<P>);
+
+    let watchAllCalls = 0;
+    let watchKeyCalls = 0;
+    pm.watchAllKeys(() => watchAllCalls++);
+    pm.watchKeys(['value'], () => watchKeyCalls++);
+
+    pm.applyRaw({ value: 1 });
+
+    expect(drain(pm)).toEqual([]);
+    expect(watchAllCalls).toBe(0);
+    expect(watchKeyCalls).toBe(0);
+  });
+
+  it('T-PROPS-0007-CASE-RESOLVED-DIFF-ONLY / C-PROPS-0011-C: raw-only changes do not trigger resolved watchers', () => {
+    type P = { value: number };
+    const pm = createModule<P>();
+    pm.define({ value: { type: 'number', default: 1 } } satisfies PropsSpecMap<P>);
+
+    let calls = 0;
+    pm.watchAllKeys(() => calls++);
+
+    pm.applyRaw({ value: 1, extra: 1 } as any);
+    expect(drain(pm)).toEqual([]);
+
+    pm.applyRaw({ value: 1, extra: 2 } as any);
+    executeResolvedTasks(pm);
+
+    expect(calls).toBe(0);
+  });
+
+  it('T-PROPS-0007-CASE-OBJECT-IS-DIFF / C-PROPS-0011-D: resolved watcher diffs use Object.is', () => {
+    type P = { value: number; objectValue: { count: number } };
+    const pm = createModule<P>();
+    pm.define({
+      value: { type: 'number' },
+      objectValue: { type: 'object' },
+    } satisfies PropsSpecMap<P>);
+
+    const objectValue = { count: 1 };
+    const changedKeys: string[][] = [];
+    pm.watchAllKeys((_run, _next, _prev, info) => {
+      changedKeys.push([...info.changedKeysAll].sort());
+    });
+
+    pm.applyRaw({ value: -0, objectValue });
+    expect(drain(pm)).toEqual([]);
+
+    pm.applyRaw({ value: -0, objectValue });
+    executeResolvedTasks(pm);
+    expect(changedKeys).toEqual([]);
+
+    pm.applyRaw({ value: 0, objectValue });
+    executeResolvedTasks(pm);
+    expect(changedKeys).toEqual([['value']]);
+
+    pm.applyRaw({ value: 0, objectValue: { count: 1 } });
+    executeResolvedTasks(pm);
+    expect(changedKeys).toEqual([['value'], ['objectValue']]);
+  });
+
+  it('T-PROPS-0007-CASE-WATCH-ALL / C-PROPS-0011-E: watchAll observes any changed declared key', () => {
+    type P = { a: number; b: number };
+    const pm = createModule<P>();
+    pm.define({
+      a: { type: 'number' },
+      b: { type: 'number' },
+    } satisfies PropsSpecMap<P>);
+
+    let calls = 0;
+    let lastMatched: string[] = [];
+    pm.watchAllKeys((_run, _next, _prev, info) => {
+      calls++;
+      lastMatched = [...info.changedKeysMatched].sort();
+    });
+
+    pm.applyRaw({ a: 1, b: 1 });
+    expect(drain(pm)).toEqual([]);
+
+    pm.applyRaw({ a: 2, b: 1 });
+    executeResolvedTasks(pm);
+
+    expect(calls).toBe(1);
+    expect(lastMatched).toEqual(['a']);
+  });
+
+  it('T-PROPS-0007-CASE-WATCH-KEYS / C-PROPS-0011-F: watch(keys) observes changed watched keys only', () => {
+    type P = { a: number; b: number; c: number };
+    const pm = createModule<P>();
+    pm.define({
+      a: { type: 'number' },
+      b: { type: 'number' },
+      c: { type: 'number' },
+    } satisfies PropsSpecMap<P>);
+
+    let calls = 0;
+    let lastMatched: string[] = [];
+    pm.watchKeys(['a', 'b'], (_run, _next, _prev, info) => {
+      calls++;
+      lastMatched = [...info.changedKeysMatched].sort();
+    });
+
+    pm.applyRaw({ a: 1, b: 1, c: 1 });
+    expect(drain(pm)).toEqual([]);
+
+    pm.applyRaw({ a: 1, b: 1, c: 2 });
+    expect(executeResolvedTasks(pm)).toEqual([]);
+    expect(calls).toBe(0);
+
+    pm.applyRaw({ a: 1, b: 2, c: 2 });
+    executeResolvedTasks(pm);
+
+    expect(calls).toBe(1);
+    expect(lastMatched).toEqual(['b']);
+  });
+
+  it('T-PROPS-0007-CASE-CALLBACK-SNAPSHOTS / C-PROPS-0011-G: callbacks receive previous and next resolved snapshots', () => {
+    type P = { value: number };
+    const pm = createModule<P>();
+    pm.define({ value: { type: 'number' } } satisfies PropsSpecMap<P>);
+
+    const snapshots: Array<{ prev: P; next: P }> = [];
+    pm.watchAllKeys((_run, next, prev) => {
+      snapshots.push({ prev, next });
+    });
+
+    pm.applyRaw({ value: 1 });
+    expect(drain(pm)).toEqual([]);
+
+    pm.applyRaw({ value: 2 });
+    executeResolvedTasks(pm);
+
+    expect(snapshots).toEqual([{ prev: { value: 1 }, next: { value: 2 } }]);
+  });
+
+  it('T-PROPS-0007-CASE-CHANGE-INFO / C-PROPS-0011-H: WatchInfo reports all and matched changed keys', () => {
+    type P = { a: number; b: number; c: number };
+    const pm = createModule<P>();
+    pm.define({
+      a: { type: 'number' },
+      b: { type: 'number' },
+      c: { type: 'number' },
+    } satisfies PropsSpecMap<P>);
+
+    let changedAll: string[] = [];
+    let changedMatched: string[] = [];
+    pm.watchKeys(['a', 'b'], (_run, _next, _prev, info) => {
+      changedAll = [...info.changedKeysAll].sort();
+      changedMatched = [...info.changedKeysMatched].sort();
+    });
+
+    pm.applyRaw({ a: 1, b: 1, c: 1 });
+    expect(drain(pm)).toEqual([]);
+
+    pm.applyRaw({ a: 2, b: 1, c: 2 });
+    executeResolvedTasks(pm);
+
+    expect(changedAll).toEqual(['a', 'c']);
+    expect(changedMatched).toEqual(['a']);
+  });
+
+  it('T-PROPS-0007-CASE-DISPATCH-COALESCING / C-PROPS-0011-I: coalesced dispatch observes first prev and latest next', () => {
+    type P = { watched: number; other: number };
+    const pm = createModule<P>();
+    pm.define({
+      watched: { type: 'number' },
+      other: { type: 'number' },
+    } satisfies PropsSpecMap<P>);
+
+    const observed: Array<{
+      prev: P;
+      next: P;
+      all: string[];
+      matched: string[];
+    }> = [];
+    pm.watchKeys(['watched'], (_run, next, prev, info) => {
+      observed.push({
+        prev,
+        next,
+        all: [...info.changedKeysAll].sort(),
+        matched: [...info.changedKeysMatched].sort(),
+      });
+    });
+
+    pm.applyRaw({ watched: 1, other: 1 });
+    expect(drain(pm)).toEqual([]);
+
+    pm.applyRaw({ watched: 1, other: 2 });
+    pm.applyRaw({ watched: 2, other: 2 });
+    executeResolvedTasks(pm);
+
+    expect(observed).toEqual([
+      {
+        prev: { watched: 1, other: 1 },
+        next: { watched: 2, other: 2 },
+        all: ['other', 'watched'],
+        matched: ['watched'],
+      },
+    ]);
+  });
+
+  it('T-PROPS-0007-CASE-DISPATCH-ORDER / C-PROPS-0011-J: dispatch runs watchAll before keyed watchers and preserves registration order', () => {
+    type P = { value: number };
+    const pm = createModule<P>();
+    pm.define({ value: { type: 'number' } } satisfies PropsSpecMap<P>);
+
+    const order: string[] = [];
+    pm.watchAllKeys(() => order.push('all-1'));
+    pm.watchAllKeys(() => order.push('all-2'));
+    pm.watchKeys(['value'], () => order.push('key-1'));
+    pm.watchKeys(['value'], () => order.push('key-2'));
+
+    pm.applyRaw({ value: 1 });
+    expect(drain(pm)).toEqual([]);
+
+    pm.applyRaw({ value: 2 });
+    executeResolvedTasks(pm);
+
+    expect(order).toEqual(['all-1', 'all-2', 'key-1', 'key-2']);
+  });
+});

--- a/packages/modules/props/test/contract/resolved-watchers.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/resolved-watchers.v0.contract.test.ts
@@ -260,16 +260,16 @@ describe('props: resolved watchers (T-PROPS-0007)', () => {
     ]);
   });
 
-  it('T-PROPS-0007-CASE-DISPATCH-ORDER / C-PROPS-0011-J: dispatch runs watchAll before keyed watchers and preserves registration order', () => {
+  it('T-PROPS-0007-CASE-DISPATCH-ORDER / C-PROPS-0011-J: dispatch preserves shared registration order across watchAll and keyed watchers', () => {
     type P = { value: number };
     const pm = createModule<P>();
     pm.define({ value: { type: 'number' } } satisfies PropsSpecMap<P>);
 
     const order: string[] = [];
-    pm.watchAllKeys(() => order.push('all-1'));
-    pm.watchAllKeys(() => order.push('all-2'));
     pm.watchKeys(['value'], () => order.push('key-1'));
+    pm.watchAllKeys(() => order.push('all-1'));
     pm.watchKeys(['value'], () => order.push('key-2'));
+    pm.watchAllKeys(() => order.push('all-2'));
 
     pm.applyRaw({ value: 1 });
     expect(drain(pm)).toEqual([]);
@@ -277,6 +277,6 @@ describe('props: resolved watchers (T-PROPS-0007)', () => {
     pm.applyRaw({ value: 2 });
     executeResolvedTasks(pm);
 
-    expect(order).toEqual(['all-1', 'all-2', 'key-1', 'key-2']);
+    expect(order).toEqual(['key-1', 'all-1', 'key-2', 'all-2']);
   });
 });

--- a/packages/modules/props/test/contract/watch-resolved.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/watch-resolved.v0.contract.test.ts
@@ -13,7 +13,7 @@ import type { PropsSpecMap } from '@proto.ui/types';
  * - watchAll trigger condition and WatchInfo semantics
  * - watch(keys) trigger condition and WatchInfo semantics
  * - Object.is based diff semantics (NaN stable)
- * - order: watchAll before keyed watches; registration order within group
+ * - order: watchAll and keyed watches share registration order
  * - resolved-based semantics (undeclared/raw-only changes do not trigger)
  *
  * NOTE:
@@ -180,18 +180,17 @@ describe('props: watch(resolved) contract (v0)', () => {
     expect(lastMatched).toEqual(['b']);
   });
 
-  it('PROP-V0-3500: order: watchAll before keyed watches; registration order preserved within group', () => {
+  it('PROP-V0-3500: order: watchAll and keyed watches share registration order', () => {
     type P = { a: number };
     const pm = createModule<P>();
     pm.define({ a: { type: 'number', default: 1 } } satisfies PropsSpecMap<P>);
 
     const order: string[] = [];
 
-    pm.watchAllKeys(() => order.push('all-1'));
-    pm.watchAllKeys(() => order.push('all-2'));
-
     pm.watchKeys(['a'], () => order.push('key-1'));
+    pm.watchAllKeys(() => order.push('all-1'));
     pm.watchKeys(['a'], () => order.push('key-2'));
+    pm.watchAllKeys(() => order.push('all-2'));
 
     // hydration
     pm.applyRaw({ a: 1 });
@@ -201,7 +200,7 @@ describe('props: watch(resolved) contract (v0)', () => {
     pm.applyRaw({ a: 2 });
     execResolvedTasks(pm);
 
-    expect(order).toEqual(['all-1', 'all-2', 'key-1', 'key-2']);
+    expect(order).toEqual(['key-1', 'all-1', 'key-2', 'all-2']);
   });
 
   it('PROP-V0-3100/3600: diff uses Object.is (NaN stable); raw invalid may not cause resolved change -> no schedule', () => {

--- a/packages/modules/props/test/props.test.ts
+++ b/packages/modules/props/test/props.test.ts
@@ -49,17 +49,28 @@ describe('@proto.ui/module-props PropsKernel (EmptyBehavior)', () => {
     expect(() => pm.define({ disabled: { type: 'string' } as any })).toThrow();
   });
 
-  it('PROP-0013/0014: enum widen allowed (warning), tighten error', () => {
+  it('PROP-0013/0014: enum options widen allowed (warning), tighten error', () => {
     const pm = new PropsKernel<any>();
-    pm.define({ mode: { type: 'string', enum: ['a', 'b'] } });
+    pm.define({ mode: { type: 'enum', options: ['a', 'b'] } });
 
-    pm.define({ mode: { type: 'string', enum: ['a', 'b', 'c'] } });
+    pm.define({ mode: { type: 'enum', options: ['a', 'b', 'c'] } });
     expect(pm.getDiagnostics().some((d: any) => d.level === 'warning')).toBe(true);
 
     // tightening from current superset to subset would be an error:
     const pm2 = new PropsKernel<any>();
-    pm2.define({ mode: { type: 'string', enum: ['a', 'b', 'c'] } });
-    expect(() => pm2.define({ mode: { type: 'string', enum: ['a', 'b'] } })).toThrow();
+    pm2.define({ mode: { type: 'enum', options: ['a', 'b', 'c'] } });
+    expect(() => pm2.define({ mode: { type: 'enum', options: ['a', 'b'] } })).toThrow();
+  });
+
+  it('PROP-0015: enum options validate string values', () => {
+    const pm = new PropsKernel<any>();
+    pm.define({ mode: { type: 'enum', options: ['a', 'b'], default: 'a' } });
+
+    pm.applyRaw({ mode: 'b' });
+    expect((pm.get() as any).mode).toBe('b');
+
+    pm.applyRaw({ mode: 'c' });
+    expect((pm.get() as any).mode).toBe('b');
   });
 
   it('PROP-0020/0021: validator invalid falls back previous-valid > default', () => {

--- a/packages/prototypes/base/src/tabs/list.ts
+++ b/packages/prototypes/base/src/tabs/list.ts
@@ -10,7 +10,7 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   let selectedValue = '';
 
   def.props.define({
-    orientation: { type: 'string', empty: 'fallback', enum: ['horizontal', 'vertical'] },
+    orientation: { type: 'enum', empty: 'fallback', options: ['horizontal', 'vertical'] },
     loop: { type: 'boolean', empty: 'fallback' },
   });
   def.props.setDefaults({

--- a/packages/prototypes/base/src/tabs/root.ts
+++ b/packages/prototypes/base/src/tabs/root.ts
@@ -10,8 +10,8 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
   def.props.define({
     value: { type: 'string', empty: 'fallback' },
     defaultValue: { type: 'string', empty: 'fallback' },
-    orientation: { type: 'string', empty: 'fallback', enum: ['horizontal', 'vertical'] },
-    activationMode: { type: 'string', empty: 'fallback', enum: ['automatic', 'manual'] },
+    orientation: { type: 'enum', empty: 'fallback', options: ['horizontal', 'vertical'] },
+    activationMode: { type: 'enum', empty: 'fallback', options: ['automatic', 'manual'] },
   });
   def.props.setDefaults({
     defaultValue: '',

--- a/packages/prototypes/lucide/src/icon/icon.ts
+++ b/packages/prototypes/lucide/src/icon/icon.ts
@@ -11,7 +11,7 @@ const DEFAULT_FILL = 'none';
 
 function setupLucideIcon(def: DefHandle<LucideIconProps, LucideIconExposes>): void {
   def.props.define({
-    name: { type: 'string', empty: 'fallback', enum: [...LUCIDE_ICON_NAMES] },
+    name: { type: 'enum', empty: 'fallback', options: [...LUCIDE_ICON_NAMES] },
     size: { type: 'number', empty: 'fallback' },
     strokeWidth: { type: 'number', empty: 'fallback' },
     stroke: { type: 'string', empty: 'fallback' },

--- a/packages/prototypes/shadcn/src/button/index.ts
+++ b/packages/prototypes/shadcn/src/button/index.ts
@@ -54,11 +54,11 @@ const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
   setup(def) {
     def.props.define({
       variant: {
-        type: 'string',
+        type: 'enum',
         empty: 'fallback',
-        enum: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+        options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
       },
-      size: { type: 'string', empty: 'fallback', enum: ['default', 'sm', 'lg', 'icon'] },
+      size: { type: 'enum', empty: 'fallback', options: ['default', 'sm', 'lg', 'icon'] },
       disabled: { type: 'boolean', empty: 'fallback' },
     });
     def.props.setDefaults({

--- a/packages/prototypes/shadcn/src/dialog/close.ts
+++ b/packages/prototypes/shadcn/src/dialog/close.ts
@@ -44,9 +44,9 @@ const dialogClose = definePrototype<ShadcnDialogCloseProps, ShadcnDialogCloseExp
   setup(def) {
     def.props.define({
       variant: {
-        type: 'string',
+        type: 'enum',
         empty: 'fallback',
-        enum: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+        options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
       },
       disabled: { type: 'boolean', empty: 'fallback' },
     });

--- a/packages/prototypes/shadcn/src/dialog/trigger.ts
+++ b/packages/prototypes/shadcn/src/dialog/trigger.ts
@@ -44,9 +44,9 @@ const dialogTrigger = definePrototype<ShadcnDialogTriggerProps, ShadcnDialogTrig
   setup(def) {
     def.props.define({
       variant: {
-        type: 'string',
+        type: 'enum',
         empty: 'fallback',
-        enum: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+        options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
       },
       disabled: { type: 'boolean', empty: 'fallback' },
     });

--- a/packages/prototypes/shadcn/src/dropdown/trigger.ts
+++ b/packages/prototypes/shadcn/src/dropdown/trigger.ts
@@ -75,9 +75,9 @@ const dropdownTrigger = definePrototype<ShadcnDropdownTriggerProps, ShadcnDropdo
       disabled: { type: 'boolean', empty: 'fallback' },
       indicator: { type: 'boolean', empty: 'fallback' },
       indicatorIcon: {
-        type: 'string',
+        type: 'enum',
         empty: 'fallback',
-        enum: ['chevron-down', 'chevrons-up-down'],
+        options: ['chevron-down', 'chevrons-up-down'],
       },
       indicatorSize: { type: 'number', empty: 'fallback' },
       indicatorStrokeWidth: { type: 'number', empty: 'fallback' },

--- a/packages/prototypes/shadcn/src/toggle/index.ts
+++ b/packages/prototypes/shadcn/src/toggle/index.ts
@@ -32,8 +32,8 @@ const toggle = definePrototype<ShadcnToggleProps, ShadcnToggleExposes>({
   name: 'shadcn-toggle',
   setup(def) {
     def.props.define({
-      variant: { type: 'string', empty: 'fallback', enum: ['default', 'outline'] },
-      size: { type: 'string', empty: 'fallback', enum: ['default', 'sm', 'lg'] },
+      variant: { type: 'enum', empty: 'fallback', options: ['default', 'outline'] },
+      size: { type: 'enum', empty: 'fallback', options: ['default', 'sm', 'lg'] },
       checked: { type: 'boolean', empty: 'fallback' },
       defaultChecked: { type: 'boolean', empty: 'fallback' },
       disabled: { type: 'boolean', empty: 'fallback' },

--- a/packages/runtime/test/contract/props-integration.v0.contract.test.ts
+++ b/packages/runtime/test/contract/props-integration.v0.contract.test.ts
@@ -298,7 +298,7 @@ describe('runtime: props integration (v0)', () => {
     expect(resRec.isProvided).toBe(true);
   });
 
-  it('PROP-RT-0300: dispatch order is raw(all->keys) then resolved(all->keys), registration order preserved', () => {
+  it('PROP-RT-0300: dispatch order is raw(all->keys) then resolved registration order', () => {
     type P = { a: number } & PropsBaseType;
 
     const specs = {
@@ -316,10 +316,10 @@ describe('runtime: props integration (v0)', () => {
         def.props.watchRaw(['a'], () => order.push('rawKey-1'));
         def.props.watchRaw(['a'], () => order.push('rawKey-2'));
 
-        def.props.watchAll(() => order.push('resAll-1'));
-        def.props.watchAll(() => order.push('resAll-2'));
         def.props.watch(['a'], () => order.push('resKey-1'));
+        def.props.watchAll(() => order.push('resAll-1'));
         def.props.watch(['a'], () => order.push('resKey-2'));
+        def.props.watchAll(() => order.push('resAll-2'));
 
         return (r) => r.el('div', {}, []);
       },
@@ -339,10 +339,10 @@ describe('runtime: props integration (v0)', () => {
       'rawAll-2',
       'rawKey-1',
       'rawKey-2',
-      'resAll-1',
-      'resAll-2',
       'resKey-1',
+      'resAll-1',
       'resKey-2',
+      'resAll-2',
     ]);
   });
 

--- a/packages/spec/engine/package.json
+++ b/packages/spec/engine/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "protoUi": {
+    "release": {
+      "scan": false
+    }
+  },
   "dependencies": {
     "@proto.ui/spec-schema": "workspace:*",
     "yaml": "^2.8.3"

--- a/packages/spec/fixtures/package.json
+++ b/packages/spec/fixtures/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "protoUi": {
+    "release": {
+      "scan": false
+    }
+  },
   "exports": {
     ".": {
       "types": "./src/index.ts",

--- a/packages/spec/graph/package.json
+++ b/packages/spec/graph/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "protoUi": {
+    "release": {
+      "scan": false
+    }
+  },
   "dependencies": {
     "@proto.ui/spec-engine": "workspace:*",
     "@proto.ui/spec-schema": "workspace:*"

--- a/packages/spec/schema/package.json
+++ b/packages/spec/schema/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "protoUi": {
+    "release": {
+      "scan": false
+    }
+  },
   "dependencies": {
     "zod": "^4.3.6"
   },

--- a/packages/types/src/props.ts
+++ b/packages/types/src/props.ts
@@ -1,14 +1,14 @@
 // packages/types/src/props.ts
 export type PropsBaseType = Record<string, any>;
 
-export type PropType = 'any' | 'boolean' | 'string' | 'number' | 'object';
+export type PropType = 'any' | 'boolean' | 'string' | 'number' | 'object' | 'enum';
 export type EmptyBehavior = 'fallback' | 'accept' | 'error';
 
 export type PropSpec = {
   type: PropType;
   empty?: EmptyBehavior;
 
-  enum?: readonly (string | number | boolean)[];
+  options?: readonly string[];
   range?: { min?: number; max?: number };
   validator?: (v: any) => boolean;
   default?: any;
@@ -29,7 +29,7 @@ type HasNull<V> = Extends<null, V>;
 type AllowedTypesFor<V> = V extends boolean
   ? 'boolean' | 'any'
   : V extends string
-    ? 'string' | 'any'
+    ? 'string' | 'enum' | 'any'
     : V extends number
       ? 'number' | 'any'
       : V extends object
@@ -49,9 +49,15 @@ type SpecShape<K extends PropType, V> = Omit<PropSpec, 'type' | 'empty'> & {
   empty?: AllowedEmptyFor<V>;
 };
 
+type EnumSpecShape<V> = Omit<PropSpec, 'type' | 'empty' | 'options'> & {
+  type: 'enum';
+  options: readonly Extract<V, string>[];
+  empty?: AllowedEmptyFor<V>;
+};
+
 // 最终：对某个值类型 V，允许的 spec（联合）
 export type SpecForValue<V> = {
-  [K in AllowedTypesFor<V>]: SpecShape<K, V>;
+  [K in AllowedTypesFor<V>]: K extends 'enum' ? EnumSpecShape<V> : SpecShape<K, V>;
 }[AllowedTypesFor<V>];
 
 export type PropsSpecMap<P extends Record<string, any>> = {

--- a/scripts/release/governance.mjs
+++ b/scripts/release/governance.mjs
@@ -29,7 +29,8 @@ export function getLaunchProfilePackageNames(governance, options = {}) {
 }
 
 export function collectLaunchGovernanceDiagnostics(packages, governance) {
-  const workspaceNames = new Set(packages.map((pkg) => pkg.name));
+  const releaseManagedPackages = packages.filter((pkg) => !pkg.isReleaseExcluded);
+  const workspaceNames = new Set(releaseManagedPackages.map((pkg) => pkg.name));
   const registrationOrder = [];
   const duplicateEntries = [];
   const unknownCandidateStatuses = [];
@@ -66,7 +67,7 @@ export function collectLaunchGovernanceDiagnostics(packages, governance) {
 
   const knownNames = new Set(registrationOrder.map((item) => item.name));
   const unclassifiedWorkspacePackages = packages
-    .filter((pkg) => !knownNames.has(pkg.name))
+    .filter((pkg) => !pkg.isReleaseExcluded && !knownNames.has(pkg.name))
     .map((pkg) => pkg.name)
     .sort();
 

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -146,16 +146,19 @@ export function getAllPackages() {
     );
     const isLegacy = relDir.startsWith('packages/legacy/');
     const isTestOnly = relDir.includes('/test-sys');
+    const isReleaseExcluded = manifest.protoUi?.release?.scan === false;
     const issues = [];
 
-    if (manifest.private) issues.push('private=true');
-    if (!manifest.version || manifest.version === '0.0.0')
-      issues.push(`version=${manifest.version ?? 'missing'}`);
-    if (!hasSrcIndex && !hasDistIndex) issues.push('missing index entry');
-    if (!manifest.license) issues.push('missing license field');
-    if (!localReadme) issues.push('missing package README');
-    if (workspaceDeps.length > 0) issues.push(`workspace deps: ${workspaceDeps.length}`);
-    if (sourceExport && !hasSrcIndex) issues.push('exports point to src/*.ts');
+    if (!isReleaseExcluded) {
+      if (manifest.private) issues.push('private=true');
+      if (!manifest.version || manifest.version === '0.0.0')
+        issues.push(`version=${manifest.version ?? 'missing'}`);
+      if (!hasSrcIndex && !hasDistIndex) issues.push('missing index entry');
+      if (!manifest.license) issues.push('missing license field');
+      if (!localReadme) issues.push('missing package README');
+      if (workspaceDeps.length > 0) issues.push(`workspace deps: ${workspaceDeps.length}`);
+      if (sourceExport && !hasSrcIndex) issues.push('exports point to src/*.ts');
+    }
 
     return {
       dir,
@@ -171,6 +174,7 @@ export function getAllPackages() {
       distExport,
       isLegacy,
       isTestOnly,
+      isReleaseExcluded,
       workspaceDeps,
       issues,
     };
@@ -230,6 +234,7 @@ export function selectPackages(packages, options = {}) {
 
   return packages.filter((pkg) => {
     if (onlySet.size > 0 && !onlySet.has(pkg.name) && !onlySet.has(pkg.relDir)) return false;
+    if (pkg.isReleaseExcluded) return false;
     if (!includeLegacy && DEFAULT_EXCLUDES.legacy && pkg.isLegacy) return false;
     if (!includeTest && DEFAULT_EXCLUDES.test && pkg.isTestOnly) return false;
     return true;
@@ -277,7 +282,7 @@ export function topoSortPackages(packages) {
 }
 
 export function recommendedPackages(packages) {
-  return packages.filter((pkg) => !pkg.isLegacy);
+  return packages.filter((pkg) => !pkg.isLegacy && !pkg.isReleaseExcluded);
 }
 
 /**

--- a/scripts/release/scan.mjs
+++ b/scripts/release/scan.mjs
@@ -19,6 +19,8 @@ Options:
   --include-legacy             Include packages under packages/legacy (workspace profile only)
   --include-test               Include test-only packages such as module-test-sys
   --only <list>                Comma-separated package names or package paths
+
+Packages with package.json#protoUi.release.scan=false are excluded from release scans.
 `);
 }
 
@@ -114,6 +116,7 @@ function toSummary(pkg) {
     version: pkg.version,
     isLegacy: pkg.isLegacy,
     isTestOnly: pkg.isTestOnly,
+    isReleaseExcluded: pkg.isReleaseExcluded,
     sourceExport: pkg.sourceExport,
     internalDeps: pkg.internalDeps,
     issues: pkg.issues,

--- a/scripts/release/sync-metadata.mjs
+++ b/scripts/release/sync-metadata.mjs
@@ -93,7 +93,9 @@ const PACKAGE_RULES = {
 };
 
 const rootPackage = JSON.parse(readFileSync(join(ROOT_DIR, 'package.json'), 'utf8'));
-const packages = getAllPackages().filter((pkg) => pkg.relDir !== 'packages/legacy/rule');
+const packages = getAllPackages().filter(
+  (pkg) => pkg.relDir !== 'packages/legacy/rule' && !pkg.isReleaseExcluded
+);
 
 for (const pkg of packages) {
   const rule = PACKAGE_RULES[pkg.name];

--- a/spec/contracts/C-CORE-CHANNEL-0001.yaml
+++ b/spec/contracts/C-CORE-CHANNEL-0001.yaml
@@ -14,24 +14,24 @@ criteria:
       en: A core portable channel must be able to state which interaction-target identity or relationship direction it corresponds to.
   - id: C-CORE-CHANNEL-0001-B
     text:
-      zh-CN: 核心可移植通路不得只是已有通路的技术别名、实现便利或 API surface 变体。
-      en: A core portable channel must not be merely a technical alias, implementation convenience, or API-surface variant of an existing channel.
+      zh-CN: 核心可移植通路不得只是已有通路的技术别名、实现便利或 `API surface` 变体。
+      en: A core portable channel must not be merely a technical alias, implementation convenience, or `API surface` variant of an existing channel.
   - id: C-CORE-CHANNEL-0001-C
     text:
       zh-CN: 一条通路进入核心可移植性承诺后，必须能被协议契约、测试映射与 adapter 能力矩阵追踪。
       en: Once a channel enters the core portability guarantee, it must be traceable through protocol contracts, test mappings, and adapter capability matrices.
   - id: C-CORE-CHANNEL-0001-D
     text:
-      zh-CN: Host/environment 相关通路可以被维护，但默认不属于核心可移植性承诺，除非另有契约明确接纳。
-      en: Host/environment-related channels can be maintained, but by default they are outside the core portability guarantee unless another contract explicitly admits them.
+      zh-CN: '`Host/environment` 相关通路可以被维护，但默认不属于核心可移植性承诺，除非另有契约明确接纳。'
+      en: '`Host/environment`-related channels can be maintained, but by default they are outside the core portability guarantee unless another contract explicitly admits them.'
 openQuestions:
   - id: C-CORE-CHANNEL-0001-Q1
     question:
       zh-CN: 当前核心可移植通路清单是否应由本契约直接枚举，还是拆成独立的 channel 实体或 contract 记录？
       en: Should the current list of core portable channels be enumerated directly by this contract, or split into independent channel entities or contract records?
     context:
-      zh-CN: 白皮书当前导出 event、feedback、props、expose、context；但通路模型本身保持开放，过早固定数字会给版本演化带来压力。
-      en: The whitepaper currently derives event, feedback, props, expose, and context, but the channel model remains open; freezing the number too early may create version-evolution pressure.
+      zh-CN: 白皮书当前导出 `event`、`feedback`、`props`、`expose`、`context`；但通路模型本身保持开放，过早固定数字会给版本演化带来压力。
+      en: The whitepaper currently derives `event`, `feedback`, `props`, `expose`, and `context`, but the channel model remains open; freezing the number too early may create version-evolution pressure.
     blocks:
       - C-CORE-CHANNEL-0001-C
 sources:

--- a/spec/contracts/C-CORE-SYNTAX-0001.yaml
+++ b/spec/contracts/C-CORE-SYNTAX-0001.yaml
@@ -3,30 +3,30 @@ type: contract
 title: Setup-time capabilities are exposed through the definition handle
 status: draft
 since: 0.1.0
-summary: Core syntax exposes setup-time planning capabilities through a definition handle rather than a runtime handle.
+summary: Core syntax exposes `setup`-time planning capabilities through a `definition handle` rather than a `runtime handle`.
 statement:
-  zh-CN: Core 语法通过 def 句柄向原型作者暴露 setup 阶段可用的计划与声明能力。
-  en: Core syntax exposes setup-time planning and declaration capabilities to prototype authors through the definition handle.
+  zh-CN: Core 语法通过 `def` 句柄向原型作者暴露 `setup` 阶段可用的计划与声明能力。
+  en: Core syntax exposes `setup`-time planning and declaration capabilities to prototype authors through the `definition handle`.
 criteria:
   - id: C-CORE-SYNTAX-0001-A
     text:
-      zh-CN: setup 阶段 API 必须由 definition handle 承载。
-      en: Setup-time APIs must be carried by the definition handle.
+      zh-CN: '`setup` 阶段 API 必须由 `definition handle` 承载。'
+      en: '`setup`-time APIs must be carried by the `definition handle`.'
   - id: C-CORE-SYNTAX-0001-B
     text:
-      zh-CN: definition handle 仅在 setup 阶段执行上下文中提供。
-      en: The definition handle is provided only in setup-time execution contexts.
+      zh-CN: '`definition handle` 仅在 `setup` 阶段执行上下文中提供。'
+      en: The `definition handle` is provided only in `setup`-time execution contexts.
   - id: C-CORE-SYNTAX-0001-C
     text:
-      zh-CN: setup 阶段上下文中不提供 run handle。
-      en: The run handle is not provided in setup-time contexts.
+      zh-CN: '`setup` 阶段上下文中不提供 `run handle`。'
+      en: The `run handle` is not provided in `setup`-time contexts.
   - id: C-CORE-SYNTAX-0001-D
     text:
-      zh-CN: setup-only API 不应通过 runtime handle 暴露。
-      en: Setup-only APIs should not be exposed through the runtime handle.
+      zh-CN: '`setup-only` API 不应通过 `runtime handle` 暴露。'
+      en: '`setup-only` APIs should not be exposed through the `runtime handle`.'
     rationale:
-      zh-CN: Proto UI 语法可能在相邻代码中混杂 setup 阶段代码与 runtime 回调代码；显式句柄能让阶段边界在 API 形状上可见。
-      en: Proto UI syntax can place setup-time code near runtime callbacks; explicit handles make phase boundaries visible in the API shape.
+      zh-CN: Proto UI 语法可能在相邻代码中混杂 `setup` 阶段代码与 `runtime` 回调代码；显式句柄能让阶段边界在 API 形状上可见。
+      en: Proto UI syntax can place `setup`-time code near `runtime` callbacks; explicit handles make phase boundaries visible in the API shape.
 sources:
   - path: internal/contracts/props/base-text/01.define-merge.v0.zh-CN.md
     sections:
@@ -37,7 +37,7 @@ dependsOn:
 revisions:
   - version: 0.1.0
     change: introduced
-    summary: Drafted the core syntax contract for setup-time definition handles.
+    summary: Drafted the core syntax contract for `setup`-time `definition handle`s.
 tags:
   - core
   - syntax

--- a/spec/contracts/C-CORE-SYNTAX-0002.yaml
+++ b/spec/contracts/C-CORE-SYNTAX-0002.yaml
@@ -1,32 +1,32 @@
 id: C-CORE-SYNTAX-0002
 type: contract
-title: Runtime capabilities are exposed through the run handle
+title: Runtime capabilities are exposed through the `run handle`
 status: draft
 since: 0.1.0
-summary: Core syntax exposes runtime execution capabilities through a run handle bound to the current execution.
+summary: Core syntax exposes `runtime` execution capabilities through a `run handle` bound to the current execution.
 statement:
-  zh-CN: Core 语法通过 run 句柄向原型作者暴露 runtime 阶段可用的当前调用能力。
-  en: Core syntax exposes runtime capabilities for the current invocation through the run handle.
+  zh-CN: Core 语法通过 `run` 句柄向原型作者暴露 `runtime` 阶段可用的当前调用能力。
+  en: Core syntax exposes `runtime` capabilities for the current invocation through the `run handle`.
 criteria:
   - id: C-CORE-SYNTAX-0002-A
     text:
-      zh-CN: runtime 阶段 API 必须由 run handle 承载。
-      en: Runtime APIs must be carried by the run handle.
+      zh-CN: '`runtime` 阶段 API 必须由 `run handle` 承载。'
+      en: '`Runtime` APIs must be carried by the `run handle`.'
   - id: C-CORE-SYNTAX-0002-B
     text:
-      zh-CN: run handle 仅在 runtime 阶段执行的函数或回调中提供。
-      en: The run handle is provided only to functions or callbacks executed during runtime.
+      zh-CN: '`run handle` 仅在 `runtime` 阶段执行的函数或回调中提供。'
+      en: The `run handle` is provided only to functions or callbacks executed during `runtime`.
   - id: C-CORE-SYNTAX-0002-C
     text:
-      zh-CN: runtime 阶段上下文中不提供 definition handle。
-      en: The definition handle is not provided in runtime contexts.
+      zh-CN: '`runtime` 阶段上下文中不提供 `definition handle`。'
+      en: The `definition handle` is not provided in `runtime` contexts.
   - id: C-CORE-SYNTAX-0002-D
     text:
-      zh-CN: runtime API 作用于当前具体调用，而不是 setup 阶段的计划。
-      en: Runtime APIs operate on the current concrete invocation rather than the setup-time plan.
+      zh-CN: '`runtime` API 作用于当前具体调用，而不是 `setup` 阶段的计划。'
+      en: '`Runtime` APIs operate on the current concrete invocation rather than the `setup`-time plan.'
     rationale:
-      zh-CN: run handle 使 runtime 回调中能够访问当前输入与状态，同时避免 runtime 阶段动态调用 setup-only API。
-      en: The run handle provides access to current input and state in runtime callbacks while avoiding dynamic calls to setup-only APIs.
+      zh-CN: '`run handle` 使 `runtime` 回调中能够访问当前输入与状态，同时避免 `runtime` 阶段动态调用 `setup-only` API。'
+      en: The `run handle` provides access to current input and state in `runtime` callbacks while avoiding dynamic calls to `setup-only` APIs.
 sources:
   - path: internal/contracts/props/base-text/02.resolve-fallback.v0.zh-CN.md
     sections:
@@ -40,7 +40,7 @@ dependsOn:
 revisions:
   - version: 0.1.0
     change: introduced
-    summary: Drafted the core syntax contract for runtime run handles.
+    summary: Drafted the core syntax contract for `runtime` `run handle`s.
 tags:
   - core
   - syntax

--- a/spec/contracts/C-CORE-SYNTAX-0002.yaml
+++ b/spec/contracts/C-CORE-SYNTAX-0002.yaml
@@ -3,10 +3,10 @@ type: contract
 title: Runtime capabilities are exposed through the `run handle`
 status: draft
 since: 0.1.0
-summary: Core syntax exposes `runtime` execution capabilities through a `run handle` bound to the current execution.
+summary: Core syntax exposes `runtime` execution capabilities through a `run handle` bound to the current runtime invocation.
 statement:
-  zh-CN: Core 语法通过 `run` 句柄向原型作者暴露 `runtime` 阶段可用的当前调用能力。
-  en: Core syntax exposes `runtime` capabilities for the current invocation through the `run handle`.
+  zh-CN: Core 语法通过 `run` 句柄向原型作者暴露 `runtime` 阶段可用的当前调用能力。由 setup 阶段注册、在 runtime 阶段执行的 callback，必须拿到绑定到当前 callback invocation 的 `run handle`，而不是 setup 阶段计划、宿主全局状态或过期 invocation 的句柄。
+  en: Core syntax exposes `runtime` capabilities for the current invocation through the `run handle`. Callbacks registered during setup and executed during runtime must receive a `run handle` bound to the current callback invocation, not to setup-time plans, host-global state, or stale invocations.
 criteria:
   - id: C-CORE-SYNTAX-0002-A
     text:
@@ -27,6 +27,17 @@ criteria:
     rationale:
       zh-CN: '`run handle` 使 `runtime` 回调中能够访问当前输入与状态，同时避免 `runtime` 阶段动态调用 `setup-only` API。'
       en: The `run handle` provides access to current input and state in `runtime` callbacks while avoiding dynamic calls to `setup-only` APIs.
+  - id: C-CORE-SYNTAX-0002-E
+    text:
+      zh-CN: 在 setup 阶段注册、runtime 阶段执行的 callback，必须接收绑定到当前 callback invocation 的 `run handle`。
+      en: Callbacks registered during setup and executed during runtime must receive a `run handle` bound to the current callback invocation.
+  - id: C-CORE-SYNTAX-0002-F
+    text:
+      zh-CN: 通过该 `run handle` 暴露的 API 必须读取或作用于当前 callback invocation 的 runtime state window，而不是过期 invocation、setup-time plan 或宿主全局快照。
+      en: APIs exposed through that `run handle` must read from or act on the runtime state window of the current callback invocation, not stale invocations, setup-time plans, or host-global snapshots.
+    rationale:
+      zh-CN: 同一个 prototype 可以在不同 runtime callback 中观察到不同输入、状态或调度窗口。`run handle` 的绑定规则让 callback 内部读取到的值与本次 callback payload 保持一致。
+      en: The same prototype may observe different inputs, state, or dispatch windows across runtime callbacks. Run-handle binding keeps values read inside a callback consistent with that callback's payload.
 sources:
   - path: internal/contracts/props/base-text/02.resolve-fallback.v0.zh-CN.md
     sections:
@@ -41,6 +52,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted the core syntax contract for `runtime` `run handle`s.
+  - version: 0.1.0
+    change: revised
+    summary: Clarified runtime callback invocation binding for `run handle` APIs.
 tags:
   - core
   - syntax

--- a/spec/contracts/C-CORE-VALUE-0001.yaml
+++ b/spec/contracts/C-CORE-VALUE-0001.yaml
@@ -1,9 +1,9 @@
 id: C-CORE-VALUE-0001
 type: contract
-title: Prototype-level semantics use null as the only canonical empty value
+title: Prototype-level semantics use `null` as the only canonical empty value
 status: draft
 since: 0.1.0
-summary: Prototype-level values should receive null as the canonical empty value even when a host can express other empty values.
+summary: Prototype-level values should receive `null` as the canonical empty value even when a host can express other empty values.
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:

--- a/spec/contracts/C-LIFECYCLE-0001.yaml
+++ b/spec/contracts/C-LIFECYCLE-0001.yaml
@@ -3,10 +3,10 @@ type: contract
 title: Prototype execution separates setup-time planning from runtime execution
 status: draft
 since: 0.1.0
-summary: Setup-time planning and runtime execution are distinct phases with different semantic responsibilities.
+summary: '`Setup`-time planning and `runtime` execution are distinct phases with different semantic responsibilities.'
 statement:
-  zh-CN: Proto UI 原型的生命周期早于组件生命周期，并分为 setup-time planning 与 runtime execution 两个语义阶段。
-  en: A Proto UI prototype lifecycle starts before the component lifecycle and separates setup-time planning from runtime execution.
+  zh-CN: Proto UI 原型的生命周期早于组件生命周期，并分为 `setup-time planning` 与 `runtime execution` 两个语义阶段。
+  en: A Proto UI prototype lifecycle starts before the component lifecycle and separates `setup-time planning` from `runtime execution`.
 criteria:
   - id: C-LIFECYCLE-0001-A
     text:
@@ -14,20 +14,20 @@ criteria:
       en: The prototype lifecycle starts before the component lifecycle because a prototype can be adapted or compiled into a component.
   - id: C-LIFECYCLE-0001-B
     text:
-      zh-CN: setup 阶段覆盖从原型被创建到组件被创建之前的时间段。
-      en: The setup phase spans from prototype creation to before component creation.
+      zh-CN: '`setup` 阶段覆盖从原型被创建到组件被创建之前的时间段。'
+      en: The `setup` phase spans from prototype creation to before component creation.
   - id: C-LIFECYCLE-0001-C
     text:
-      zh-CN: runtime 阶段覆盖从组件被创建到组件被销毁的时间段。
-      en: The runtime phase spans from component creation to component destruction.
+      zh-CN: '`runtime` 阶段覆盖从组件被创建到组件被销毁的时间段。'
+      en: The `runtime` phase spans from component creation to component destruction.
   - id: C-LIFECYCLE-0001-D
     text:
-      zh-CN: setup 阶段的语法语义是计划、声明、注册或预演，而不是具体某次调用的执行。
-      en: Setup-time syntax describes plans, declarations, registrations, or previews rather than execution for a concrete invocation.
+      zh-CN: '`setup` 阶段的语法语义是计划、声明、注册或预演，而不是具体某次调用的执行。'
+      en: '`Setup`-time syntax describes plans, declarations, registrations, or previews rather than execution for a concrete invocation.'
   - id: C-LIFECYCLE-0001-E
     text:
-      zh-CN: runtime 阶段的语法语义服务于具体某次调用，可以观察或作用于当前运行输入与状态。
-      en: Runtime syntax serves a concrete invocation and may observe or act on current runtime input and state.
+      zh-CN: '`runtime` 阶段的语法语义服务于具体某次调用，可以观察或作用于当前运行输入与状态。'
+      en: '`Runtime` syntax serves a concrete invocation and may observe or act on current runtime input and state.'
 sources:
   - path: internal/contracts/props/base-text/01.define-merge.v0.zh-CN.md
     sections:

--- a/spec/contracts/C-PROPS-0002.yaml
+++ b/spec/contracts/C-PROPS-0002.yaml
@@ -5,37 +5,37 @@ status: draft
 since: 0.1.0
 summary: Props provides setup-time declaration and watcher-registration surfaces, plus runtime access surfaces.
 statement:
-  zh-CN: Props 通路必须回应 setup/runtime 分离，分别提供 setup 阶段的声明与监听注册能力，以及 runtime 阶段的只读访问能力。
-  en: The Props channel must reflect setup/runtime separation by providing setup-time declaration and watcher-registration surfaces and runtime read-only access surfaces.
+  zh-CN: Props 通路必须回应 `setup`/`runtime` 分离，分别提供 `setup` 阶段的声明与监听注册能力，以及 `runtime` 阶段的只读访问能力。
+  en: The Props channel must reflect `setup`/`runtime` separation by providing `setup`-time declaration and watcher-registration surfaces and `runtime` read-only access surfaces.
 criteria:
   - id: C-PROPS-0002-A
     text:
-      zh-CN: Props 必须提供 setup-only 的声明 surface，用于声明 app maker 在 runtime 期间允许传入哪些 props 以及相关默认值、兜底或空值策略。
-      en: Props must provide a setup-only declaration surface for declaring which props app makers may provide at runtime and the associated default, fallback, or empty-value policies.
+      zh-CN: Props 必须提供 `setup-only` 的声明 surface，用于声明 app maker 在 `runtime` 期间允许传入哪些 props 以及相关默认值、兜底或空值策略。
+      en: Props must provide a `setup-only` declaration surface for declaring which props app makers may provide at `runtime` and the associated `default`, `fallback`, or empty-value policies.
   - id: C-PROPS-0002-B
     text:
-      zh-CN: Props 必须提供 setup-only 的 watcher registration surface，用于声明 runtime 期间 props 重新传入或变化时应执行的动作。
-      en: Props must provide a setup-only watcher registration surface for declaring actions to run when props are re-applied or changed during runtime.
+      zh-CN: Props 必须提供 `setup-only` 的 watcher registration surface，用于声明 `runtime` 期间 props 重新传入或变化时应执行的动作。
+      en: Props must provide a `setup-only` watcher registration surface for declaring actions to run when props are re-applied or changed during `runtime`.
   - id: C-PROPS-0002-C
     text:
-      zh-CN: Props 必须提供 runtime-only 的访问 surface，用于读取当前调用的 props 值。
-      en: Props must provide a runtime-only access surface for reading prop values for the current invocation.
+      zh-CN: Props 必须提供 `runtime-only` 的访问 surface，用于读取当前调用的 props 值。
+      en: Props must provide a `runtime-only` access surface for reading prop values for the current invocation.
   - id: C-PROPS-0002-D
     text:
-      zh-CN: runtime props value 对原型作者而言必须表现为只读快照；修改该快照不应被视为修改 props 通路。
-      en: Runtime prop values must behave as read-only snapshots from the prototype author's perspective; mutating the snapshot must not be treated as mutating the Props channel.
+      zh-CN: '`runtime props value` 对原型作者而言必须表现为只读快照；修改该快照不应被视为修改 Props 通路。'
+      en: "`Runtime prop values` must behave as read-only snapshots from the prototype author's perspective; mutating the snapshot must not be treated as mutating the Props channel."
   - id: C-PROPS-0002-E
     text:
-      zh-CN: Props 变化或 watcher callback 执行本身不得隐含视图更新。
-      en: Props changes or watcher callback execution must not imply a view update by itself.
+      zh-CN: Props 变化或 `watcher callback` 执行本身不得隐含视图更新。
+      en: Props changes or `watcher callback` execution must not imply a view update by itself.
     rationale:
-      zh-CN: Proto UI 的视图更新应由更基础的 runtime 更新契约约束；Props 只负责传递、解析与监听配置输入。
-      en: Proto UI view updates should be governed by a lower-level runtime update contract; Props only carries, resolves, and observes configuration input.
+      zh-CN: Proto UI 的视图更新应由更基础的 `runtime update` 契约约束；Props 只负责传递、解析与监听配置输入。
+      en: Proto UI view updates should be governed by a lower-level `runtime update` contract; Props only carries, resolves, and observes configuration input.
 openQuestions:
   - id: C-PROPS-0002-Q1
     question:
-      zh-CN: 应建立哪条 core/runtime 契约来承接 run.update() 与“Props 变化不隐含视图更新”的语义？
-      en: Which core/runtime contract should own run.update() and the rule that Props changes do not imply view updates?
+      zh-CN: 应建立哪条 core/runtime 契约来承接 `run.update()` 与“Props 变化不隐含视图更新”的语义？
+      en: Which core/runtime contract should own `run.update()` and the rule that Props changes do not imply view updates?
     context:
       zh-CN: 当前 C-PROPS-0002-E 暂时记录了该规则，但其基础不属于 Props 通路本身。
       en: C-PROPS-0002-E currently records this rule, but its foundation is outside the Props channel itself.

--- a/spec/contracts/C-PROPS-0002.yaml
+++ b/spec/contracts/C-PROPS-0002.yaml
@@ -1,46 +1,46 @@
 id: C-PROPS-0002
 type: contract
 title: Props defines setup-time declaration and runtime access surfaces
-status: draft
+status: active
 since: 0.1.0
-summary: Props provides setup-time declaration and watcher-registration surfaces, plus runtime access surfaces.
+summary: Props exposes declaration and watcher registration through `def.props`, and runtime read access through `run.props`.
 statement:
-  zh-CN: Props 通路必须回应 `setup`/`runtime` 分离，分别提供 `setup` 阶段的声明与监听注册能力，以及 `runtime` 阶段的只读访问能力。
-  en: The Props channel must reflect `setup`/`runtime` separation by providing `setup`-time declaration and watcher-registration surfaces and `runtime` read-only access surfaces.
+  zh-CN: >-
+    Props 通路必须回应 `setup`/`runtime` 分离：setup 阶段的声明、默认值计划与 watcher registration surface 由 `def.props` 暴露；runtime 阶段读取本次调用 props state 的 surface 由 `run.props` 暴露。`C-PROPS-0002` 只约束 Props API surface 的阶段归属与最小入口，不承接 declaration shape、fallback、watch diff、raw escape hatch 或 render commit 调度等具体语义。
+
+
+  en: >-
+    The Props channel must reflect `setup`/`runtime` separation: setup-time declaration, default planning, and watcher-registration surfaces are exposed through `def.props`; runtime read access to the current props state is exposed through `run.props`. `C-PROPS-0002` only constrains the phase ownership and minimum entries of the Props API surface; concrete declaration shape, fallback, watch diff, raw escape hatch, and render-commit scheduling semantics are owned by narrower contracts.
+
+
 criteria:
   - id: C-PROPS-0002-A
     text:
-      zh-CN: Props 必须提供 `setup-only` 的声明 surface，用于声明 app maker 在 `runtime` 期间允许传入哪些 props 以及相关默认值、兜底或空值策略。
-      en: Props must provide a `setup-only` declaration surface for declaring which props app makers may provide at `runtime` and the associated `default`, `fallback`, or empty-value policies.
+      zh-CN: Props 的 setup-time declaration surface 必须通过 `def.props.define(decl)` 暴露。
+      en: The setup-time Props declaration surface must be exposed through `def.props.define(decl)`.
   - id: C-PROPS-0002-B
     text:
-      zh-CN: Props 必须提供 `setup-only` 的 watcher registration surface，用于声明 `runtime` 期间 props 重新传入或变化时应执行的动作。
-      en: Props must provide a `setup-only` watcher registration surface for declaring actions to run when props are re-applied or changed during `runtime`.
+      zh-CN: Props 的 setup-time defaults planning surface 必须通过 `def.props.setDefaults(partialDefaults)` 暴露。
+      en: The setup-time Props defaults-planning surface must be exposed through `def.props.setDefaults(partialDefaults)`.
   - id: C-PROPS-0002-C
     text:
-      zh-CN: Props 必须提供 `runtime-only` 的访问 surface，用于读取当前调用的 props 值。
-      en: Props must provide a `runtime-only` access surface for reading prop values for the current invocation.
+      zh-CN: Props 的 resolved watcher registration surface 必须通过 `def.props.watch(keys, cb)` 与 `def.props.watchAll(cb)` 暴露。
+      en: The resolved Props watcher-registration surface must be exposed through `def.props.watch(keys, cb)` and `def.props.watchAll(cb)`.
   - id: C-PROPS-0002-D
     text:
-      zh-CN: '`runtime props value` 对原型作者而言必须表现为只读快照；修改该快照不应被视为修改 Props 通路。'
-      en: "`Runtime prop values` must behave as read-only snapshots from the prototype author's perspective; mutating the snapshot must not be treated as mutating the Props channel."
+      zh-CN: Props 的 raw escape-hatch watcher registration surface 必须通过 `def.props.watchRaw(keys, cb)` 与 `def.props.watchRawAll(cb)` 暴露。
+      en: The raw Props escape-hatch watcher-registration surface must be exposed through `def.props.watchRaw(keys, cb)` and `def.props.watchRawAll(cb)`.
   - id: C-PROPS-0002-E
     text:
-      zh-CN: Props 变化或 `watcher callback` 执行本身不得隐含视图更新。
-      en: Props changes or `watcher callback` execution must not imply a view update by itself.
+      zh-CN: Props 的 runtime read surface 必须通过 `run.props.get()`、`run.props.getRaw()` 与 `run.props.isProvided(key)` 暴露。
+      en: The runtime Props read surface must be exposed through `run.props.get()`, `run.props.getRaw()`, and `run.props.isProvided(key)`.
+  - id: C-PROPS-0002-F
+    text:
+      zh-CN: '`def.props.*` API 必须是 setup-only；`run.props.*` API 不得暴露 declaration、default planning 或 watcher registration 能力。'
+      en: '`def.props.*` APIs must be setup-only; `run.props.*` APIs must not expose declaration, default-planning, or watcher-registration capabilities.'
     rationale:
-      zh-CN: Proto UI 的视图更新应由更基础的 `runtime update` 契约约束；Props 只负责传递、解析与监听配置输入。
-      en: Proto UI view updates should be governed by a lower-level `runtime update` contract; Props only carries, resolves, and observes configuration input.
-openQuestions:
-  - id: C-PROPS-0002-Q1
-    question:
-      zh-CN: 应建立哪条 core/runtime 契约来承接 `run.update()` 与“Props 变化不隐含视图更新”的语义？
-      en: Which core/runtime contract should own `run.update()` and the rule that Props changes do not imply view updates?
-    context:
-      zh-CN: 当前 C-PROPS-0002-E 暂时记录了该规则，但其基础不属于 Props 通路本身。
-      en: C-PROPS-0002-E currently records this rule, but its foundation is outside the Props channel itself.
-    blocks:
-      - C-PROPS-0002-E
+      zh-CN: Props API surface 的核心职责是让 `setup` 计划和 `runtime` 调用在句柄形状上可见。具体行为细节由子契约承接。
+      en: The core responsibility of the Props API surface is to make `setup` planning and `runtime` invocation boundaries visible in handle shape. Narrower contracts own concrete behavior details.
 sources:
   - path: internal/contracts/props/base-text/01.define-merge.v0.zh-CN.md
     sections:
@@ -52,6 +52,13 @@ sources:
     sections:
       - '3. watchAll(cb)'
       - '4. watch(keys, cb)'
+  - path: internal/contracts/props/base-text/04.watch-raw.v0.zh-CN.md
+    sections:
+      - '3. watchRawAll(cb)'
+      - '4. watchRaw(keys, cb)'
+  - path: internal/contracts/props/base-text/05.runtime-integration.v0.zh-CN.md
+    sections:
+      - '2. RunHandle.props surface'
 dependsOn:
   contracts:
     - C-LIFECYCLE-0001
@@ -61,11 +68,12 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted a placeholder for setup/runtime props surface semantics.
+  - version: 0.1.0
+    change: revised
+    summary: Promoted Props API surface ownership to active criteria and moved render-commit scheduling out to narrower runtime/update contracts.
 tags:
   - props
   - api
   - surface
   - setup
   - runtime
-  - draft
-  - deferred

--- a/spec/contracts/C-PROPS-0003.yaml
+++ b/spec/contracts/C-PROPS-0003.yaml
@@ -5,25 +5,25 @@ status: active
 since: 0.1.0
 summary: Props values must be JSON values so that the props channel remains serializable, portable, and semantically consistent across hosts.
 statement:
-  zh-CN: Props value 必须是 JSON value；也就是说，它只能由 string、number、boolean、null、array 和 object 递归组成，不得包含 JSON 无法表达的数据。
-  en: A Props value must be a JSON value; it may only be recursively composed from string, number, boolean, null, array, and object, and must not contain data that JSON cannot express.
+  zh-CN: Props value 必须是 `JSON value`；也就是说，它只能由 `string`、`number`、`boolean`、`null`、`array` 和 `object` 递归组成，不得包含 JSON 无法表达的数据。
+  en: A Props value must be a `JSON value`; it may only be recursively composed from `string`, `number`, `boolean`, `null`, `array`, and `object`, and must not contain data that JSON cannot express.
 criteria:
   - id: C-PROPS-0003-A
     text:
-      zh-CN: Props value 允许 string、number、boolean 和 null。
-      en: Props values may be strings, numbers, booleans, and null.
+      zh-CN: Props value 允许 `string`、`number`、`boolean` 和 `null`。
+      en: Props values may be `string`, `number`, `boolean`, and `null`.
   - id: C-PROPS-0003-B
     text:
-      zh-CN: Props value 允许 array，但 array 的每一项也必须是 JSON value。
-      en: Props values may be arrays, but every array item must also be a JSON value.
+      zh-CN: Props value 允许 `array`，但 `array` 的每一项也必须是 `JSON value`。
+      en: Props values may be `array`, but every array item must also be a `JSON value`.
   - id: C-PROPS-0003-C
     text:
-      zh-CN: Props value 允许 object，但 object 的每个属性值也必须是 JSON value。
-      en: Props values may be objects, but every object property value must also be a JSON value.
+      zh-CN: Props value 允许 `object`，但 `object` 的每个属性值也必须是 `JSON value`。
+      en: Props values may be `object`, but every object property value must also be a `JSON value`.
   - id: C-PROPS-0003-D
     text:
-      zh-CN: Props value 不得包含 undefined、function、symbol、bigint、class instance、Date、RegExp、Map、Set、DOM 对象或其他 JSON 无法表达的数据。
-      en: Props values must not contain undefined, functions, symbols, bigint, class instances, Date, RegExp, Map, Set, DOM objects, or other data JSON cannot express.
+      zh-CN: Props value 不得包含 `undefined`、`function`、`symbol`、`bigint`、`class instance`、`Date`、`RegExp`、`Map`、`Set`、DOM 对象或其他 JSON 无法表达的数据。
+      en: Props values must not contain `undefined`, `function`, `symbol`, `bigint`, `class instances`, `Date`, `RegExp`, `Map`, `Set`, DOM objects, or other data JSON cannot express.
   - id: C-PROPS-0003-E
     text:
       zh-CN: 不可 JSON 表达的数据即使在某个宿主中可用，也不得进入 Props 的可移植语义承诺。

--- a/spec/contracts/C-PROPS-0004.yaml
+++ b/spec/contracts/C-PROPS-0004.yaml
@@ -3,7 +3,7 @@ type: contract
 title: Prop semantic state is classified per key
 status: active
 since: 0.1.0
-summary: Missing, empty, non-empty, and invalid states are evaluated for each individual prop key.
+summary: '`missing`, `empty`, `non-empty`, and `invalid` states are evaluated for each individual prop key.'
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:

--- a/spec/contracts/C-PROPS-0004.yaml
+++ b/spec/contracts/C-PROPS-0004.yaml
@@ -4,6 +4,33 @@ title: Prop semantic state is classified per key
 status: active
 since: 0.1.0
 summary: '`missing`, `empty`, `non-empty`, and `invalid` states are evaluated for each individual prop key.'
+statement:
+  zh-CN: Props 输入状态必须按 `prop key` 独立分类。对某个 key 来说，raw input 可以是 `missing`、`provided-empty`、`provided-non-empty valid` 或 `provided-non-empty invalid`；这些状态不得把整份 props record 作为一个不可分割的校验单元。
+  en: Props input state must be classified independently per `prop key`. For a key, raw input may be `missing`, `provided-empty`, `provided-non-empty valid`, or `provided-non-empty invalid`; these states must not treat the whole props record as one indivisible validation unit.
+criteria:
+  - id: C-PROPS-0004-A
+    text:
+      zh-CN: 当 raw props 中不存在某个已声明 key 的 own property 时，该 key 的状态为 `missing`。
+      en: When raw props do not contain an own property for a declared key, that key is `missing`.
+  - id: C-PROPS-0004-B
+    text:
+      zh-CN: 当 raw props 中存在某个 key，且其输入值为空值表示时，该 key 的状态为 `provided-empty`。
+      en: When raw props contain a key and its input value is an empty-value representation, that key is `provided-empty`.
+    rationale:
+      zh-CN: 在 JavaScript 宿主中，adapter 或 Props module 可以接收到 `undefined`；进入 resolved props 语义前必须按空值输入处理，最终不得把 `undefined` 暴露给原型。
+      en: In JavaScript hosts, adapters or the Props module may receive `undefined`; before entering resolved props semantics it must be treated as empty input and must never be exposed to prototypes as `undefined`.
+  - id: C-PROPS-0004-C
+    text:
+      zh-CN: 当 raw props 中存在某个 key，且其输入值不是空值表示时，该 key 先进入 `provided-non-empty` 状态，再依据声明进行合法性判断。
+      en: When raw props contain a key and its input value is not an empty-value representation, that key first enters the `provided-non-empty` state and is then validated against its declaration.
+  - id: C-PROPS-0004-D
+    text:
+      zh-CN: '`provided-non-empty` 输入若不满足该 key 的声明约束，则该 key 的状态为 `invalid`。'
+      en: A `provided-non-empty` input that does not satisfy that key's declaration constraints is `invalid`.
+  - id: C-PROPS-0004-E
+    text:
+      zh-CN: 某个 key 的 `missing`、`provided-empty` 或 `invalid` 状态不得改变其他 key 的分类或解析语义。
+      en: The `missing`, `provided-empty`, or `invalid` state of one key must not change the classification or resolution semantics of another key.
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:

--- a/spec/contracts/C-PROPS-0005.yaml
+++ b/spec/contracts/C-PROPS-0005.yaml
@@ -3,7 +3,7 @@ type: contract
 title: Setup-time prop declarations are mergeable plans
 status: active
 since: 0.1.0
-summary: Setup-time props define calls contribute to a planned configurable prop surface and can be merged before runtime execution.
+summary: '`Setup`-time props `define` calls contribute to a planned configurable prop surface and can be merged before `runtime` execution.'
 sources:
   - path: internal/contracts/props/base-text/01.define-merge.v0.zh-CN.md
     sections:

--- a/spec/contracts/C-PROPS-0006.yaml
+++ b/spec/contracts/C-PROPS-0006.yaml
@@ -3,7 +3,7 @@ type: contract
 title: Prop declaration descriptors have constrained shape
 status: active
 since: 0.1.0
-summary: Incoming prop declarations must satisfy the minimal v0 descriptor shape for type, empty behavior, and range.
+summary: Incoming prop declarations must satisfy the minimal v0 descriptor shape for `type`, `empty` behavior, and `range`.
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:
@@ -16,7 +16,7 @@ dependsOn:
     - id: C-PROPS-0003
       role: value-boundary
       coverageImpact: expands-test-surface
-      note: Prop declaration descriptors may carry default or fallback candidate values; those values must use the JSON value boundary.
+      note: Prop declaration descriptors may carry `default` or `fallback` candidate values; those values must use the JSON value boundary.
 refines:
   contracts:
     - C-PROPS-0005

--- a/spec/contracts/C-PROPS-0006.yaml
+++ b/spec/contracts/C-PROPS-0006.yaml
@@ -3,7 +3,73 @@ type: contract
 title: Prop declaration descriptors have constrained shape
 status: active
 since: 0.1.0
-summary: Incoming prop declarations must satisfy the minimal v0 descriptor shape for `type`, `empty` behavior, and `range`.
+summary: Incoming prop declarations must satisfy the minimal v0 descriptor shape for `type`, `empty`, enum `options`, `range`, and JSON-valued `default`.
+statement:
+  zh-CN: >-
+    `def.props.define()` 接收的每个 incoming prop declaration 必须先满足 v0 的最小 descriptor shape，才能进入同 key merge 规则。该 shape 约束只判断 declaration descriptor 自身是否可被 Props module 理解：`type` 必须存在且属于 v0 支持的 prop type，显式 `empty` 必须属于受支持的 empty behavior，`type: "enum"` 必须提供非空 string `options`，非 enum type 不得提供 `options`，显式 `range.min/max` 必须是有效 number，显式 `default` 必须满足 JSON props value 边界。shape 校验失败是 blocking error；更细的同 key 兼容性与演进安全由 `C-PROPS-0007` 约束。
+
+
+  en: >-
+    Every incoming prop declaration passed to `def.props.define()` must satisfy the minimal v0 descriptor shape before same-key merge rules apply. This shape constraint only decides whether the declaration descriptor itself can be understood by the Props module: `type` must be present and must be one of the v0 supported prop types, explicit `empty` must be one of the supported empty behaviors, `type: "enum"` must provide non-empty string `options`, non-enum types must not provide `options`, explicit `range.min/max` must be valid numbers, and explicit `default` must satisfy the JSON props value boundary. Shape validation failures are blocking errors; finer same-key compatibility and evolution-safety rules are governed by `C-PROPS-0007`.
+
+
+criteria:
+  - id: C-PROPS-0006-A
+    text:
+      zh-CN: 每个 incoming prop declaration descriptor 必须显式提供 `type`。
+      en: Every incoming prop declaration descriptor must explicitly provide `type`.
+  - id: C-PROPS-0006-B
+    text:
+      zh-CN: '`type` 必须是 `any`、`boolean`、`string`、`number`、`object` 或 `enum` 之一。'
+      en: '`type` must be one of `any`, `boolean`, `string`, `number`, `object`, or `enum`.'
+  - id: C-PROPS-0006-C
+    text:
+      zh-CN: 显式提供的 `empty` 必须是 `accept`、`fallback` 或 `error` 之一；省略 `empty` 是合法 shape。
+      en: Explicit `empty` must be one of `accept`, `fallback`, or `error`; omitting `empty` is a valid shape.
+    rationale:
+      zh-CN: 省略 `empty` 不表示新的 empty behavior。默认 empty 语义由 fallback resolution 契约解释。
+      en: Omitting `empty` does not introduce a new empty behavior. Default empty semantics are interpreted by the fallback resolution contract.
+  - id: C-PROPS-0006-D
+    text:
+      zh-CN: '`type: "enum"` 必须提供 `options`，且 `options` 必须是非空 string 数组。'
+      en: '`type: "enum"` must provide `options`, and `options` must be a non-empty string array.'
+    rationale:
+      zh-CN: Props enum 与 State enum 对齐为独立类型加 `options` 的形状。v0 只支持 string enum，number 离散值和 boolean 不由 enum 承接。
+      en: Props enum aligns with State enum as an explicit type plus `options`. v0 only supports string enums; numeric discrete values and booleans are not modeled as enum props.
+  - id: C-PROPS-0006-E
+    text:
+      zh-CN: '非 `type: "enum"` 的 descriptor 不得提供 `options`。'
+      en: Descriptors whose `type` is not `enum` must not provide `options`.
+  - id: C-PROPS-0006-F
+    text:
+      zh-CN: 若提供 `range`，其 `min` 与 `max` 在出现时必须是有效 number，且不得是 `NaN`。
+      en: If `range` is provided, its `min` and `max`, when present, must be valid numbers and must not be `NaN`.
+  - id: C-PROPS-0006-G
+    text:
+      zh-CN: 若提供 `default`，其值必须满足 `C-PROPS-0003` 定义的 JSON props value 边界。
+      en: If `default` is provided, its value must satisfy the JSON props value boundary defined by `C-PROPS-0003`.
+  - id: C-PROPS-0006-H
+    text:
+      zh-CN: descriptor shape 校验失败必须产生 blocking error，而不是 warning 或静默忽略。
+      en: Descriptor shape validation failures must produce blocking errors, not warnings or silent ignores.
+openQuestions:
+  - id: C-PROPS-0006-Q-VALIDATOR-PORTABILITY
+    question:
+      zh-CN: '`validator` 作为函数型 descriptor 字段是否仍应属于 portable Props declaration，还是应被移到 host/runtime-local extension 或后续静态规则中？'
+      en: Should function-valued `validator` remain part of portable Props declarations, or move to a host/runtime-local extension or future static rule?
+    context:
+      zh-CN: >-
+        当前 `PropSpec` 类型允许 `validator?: (v: any) => boolean`，旧 merge 契约也定义了 validator 的新增、替换、移除规则。但函数 descriptor 与长期结构化 spec source 的可移植性存在张力，暂不把 validator shape 写入本轮 active criteria。
+
+
+      en: >-
+        The current `PropSpec` type allows `validator?: (v: any) => boolean`, and the old merge contract defines add, replace, and remove rules for validators. Function-valued descriptors are in tension with the long-term portable structured spec source, so validator shape is not added to this round of active criteria.
+
+
+    blocks:
+      - C-PROPS-0006
+      - C-PROPS-0007
+      - T-PROPS-0003
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:
@@ -24,6 +90,12 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured minimal shape validation for prop declarations.
+  - version: 0.1.0
+    change: revised
+    summary: Added statement, criteria, and an explicit open question for validator descriptor portability.
+  - version: 0.1.0
+    change: revised
+    summary: 'Replaced legacy `enum` descriptor field with state-aligned `type: "enum"` plus required string `options`.'
 tags:
   - props
   - define

--- a/spec/contracts/C-PROPS-0007.yaml
+++ b/spec/contracts/C-PROPS-0007.yaml
@@ -4,6 +4,44 @@ title: Prop declaration merge preserves evolution safety
 status: active
 since: 0.1.0
 summary: Prop declaration merging must reject breaking narrowing and keep widening changes traceable.
+statement:
+  zh-CN: >-
+    当同一个 prop key 被多次声明时，Props declaration merge 必须保护已建立声明的演进安全：会缩小 app maker 既有合法输入空间的 incoming declaration 必须被拒绝；会扩大或放松输入空间的 incoming declaration 可以合并，但必须产生 warning 以保留可追踪性。该契约假定 incoming descriptor 已经满足 `C-PROPS-0006` 的 shape 校验。
+
+
+  en: >-
+    When the same prop key is declared more than once, Props declaration merge must preserve the evolution safety of the established declaration: incoming declarations that narrow the already-valid input space for app makers must be rejected, while incoming declarations that widen or loosen that input space may merge but must produce warnings for traceability. This contract assumes that incoming descriptors have already passed the shape validation defined by `C-PROPS-0006`.
+
+
+criteria:
+  - id: C-PROPS-0007-A
+    text:
+      zh-CN: 同 key merge 时，base 与 incoming 的 `type` 必须一致；不一致必须 error。
+      en: During same-key merge, base and incoming `type` must match; mismatches must be errors.
+  - id: C-PROPS-0007-B
+    text:
+      zh-CN: '`empty` 的严格度顺序为 `accept < fallback < error`；incoming 更严格必须 error，incoming 更宽松必须 warning 并保留 base 的更严格行为。'
+      en: The strictness order for `empty` is `accept < fallback < error`; stricter incoming behavior must be an error, while looser incoming behavior must warn and keep the stricter base behavior.
+  - id: C-PROPS-0007-C
+    text:
+      zh-CN: '`type: "enum"` 的 incoming `options` 若是 base `options` 的子集必须 error；若是超集必须 warning；相等则 ok。'
+      en: 'For `type: "enum"`, incoming `options` that are a subset of base `options` must be an error; a superset must warn; equal options are ok.'
+  - id: C-PROPS-0007-D
+    text:
+      zh-CN: '`range` 的 incoming 区间若更窄必须 error；若更宽必须 warning。'
+      en: Incoming `range` intervals that are narrower must be errors; wider intervals must warn.
+  - id: C-PROPS-0007-E
+    text:
+      zh-CN: '`validator` 允许首次新增；替换或移除已有 validator 必须 error。'
+      en: '`validator` may be added for the first time; replacing or removing an existing validator must be an error.'
+  - id: C-PROPS-0007-F
+    text:
+      zh-CN: '`default` 允许首次新增；变更已有 default 必须 warning，并保留 base default。'
+      en: '`default` may be added for the first time; changing an existing default must warn and keep the base default.'
+  - id: C-PROPS-0007-G
+    text:
+      zh-CN: 合并输出必须确定；相同声明集合不得因 define 顺序不同而产生不同 resolved 行为或 diagnostics。
+      en: Merge output must be deterministic; the same declaration set must not produce different resolved behavior or diagnostics due to define order.
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:
@@ -20,6 +58,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured the v0 evolution-safety merge policy for prop declarations.
+  - version: 0.1.0
+    change: revised
+    summary: 'Added statement and criteria, and aligned enum merge semantics with `type: "enum"` plus string `options`.'
 tags:
   - props
   - define

--- a/spec/contracts/C-PROPS-0008.yaml
+++ b/spec/contracts/C-PROPS-0008.yaml
@@ -3,45 +3,45 @@ type: contract
 title: Runtime props resolution produces a declared-key resolved snapshot
 status: active
 since: 0.1.0
-summary: Resolved props contain all and only declared keys, never expose undefined, and use null as the canonical empty value.
+summary: '`Resolved props` contain all and only declared keys, never expose `undefined`, and use `null` as the canonical empty value.'
 statement:
-  zh-CN: 运行期 props resolution 会基于当前 adapter 提供的 raw props 快照，生成一份语义只读的 resolved snapshot。该快照包含且仅包含已声明的 prop key。每个已声明 key 按 key 维度独立完成 resolve，因此某个 key 的缺失、空值或非法输入不得改变其他 key 的 resolve 语义。resolved snapshot 的值必须保持在 JSON props value 边界内，且不得暴露 undefined；当 resolve 允许空结果时，null 是唯一规范空值。
-  en: Runtime props resolution produces a semantically read-only resolved snapshot from the current adapter-supplied raw props snapshot. The snapshot contains all and only declared prop keys. Each declared key resolves independently at key granularity, so missing, empty, or invalid input for one key must not change the resolution semantics of other keys. Resolved snapshot values must remain within the JSON props value boundary and must never expose undefined; when resolution permits an empty result, null is the only canonical empty value.
+  zh-CN: 运行期 props resolution 会基于当前 adapter 提供给 Props module 的 `raw props` 快照，生成一份语义只读的 `resolved snapshot`。该快照包含且仅包含已声明的 `prop key`。每个已声明 key 按 key 维度独立完成 `resolve`，因此某个 key 的缺失、空值或非法输入不得改变其他 key 的 resolve 语义。`resolved snapshot` 的值必须保持在 JSON props value 边界内，且不得暴露 `undefined`；当 `resolve` 允许空结果时，`null` 是唯一规范空值。
+  en: Runtime props resolution produces a semantically read-only `resolved snapshot` from the current adapter-supplied `raw props` snapshot passed into the Props module. The snapshot contains all and only declared `prop keys`. Each declared key resolves independently at key granularity, so missing, empty, or invalid input for one key must not change the resolution semantics of other keys. `resolved snapshot` values must remain within the JSON props value boundary and must never expose `undefined`; when `resolve` permits an empty result, `null` is the only canonical empty value.
 criteria:
   - id: C-PROPS-0008-A
     text:
-      zh-CN: run.props.get() 返回当前 runtime 调用所对应的 resolved props snapshot。
-      en: run.props.get() returns the resolved props snapshot for the current runtime invocation.
+      zh-CN: '`run.props.get()` 返回当前 runtime 调用所对应的 `resolved props snapshot`。'
+      en: '`run.props.get()` returns the `resolved props snapshot` for the current runtime invocation.'
   - id: C-PROPS-0008-B
     text:
-      zh-CN: resolved snapshot 必须包含每一个已声明的 prop key。
-      en: The resolved snapshot must contain every declared prop key.
+      zh-CN: '`resolved snapshot` 必须包含每一个已声明的 `prop key`。'
+      en: The `resolved snapshot` must contain every declared `prop key`.
   - id: C-PROPS-0008-C
     text:
-      zh-CN: resolved snapshot 不得包含未声明的 raw prop key。
-      en: The resolved snapshot must not contain undeclared raw prop keys.
+      zh-CN: '`resolved snapshot` 不得包含未声明的 `raw prop key`。'
+      en: The `resolved snapshot` must not contain undeclared `raw prop keys`.
   - id: C-PROPS-0008-D
     text:
-      zh-CN: props resolution 必须按 key 维度执行；某个 key 的 missing、provided-empty、provided-non-empty 或 invalid 状态不得改变其他 key 的 resolve 语义。
-      en: Props resolution must run at key granularity; the missing, provided-empty, provided-non-empty, or invalid state of one key must not change the resolution semantics of other keys.
+      zh-CN: props resolution 必须按 key 维度执行；某个 key 的 `missing`、`provided-empty`、`provided-non-empty` 或 `invalid` 状态不得改变其他 key 的 `resolve` 语义。
+      en: Props resolution must run at key granularity; the `missing`, `provided-empty`, `provided-non-empty`, or `invalid` state of one key must not change the resolution semantics of other keys.
     rationale:
-      zh-CN: Props value 的顶层语义是 record<string, value>。只有 key 对应的 value 需要按声明与 fallback 规则进入具体 resolve，不能把整份 props record 作为一个不可分割的校验单元。
-      en: The top-level semantics of Props values are record<string, value>. Only each key's value should enter concrete resolution through its declaration and fallback rules; the whole props record must not be treated as one indivisible validation unit.
+      zh-CN: Props value 的顶层语义是 `record<string, value>`。只有 key 对应的 value 需要按声明与 fallback 规则进入具体 `resolve`，不能把整份 props record 作为一个不可分割的校验单元。
+      en: The top-level semantics of Props values are `record<string, value>`. Only each key's value should enter concrete resolution through its declaration and fallback rules; the whole props record must not be treated as one indivisible validation unit.
   - id: C-PROPS-0008-E
     text:
-      zh-CN: resolved snapshot 的顶层形状必须是由 string key 索引的 record，且每个 resolved value 必须满足 C-PROPS-0003 的 JSON value 边界。
-      en: The resolved snapshot must have a top-level record shape indexed by string keys, and every resolved value must satisfy the JSON value boundary defined by C-PROPS-0003.
+      zh-CN: '`resolved snapshot` 的顶层形状必须是由 string key 索引的 record，且每个 resolved value 必须满足 `C-PROPS-0003` 的 JSON value 边界。'
+      en: The `resolved snapshot` must have a top-level record shape indexed by string keys, and every resolved value must satisfy the JSON value boundary defined by `C-PROPS-0003`.
   - id: C-PROPS-0008-F
     text:
-      zh-CN: resolved snapshot 不得暴露 undefined；当某个 key resolve 为空值结果时，该结果必须是 null。
-      en: The resolved snapshot must not expose undefined; when a key resolves to an empty result, that result must be null.
+      zh-CN: '`resolved snapshot` 不得暴露 `undefined`；当某个 key resolve 为空值结果时，该结果必须是 `null`。'
+      en: The `resolved snapshot` must not expose `undefined`; when a key resolves to an empty result, that result must be `null`.
   - id: C-PROPS-0008-G
     text:
-      zh-CN: resolved props snapshot 在语义上是只读的；原型作者不得修改该 snapshot 对象或通过它取得的嵌套值。
-      en: Resolved props snapshots are semantically read-only; prototype authors must not mutate the snapshot object or nested values obtained through it.
+      zh-CN: '`resolved props snapshot` 在语义上是只读的；原型作者不得修改该 snapshot 对象或通过它取得的嵌套值。'
+      en: '`resolved props snapshots` are semantically read-only; prototype authors must not mutate the snapshot object or nested values obtained through it.'
     rationale:
-      zh-CN: 修改 resolved snapshot 不具有 Proto UI 协议语义，不得用于传递状态或配置变化。v0 runtime 可以出于性能考虑不做深层不可变性限制，但静态分析应将 snapshot mutation 视为契约违规。
-      en: Mutating a resolved snapshot has no Proto UI protocol meaning and must not be used to communicate state or configuration changes. v0 runtimes may avoid deep immutability enforcement for performance reasons, but static analysis should treat snapshot mutation as a contract violation.
+      zh-CN: 修改 `resolved snapshot` 不具有 Proto UI 协议语义，不得用于传递状态或配置变化。v0 runtime 可以出于性能考虑不做深层不可变性限制，但静态分析应将 snapshot mutation 视为契约违规。
+      en: Mutating a `resolved snapshot` has no Proto UI protocol meaning and must not be used to communicate state or configuration changes. v0 runtimes may avoid deep immutability enforcement for performance reasons, but static analysis should treat snapshot mutation as a contract violation.
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:
@@ -57,7 +57,7 @@ dependsOn:
     - id: C-PROPS-0003
       role: value-boundary
       coverageImpact: expands-test-surface
-      note: The resolved snapshot exposes portable props values, so every resolved value must satisfy the JSON value boundary.
+      note: The `resolved snapshot` exposes portable props values, so every resolved value must satisfy the JSON value boundary.
     - C-CORE-VALUE-0001
 refines:
   contracts:
@@ -65,7 +65,7 @@ refines:
 revisions:
   - version: 0.1.0
     change: introduced
-    summary: Captured resolved snapshot shape and empty-value invariants.
+    summary: Captured `resolved snapshot` shape and empty-value invariants.
 tags:
   - props
   - runtime

--- a/spec/contracts/C-PROPS-0008.yaml
+++ b/spec/contracts/C-PROPS-0008.yaml
@@ -4,6 +4,44 @@ title: Runtime props resolution produces a declared-key resolved snapshot
 status: active
 since: 0.1.0
 summary: Resolved props contain all and only declared keys, never expose undefined, and use null as the canonical empty value.
+statement:
+  zh-CN: 运行期 props resolution 会基于当前 adapter 提供的 raw props 快照，生成一份语义只读的 resolved snapshot。该快照包含且仅包含已声明的 prop key。每个已声明 key 按 key 维度独立完成 resolve，因此某个 key 的缺失、空值或非法输入不得改变其他 key 的 resolve 语义。resolved snapshot 的值必须保持在 JSON props value 边界内，且不得暴露 undefined；当 resolve 允许空结果时，null 是唯一规范空值。
+  en: Runtime props resolution produces a semantically read-only resolved snapshot from the current adapter-supplied raw props snapshot. The snapshot contains all and only declared prop keys. Each declared key resolves independently at key granularity, so missing, empty, or invalid input for one key must not change the resolution semantics of other keys. Resolved snapshot values must remain within the JSON props value boundary and must never expose undefined; when resolution permits an empty result, null is the only canonical empty value.
+criteria:
+  - id: C-PROPS-0008-A
+    text:
+      zh-CN: run.props.get() 返回当前 runtime 调用所对应的 resolved props snapshot。
+      en: run.props.get() returns the resolved props snapshot for the current runtime invocation.
+  - id: C-PROPS-0008-B
+    text:
+      zh-CN: resolved snapshot 必须包含每一个已声明的 prop key。
+      en: The resolved snapshot must contain every declared prop key.
+  - id: C-PROPS-0008-C
+    text:
+      zh-CN: resolved snapshot 不得包含未声明的 raw prop key。
+      en: The resolved snapshot must not contain undeclared raw prop keys.
+  - id: C-PROPS-0008-D
+    text:
+      zh-CN: props resolution 必须按 key 维度执行；某个 key 的 missing、provided-empty、provided-non-empty 或 invalid 状态不得改变其他 key 的 resolve 语义。
+      en: Props resolution must run at key granularity; the missing, provided-empty, provided-non-empty, or invalid state of one key must not change the resolution semantics of other keys.
+    rationale:
+      zh-CN: Props value 的顶层语义是 record<string, value>。只有 key 对应的 value 需要按声明与 fallback 规则进入具体 resolve，不能把整份 props record 作为一个不可分割的校验单元。
+      en: The top-level semantics of Props values are record<string, value>. Only each key's value should enter concrete resolution through its declaration and fallback rules; the whole props record must not be treated as one indivisible validation unit.
+  - id: C-PROPS-0008-E
+    text:
+      zh-CN: resolved snapshot 的顶层形状必须是由 string key 索引的 record，且每个 resolved value 必须满足 C-PROPS-0003 的 JSON value 边界。
+      en: The resolved snapshot must have a top-level record shape indexed by string keys, and every resolved value must satisfy the JSON value boundary defined by C-PROPS-0003.
+  - id: C-PROPS-0008-F
+    text:
+      zh-CN: resolved snapshot 不得暴露 undefined；当某个 key resolve 为空值结果时，该结果必须是 null。
+      en: The resolved snapshot must not expose undefined; when a key resolves to an empty result, that result must be null.
+  - id: C-PROPS-0008-G
+    text:
+      zh-CN: resolved props snapshot 在语义上是只读的；原型作者不得修改该 snapshot 对象或通过它取得的嵌套值。
+      en: Resolved props snapshots are semantically read-only; prototype authors must not mutate the snapshot object or nested values obtained through it.
+    rationale:
+      zh-CN: 修改 resolved snapshot 不具有 Proto UI 协议语义，不得用于传递状态或配置变化。v0 runtime 可以出于性能考虑不做深层不可变性限制，但静态分析应将 snapshot mutation 视为契约违规。
+      en: Mutating a resolved snapshot has no Proto UI protocol meaning and must not be used to communicate state or configuration changes. v0 runtimes may avoid deep immutability enforcement for performance reasons, but static analysis should treat snapshot mutation as a contract violation.
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:

--- a/spec/contracts/C-PROPS-0009.yaml
+++ b/spec/contracts/C-PROPS-0009.yaml
@@ -3,15 +3,15 @@ type: contract
 title: Empty and invalid prop values resolve through deterministic fallback
 status: active
 since: 0.1.0
-summary: Missing, empty, and invalid prop values resolve through the configured empty behavior and fallback chain.
+summary: '`Missing`, `empty`, and `invalid` prop values resolve through the configured `empty` behavior and fallback chain.'
 openQuestions:
   - id: C-PROPS-0009-Q1
     question:
-      zh-CN: 当 fallback 链最终落到 null 时，resolved props 是否允许 typed prop（例如 number）获得 null 值，还是应视 empty behavior 配置决定？
-      en: When the fallback chain reaches null, may a typed prop such as number resolve to null, or must this depend on the configured empty behavior?
+      zh-CN: 当 fallback 链最终落到 `null` 时，`resolved props` 是否允许 typed prop（例如 `number`）获得 `null` 值，还是应视 `empty behavior` 配置决定？
+      en: When the fallback chain reaches `null`, may a typed prop such as `number` resolve to `null`, or must this depend on the configured `empty behavior`?
     context:
-      zh-CN: 现有底本允许 empty 非 error 时 fallback 链末尾为 null；但这可能与“typed prop 默认不应得到 null resolved value”的直觉冲突，需要回看实现与测试。
-      en: The current base text allows null at the end of the fallback chain when empty is not error; this may conflict with the intuition that typed props should not resolve to null by default, so implementation and tests need review.
+      zh-CN: 现有底本允许 `empty` 非 `error` 时 fallback 链末尾为 `null`；但这可能与“typed prop 默认不应得到 `null` resolved value”的直觉冲突，需要回看实现与测试。
+      en: The current base text allows `null` at the end of the fallback chain when `empty` is not `error`; this may conflict with the intuition that typed props should not resolve to `null` by default, so implementation and tests need review.
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:
@@ -29,12 +29,12 @@ dependsOn:
     - id: C-PROPS-0003
       role: value-boundary
       coverageImpact: expands-test-surface
-      note: The fallback chain selects or produces props values, so accepted fallback results must satisfy the JSON value boundary.
+      note: The fallback chain selects or produces props values, so accepted fallback results must satisfy the `JSON value` boundary.
     - C-PROPS-0008
 revisions:
   - version: 0.1.0
     change: introduced
-    summary: Captured deterministic empty, invalid, fallback, and prevValid behavior.
+    summary: Captured deterministic `empty`, `invalid`, `fallback`, and `prevValid` behavior.
 tags:
   - props
   - fallback

--- a/spec/contracts/C-PROPS-0009.yaml
+++ b/spec/contracts/C-PROPS-0009.yaml
@@ -4,14 +4,51 @@ title: Empty and invalid prop values resolve through deterministic fallback
 status: active
 since: 0.1.0
 summary: '`Missing`, `empty`, and `invalid` prop values resolve through the configured `empty` behavior and fallback chain.'
-openQuestions:
-  - id: C-PROPS-0009-Q1
-    question:
-      zh-CN: 当 fallback 链最终落到 `null` 时，`resolved props` 是否允许 typed prop（例如 `number`）获得 `null` 值，还是应视 `empty behavior` 配置决定？
-      en: When the fallback chain reaches `null`, may a typed prop such as `number` resolve to `null`, or must this depend on the configured `empty behavior`?
-    context:
-      zh-CN: 现有底本允许 `empty` 非 `error` 时 fallback 链末尾为 `null`；但这可能与“typed prop 默认不应得到 `null` resolved value”的直觉冲突，需要回看实现与测试。
-      en: The current base text allows `null` at the end of the fallback chain when `empty` is not `error`; this may conflict with the intuition that typed props should not resolve to `null` by default, so implementation and tests need review.
+statement:
+  zh-CN: >-
+    当某个 prop key 的输入为 `missing`、`provided-empty` 或 `invalid` 时，Props resolution 必须根据该 key 的 `empty` 行为与 fallback 链产生确定的 resolved value。默认 `empty: "fallback"` 行为允许 fallback 链在没有可用非空候选值时最终产出 `null`；这表示 canonical empty result，而不是 typed prop 接受了 `null` 作为非空合法值。只有 `empty: "error"` 要求在没有非空 fallback 时失败。
+
+
+  en: >-
+    When a prop key is `missing`, `provided-empty`, or `invalid`, Props resolution must produce a deterministic resolved value according to that key's `empty` behavior and fallback chain. The default `empty: "fallback"` behavior permits the fallback chain to produce `null` when no usable non-empty candidate exists; this is a canonical empty result, not typed acceptance of `null` as a non-empty valid value. Only `empty: "error"` requires failure when no non-empty fallback exists.
+
+
+criteria:
+  - id: C-PROPS-0009-A
+    text:
+      zh-CN: '`missing` 输入必须进入 fallback 链，而不是让该 key 从 `resolved snapshot` 中消失。'
+      en: '`Missing` input must enter the fallback chain instead of removing that key from the `resolved snapshot`.'
+  - id: C-PROPS-0009-B
+    text:
+      zh-CN: '`provided-empty` 输入在 `empty: "accept"` 时必须 resolve 为 `null`，且不得写入 `prevValid`。'
+      en: '`Provided-empty` input with `empty: "accept"` must resolve to `null` and must not write `prevValid`.'
+  - id: C-PROPS-0009-C
+    text:
+      zh-CN: '`provided-empty` 输入在默认 `empty: "fallback"` 时必须进入 fallback 链。'
+      en: '`Provided-empty` input with the default `empty: "fallback"` behavior must enter the fallback chain.'
+  - id: C-PROPS-0009-D
+    text:
+      zh-CN: '`provided-non-empty invalid` 输入必须进入 fallback 链；它不是 `provided-empty`，也不得被 `empty: "accept"` 直接接受为 `null`。'
+      en: '`Provided-non-empty invalid` input must enter the fallback chain; it is not `provided-empty` and must not be directly accepted as `null` by `empty: "accept"`.'
+  - id: C-PROPS-0009-E
+    text:
+      zh-CN: 'fallback 链的候选顺序必须是 `prevValid`、`setDefaults`、声明中的 `default`、最后的 `null`。'
+      en: 'The fallback candidate order must be `prevValid`, `setDefaults`, declaration `default`, then final `null`.'
+  - id: C-PROPS-0009-F
+    text:
+      zh-CN: 'fallback 链最终落到 `null` 是允许的 canonical empty result；它不表示该 key 的声明类型把 `null` 视为非空合法输入。'
+      en: "A fallback chain that ends in `null` is an allowed canonical empty result; it does not mean that the key's declared type treats `null` as a non-empty valid input."
+    rationale:
+      zh-CN: '这让 `resolved snapshot` 保持稳定 key 集合，同时避免把 `undefined` 或缺失 key 暴露给原型。'
+      en: 'This keeps the `resolved snapshot` key set stable while avoiding exposure of `undefined` or absent keys to prototypes.'
+  - id: C-PROPS-0009-G
+    text:
+      zh-CN: '`empty: "error"` 要求 fallback 结果必须是非空合法值；若不存在这样的候选值，resolution 必须失败。'
+      en: '`empty: "error"` requires the fallback result to be a non-empty valid value; if no such candidate exists, resolution must fail.'
+  - id: C-PROPS-0009-H
+    text:
+      zh-CN: '`prevValid` 只记录非空且通过该 key 声明校验的值；`null` 不得成为 `prevValid`。'
+      en: "`prevValid` records only non-empty values that pass that key's declaration validation; `null` must not become `prevValid`."
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:
@@ -31,10 +68,14 @@ dependsOn:
       coverageImpact: expands-test-surface
       note: The fallback chain selects or produces props values, so accepted fallback results must satisfy the `JSON value` boundary.
     - C-PROPS-0008
+    - C-CORE-VALUE-0001
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured deterministic `empty`, `invalid`, `fallback`, and `prevValid` behavior.
+  - version: 0.1.0
+    change: revised
+    summary: 'Clarified that default fallback may end in `null` as a canonical empty result, while `empty: "error"` requires a non-empty fallback.'
 tags:
   - props
   - fallback

--- a/spec/contracts/C-PROPS-0010.yaml
+++ b/spec/contracts/C-PROPS-0010.yaml
@@ -3,7 +3,7 @@ type: contract
 title: Failed declaration merge must not partially apply
 status: draft
 since: 0.1.0
-summary: Blocking diagnostics during setup-time prop declaration merge should reject the merge transaction without partially applying changes.
+summary: Blocking diagnostics during `setup`-time prop declaration merge should reject the merge transaction without partially applying changes.
 sources:
   - path: internal/contracts/props/base-text/01.define-merge.v0.zh-CN.md
     sections:

--- a/spec/contracts/C-PROPS-0010.yaml
+++ b/spec/contracts/C-PROPS-0010.yaml
@@ -3,7 +3,7 @@ type: contract
 title: Failed declaration merge must not partially apply
 status: active
 since: 0.1.0
-summary: Blocking diagnostics during `setup`-time prop declaration merge should reject the merge transaction without partially applying changes.
+summary: Blocking diagnostics during `setup`-time prop declaration merge reject the merge transaction without partially applying changes.
 statement:
   zh-CN: >-
     当 setup 期间的 prop declaration merge 产生任意 blocking error 时，本次 `define()` 必须作为一个事务整体失败。失败的 incoming declaration 不得改变已存在的 declaration、resolved 行为、fallback 行为或 diagnostics；尤其不得留下本次失败 merge 过程中产生的部分 warning。
@@ -44,6 +44,9 @@ revisions:
   - version: 0.1.0
     change: revised
     summary: Promoted declaration merge atomicity to active criteria and linked it as a refinement of `C-PROPS-0007`.
+  - version: 0.1.0
+    change: revised
+    summary: Resolved declaration merge conflicts as blocking errors and moved the rationale to `D-PROPS-MERGE-BLOCKING-0001`.
 tags:
   - props
   - define

--- a/spec/contracts/C-PROPS-0010.yaml
+++ b/spec/contracts/C-PROPS-0010.yaml
@@ -1,9 +1,31 @@
 id: C-PROPS-0010
 type: contract
 title: Failed declaration merge must not partially apply
-status: draft
+status: active
 since: 0.1.0
 summary: Blocking diagnostics during `setup`-time prop declaration merge should reject the merge transaction without partially applying changes.
+statement:
+  zh-CN: >-
+    当 setup 期间的 prop declaration merge 产生任意 blocking error 时，本次 `define()` 必须作为一个事务整体失败。失败的 incoming declaration 不得改变已存在的 declaration、resolved 行为、fallback 行为或 diagnostics；尤其不得留下本次失败 merge 过程中产生的部分 warning。
+
+
+  en: >-
+    When setup-time prop declaration merge produces any blocking error, the current `define()` call must fail as one transaction. The failed incoming declaration must not change existing declarations, resolved behavior, fallback behavior, or diagnostics; in particular, it must not leave partial warnings produced during the failed merge attempt.
+
+
+criteria:
+  - id: C-PROPS-0010-A
+    text:
+      zh-CN: 任意 blocking merge error 必须阻止整个 incoming declaration batch 应用。
+      en: Any blocking merge error must prevent the entire incoming declaration batch from applying.
+  - id: C-PROPS-0010-B
+    text:
+      zh-CN: merge 失败后，已存在 declaration 的 observable behavior 必须保持不变。
+      en: After merge failure, observable behavior of existing declarations must remain unchanged.
+  - id: C-PROPS-0010-C
+    text:
+      zh-CN: merge 失败后，不得记录本次失败 merge 过程中产生的部分 warning diagnostics。
+      en: After merge failure, partial warning diagnostics produced during the failed merge attempt must not be recorded.
 sources:
   - path: internal/contracts/props/base-text/01.define-merge.v0.zh-CN.md
     sections:
@@ -12,13 +34,17 @@ dependsOn:
   contracts:
     - C-PROPS-0005
     - C-PROPS-0007
+refines:
+  contracts:
+    - C-PROPS-0007
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted a placeholder for declaration merge atomicity pending implementation and test review.
+  - version: 0.1.0
+    change: revised
+    summary: Promoted declaration merge atomicity to active criteria and linked it as a refinement of `C-PROPS-0007`.
 tags:
   - props
   - define
   - merge
-  - draft
-  - deferred

--- a/spec/contracts/C-PROPS-0011.yaml
+++ b/spec/contracts/C-PROPS-0011.yaml
@@ -3,7 +3,7 @@ type: contract
 title: Resolved props watchers observe resolved snapshot changes
 status: draft
 since: 0.1.0
-summary: Resolved props watchers should fire from resolved snapshot diffs, skip hydration, and preserve watchAll/watch(keys) ordering.
+summary: Resolved props watchers should fire from `resolved snapshot` diffs, skip `hydration`, and preserve `watchAll`/`watch(keys)` ordering.
 sources:
   - path: internal/contracts/props/base-text/03.watch-resolved.v0.zh-CN.md
     sections:
@@ -17,7 +17,7 @@ dependsOn:
     - id: C-PROPS-0003
       role: value-boundary
       coverageImpact: expands-test-surface
-      note: Resolved watchers are another observation surface for resolved props values and must not propagate non-JSON values as portable resolved values.
+      note: Resolved watchers are another observation surface for `resolved props` values and must not propagate non-JSON values as portable resolved values.
     - C-PROPS-0008
 refines:
   contracts:

--- a/spec/contracts/C-PROPS-0011.yaml
+++ b/spec/contracts/C-PROPS-0011.yaml
@@ -1,9 +1,65 @@
 id: C-PROPS-0011
 type: contract
 title: Resolved props watchers observe resolved snapshot changes
-status: draft
+status: active
 since: 0.1.0
-summary: Resolved props watchers should fire from `resolved snapshot` diffs, skip `hydration`, and preserve `watchAll`/`watch(keys)` ordering.
+summary: Resolved props watchers fire from declared-key `resolved snapshot` diffs, skip `hydration`, may observe coalesced update windows, and preserve `watchAll`/`watch(keys)` ordering.
+statement:
+  zh-CN: >-
+    `def.props.watchAll(cb)` 与 `def.props.watch(keys, cb)` 是 setup 阶段声明的 resolved props watcher API。它们不监听 raw props 重新传入这一事实本身，而是监听 declared `prop key` 在 `resolved snapshot` 中的语义变化。初次 `hydration` 不触发 watcher；后续变更使用 `Object.is` 比较 resolved value。若多次 raw props 应用在一次 watcher dispatch 前被合并，watcher 观察的是该 dispatch window 中第一份 previous `resolved snapshot` 到最后一份 next `resolved snapshot` 的净变化。
+
+
+  en: >-
+    `def.props.watchAll(cb)` and `def.props.watch(keys, cb)` are setup-phase APIs for registering resolved props watchers. They do not observe the mere fact that raw props were provided again; they observe semantic changes of declared `prop keys` in the `resolved snapshot`. Initial `hydration` must not trigger watchers; later changes compare resolved values with `Object.is`. If multiple raw props applications are coalesced before one watcher dispatch, watchers observe the net change from the first previous `resolved snapshot` to the last next `resolved snapshot` in that dispatch window.
+
+
+criteria:
+  - id: C-PROPS-0011-A
+    text:
+      zh-CN: '`def.props.watchAll(cb)` 与 `def.props.watch(keys, cb)` 必须是 setup-only 的 resolved watcher 注册 API。'
+      en: '`def.props.watchAll(cb)` and `def.props.watch(keys, cb)` must be setup-only APIs for registering resolved watchers.'
+  - id: C-PROPS-0011-B
+    text:
+      zh-CN: 初次 `hydration` 不得触发 resolved watcher callback。
+      en: Initial `hydration` must not trigger resolved watcher callbacks.
+  - id: C-PROPS-0011-C
+    text:
+      zh-CN: resolved watcher 的触发条件必须基于 declared-key `resolved snapshot` diff，而不是 raw props 是否被重新传入。
+      en: Resolved watcher triggering must be based on declared-key `resolved snapshot` diffs, not on whether raw props were provided again.
+  - id: C-PROPS-0011-D
+    text:
+      zh-CN: resolved value diff 必须使用 `Object.is` 语义。
+      en: Resolved value diffs must use `Object.is` semantics.
+    rationale:
+      zh-CN: 这使 primitive value、`NaN`、`-0`、object/array reference 的变化判断与 JS runtime 当前契约保持一致。跨 host 可能因序列化/反序列化导致 object/array reference 变化，这属于 adapter 需要面对的可观察差异。
+      en: This keeps primitive values, `NaN`, `-0`, and object/array reference comparisons aligned with the current JS runtime contract. Cross-host serialization and deserialization may change object/array references; that is an observable adapter concern.
+  - id: C-PROPS-0011-E
+    text:
+      zh-CN: '`watchAll(cb)` 必须在至少一个 declared key 的 resolved value 发生变化时触发；其 `changedKeysMatched` 必须等于全部 changed declared keys。'
+      en: '`watchAll(cb)` must trigger when at least one declared key has a changed resolved value; its `changedKeysMatched` must equal all changed declared keys.'
+  - id: C-PROPS-0011-F
+    text:
+      zh-CN: '`watch(keys, cb)` 必须要求 `keys` 非空且均为 declared keys，并且只在至少一个被监听 key 的 resolved value 发生变化时触发。'
+      en: '`watch(keys, cb)` must require non-empty declared `keys`, and must trigger only when at least one watched key has a changed resolved value.'
+  - id: C-PROPS-0011-G
+    text:
+      zh-CN: watcher callback 的 `next` 与 `prev` 参数必须分别是当前 dispatch window 的 next 与 previous `resolved snapshot`。
+      en: Watcher callback `next` and `prev` parameters must be the next and previous `resolved snapshots` for the current dispatch window.
+  - id: C-PROPS-0011-H
+    text:
+      zh-CN: '`WatchInfo.changedKeysAll` 必须包含当前 dispatch window 中所有 changed declared keys；`changedKeysMatched` 必须包含与当前 watcher 相关的 changed keys。'
+      en: '`WatchInfo.changedKeysAll` must contain all changed declared keys in the current dispatch window; `changedKeysMatched` must contain the changed keys relevant to the current watcher.'
+  - id: C-PROPS-0011-I
+    text:
+      zh-CN: 多次 raw props 应用可以在一次 watcher dispatch 前合并；合并时必须保留该窗口中的第一份 previous snapshot，并以后一次应用产生的 next snapshot 为准。
+      en: Multiple raw props applications may be coalesced before one watcher dispatch; coalescing must keep the first previous snapshot in that window and use the next snapshot produced by the latest application.
+    rationale:
+      zh-CN: 该行为允许 runtime 在 callback-safe point 统一派发 watcher，避免在 props 输入同步过程中立即执行 prototype callback。它也意味着 watcher 观察的是窗口内净变化，而不是每一次 raw props 应用。
+      en: This allows the runtime to dispatch watchers at a callback-safe point instead of executing prototype callbacks immediately during props input synchronization. It also means watchers observe the net change within the window, not every raw props application.
+  - id: C-PROPS-0011-J
+    text:
+      zh-CN: resolved watcher dispatch 顺序必须是所有 `watchAll` callback 先于 keyed `watch(keys)` callback；同组内保持注册顺序。
+      en: Resolved watcher dispatch order must run all `watchAll` callbacks before keyed `watch(keys)` callbacks; registration order must be preserved within each group.
 sources:
   - path: internal/contracts/props/base-text/03.watch-resolved.v0.zh-CN.md
     sections:
@@ -14,11 +70,16 @@ sources:
       - '5. 调用顺序'
 dependsOn:
   contracts:
+    - C-CORE-SYNTAX-0001
     - id: C-PROPS-0003
       role: value-boundary
       coverageImpact: expands-test-surface
       note: Resolved watchers are another observation surface for `resolved props` values and must not propagate non-JSON values as portable resolved values.
     - C-PROPS-0008
+    - id: C-PROPS-0009
+      role: test-surface
+      coverageImpact: expands-test-surface
+      note: Fallback behavior can determine whether raw input changes produce changed resolved values.
 refines:
   contracts:
     - C-PROPS-0002
@@ -26,9 +87,10 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted a placeholder for resolved watcher semantics pending test mapping.
+  - version: 0.1.0
+    change: revised
+    summary: Expanded resolved watcher semantics into criteria covering registration, hydration skip, `Object.is` diffs, callback payloads, dispatch coalescing, and ordering.
 tags:
   - props
   - watch
   - resolved
-  - draft
-  - deferred

--- a/spec/contracts/C-PROPS-0011.yaml
+++ b/spec/contracts/C-PROPS-0011.yaml
@@ -3,7 +3,7 @@ type: contract
 title: Resolved props watchers observe resolved snapshot changes
 status: active
 since: 0.1.0
-summary: Resolved props watchers fire from declared-key `resolved snapshot` diffs, skip `hydration`, may observe coalesced update windows, and preserve `watchAll`/`watch(keys)` ordering.
+summary: Resolved props watchers fire from declared-key `resolved snapshot` diffs, skip `hydration`, may observe coalesced update windows, and preserve shared registration order.
 statement:
   zh-CN: >-
     `def.props.watchAll(cb)` 与 `def.props.watch(keys, cb)` 是 setup 阶段声明的 resolved props watcher API。它们不监听 raw props 重新传入这一事实本身，而是监听 declared `prop key` 在 `resolved snapshot` 中的语义变化。初次 `hydration` 不触发 watcher；后续变更使用 `Object.is` 比较 resolved value。若多次 raw props 应用在一次 watcher dispatch 前被合并，watcher 观察的是该 dispatch window 中第一份 previous `resolved snapshot` 到最后一份 next `resolved snapshot` 的净变化。
@@ -58,8 +58,11 @@ criteria:
       en: This allows the runtime to dispatch watchers at a callback-safe point instead of executing prototype callbacks immediately during props input synchronization. It also means watchers observe the net change within the window, not every raw props application.
   - id: C-PROPS-0011-J
     text:
-      zh-CN: resolved watcher dispatch 顺序必须是所有 `watchAll` callback 先于 keyed `watch(keys)` callback；同组内保持注册顺序。
-      en: Resolved watcher dispatch order must run all `watchAll` callbacks before keyed `watch(keys)` callbacks; registration order must be preserved within each group.
+      zh-CN: resolved watcher dispatch 顺序必须在所有匹配的 `watchAll(cb)` 与 `watch(keys, cb)` callback 之间保持 setup 阶段的注册顺序。
+      en: Resolved watcher dispatch order must preserve setup-time registration order across all matching `watchAll(cb)` and `watch(keys, cb)` callbacks.
+    rationale:
+      zh-CN: '`watchAll` 与 `watch(keys)` 都观察同一个 dispatch window 中的 resolved snapshot diff；`watchAll` 并不建立 keyed watcher 正确执行所需的前置语义。共享注册顺序更符合原型作者对 setup 代码执行顺序的直觉。'
+      en: "`watchAll` and `watch(keys)` observe the same resolved snapshot diff in the same dispatch window; `watchAll` does not establish prerequisite semantics needed by keyed watchers. Shared registration order better matches prototype authors' expectations from setup code order."
 sources:
   - path: internal/contracts/props/base-text/03.watch-resolved.v0.zh-CN.md
     sections:
@@ -90,6 +93,9 @@ revisions:
   - version: 0.1.0
     change: revised
     summary: Expanded resolved watcher semantics into criteria covering registration, hydration skip, `Object.is` diffs, callback payloads, dispatch coalescing, and ordering.
+  - version: 0.1.0
+    change: revised
+    summary: Changed resolved watcher dispatch ordering from `watchAll` before keyed watchers to shared registration order.
 tags:
   - props
   - watch

--- a/spec/contracts/C-PROPS-0012.yaml
+++ b/spec/contracts/C-PROPS-0012.yaml
@@ -3,7 +3,7 @@ type: contract
 title: Raw props APIs expose raw input as an escape hatch
 status: draft
 since: 0.1.0
-summary: Raw props APIs may observe undeclared keys and non-normalized values, but remain an escape hatch rather than the preferred props surface.
+summary: '`Raw props` APIs may observe undeclared keys and non-normalized values, but remain an escape hatch rather than the preferred props surface.'
 sources:
   - path: internal/contracts/props/base-text/04.watch-raw.v0.zh-CN.md
     sections:
@@ -23,7 +23,7 @@ refines:
 revisions:
   - version: 0.1.0
     change: introduced
-    summary: Drafted a placeholder for raw props escape-hatch semantics.
+    summary: Drafted a placeholder for `raw props` escape-hatch semantics.
 tags:
   - props
   - raw

--- a/spec/contracts/C-PROPS-0012.yaml
+++ b/spec/contracts/C-PROPS-0012.yaml
@@ -1,22 +1,97 @@
 id: C-PROPS-0012
 type: contract
 title: Raw props APIs expose raw input as an escape hatch
-status: draft
+status: active
 since: 0.1.0
-summary: '`Raw props` APIs may observe undeclared keys and non-normalized values, but remain an escape hatch rather than the preferred props surface.'
+summary: '`Raw props` APIs expose the adapter-supplied pre-resolution props snapshot as an escape hatch without extending portable props semantics.'
+statement:
+  zh-CN: >-
+    `raw props` 是 adapter 提交给 Props module 的、尚未经过 Props declaration resolution 的 props input snapshot。它不是宿主平台输入的绝对原样值；adapter 可以先完成自己的 props/attrs/listeners 切分与规范化，Props module 也可以在进入 raw snapshot 前做边界归一。`run.props.getRaw()`、`def.props.watchRaw(keys, cb)` 与 `def.props.watchRawAll(cb)` 暴露的是这层 adapter-supplied pre-resolution snapshot，用于诊断、迁移或 host-specific escape hatch。依赖 raw props 不属于 Proto UI 的 portable resolved props 语义承诺。
+
+
+  en: >-
+    `Raw props` are the adapter-supplied props input snapshot passed into the Props module before Props declaration resolution. They are not the absolute untouched host-platform input; adapters may first split and normalize props, attrs, and listeners, and the Props module may also apply boundary normalization before storing the raw snapshot. `run.props.getRaw()`, `def.props.watchRaw(keys, cb)`, and `def.props.watchRawAll(cb)` expose this adapter-supplied pre-resolution snapshot for diagnostics, migration, or host-specific escape hatches. Depending on raw props is outside Proto UI's portable resolved props semantics.
+
+
+criteria:
+  - id: C-PROPS-0012-A
+    text:
+      zh-CN: '`raw props` 必须定义为 adapter 提交给 Props module 的 pre-resolution props input snapshot。'
+      en: '`Raw props` must be defined as the adapter-supplied pre-resolution props input snapshot passed into the Props module.'
+  - id: C-PROPS-0012-B
+    text:
+      zh-CN: '`raw props` 不得被解释为宿主平台输入的绝对原样值；adapter 可以决定哪些 host 输入进入 raw props，以及如何在提交前处理它们。'
+      en: '`Raw props` must not be interpreted as the absolute untouched host-platform input; adapters may decide which host inputs enter raw props and how they are processed before submission.'
+    rationale:
+      zh-CN: React、Vue 与 Web Component adapter 对 props、attrs、listeners、DOM attributes 的切分不同。raw API 因此只能表达 adapter 边界内的 escape hatch，而不能成为跨 adapter 的稳定语义层。
+      en: React, Vue, and Web Component adapters split props, attrs, listeners, and DOM attributes differently. Raw APIs therefore expose an adapter-boundary escape hatch rather than a stable cross-adapter semantic layer.
+  - id: C-PROPS-0012-C
+    text:
+      zh-CN: '`run.props.getRaw()` 必须返回当前 runtime invocation 对应的 `raw props snapshot`。'
+      en: '`run.props.getRaw()` must return the `raw props snapshot` for the current runtime invocation.'
+  - id: C-PROPS-0012-D
+    text:
+      zh-CN: '`raw props snapshot` 可以包含未声明 key；这些 key 不得因此进入 portable `resolved snapshot`。'
+      en: '`Raw props snapshots` may contain undeclared keys; those keys must not enter the portable `resolved snapshot` because of that.'
+  - id: C-PROPS-0012-E
+    text:
+      zh-CN: '`raw props` API 不扩展 `C-PROPS-0003` 的 portable JSON props value 边界；依赖 host-local raw value 会降低原型可移植性。'
+      en: '`Raw props` APIs do not extend the portable JSON props value boundary defined by `C-PROPS-0003`; depending on host-local raw values reduces prototype portability.'
+  - id: C-PROPS-0012-F
+    text:
+      zh-CN: '`def.props.watchRawAll(cb)` 与 `def.props.watchRaw(keys, cb)` 必须是 setup-only 的 raw watcher 注册 API。'
+      en: '`def.props.watchRawAll(cb)` and `def.props.watchRaw(keys, cb)` must be setup-only APIs for registering raw watchers.'
+  - id: C-PROPS-0012-G
+    text:
+      zh-CN: raw watcher 的触发条件必须基于 `raw snapshot` diff，而不是每一次 raw props delivery event；首次 `hydration` 不得触发 raw watcher。
+      en: Raw watcher triggering must be based on `raw snapshot` diffs, not on every raw props delivery event; initial `hydration` must not trigger raw watchers.
+  - id: C-PROPS-0012-H
+    text:
+      zh-CN: raw watcher diff 必须基于 `prevRaw` 与 `nextRaw` 的 union key set，并使用 `Object.is` 比较对应 key 的 raw value。
+      en: Raw watcher diffs must use the union key set of `prevRaw` and `nextRaw`, comparing corresponding raw values with `Object.is`.
+  - id: C-PROPS-0012-I
+    text:
+      zh-CN: '`watchRawAll(cb)` 必须在至少一个 raw union key 发生变化时触发；其 `changedKeysMatched` 必须等于全部 changed raw keys。'
+      en: '`watchRawAll(cb)` must trigger when at least one raw union key changes; its `changedKeysMatched` must equal all changed raw keys.'
+  - id: C-PROPS-0012-J
+    text:
+      zh-CN: '`watchRaw(keys, cb)` 必须要求 keys 非空，但 keys 不要求是 declared keys；它只在至少一个被监听 raw key 发生变化时触发。'
+      en: '`watchRaw(keys, cb)` must require non-empty keys, but those keys need not be declared keys; it triggers only when at least one watched raw key changes.'
+  - id: C-PROPS-0012-K
+    text:
+      zh-CN: raw watcher dispatch 顺序必须是 `watchRawAll` 先于 keyed `watchRaw(keys)`，同组内保持注册顺序，并且 raw watchers 必须先于 resolved watchers dispatch。
+      en: Raw watcher dispatch order must run `watchRawAll` before keyed `watchRaw(keys)`, preserve registration order within each group, and dispatch raw watchers before resolved watchers.
+  - id: C-PROPS-0012-L
+    text:
+      zh-CN: raw watcher 使用应能产生或支持开发期 warning/diagnostic，以标记其 escape hatch 属性。
+      en: Raw watcher usage should be able to produce or support development-time warnings or diagnostics that mark its escape-hatch nature.
+openQuestions:
+  - id: C-PROPS-0012-Q-RAW-DELIVERY-EVENT
+    question:
+      zh-CN: 是否需要新增独立的 raw props delivery event API，用于观察每一次 adapter props application，即使 raw snapshot 没有变化？
+      en: Should Proto UI add a separate raw props delivery event API for observing every adapter props application, even when the raw snapshot does not change?
+    context:
+      zh-CN: '`watchRawAll` 监听的是 raw snapshot diff，而不是每一次 props 传递行为。若未来确实需要 delivery event，应该新增独立 API，而不是改变 `watchRawAll` 的 diff watcher 语义。'
+      en: '`watchRawAll` observes raw snapshot diffs, not every props delivery action. If a delivery event is needed later, it should be a separate API instead of changing the diff-watcher semantics of `watchRawAll`.'
+    blocks:
+      - Raw props delivery event API
 sources:
   - path: internal/contracts/props/base-text/04.watch-raw.v0.zh-CN.md
     sections:
       - '1. 定义'
+      - '2. Hydration 规则'
       - '3. watchRawAll(cb)'
       - '4. watchRaw(keys, cb)'
+      - '5. 调用顺序'
       - '6. Warning 约束（escape hatch）'
   - path: internal/contracts/props/base-text/02.resolve-fallback.v0.zh-CN.md
     sections:
       - '2. 公共运行时 API'
 dependsOn:
   contracts:
+    - C-PROPS-0003
     - C-PROPS-0008
+    - C-PROPS-0011
 refines:
   contracts:
     - C-PROPS-0002
@@ -24,9 +99,10 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted a placeholder for `raw props` escape-hatch semantics.
+  - version: 0.1.0
+    change: revised
+    summary: Promoted raw props escape-hatch semantics to active criteria and clarified that raw watchers observe diffs, not every delivery event.
 tags:
   - props
   - raw
   - escape-hatch
-  - draft
-  - deferred

--- a/spec/contracts/C-PROPS-0013.yaml
+++ b/spec/contracts/C-PROPS-0013.yaml
@@ -1,9 +1,9 @@
 id: C-PROPS-0013
 type: contract
-title: Props watcher callbacks receive run handle bound to current props state
+title: Props watcher callbacks receive `run handle` bound to current props state
 status: draft
 since: 0.1.0
-summary: Props watcher callbacks should receive a run handle whose props APIs observe the current watcher invocation state.
+summary: Props watcher callbacks should receive a `run handle` whose props APIs observe the current watcher invocation state.
 sources:
   - path: internal/contracts/props/base-text/05.runtime-integration.v0.zh-CN.md
     sections:
@@ -15,7 +15,7 @@ dependsOn:
 revisions:
   - version: 0.1.0
     change: introduced
-    summary: Drafted a placeholder for runtime run-handle binding pending runtime boundary review.
+    summary: Drafted a placeholder for `runtime` `run handle` binding pending runtime boundary review.
 tags:
   - props
   - runtime

--- a/spec/contracts/C-PROPS-0013.yaml
+++ b/spec/contracts/C-PROPS-0013.yaml
@@ -1,24 +1,64 @@
 id: C-PROPS-0013
 type: contract
-title: Props watcher callbacks receive `run handle` bound to current props state
-status: draft
+title: Props watcher callbacks follow runtime `run handle` binding
+status: active
 since: 0.1.0
-summary: Props watcher callbacks should receive a `run handle` whose props APIs observe the current watcher invocation state.
+summary: Props watcher callbacks refine core runtime callback binding by requiring `run.props.*` to align with the current watcher dispatch window.
+statement:
+  zh-CN: >-
+    Props watcher callback 是 setup 阶段注册、runtime 阶段执行的 callback，因此必须遵守 `C-CORE-SYNTAX-0002` 的 `run handle` invocation binding。对 Props watcher 来说，额外的一致性要求是：callback 收到的 `run.props.*` API 必须观察当前 watcher dispatch window，而不是 setup-time plan、过期 props state 或宿主全局 raw props。
+
+
+  en: >-
+    Props watcher callbacks are registered during setup and executed during runtime, so they must follow the `run handle` invocation binding defined by `C-CORE-SYNTAX-0002`. The Props-specific consistency rule is that `run.props.*` APIs received by the callback must observe the current watcher dispatch window rather than setup-time plans, stale props state, or host-global raw props.
+
+
+criteria:
+  - id: C-PROPS-0013-A
+    text:
+      zh-CN: resolved props watcher callback 必须把当前 callback invocation 的 `run handle` 作为第一个参数。
+      en: Resolved props watcher callbacks must receive the `run handle` for the current callback invocation as their first argument.
+  - id: C-PROPS-0013-B
+    text:
+      zh-CN: raw props watcher callback 必须把当前 callback invocation 的 `run handle` 作为第一个参数。
+      en: Raw props watcher callbacks must receive the `run handle` for the current callback invocation as their first argument.
+  - id: C-PROPS-0013-C
+    text:
+      zh-CN: 在 resolved props watcher callback 内，`run.props.get()` 必须与该 callback 的 `next` resolved snapshot 对齐。
+      en: Inside a resolved props watcher callback, `run.props.get()` must align with that callback's `next` resolved snapshot.
+  - id: C-PROPS-0013-D
+    text:
+      zh-CN: 在 raw props watcher callback 内，`run.props.getRaw()` 必须与该 callback 的 `nextRaw` snapshot 对齐。
+      en: Inside a raw props watcher callback, `run.props.getRaw()` must align with that callback's `nextRaw` snapshot.
+  - id: C-PROPS-0013-E
+    text:
+      zh-CN: 在 props watcher callback 内，`run.props.isProvided(key)` 必须基于当前 watcher dispatch window 的 raw snapshot own-property 语义判断。
+      en: Inside a props watcher callback, `run.props.isProvided(key)` must use own-property semantics against the raw snapshot of the current watcher dispatch window.
 sources:
   - path: internal/contracts/props/base-text/05.runtime-integration.v0.zh-CN.md
     sections:
       - '3. Watcher 回调的 RunHandle 绑定（PROP-V0-2110）'
 dependsOn:
   contracts:
+    - id: C-CORE-SYNTAX-0002
+      anchors:
+        - C-CORE-SYNTAX-0002-E
+        - C-CORE-SYNTAX-0002-F
     - C-PROPS-0011
     - C-PROPS-0012
+refines:
+  contracts:
+    - C-CORE-SYNTAX-0002
+    - C-PROPS-0002
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted a placeholder for `runtime` `run handle` binding pending runtime boundary review.
+  - version: 0.1.0
+    change: revised
+    summary: Reframed props watcher `run handle` binding as a Props-specific refinement of the core runtime callback binding rule.
 tags:
   - props
   - runtime
   - watch
-  - draft
-  - deferred
+  - run-handle

--- a/spec/contracts/C-PROPS-0014.yaml
+++ b/spec/contracts/C-PROPS-0014.yaml
@@ -3,7 +3,7 @@ type: contract
 title: applyRawProps updates the props channel without implicit render commit
 status: draft
 since: 0.1.0
-summary: Applying raw props through the controller may update props state and trigger watchers, but should not itself imply render commit.
+summary: Applying `raw props` through the controller may update props state and trigger watchers, but should not itself imply render commit.
 sources:
   - path: internal/contracts/props/base-text/05.runtime-integration.v0.zh-CN.md
     sections:
@@ -13,11 +13,11 @@ dependsOn:
     - id: C-PROPS-0002
       anchors:
         - C-PROPS-0002-E
-      note: applyRawProps inherits the rule that Props changes do not imply view updates.
+      note: '`applyRawProps` inherits the rule that Props changes do not imply view updates.'
 revisions:
   - version: 0.1.0
     change: introduced
-    summary: Drafted a placeholder for applyRawProps scheduling semantics pending runtime and host-cap analysis.
+    summary: Drafted a placeholder for `applyRawProps` scheduling semantics pending runtime and host-cap analysis.
 tags:
   - props
   - runtime

--- a/spec/contracts/C-PROPS-0014.yaml
+++ b/spec/contracts/C-PROPS-0014.yaml
@@ -1,16 +1,53 @@
 id: C-PROPS-0014
 type: contract
 title: applyRawProps updates the props channel without implicit render commit
-status: draft
+status: active
 since: 0.1.0
 summary: Applying `raw props` through the controller may update props state and trigger watchers, but should not itself imply render commit.
+statement:
+  zh-CN: >-
+    `controller.applyRawProps(nextRaw)` 是 runtime/controller 层用于向 Props channel 应用新的 `raw props snapshot` 的动作，不是原型作者通过 `def.props` 或 `run.props` 使用的 API。该动作必须走 Props channel 的 raw/resolved resolution 与 watcher dispatch 语义，因此可以触发 raw 或 resolved watcher；但它不得隐式触发 render commit。`run.update()` 与 runtime render commit 的正向调度规则属于更上游的 core runtime/update 契约，本契约只保留该断口。
+
+
+  en: >-
+    `controller.applyRawProps(nextRaw)` is a runtime/controller action for applying a new `raw props snapshot` to the Props channel. It is not a prototype-author API exposed through `def.props` or `run.props`. This action must use the Props channel's raw/resolved resolution and watcher-dispatch semantics, so it may trigger raw or resolved watchers; however, it must not implicitly trigger a render commit. Positive scheduling rules for `run.update()` and runtime render commits belong to a higher-level core runtime/update contract; this contract keeps that gap explicit.
+
+
+criteria:
+  - id: C-PROPS-0014-A
+    text:
+      zh-CN: '`controller.applyRawProps(nextRaw)` 必须被建模为 runtime/controller 动作，而不是 `def.props` 或 `run.props` 的原型作者 API。'
+      en: '`controller.applyRawProps(nextRaw)` must be modeled as a runtime/controller action, not as a prototype-author API on `def.props` or `run.props`.'
+  - id: C-PROPS-0014-B
+    text:
+      zh-CN: '`applyRawProps(nextRaw)` 必须将 `nextRaw` 作为新的 `raw props snapshot` 应用到 Props channel。'
+      en: '`applyRawProps(nextRaw)` must apply `nextRaw` to the Props channel as the new `raw props snapshot`.'
+  - id: C-PROPS-0014-C
+    text:
+      zh-CN: 若该 raw props 应用产生 raw 或 resolved diff，`applyRawProps` 必须允许对应 watcher 按 `C-PROPS-0011` 与 `C-PROPS-0012` 的规则 dispatch。
+      en: If the raw props application produces raw or resolved diffs, `applyRawProps` must allow the corresponding watchers to dispatch according to `C-PROPS-0011` and `C-PROPS-0012`.
+  - id: C-PROPS-0014-D
+    text:
+      zh-CN: 由 `applyRawProps` 触发的 watcher callback 必须遵守 `C-PROPS-0013` 的 `run handle` 绑定规则。
+      en: Watcher callbacks triggered by `applyRawProps` must follow the `run handle` binding rules defined by `C-PROPS-0013`.
+  - id: C-PROPS-0014-E
+    text:
+      zh-CN: '`applyRawProps` 本身不得隐式触发 render commit。'
+      en: '`applyRawProps` itself must not implicitly trigger a render commit.'
+    rationale:
+      zh-CN: Props 输入变化只更新 Props channel 并派发 watcher；原型作者层的 `run.update()` 与 runtime 层的 render commit 是不同 API，其正向触发规则应由 core runtime/update 契约承接。
+      en: Props input changes update the Props channel and dispatch watchers; prototype-author-level `run.update()` and runtime-level render commit are separate APIs, and their positive triggering rules should be owned by a core runtime/update contract.
 sources:
   - path: internal/contracts/props/base-text/05.runtime-integration.v0.zh-CN.md
     sections:
+      - '1. 范围'
       - '5. applyRawProps 不触发渲染'
 dependsOn:
   contracts:
     - C-PROPS-0002
+    - C-PROPS-0011
+    - C-PROPS-0012
+    - C-PROPS-0013
 openQuestions:
   - id: C-PROPS-0014-Q-CORE-UPDATE-OWNER
     question:
@@ -25,9 +62,10 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted a placeholder for `applyRawProps` scheduling semantics pending runtime and host-cap analysis.
+  - version: 0.1.0
+    change: revised
+    summary: Promoted `applyRawProps` runtime/controller behavior to active criteria while keeping core update/render commit ownership open.
 tags:
   - props
   - runtime
   - scheduling
-  - draft
-  - deferred

--- a/spec/contracts/C-PROPS-0014.yaml
+++ b/spec/contracts/C-PROPS-0014.yaml
@@ -10,10 +10,17 @@ sources:
       - '5. applyRawProps 不触发渲染'
 dependsOn:
   contracts:
-    - id: C-PROPS-0002
-      anchors:
-        - C-PROPS-0002-E
-      note: '`applyRawProps` inherits the rule that Props changes do not imply view updates.'
+    - C-PROPS-0002
+openQuestions:
+  - id: C-PROPS-0014-Q-CORE-UPDATE-OWNER
+    question:
+      zh-CN: 应建立哪条 core/runtime 契约来承接 `run.update()` 与“Props 变化不隐含视图更新”的语义？
+      en: Which core/runtime contract should own `run.update()` and the rule that Props changes do not imply view updates?
+    context:
+      zh-CN: '`applyRawProps` 的 props state update 和 watcher dispatch 属于 Props 通路；render commit 调度是否发生则属于更上游的 runtime update 语义。'
+      en: '`applyRawProps` state updates and watcher dispatch belong to the Props channel; whether render commit scheduling happens belongs to higher-level runtime update semantics.'
+    blocks:
+      - C-PROPS-0014
 revisions:
   - version: 0.1.0
     change: introduced

--- a/spec/decisions/D-PROPS-MERGE-BLOCKING-0001.md
+++ b/spec/decisions/D-PROPS-MERGE-BLOCKING-0001.md
@@ -1,0 +1,19 @@
+# Props declaration merge conflicts are blocking errors
+
+## Decision
+
+Props declaration merge conflicts must fail the current `define()` call as blocking errors. The failed incoming declaration must not partially apply or leave diagnostics from the failed transaction.
+
+Decision makers: guangliang2019, baiyucore.
+
+## Rationale
+
+Props declaration merging usually happens while authoring prototypes. Changing a prototype belongs to the prototype author's responsibility, and Proto UI expects authors to understand the prototype's interaction semantics. A console error plus a silently ignored incoming merge is not visible enough.
+
+When two contributors, such as `asHook`s, conflict on the same prop key, merely ignoring the later declaration can let incompatible props flow into logic that did not declare support for them. For example, if `asHook A` and `asHook B` disagree about a prop key, preserving only the earlier declaration may still make one hook observe unexpected prop values in some scenarios, leading to less predictable failures.
+
+A blocking error forces the author to resolve the semantic conflict directly before the prototype can continue.
+
+## Rejected Alternatives
+
+Report a console error and keep the previous props declaration result. This was rejected because the failure can be too easy to miss and can preserve a partially incompatible prototype composition.

--- a/spec/decisions/D-PROPS-MERGE-BLOCKING-0001.yaml
+++ b/spec/decisions/D-PROPS-MERGE-BLOCKING-0001.yaml
@@ -1,0 +1,20 @@
+id: D-PROPS-MERGE-BLOCKING-0001
+type: decision
+title: Props declaration merge conflicts are blocking errors
+status: active
+since: 0.1.0
+summary: Props declaration merge conflicts must fail the current `define()` call as blocking errors instead of preserving prior declarations after console errors.
+notes: ./D-PROPS-MERGE-BLOCKING-0001.md
+explains:
+  contracts:
+    - C-PROPS-0007
+    - C-PROPS-0010
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Recorded the maintainer decision for blocking props declaration merge conflicts.
+tags:
+  - props
+  - define
+  - merge
+  - rationale

--- a/spec/decisions/D-PROPS-WATCHER-ORDER-0001.md
+++ b/spec/decisions/D-PROPS-WATCHER-ORDER-0001.md
@@ -1,0 +1,17 @@
+# Resolved props watchers preserve registration order
+
+## Decision
+
+Resolved props watcher dispatch must preserve setup-time registration order across `watchAll(cb)` and keyed `watch(keys, cb)` callbacks.
+
+Decision makers: guangliang2019, baiyucore.
+
+## Rationale
+
+`watchAll` and `watch(keys)` observe the same `resolved snapshot` diff in the same dispatch window. `watchAll` does not establish prerequisite semantics that keyed watchers need in order to run correctly, so giving it dispatch priority is not semantically necessary.
+
+Preserving shared registration order matches the prototype author's expectation that callbacks registered earlier in setup run earlier when they match the same dispatch window.
+
+## Rejected Alternatives
+
+Run every `watchAll` callback before keyed `watch(keys)` callbacks. This was rejected because it can make callback order differ from the setup code order without a stronger semantic reason.

--- a/spec/decisions/D-PROPS-WATCHER-ORDER-0001.yaml
+++ b/spec/decisions/D-PROPS-WATCHER-ORDER-0001.yaml
@@ -1,0 +1,19 @@
+id: D-PROPS-WATCHER-ORDER-0001
+type: decision
+title: Resolved props watchers preserve registration order
+status: active
+since: 0.1.0
+summary: Resolved `watchAll` and keyed `watch(keys)` callbacks share one registration order instead of giving `watchAll` a dispatch priority.
+notes: ./D-PROPS-WATCHER-ORDER-0001.md
+explains:
+  contracts:
+    - C-PROPS-0011
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Recorded the maintainer decision to use shared registration order for resolved props watchers.
+tags:
+  - props
+  - watch
+  - resolved
+  - rationale

--- a/spec/tests/T-PROPS-0001.yaml
+++ b/spec/tests/T-PROPS-0001.yaml
@@ -94,7 +94,55 @@ implementations:
       - C-PROPS-0009
     notes:
       - Tests runtime applyRaw() to get() resolution with the shared JSON props value boundary fixture.
-  - id: adapter-props-json-value-boundary
+  - id: adapter-props-json-value-boundary-conformance
+    kind: adapter-test
+    status: active
+    path: packages/adapters/base/test-utils/props-json-value-boundary.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0001-CASE-JSON-PRIMITIVES
+      - T-PROPS-0001-CASE-JSON-CONTAINERS
+      - T-PROPS-0001-CASE-NON-JSON-TOP-LEVEL
+      - T-PROPS-0001-CASE-NON-JSON-NESTED
+      - T-PROPS-0001-CASE-RAW-ESCAPE-HATCH
+    exercises:
+      - C-PROPS-0008
+      - C-PROPS-0009
+    notes:
+      - Shared adapter conformance harness; each adapter supplies mount/update wiring for its host-specific props path.
+  - id: adapter-react-props-json-value-boundary
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/contract/props-json-value-boundary.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0001-CASE-JSON-PRIMITIVES
+      - T-PROPS-0001-CASE-JSON-CONTAINERS
+      - T-PROPS-0001-CASE-NON-JSON-TOP-LEVEL
+      - T-PROPS-0001-CASE-NON-JSON-NESTED
+      - T-PROPS-0001-CASE-RAW-ESCAPE-HATCH
+    exercises:
+      - C-PROPS-0008
+      - C-PROPS-0009
+    notes:
+      - React adapter conformance coverage for mount and props update paths.
+  - id: adapter-vue-props-json-value-boundary
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/contract/props-json-value-boundary.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0001-CASE-JSON-PRIMITIVES
+      - T-PROPS-0001-CASE-JSON-CONTAINERS
+      - T-PROPS-0001-CASE-NON-JSON-TOP-LEVEL
+      - T-PROPS-0001-CASE-NON-JSON-NESTED
+      - T-PROPS-0001-CASE-RAW-ESCAPE-HATCH
+    exercises:
+      - C-PROPS-0008
+      - C-PROPS-0009
+    notes:
+      - Vue adapter conformance coverage for mount and props update paths.
+  - id: adapter-web-component-props-json-value-boundary
     kind: adapter-test
     status: missing
     required: true
@@ -108,7 +156,7 @@ implementations:
       - C-PROPS-0008
       - C-PROPS-0009
     notes:
-      - Adapter-specific tests may differ in raw input tolerance, but must not expand portable resolved props semantics beyond JSON values.
+      - Pending Web Component adapter harness wiring; should account for property and attribute input differences.
 verifies:
   contracts:
     - id: C-PROPS-0003

--- a/spec/tests/T-PROPS-0001.yaml
+++ b/spec/tests/T-PROPS-0001.yaml
@@ -4,6 +4,16 @@ title: JSON props value boundary tests
 status: draft
 since: 0.1.0
 summary: Placeholder mapping for tests that verify the JSON value boundary for props values.
+openQuestions:
+  - id: T-PROPS-0001-Q-WC-INITIAL-PROPS-HELPER
+    question:
+      zh-CN: Web Component adapter 是否需要提供一个通过 tag name 与 props 一次性创建元素的 helper？
+      en: Should the Web Component adapter provide a helper that creates an element from a tag name and initial props in one step?
+    context:
+      zh-CN: 当前 WC props 的 canonical 通道是 setElementProps()/setProps，而不是 attribute。现有 API 可以在 append 前手动 setElementProps，但缺少一个便于测试与使用的创建 helper。本断口不改变本轮测试范围。
+      en: The canonical WC props channel is setElementProps()/setProps rather than attributes. Existing APIs can call setElementProps before append, but there is no convenience helper for tests and consumers. This gap does not change the current test scope.
+    blocks:
+      - WC props creation helper ergonomics
 cases:
   - id: T-PROPS-0001-CASE-JSON-PRIMITIVES
     title: JSON primitive values are portable props values
@@ -144,7 +154,8 @@ implementations:
       - Vue adapter conformance coverage for mount and props update paths.
   - id: adapter-web-component-props-json-value-boundary
     kind: adapter-test
-    status: missing
+    status: passing
+    path: packages/adapters/web-component/test/contract/props-json-value-boundary.v0.contract.test.ts
     required: true
     consumesCases:
       - T-PROPS-0001-CASE-JSON-PRIMITIVES
@@ -156,7 +167,7 @@ implementations:
       - C-PROPS-0008
       - C-PROPS-0009
     notes:
-      - Pending Web Component adapter harness wiring; should account for property and attribute input differences.
+      - Web Component adapter conformance coverage uses setElementProps()/update() as the canonical props channel; arbitrary attributes are intentionally not treated as props.
 verifies:
   contracts:
     - id: C-PROPS-0003

--- a/spec/tests/T-PROPS-0002.yaml
+++ b/spec/tests/T-PROPS-0002.yaml
@@ -1,12 +1,108 @@
 id: T-PROPS-0002
 type: test
 title: Per-key prop semantic state classification tests
-status: draft
+status: active
 since: 0.1.0
-summary: Placeholder mapping for tests that verify missing, empty, non-empty, and invalid states per prop key.
+summary: Tests that verify `missing`, `provided-empty`, `provided-non-empty`, and `invalid` states are classified per prop key.
+cases:
+  - id: T-PROPS-0002-CASE-MISSING
+    title: Missing input is classified by own-property absence
+    covers:
+      - C-PROPS-0004-A
+    valueKind: missing-input
+    expectation: own-property-absent
+    notes:
+      - A declared key is `missing` when raw props do not contain that key as an own property.
+  - id: T-PROPS-0002-CASE-PROVIDED-EMPTY
+    title: Empty input is classified as `provided-empty`
+    covers:
+      - C-PROPS-0004-B
+    valueKind: provided-empty
+    expectation: empty-value-present
+    notes:
+      - Covers `null` and host-local empty input such as JavaScript `undefined`.
+  - id: T-PROPS-0002-CASE-PROVIDED-NON-EMPTY
+    title: Non-empty input is validated after presence is established
+    covers:
+      - C-PROPS-0004-C
+    valueKind: provided-non-empty
+    expectation: validate-against-declaration
+    notes:
+      - Classification separates presence/emptiness from type and validator checks.
+  - id: T-PROPS-0002-CASE-INVALID
+    title: Invalid input is non-empty input that fails declaration validation
+    covers:
+      - C-PROPS-0004-D
+    valueKind: invalid-non-empty
+    expectation: declaration-validation-failed
+    notes:
+      - Invalid input must not be treated as accepted empty input.
+  - id: T-PROPS-0002-CASE-PER-KEY-INDEPENDENCE
+    title: One key's state does not change another key's classification
+    covers:
+      - C-PROPS-0004-E
+    valueKind: per-key-classification
+    expectation: key-state-is-independent
+    notes:
+      - Classification is a key-level semantic, not a whole-record semantic.
+implementations:
+  - id: module-props-resolve-fallback-classification
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolve-fallback.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0002-CASE-MISSING
+      - T-PROPS-0002-CASE-PROVIDED-EMPTY
+      - T-PROPS-0002-CASE-PROVIDED-NON-EMPTY
+      - T-PROPS-0002-CASE-INVALID
+    exercises:
+      - C-PROPS-0009
+    notes:
+      - Existing fallback contract test explicitly covers missing, provided-empty, provided-non-empty, and invalid input states.
+  - id: module-props-empty-accept-meta-classification
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/props.meta.empty-accept.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0002-CASE-PROVIDED-EMPTY
+      - T-PROPS-0002-CASE-INVALID
+    exercises:
+      - C-PROPS-0009
+    notes:
+      - Supporting meta-level assertions distinguish accepted empty input from invalid non-empty input.
+  - id: module-props-resolved-snapshot-key-granularity
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0002-CASE-PER-KEY-INDEPENDENCE
+    exercises:
+      - C-PROPS-0008
+      - C-PROPS-0009
+    notes:
+      - Supporting snapshot-shape test verifies one key's missing, empty, or invalid state does not change other keys' resolved values.
 verifies:
   contracts:
-    - C-PROPS-0004
+    - id: C-PROPS-0004
+      anchors:
+        - C-PROPS-0004-A
+        - C-PROPS-0004-B
+        - C-PROPS-0004-C
+        - C-PROPS-0004-D
+        - C-PROPS-0004-E
+exercises:
+  contracts:
+    - id: C-PROPS-0008
+      role: test-entrypoint
+      coverageImpact: exercises-test-surface
+      note: Per-key classification is observed through resolved snapshot behavior.
+    - id: C-PROPS-0009
+      role: test-entrypoint
+      coverageImpact: exercises-test-surface
+      note: Fallback tests use per-key classification as their input state model.
 relates:
   modules:
     - M-PROPS-0001
@@ -14,7 +110,11 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted the per-key state classification test mapping placeholder.
+  - version: 0.1.0
+    change: revised
+    summary: Expanded per-key state classification into cases and mapped existing module coverage.
 tags:
   - props
   - contract-test
-  - draft
+  - state
+  - per-key

--- a/spec/tests/T-PROPS-0003.yaml
+++ b/spec/tests/T-PROPS-0003.yaml
@@ -1,12 +1,97 @@
 id: T-PROPS-0003
 type: test
 title: Prop declaration descriptor shape tests
-status: draft
+status: active
 since: 0.1.0
-summary: Placeholder mapping for tests that verify v0 prop declaration descriptor shape constraints.
+summary: Tests that verify v0 prop declaration descriptor shape constraints before same-key merge rules apply.
+cases:
+  - id: T-PROPS-0003-CASE-TYPE-REQUIRED
+    title: Incoming prop declarations require `type`
+    covers:
+      - C-PROPS-0006-A
+      - C-PROPS-0006-H
+    expectation: missing-type-is-blocking-error
+  - id: T-PROPS-0003-CASE-TYPE-SET
+    title: '`type` is one of the v0 supported prop types'
+    covers:
+      - C-PROPS-0006-B
+      - C-PROPS-0006-H
+    expectation: unsupported-type-is-blocking-error
+  - id: T-PROPS-0003-CASE-EMPTY-SHAPE
+    title: Explicit `empty` must be a supported empty behavior
+    covers:
+      - C-PROPS-0006-C
+      - C-PROPS-0006-H
+    expectation: unsupported-empty-is-blocking-error
+  - id: T-PROPS-0003-CASE-ENUM-OPTIONS
+    title: '`type: "enum"` requires non-empty string `options`'
+    covers:
+      - C-PROPS-0006-D
+      - C-PROPS-0006-H
+    expectation: enum-options-required-and-string-only
+  - id: T-PROPS-0003-CASE-OPTIONS-SCOPED-TO-ENUM
+    title: Non-enum prop declarations must not provide `options`
+    covers:
+      - C-PROPS-0006-E
+      - C-PROPS-0006-H
+    expectation: options-only-valid-on-enum-type
+  - id: T-PROPS-0003-CASE-RANGE-SHAPE
+    title: '`range.min/max` must be valid numbers when present'
+    covers:
+      - C-PROPS-0006-F
+      - C-PROPS-0006-H
+    expectation: invalid-range-bound-is-blocking-error
+  - id: T-PROPS-0003-CASE-DEFAULT-JSON
+    title: '`default` must be a JSON props value'
+    covers:
+      - C-PROPS-0006-G
+      - C-PROPS-0006-H
+    expectation: non-json-default-is-blocking-error
+implementations:
+  - id: module-props-define-shape
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/define-merge.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0003-CASE-TYPE-REQUIRED
+      - T-PROPS-0003-CASE-TYPE-SET
+      - T-PROPS-0003-CASE-EMPTY-SHAPE
+      - T-PROPS-0003-CASE-ENUM-OPTIONS
+      - T-PROPS-0003-CASE-OPTIONS-SCOPED-TO-ENUM
+      - T-PROPS-0003-CASE-RANGE-SHAPE
+      - T-PROPS-0003-CASE-DEFAULT-JSON
+    exercises:
+      - C-PROPS-0003
+    notes:
+      - Existing module-level define merge test includes descriptor shape rejection before merge behavior assertions.
+  - id: type-props-specmap-shape
+    kind: workspace-check
+    status: passing
+    path: internal/contracts/types/props.specmap.v0.type-test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0003-CASE-ENUM-OPTIONS
+    notes:
+      - 'Supporting compile-time coverage for `type: "enum"` plus required `options`.'
 verifies:
   contracts:
-    - C-PROPS-0006
+    - id: C-PROPS-0006
+      anchors:
+        - C-PROPS-0006-A
+        - C-PROPS-0006-B
+        - C-PROPS-0006-C
+        - C-PROPS-0006-D
+        - C-PROPS-0006-E
+        - C-PROPS-0006-F
+        - C-PROPS-0006-G
+        - C-PROPS-0006-H
+exercises:
+  contracts:
+    - id: C-PROPS-0003
+      role: value-boundary
+      coverageImpact: exercises-test-surface
+      note: Descriptor `default` values use the JSON props value boundary.
 relates:
   modules:
     - M-PROPS-0001
@@ -14,7 +99,10 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted the declaration shape validation test mapping placeholder.
+  - version: 0.1.0
+    change: revised
+    summary: Expanded descriptor shape tests into criteria-level cases for `C-PROPS-0006`.
 tags:
   - props
   - contract-test
-  - draft
+  - define

--- a/spec/tests/T-PROPS-0004.yaml
+++ b/spec/tests/T-PROPS-0004.yaml
@@ -40,11 +40,21 @@ cases:
     covers:
       - C-PROPS-0007-G
     expectation: same-declarations-produce-same-behavior-and-diagnostics
-  - id: T-PROPS-0004-CASE-ATOMIC-FAILURE
-    title: Failed declaration merge is atomic
+  - id: T-PROPS-0004-CASE-ATOMIC-BATCH-REJECTION
+    title: Failed declaration merge rejects the whole incoming batch
     covers:
-      - C-PROPS-0010
-    expectation: failed-merge-does-not-partially-apply
+      - C-PROPS-0010-A
+    expectation: blocking-error-rejects-whole-batch
+  - id: T-PROPS-0004-CASE-ATOMIC-BEHAVIOR-UNCHANGED
+    title: Failed declaration merge leaves observable behavior unchanged
+    covers:
+      - C-PROPS-0010-B
+    expectation: existing-declarations-remain-observably-unchanged
+  - id: T-PROPS-0004-CASE-ATOMIC-NO-PARTIAL-WARNINGS
+    title: Failed declaration merge does not record partial warnings
+    covers:
+      - C-PROPS-0010-C
+    expectation: failed-merge-warnings-are-not-recorded
 implementations:
   - id: module-props-define-merge
     kind: module-test
@@ -59,7 +69,9 @@ implementations:
       - T-PROPS-0004-CASE-VALIDATOR-MERGE
       - T-PROPS-0004-CASE-DEFAULT-MERGE
       - T-PROPS-0004-CASE-DETERMINISTIC-MERGE
-      - T-PROPS-0004-CASE-ATOMIC-FAILURE
+      - T-PROPS-0004-CASE-ATOMIC-BATCH-REJECTION
+      - T-PROPS-0004-CASE-ATOMIC-BEHAVIOR-UNCHANGED
+      - T-PROPS-0004-CASE-ATOMIC-NO-PARTIAL-WARNINGS
     exercises:
       - C-PROPS-0006
     notes:
@@ -75,7 +87,11 @@ verifies:
         - C-PROPS-0007-E
         - C-PROPS-0007-F
         - C-PROPS-0007-G
-    - C-PROPS-0010
+    - id: C-PROPS-0010
+      anchors:
+        - C-PROPS-0010-A
+        - C-PROPS-0010-B
+        - C-PROPS-0010-C
 exercises:
   contracts:
     - id: C-PROPS-0006
@@ -92,6 +108,9 @@ revisions:
   - version: 0.1.0
     change: revised
     summary: Expanded declaration merge safety tests into criteria-level cases for `C-PROPS-0007` and atomic failure coverage for `C-PROPS-0010`.
+  - version: 0.1.0
+    change: revised
+    summary: Split declaration merge atomicity coverage into `C-PROPS-0010` criteria-level cases.
 tags:
   - props
   - contract-test

--- a/spec/tests/T-PROPS-0004.yaml
+++ b/spec/tests/T-PROPS-0004.yaml
@@ -1,12 +1,87 @@
 id: T-PROPS-0004
 type: test
 title: Prop declaration merge safety tests
-status: draft
+status: active
 since: 0.1.0
-summary: Placeholder mapping for tests that verify evolution-safety merge behavior for setup-time prop declarations.
+summary: Tests that verify evolution-safety merge behavior for setup-time prop declarations.
+cases:
+  - id: T-PROPS-0004-CASE-TYPE-MATCH
+    title: Same-key declaration merge rejects type mismatch
+    covers:
+      - C-PROPS-0007-A
+    expectation: type-mismatch-is-blocking-error
+  - id: T-PROPS-0004-CASE-EMPTY-MERGE
+    title: Empty behavior merge rejects stricter incoming behavior and warns on looser behavior
+    covers:
+      - C-PROPS-0007-B
+    expectation: stricter-empty-errors-looser-empty-warns
+  - id: T-PROPS-0004-CASE-ENUM-OPTIONS-MERGE
+    title: Enum options merge rejects narrowing and warns on widening
+    covers:
+      - C-PROPS-0007-C
+    expectation: enum-options-narrowing-errors-widening-warns
+  - id: T-PROPS-0004-CASE-RANGE-MERGE
+    title: Range merge rejects narrowing and warns on widening
+    covers:
+      - C-PROPS-0007-D
+    expectation: range-narrowing-errors-widening-warns
+  - id: T-PROPS-0004-CASE-VALIDATOR-MERGE
+    title: Validator merge allows first addition and rejects replacement or removal
+    covers:
+      - C-PROPS-0007-E
+    expectation: validator-replacement-or-removal-errors
+  - id: T-PROPS-0004-CASE-DEFAULT-MERGE
+    title: Default merge allows first addition and warns while keeping base on change
+    covers:
+      - C-PROPS-0007-F
+    expectation: default-change-warns-and-keeps-base
+  - id: T-PROPS-0004-CASE-DETERMINISTIC-MERGE
+    title: Merge output is deterministic
+    covers:
+      - C-PROPS-0007-G
+    expectation: same-declarations-produce-same-behavior-and-diagnostics
+  - id: T-PROPS-0004-CASE-ATOMIC-FAILURE
+    title: Failed declaration merge is atomic
+    covers:
+      - C-PROPS-0010
+    expectation: failed-merge-does-not-partially-apply
+implementations:
+  - id: module-props-define-merge
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/define-merge.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0004-CASE-TYPE-MATCH
+      - T-PROPS-0004-CASE-EMPTY-MERGE
+      - T-PROPS-0004-CASE-ENUM-OPTIONS-MERGE
+      - T-PROPS-0004-CASE-RANGE-MERGE
+      - T-PROPS-0004-CASE-VALIDATOR-MERGE
+      - T-PROPS-0004-CASE-DEFAULT-MERGE
+      - T-PROPS-0004-CASE-DETERMINISTIC-MERGE
+      - T-PROPS-0004-CASE-ATOMIC-FAILURE
+    exercises:
+      - C-PROPS-0006
+    notes:
+      - Existing module-level test covers v0 define merge behavior and atomic failure.
 verifies:
   contracts:
-    - C-PROPS-0007
+    - id: C-PROPS-0007
+      anchors:
+        - C-PROPS-0007-A
+        - C-PROPS-0007-B
+        - C-PROPS-0007-C
+        - C-PROPS-0007-D
+        - C-PROPS-0007-E
+        - C-PROPS-0007-F
+        - C-PROPS-0007-G
+    - C-PROPS-0010
+exercises:
+  contracts:
+    - id: C-PROPS-0006
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Define merge tests begin with descriptor shape validation before same-key merge behavior.
 relates:
   modules:
     - M-PROPS-0001
@@ -14,7 +89,11 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted the declaration merge safety test mapping placeholder.
+  - version: 0.1.0
+    change: revised
+    summary: Expanded declaration merge safety tests into criteria-level cases for `C-PROPS-0007` and atomic failure coverage for `C-PROPS-0010`.
 tags:
   - props
   - contract-test
-  - draft
+  - define
+  - merge

--- a/spec/tests/T-PROPS-0005.yaml
+++ b/spec/tests/T-PROPS-0005.yaml
@@ -145,7 +145,7 @@ implementations:
       - Supporting runtime integration coverage for watcher-time `run.props.get()` behavior and non-`undefined` resolved values.
   - id: adapter-resolved-snapshot-shape-conformance
     kind: adapter-test
-    status: planned
+    status: active
     path: packages/adapters/base/test-utils/resolved-snapshot-shape.ts
     required: true
     consumesCases:
@@ -159,7 +159,55 @@ implementations:
       - C-PROPS-0009
     notes:
       - Shared adapter harness should verify mount and update props paths without assuming a host-specific props transport.
-      - React, Vue, and Web Component adapters should consume this harness once it exists.
+      - React, Vue, and Web Component adapters should consume this harness.
+  - id: adapter-react-resolved-snapshot-shape
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0005-CASE-RUNTIME-CURRENT-SNAPSHOT
+      - T-PROPS-0005-CASE-DECLARED-KEYS-PRESENT
+      - T-PROPS-0005-CASE-UNDECLARED-KEYS-EXCLUDED
+      - T-PROPS-0005-CASE-KEY-GRANULARITY
+      - T-PROPS-0005-CASE-UNDEFINED-EMPTY-NORMALIZATION
+    exercises:
+      - C-PROPS-0002
+      - C-PROPS-0009
+    notes:
+      - React adapter coverage for mount and update paths using the shared resolved snapshot shape conformance harness.
+  - id: adapter-vue-resolved-snapshot-shape
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0005-CASE-RUNTIME-CURRENT-SNAPSHOT
+      - T-PROPS-0005-CASE-DECLARED-KEYS-PRESENT
+      - T-PROPS-0005-CASE-UNDECLARED-KEYS-EXCLUDED
+      - T-PROPS-0005-CASE-KEY-GRANULARITY
+      - T-PROPS-0005-CASE-UNDEFINED-EMPTY-NORMALIZATION
+    exercises:
+      - C-PROPS-0002
+      - C-PROPS-0009
+    notes:
+      - Vue adapter coverage for mount and update paths using the shared resolved snapshot shape conformance harness.
+  - id: adapter-web-component-resolved-snapshot-shape
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0005-CASE-RUNTIME-CURRENT-SNAPSHOT
+      - T-PROPS-0005-CASE-DECLARED-KEYS-PRESENT
+      - T-PROPS-0005-CASE-UNDECLARED-KEYS-EXCLUDED
+      - T-PROPS-0005-CASE-KEY-GRANULARITY
+      - T-PROPS-0005-CASE-UNDEFINED-EMPTY-NORMALIZATION
+    exercises:
+      - C-PROPS-0002
+      - C-PROPS-0009
+    notes:
+      - Web Component adapter coverage uses `setElementProps()`/`update()` as the canonical props channel; arbitrary attributes are intentionally not treated as props.
 verifies:
   contracts:
     - id: C-PROPS-0008
@@ -202,6 +250,15 @@ revisions:
   - version: 0.1.0
     change: revised
     summary: Marked focused module-level resolved snapshot shape coverage as passing.
+  - version: 0.1.0
+    change: revised
+    summary: Added shared adapter conformance harness and React adapter coverage for resolved snapshot shape.
+  - version: 0.1.0
+    change: revised
+    summary: Added Vue adapter coverage for resolved snapshot shape.
+  - version: 0.1.0
+    change: revised
+    summary: Added Web Component adapter coverage for resolved snapshot shape.
 tags:
   - props
   - contract-test

--- a/spec/tests/T-PROPS-0005.yaml
+++ b/spec/tests/T-PROPS-0005.yaml
@@ -1,12 +1,194 @@
 id: T-PROPS-0005
 type: test
 title: Resolved props snapshot shape tests
-status: draft
+status: active
 since: 0.1.0
-summary: Placeholder mapping for tests that verify declared-key resolved snapshot invariants.
+summary: Tests that verify `run.props.get()` and module-level props resolution produce the declared-key `resolved snapshot` required by `C-PROPS-0008`.
+openQuestions:
+  - id: T-PROPS-0005-Q-STATIC-SNAPSHOT-MUTATION
+    question:
+      zh-CN: 是否需要新增静态分析测试，用于禁止原型作者修改 `resolved props snapshot` 或其嵌套值？
+      en: Should Proto UI add static-analysis tests that reject prototype code mutating the `resolved props snapshot` or nested values read from it?
+    context:
+      zh-CN: '`C-PROPS-0008-G` 定义的是语义只读。v0 runtime 可以保留浅层冻结测试，但 deep immutability 更适合由未来静态检查承担。'
+      en: '`C-PROPS-0008-G` defines semantic read-only behavior. The v0 runtime may keep shallow-freeze tests, while deep immutability is better enforced by future static analysis.'
+    blocks:
+      - Static analysis policy for props snapshot mutation
+cases:
+  - id: T-PROPS-0005-CASE-RUNTIME-CURRENT-SNAPSHOT
+    title: '`run.props.get()` reads the current runtime invocation snapshot'
+    covers:
+      - C-PROPS-0008-A
+    valueKind: runtime-resolved-snapshot
+    expectation: current-runtime-invocation
+    notes:
+      - Runtime callbacks should observe the same resolved snapshot through `run.props.get()` that the watcher or lifecycle invocation is currently handling.
+  - id: T-PROPS-0005-CASE-DECLARED-KEYS-PRESENT
+    title: '`resolved snapshot` contains every declared prop key'
+    covers:
+      - C-PROPS-0008-B
+    valueKind: declared-key-set
+    expectation: all-declared-keys-present
+    notes:
+      - Missing raw input for a declared key should still produce a resolved entry through fallback or canonical empty-value resolution.
+  - id: T-PROPS-0005-CASE-UNDECLARED-KEYS-EXCLUDED
+    title: '`resolved snapshot` excludes undeclared raw prop keys'
+    covers:
+      - C-PROPS-0008-C
+    valueKind: undeclared-raw-key
+    expectation: excluded-from-resolved-snapshot
+    notes:
+      - Extra raw input may remain visible through raw escape-hatch APIs, but must not appear in portable resolved props.
+  - id: T-PROPS-0005-CASE-KEY-GRANULARITY
+    title: Props resolution is isolated per key
+    covers:
+      - C-PROPS-0008-D
+    valueKind: per-key-resolution
+    expectation: one-key-state-does-not-change-other-key-resolution
+    notes:
+      - A missing, empty, or invalid value for one prop key must not invalidate the whole props record or alter other keys' resolved values.
+  - id: T-PROPS-0005-CASE-RECORD-JSON-VALUES
+    title: '`resolved snapshot` is a string-keyed record of JSON values'
+    covers:
+      - C-PROPS-0008-E
+    valueKind: resolved-record-json-values
+    expectation: record-shape-with-json-values
+    notes:
+      - This case exercises `C-PROPS-0003`; the existing JSON boundary fixture supplies most value-shape examples.
+  - id: T-PROPS-0005-CASE-UNDEFINED-EMPTY-NORMALIZATION
+    title: '`resolved snapshot` never exposes `undefined` and uses `null` as canonical empty value'
+    covers:
+      - C-PROPS-0008-F
+    valueKind: canonical-empty-value
+    expectation: no-undefined-null-for-empty-result
+    notes:
+      - Raw `undefined`, missing input, or empty resolution must not leak `undefined` into resolved portable props.
+  - id: T-PROPS-0005-CASE-SEMANTIC-READONLY
+    title: '`resolved snapshot` is semantically read-only'
+    covers:
+      - C-PROPS-0008-G
+    valueKind: readonly-resolved-snapshot
+    expectation: mutation-is-contract-violation
+    notes:
+      - Runtime tests may assert shallow immutability where implemented; deep mutation should eventually be covered by static analysis.
+implementations:
+  - id: module-props-resolved-snapshot-shape
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0005-CASE-DECLARED-KEYS-PRESENT
+      - T-PROPS-0005-CASE-UNDECLARED-KEYS-EXCLUDED
+      - T-PROPS-0005-CASE-KEY-GRANULARITY
+      - T-PROPS-0005-CASE-UNDEFINED-EMPTY-NORMALIZATION
+      - T-PROPS-0005-CASE-SEMANTIC-READONLY
+    exercises:
+      - C-PROPS-0004
+      - C-PROPS-0009
+      - C-CORE-VALUE-0001
+    notes:
+      - Focused module-level test target for `PropsKernel.applyRaw()` to `PropsKernel.get()` snapshot shape.
+      - Makes `C-PROPS-0008` the direct test subject for declared-key presence, undeclared-key exclusion, key-granular resolution, canonical empty values, and shallow immutability.
+  - id: module-props-resolve-fallback-legacy
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolve-fallback.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0005-CASE-DECLARED-KEYS-PRESENT
+      - T-PROPS-0005-CASE-UNDECLARED-KEYS-EXCLUDED
+      - T-PROPS-0005-CASE-UNDEFINED-EMPTY-NORMALIZATION
+      - T-PROPS-0005-CASE-SEMANTIC-READONLY
+    exercises:
+      - C-PROPS-0009
+    notes:
+      - Legacy coverage currently asserts declared-key presence, undeclared-key exclusion, `undefined` absence, canonical `null`, and shallow freeze behavior.
+      - Keep this as supporting coverage after the focused `resolved-snapshot-shape` test exists.
+  - id: module-props-resolved-json-value-boundary
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolved-json-value-boundary.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0005-CASE-RECORD-JSON-VALUES
+    exercises:
+      - C-PROPS-0003
+      - C-PROPS-0009
+    notes:
+      - Reuses `T-PROPS-0001` JSON value-boundary fixture to ensure resolved values stay inside portable JSON semantics.
+  - id: runtime-run-props-resolved-snapshot
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/run-props-wiring.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0005-CASE-RUNTIME-CURRENT-SNAPSHOT
+    exercises:
+      - C-CORE-SYNTAX-0002
+      - C-PROPS-0011
+      - C-PROPS-0013
+    notes:
+      - Existing runtime wiring tests assert watcher callback `run.props.get()` alignment with the current resolved watcher snapshot.
+  - id: runtime-props-integration-resolved-snapshot
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/props-integration.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0005-CASE-RUNTIME-CURRENT-SNAPSHOT
+      - T-PROPS-0005-CASE-UNDEFINED-EMPTY-NORMALIZATION
+    exercises:
+      - C-PROPS-0011
+      - C-PROPS-0013
+    notes:
+      - Supporting runtime integration coverage for watcher-time `run.props.get()` behavior and non-`undefined` resolved values.
+  - id: adapter-resolved-snapshot-shape-conformance
+    kind: adapter-test
+    status: planned
+    path: packages/adapters/base/test-utils/resolved-snapshot-shape.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0005-CASE-RUNTIME-CURRENT-SNAPSHOT
+      - T-PROPS-0005-CASE-DECLARED-KEYS-PRESENT
+      - T-PROPS-0005-CASE-UNDECLARED-KEYS-EXCLUDED
+      - T-PROPS-0005-CASE-UNDEFINED-EMPTY-NORMALIZATION
+    exercises:
+      - C-PROPS-0002
+      - C-PROPS-0003
+      - C-PROPS-0009
+    notes:
+      - Shared adapter harness should verify mount and update props paths without assuming a host-specific props transport.
+      - React, Vue, and Web Component adapters should consume this harness once it exists.
 verifies:
   contracts:
-    - C-PROPS-0008
+    - id: C-PROPS-0008
+      anchors:
+        - C-PROPS-0008-A
+        - C-PROPS-0008-B
+        - C-PROPS-0008-C
+        - C-PROPS-0008-D
+        - C-PROPS-0008-E
+        - C-PROPS-0008-F
+        - C-PROPS-0008-G
+exercises:
+  contracts:
+    - id: C-PROPS-0003
+      role: value-boundary
+      coverageImpact: exercises-test-surface
+      note: The `resolved snapshot` value set must remain inside JSON props value semantics.
+    - id: C-PROPS-0004
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Per-key missing, empty, non-empty, and invalid states provide the input surface for key-granular resolution tests.
+    - id: C-PROPS-0009
+      role: test-entrypoint
+      coverageImpact: exercises-test-surface
+      note: Fallback behavior supplies concrete resolved values for missing, empty, and invalid inputs.
+    - id: C-CORE-VALUE-0001
+      role: value-boundary
+      coverageImpact: exercises-test-surface
+      note: Canonical empty-value tests assert that `null` is used instead of host-local empty values such as `undefined`.
 relates:
   modules:
     - M-PROPS-0001
@@ -14,7 +196,13 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted the resolved snapshot shape test mapping placeholder.
+  - version: 0.1.0
+    change: revised
+    summary: Expanded `T-PROPS-0005` into concrete cases and implementation targets for `C-PROPS-0008`.
+  - version: 0.1.0
+    change: revised
+    summary: Marked focused module-level resolved snapshot shape coverage as passing.
 tags:
   - props
   - contract-test
-  - draft
+  - resolved

--- a/spec/tests/T-PROPS-0006.yaml
+++ b/spec/tests/T-PROPS-0006.yaml
@@ -1,12 +1,157 @@
 id: T-PROPS-0006
 type: test
 title: Empty and fallback resolution tests
-status: draft
+status: active
 since: 0.1.0
-summary: Placeholder mapping for tests that verify empty behavior, fallback chain, and prevValid behavior.
+summary: Tests that verify `missing`, `provided-empty`, and `invalid` prop values resolve through deterministic fallback behavior.
+cases:
+  - id: T-PROPS-0006-CASE-MISSING-FALLBACK
+    title: '`missing` input enters the fallback chain'
+    covers:
+      - C-PROPS-0009-A
+    valueKind: missing-input
+    expectation: fallback-chain-used
+    notes:
+      - A declared key must remain in the `resolved snapshot` even when raw props omit it.
+  - id: T-PROPS-0006-CASE-EMPTY-ACCEPT
+    title: '`provided-empty` with `empty: "accept"` resolves to `null`'
+    covers:
+      - C-PROPS-0009-B
+    valueKind: provided-empty
+    expectation: accepted-as-canonical-null
+    notes:
+      - Accepted empty values must not update `prevValid`.
+  - id: T-PROPS-0006-CASE-EMPTY-FALLBACK
+    title: '`provided-empty` with `empty: "fallback"` enters fallback chain'
+    covers:
+      - C-PROPS-0009-C
+    valueKind: provided-empty
+    expectation: fallback-chain-used
+    notes:
+      - Default empty behavior is `fallback`.
+  - id: T-PROPS-0006-CASE-INVALID-FALLBACK
+    title: '`provided-non-empty invalid` input enters fallback chain'
+    covers:
+      - C-PROPS-0009-D
+    valueKind: invalid-non-empty
+    expectation: fallback-chain-used
+    notes:
+      - Invalid non-empty input is not the same state as `provided-empty`.
+  - id: T-PROPS-0006-CASE-FALLBACK-ORDER
+    title: Fallback order is `prevValid`, `setDefaults`, declaration `default`, then `null`
+    covers:
+      - C-PROPS-0009-E
+    valueKind: fallback-candidates
+    expectation: deterministic-candidate-order
+    notes:
+      - '`prevValid` should win over configured defaults once established.'
+  - id: T-PROPS-0006-CASE-FALLBACK-TO-NULL
+    title: Default fallback may end in `null` as canonical empty result
+    covers:
+      - C-PROPS-0009-F
+    valueKind: fallback-terminal-null
+    expectation: canonical-empty-null
+    notes:
+      - This does not mean typed props accept `null` as a non-empty valid input.
+  - id: T-PROPS-0006-CASE-EMPTY-ERROR
+    title: '`empty: "error"` requires a non-empty fallback or throws'
+    covers:
+      - C-PROPS-0009-G
+    valueKind: error-empty-behavior
+    expectation: throws-without-non-empty-fallback
+    notes:
+      - '`empty: "error"` may still resolve through `prevValid` when a non-empty valid previous value exists.'
+  - id: T-PROPS-0006-CASE-PREV-VALID-NON-EMPTY
+    title: '`prevValid` stores only non-empty valid values'
+    covers:
+      - C-PROPS-0009-H
+    valueKind: prev-valid
+    expectation: null-is-not-prev-valid
+    notes:
+      - Accepted `null` must not become the next fallback candidate.
+implementations:
+  - id: module-props-fallback-resolution
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/fallback-resolution.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0006-CASE-MISSING-FALLBACK
+      - T-PROPS-0006-CASE-EMPTY-ACCEPT
+      - T-PROPS-0006-CASE-EMPTY-FALLBACK
+      - T-PROPS-0006-CASE-INVALID-FALLBACK
+      - T-PROPS-0006-CASE-FALLBACK-ORDER
+      - T-PROPS-0006-CASE-FALLBACK-TO-NULL
+      - T-PROPS-0006-CASE-EMPTY-ERROR
+      - T-PROPS-0006-CASE-PREV-VALID-NON-EMPTY
+    exercises:
+      - C-PROPS-0004
+      - C-PROPS-0008
+      - C-CORE-VALUE-0001
+    notes:
+      - Focused module-level test whose individual test names reference the `T-PROPS-0006` case ID and `C-PROPS-0009` criterion ID.
+      - This is the primary implementation for the current contract-test mapping.
+  - id: module-props-resolve-fallback-legacy
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolve-fallback.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0006-CASE-MISSING-FALLBACK
+      - T-PROPS-0006-CASE-EMPTY-ACCEPT
+      - T-PROPS-0006-CASE-EMPTY-FALLBACK
+      - T-PROPS-0006-CASE-INVALID-FALLBACK
+      - T-PROPS-0006-CASE-FALLBACK-ORDER
+      - T-PROPS-0006-CASE-FALLBACK-TO-NULL
+      - T-PROPS-0006-CASE-EMPTY-ERROR
+      - T-PROPS-0006-CASE-PREV-VALID-NON-EMPTY
+    exercises:
+      - C-PROPS-0004
+      - C-PROPS-0008
+      - C-CORE-VALUE-0001
+    notes:
+      - 'Existing module-level contract test covers input classification, empty behavior, fallback order, terminal `null`, `empty: "error"`, and `prevValid` behavior.'
+      - Kept as supporting historical coverage independent from the current criteria-indexed test mapping.
+  - id: module-props-empty-accept-meta
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/props.meta.empty-accept.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0006-CASE-EMPTY-ACCEPT
+      - T-PROPS-0006-CASE-INVALID-FALLBACK
+      - T-PROPS-0006-CASE-FALLBACK-TO-NULL
+      - T-PROPS-0006-CASE-EMPTY-ERROR
+    exercises:
+      - C-PROPS-0004
+    notes:
+      - Supporting meta-level coverage that verifies accepted-empty, invalid, fallback, and error classification metadata.
 verifies:
   contracts:
-    - C-PROPS-0009
+    - id: C-PROPS-0009
+      anchors:
+        - C-PROPS-0009-A
+        - C-PROPS-0009-B
+        - C-PROPS-0009-C
+        - C-PROPS-0009-D
+        - C-PROPS-0009-E
+        - C-PROPS-0009-F
+        - C-PROPS-0009-G
+        - C-PROPS-0009-H
+exercises:
+  contracts:
+    - id: C-PROPS-0004
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Fallback tests use per-key input classification as their input surface.
+    - id: C-PROPS-0008
+      role: test-entrypoint
+      coverageImpact: exercises-test-surface
+      note: Fallback outputs are observed through the declared-key `resolved snapshot`.
+    - id: C-CORE-VALUE-0001
+      role: value-boundary
+      coverageImpact: exercises-test-surface
+      note: Terminal fallback to `null` verifies canonical empty-value behavior.
 relates:
   modules:
     - M-PROPS-0001
@@ -14,7 +159,13 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted the empty and fallback resolution test mapping placeholder.
+  - version: 0.1.0
+    change: revised
+    summary: Expanded fallback resolution into criteria-level cases and mapped existing module coverage.
+  - version: 0.1.0
+    change: revised
+    summary: Added a focused module test with direct `T-PROPS-0006` case and `C-PROPS-0009` criterion references.
 tags:
   - props
   - contract-test
-  - draft
+  - fallback

--- a/spec/tests/T-PROPS-0007.yaml
+++ b/spec/tests/T-PROPS-0007.yaml
@@ -1,0 +1,164 @@
+id: T-PROPS-0007
+type: test
+title: Resolved props watcher tests
+status: active
+since: 0.1.0
+summary: Tests that verify `def.props.watchAll(cb)` and `def.props.watch(keys, cb)` observe declared-key `resolved snapshot` changes.
+cases:
+  - id: T-PROPS-0007-CASE-REGISTRATION-SURFACE
+    title: Resolved watcher registration is setup-only and declared-key scoped
+    covers:
+      - C-PROPS-0011-A
+      - C-PROPS-0011-F
+    valueKind: watcher-registration
+    expectation: setup-only-declared-key-registration
+    notes:
+      - '`watch(keys)` rejects empty key lists, undeclared keys, and registration before props definition.'
+      - Runtime phase guarding is owned by the module setup-only guard and should remain covered by module facade tests as the API surface expands.
+  - id: T-PROPS-0007-CASE-HYDRATION-SKIP
+    title: Initial `hydration` does not trigger resolved watchers
+    covers:
+      - C-PROPS-0011-B
+    valueKind: hydration
+    expectation: no-resolved-watcher-callback
+  - id: T-PROPS-0007-CASE-RESOLVED-DIFF-ONLY
+    title: Raw-only changes do not trigger resolved watchers
+    covers:
+      - C-PROPS-0011-C
+    valueKind: resolved-diff
+    expectation: raw-only-changes-ignored
+    notes:
+      - Undeclared raw keys and raw values that resolve to the same declared-key snapshot must not trigger resolved watchers.
+  - id: T-PROPS-0007-CASE-OBJECT-IS-DIFF
+    title: Resolved watcher diffs use `Object.is`
+    covers:
+      - C-PROPS-0011-D
+    valueKind: diff-comparator
+    expectation: object-is-semantics
+  - id: T-PROPS-0007-CASE-WATCH-ALL
+    title: '`watchAll(cb)` observes any changed declared key'
+    covers:
+      - C-PROPS-0011-E
+    valueKind: watch-all
+    expectation: fires-on-any-declared-key-change
+  - id: T-PROPS-0007-CASE-WATCH-KEYS
+    title: '`watch(keys, cb)` observes changed watched keys only'
+    covers:
+      - C-PROPS-0011-F
+    valueKind: watch-keys
+    expectation: fires-on-watched-key-change
+  - id: T-PROPS-0007-CASE-CALLBACK-SNAPSHOTS
+    title: Watcher callbacks receive previous and next `resolved snapshots`
+    covers:
+      - C-PROPS-0011-G
+    valueKind: watcher-payload
+    expectation: prev-next-resolved-snapshots
+  - id: T-PROPS-0007-CASE-CHANGE-INFO
+    title: '`WatchInfo` reports all changed keys and watcher-matched changed keys'
+    covers:
+      - C-PROPS-0011-H
+    valueKind: watcher-info
+    expectation: all-and-matched-changed-keys
+  - id: T-PROPS-0007-CASE-DISPATCH-COALESCING
+    title: Coalesced dispatch observes the net resolved diff
+    covers:
+      - C-PROPS-0011-I
+    valueKind: dispatch-window
+    expectation: first-prev-latest-next
+  - id: T-PROPS-0007-CASE-DISPATCH-ORDER
+    title: Resolved watcher dispatch preserves `watchAll` before keyed watcher ordering
+    covers:
+      - C-PROPS-0011-J
+    valueKind: dispatch-order
+    expectation: watch-all-before-keyed-registration-order
+implementations:
+  - id: module-props-resolved-watchers
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolved-watchers.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0007-CASE-REGISTRATION-SURFACE
+      - T-PROPS-0007-CASE-HYDRATION-SKIP
+      - T-PROPS-0007-CASE-RESOLVED-DIFF-ONLY
+      - T-PROPS-0007-CASE-OBJECT-IS-DIFF
+      - T-PROPS-0007-CASE-WATCH-ALL
+      - T-PROPS-0007-CASE-WATCH-KEYS
+      - T-PROPS-0007-CASE-CALLBACK-SNAPSHOTS
+      - T-PROPS-0007-CASE-CHANGE-INFO
+      - T-PROPS-0007-CASE-DISPATCH-COALESCING
+      - T-PROPS-0007-CASE-DISPATCH-ORDER
+    exercises:
+      - C-PROPS-0008
+      - C-PROPS-0009
+    notes:
+      - Focused module-level test whose individual test names reference the `T-PROPS-0007` case ID and `C-PROPS-0011` criterion ID.
+      - This is the primary implementation for the current contract-test mapping.
+  - id: module-props-watch-resolved-legacy
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/watch-resolved.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0007-CASE-HYDRATION-SKIP
+      - T-PROPS-0007-CASE-RESOLVED-DIFF-ONLY
+      - T-PROPS-0007-CASE-OBJECT-IS-DIFF
+      - T-PROPS-0007-CASE-WATCH-ALL
+      - T-PROPS-0007-CASE-WATCH-KEYS
+      - T-PROPS-0007-CASE-CHANGE-INFO
+      - T-PROPS-0007-CASE-DISPATCH-COALESCING
+      - T-PROPS-0007-CASE-DISPATCH-ORDER
+    exercises:
+      - C-PROPS-0008
+      - C-PROPS-0009
+    notes:
+      - Historical module-level coverage for resolved watcher semantics.
+      - Kept as supporting coverage independent from the current criteria-indexed test mapping.
+  - id: runtime-props-integration-resolved-watchers
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/props-integration.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0007-CASE-CALLBACK-SNAPSHOTS
+      - T-PROPS-0007-CASE-DISPATCH-ORDER
+    exercises:
+      - C-PROPS-0013
+    notes:
+      - Supporting runtime integration coverage verifies callback-time wiring and dispatch ordering through public `def.props.*` APIs.
+verifies:
+  contracts:
+    - id: C-PROPS-0011
+      anchors:
+        - C-PROPS-0011-A
+        - C-PROPS-0011-B
+        - C-PROPS-0011-C
+        - C-PROPS-0011-D
+        - C-PROPS-0011-E
+        - C-PROPS-0011-F
+        - C-PROPS-0011-G
+        - C-PROPS-0011-H
+        - C-PROPS-0011-I
+        - C-PROPS-0011-J
+exercises:
+  contracts:
+    - id: C-PROPS-0008
+      role: test-entrypoint
+      coverageImpact: exercises-test-surface
+      note: Resolved watcher inputs and diffs are observed through declared-key `resolved snapshots`.
+    - id: C-PROPS-0009
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Fallback behavior determines whether raw input changes produce changed resolved values.
+relates:
+  modules:
+    - M-PROPS-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added criteria-level resolved watcher test mapping for `C-PROPS-0011`.
+tags:
+  - props
+  - contract-test
+  - watch
+  - resolved

--- a/spec/tests/T-PROPS-0007.yaml
+++ b/spec/tests/T-PROPS-0007.yaml
@@ -66,11 +66,11 @@ cases:
     valueKind: dispatch-window
     expectation: first-prev-latest-next
   - id: T-PROPS-0007-CASE-DISPATCH-ORDER
-    title: Resolved watcher dispatch preserves `watchAll` before keyed watcher ordering
+    title: Resolved watcher dispatch preserves shared registration order
     covers:
       - C-PROPS-0011-J
     valueKind: dispatch-order
-    expectation: watch-all-before-keyed-registration-order
+    expectation: shared-registration-order
 implementations:
   - id: module-props-resolved-watchers
     kind: module-test

--- a/spec/tests/T-PROPS-0008.yaml
+++ b/spec/tests/T-PROPS-0008.yaml
@@ -1,0 +1,184 @@
+id: T-PROPS-0008
+type: test
+title: Raw props escape hatch tests
+status: active
+since: 0.1.0
+summary: Tests that verify `run.props.getRaw()`, `def.props.watchRawAll(cb)`, and `def.props.watchRaw(keys, cb)` expose raw props as an escape hatch.
+openQuestions:
+  - id: T-PROPS-0008-Q-RAW-DELIVERY-EVENT
+    question:
+      zh-CN: 若未来新增 raw props delivery event API，是否需要独立测试实体，而不是扩展 `T-PROPS-0008`？
+      en: If Proto UI adds a raw props delivery event API later, should it get a separate test entity instead of extending `T-PROPS-0008`?
+    context:
+      zh-CN: 当前测试实体只验证 raw snapshot diff watcher 语义，不验证每一次 adapter props application。
+      en: This test entity verifies raw snapshot diff watcher semantics, not every adapter props application.
+    blocks:
+      - Raw props delivery event API tests
+cases:
+  - id: T-PROPS-0008-CASE-RAW-DEFINITION
+    title: Raw props are adapter-supplied pre-resolution snapshots
+    covers:
+      - C-PROPS-0012-A
+      - C-PROPS-0012-B
+    expectation: adapter-boundary-pre-resolution-snapshot
+    notes:
+      - Adapter conformance and host wiring tests provide the concrete raw props source.
+  - id: T-PROPS-0008-CASE-GET-RAW
+    title: '`run.props.getRaw()` returns the current raw snapshot'
+    covers:
+      - C-PROPS-0012-C
+    expectation: current-runtime-raw-snapshot
+  - id: T-PROPS-0008-CASE-UNDECLARED-KEYS
+    title: Raw props may preserve undeclared keys
+    covers:
+      - C-PROPS-0012-D
+    expectation: undeclared-keys-raw-only
+  - id: T-PROPS-0008-CASE-PORTABILITY-BOUNDARY
+    title: Raw props do not extend portable props semantics
+    covers:
+      - C-PROPS-0012-E
+    expectation: host-local-raw-values-not-portable
+  - id: T-PROPS-0008-CASE-REGISTRATION-SURFACE
+    title: Raw watchers are setup-only escape hatch registration APIs
+    covers:
+      - C-PROPS-0012-F
+      - C-PROPS-0012-L
+    expectation: setup-only-escape-hatch-registration
+  - id: T-PROPS-0008-CASE-HYDRATION-SKIP
+    title: Initial `hydration` does not trigger raw watchers
+    covers:
+      - C-PROPS-0012-G
+    expectation: hydration-skips-raw-watchers
+  - id: T-PROPS-0008-CASE-RAW-DIFF
+    title: Raw watcher triggering is based on raw snapshot diff
+    covers:
+      - C-PROPS-0012-G
+      - C-PROPS-0012-H
+    expectation: raw-union-key-object-is-diff
+  - id: T-PROPS-0008-CASE-WATCH-RAW-ALL
+    title: '`watchRawAll(cb)` observes any changed raw union key'
+    covers:
+      - C-PROPS-0012-I
+    expectation: fires-on-any-raw-key-change
+  - id: T-PROPS-0008-CASE-WATCH-RAW-KEYS
+    title: '`watchRaw(keys, cb)` observes changed watched raw keys, including undeclared keys'
+    covers:
+      - C-PROPS-0012-J
+    expectation: fires-on-watched-raw-key-change
+  - id: T-PROPS-0008-CASE-DISPATCH-ORDER
+    title: Raw watcher dispatch precedes resolved watcher dispatch
+    covers:
+      - C-PROPS-0012-K
+    expectation: raw-before-resolved-registration-order
+implementations:
+  - id: module-props-watch-raw
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/watch-raw.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0008-CASE-REGISTRATION-SURFACE
+      - T-PROPS-0008-CASE-HYDRATION-SKIP
+      - T-PROPS-0008-CASE-RAW-DIFF
+      - T-PROPS-0008-CASE-WATCH-RAW-ALL
+      - T-PROPS-0008-CASE-WATCH-RAW-KEYS
+      - T-PROPS-0008-CASE-DISPATCH-ORDER
+    exercises:
+      - C-PROPS-0011
+    notes:
+      - Existing module-level test covers raw watcher diff semantics, undeclared keys, `Object.is`, and raw-before-resolved ordering.
+      - Warning diagnostics are not yet asserted by this test.
+  - id: module-props-get-raw-legacy
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolve-fallback.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0008-CASE-GET-RAW
+      - T-PROPS-0008-CASE-UNDECLARED-KEYS
+    exercises:
+      - C-PROPS-0008
+    notes:
+      - Supporting legacy module-level coverage for `getRaw()` and `isProvided()` semantics.
+  - id: module-props-resolved-snapshot-raw-preservation
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolved-snapshot-shape.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0008-CASE-UNDECLARED-KEYS
+    exercises:
+      - C-PROPS-0008
+    notes:
+      - Supporting coverage showing undeclared raw keys remain visible through `getRaw()` while excluded from `resolved snapshot`.
+  - id: runtime-run-props-raw-wiring
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/run-props-wiring.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0008-CASE-RAW-DEFINITION
+      - T-PROPS-0008-CASE-GET-RAW
+      - T-PROPS-0008-CASE-HYDRATION-SKIP
+    exercises:
+      - C-PROPS-0013
+    notes:
+      - Runtime wiring test asserts `run.props.getRaw()` alignment with raw watcher `nextRaw` and host-supplied raw props.
+  - id: adapter-props-json-value-boundary-raw-case
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/base/test-utils/props-json-value-boundary.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0008-CASE-PORTABILITY-BOUNDARY
+    exercises:
+      - C-PROPS-0003
+      - C-PROPS-0008
+    notes:
+      - Shared adapter conformance harness verifies raw escape-hatch visibility without promoting host-local raw values to resolved portable props.
+verifies:
+  contracts:
+    - id: C-PROPS-0012
+      anchors:
+        - C-PROPS-0012-A
+        - C-PROPS-0012-B
+        - C-PROPS-0012-C
+        - C-PROPS-0012-D
+        - C-PROPS-0012-E
+        - C-PROPS-0012-F
+        - C-PROPS-0012-G
+        - C-PROPS-0012-H
+        - C-PROPS-0012-I
+        - C-PROPS-0012-J
+        - C-PROPS-0012-K
+        - C-PROPS-0012-L
+exercises:
+  contracts:
+    - id: C-PROPS-0003
+      role: value-boundary
+      coverageImpact: exercises-test-surface
+      note: Raw props may expose host-local values without extending portable JSON props semantics.
+    - id: C-PROPS-0008
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Raw snapshot tests compare raw visibility with resolved snapshot exclusion.
+    - id: C-PROPS-0011
+      role: execution-order
+      coverageImpact: exercises-test-surface
+      note: Raw-before-resolved ordering is tested together with resolved watcher dispatch.
+    - id: C-PROPS-0013
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Runtime tests observe raw props through callback-time `run handle` wiring.
+relates:
+  modules:
+    - M-PROPS-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added criteria-level raw props escape hatch test mapping for `C-PROPS-0012`.
+tags:
+  - props
+  - contract-test
+  - raw
+  - escape-hatch

--- a/spec/tests/T-PROPS-0009.yaml
+++ b/spec/tests/T-PROPS-0009.yaml
@@ -1,0 +1,98 @@
+id: T-PROPS-0009
+type: test
+title: Props watcher run handle binding tests
+status: active
+since: 0.1.0
+summary: Tests that verify props watcher callbacks receive the current runtime `run handle` and that `run.props.*` aligns with the current watcher dispatch window.
+cases:
+  - id: T-PROPS-0009-CASE-RESOLVED-RUN-HANDLE
+    title: Resolved watcher callbacks receive current `run handle`
+    covers:
+      - C-PROPS-0013-A
+    expectation: resolved-watcher-receives-current-run-handle
+  - id: T-PROPS-0009-CASE-RAW-RUN-HANDLE
+    title: Raw watcher callbacks receive current `run handle`
+    covers:
+      - C-PROPS-0013-B
+    expectation: raw-watcher-receives-current-run-handle
+  - id: T-PROPS-0009-CASE-RESOLVED-GET-ALIGNMENT
+    title: '`run.props.get()` aligns with resolved watcher `next`'
+    covers:
+      - C-PROPS-0013-C
+    expectation: run-props-get-aligns-with-next-resolved-snapshot
+  - id: T-PROPS-0009-CASE-RAW-GET-ALIGNMENT
+    title: '`run.props.getRaw()` aligns with raw watcher `nextRaw`'
+    covers:
+      - C-PROPS-0013-D
+    expectation: run-props-get-raw-aligns-with-next-raw-snapshot
+  - id: T-PROPS-0009-CASE-IS-PROVIDED-ALIGNMENT
+    title: '`run.props.isProvided(key)` uses current raw own-property semantics'
+    covers:
+      - C-PROPS-0013-E
+    expectation: run-props-is-provided-aligns-with-current-raw-snapshot
+implementations:
+  - id: runtime-run-props-wiring
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/run-props-wiring.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0009-CASE-RESOLVED-RUN-HANDLE
+      - T-PROPS-0009-CASE-RAW-RUN-HANDLE
+      - T-PROPS-0009-CASE-RESOLVED-GET-ALIGNMENT
+      - T-PROPS-0009-CASE-RAW-GET-ALIGNMENT
+      - T-PROPS-0009-CASE-IS-PROVIDED-ALIGNMENT
+    exercises:
+      - C-CORE-SYNTAX-0002
+      - C-PROPS-0011
+      - C-PROPS-0012
+    notes:
+      - Existing runtime test asserts callback-time `run.props.*` availability and alignment with watcher callback payloads.
+  - id: runtime-props-integration-run-binding
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/props-integration.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0009-CASE-RESOLVED-GET-ALIGNMENT
+      - T-PROPS-0009-CASE-RAW-GET-ALIGNMENT
+    exercises:
+      - C-PROPS-0011
+      - C-PROPS-0012
+    notes:
+      - Supporting integration coverage for watcher-time `run.props.get()` and `run.props.getRaw()` behavior.
+verifies:
+  contracts:
+    - id: C-PROPS-0013
+      anchors:
+        - C-PROPS-0013-A
+        - C-PROPS-0013-B
+        - C-PROPS-0013-C
+        - C-PROPS-0013-D
+        - C-PROPS-0013-E
+exercises:
+  contracts:
+    - id: C-CORE-SYNTAX-0002
+      role: phase-boundary
+      coverageImpact: exercises-test-surface
+      note: Props watcher callbacks instantiate the core runtime callback `run handle` binding rule.
+    - id: C-PROPS-0011
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Resolved watcher dispatch provides the callback window for `run.props.get()` alignment.
+    - id: C-PROPS-0012
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Raw watcher dispatch provides the callback window for `run.props.getRaw()` and `isProvided()` alignment.
+relates:
+  modules:
+    - M-PROPS-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added criteria-level props watcher run-handle binding test mapping for `C-PROPS-0013`.
+tags:
+  - props
+  - contract-test
+  - runtime
+  - run-handle

--- a/spec/tests/T-PROPS-0010.yaml
+++ b/spec/tests/T-PROPS-0010.yaml
@@ -1,0 +1,155 @@
+id: T-PROPS-0010
+type: test
+title: Props API surface tests
+status: active
+since: 0.1.0
+summary: Tests and checks that verify the Props API surface is split between setup-time `def.props` entries and runtime `run.props` read entries.
+cases:
+  - id: T-PROPS-0010-CASE-DEFINE-SURFACE
+    title: '`def.props.define(decl)` exposes setup-time declaration'
+    covers:
+      - C-PROPS-0002-A
+    expectation: def-props-define-setup-surface-exists
+  - id: T-PROPS-0010-CASE-DEFAULTS-SURFACE
+    title: '`def.props.setDefaults(partialDefaults)` exposes setup-time defaults planning'
+    covers:
+      - C-PROPS-0002-B
+    expectation: def-props-set-defaults-setup-surface-exists
+  - id: T-PROPS-0010-CASE-RESOLVED-WATCHER-SURFACE
+    title: '`def.props.watch` and `def.props.watchAll` expose resolved watcher registration'
+    covers:
+      - C-PROPS-0002-C
+    expectation: def-props-resolved-watchers-setup-surface-exists
+  - id: T-PROPS-0010-CASE-RAW-WATCHER-SURFACE
+    title: '`def.props.watchRaw` and `def.props.watchRawAll` expose raw watcher registration'
+    covers:
+      - C-PROPS-0002-D
+    expectation: def-props-raw-watchers-setup-surface-exists
+  - id: T-PROPS-0010-CASE-RUNTIME-READ-SURFACE
+    title: '`run.props.get`, `getRaw`, and `isProvided` expose runtime read access'
+    covers:
+      - C-PROPS-0002-E
+    expectation: run-props-read-surface-exists
+  - id: T-PROPS-0010-CASE-PHASE-SEPARATION
+    title: Props setup APIs and runtime read APIs remain phase-separated
+    covers:
+      - C-PROPS-0002-F
+    expectation: def-props-setup-only-run-props-read-only
+implementations:
+  - id: type-core-props-handle-surface
+    kind: workspace-check
+    status: passing
+    path: packages/core/src/handles.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0010-CASE-DEFINE-SURFACE
+      - T-PROPS-0010-CASE-DEFAULTS-SURFACE
+      - T-PROPS-0010-CASE-RESOLVED-WATCHER-SURFACE
+      - T-PROPS-0010-CASE-RAW-WATCHER-SURFACE
+      - T-PROPS-0010-CASE-RUNTIME-READ-SURFACE
+      - T-PROPS-0010-CASE-PHASE-SEPARATION
+    exercises:
+      - C-CORE-SYNTAX-0001
+      - C-CORE-SYNTAX-0002
+    notes:
+      - Core handle types define the public `def.props` and `run.props` surface split.
+  - id: module-props-define-shape-surface
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/define-merge.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0010-CASE-DEFINE-SURFACE
+    exercises:
+      - C-PROPS-0006
+      - C-PROPS-0007
+    notes:
+      - Supporting module coverage for the declaration entrypoint behind `def.props.define`.
+  - id: module-props-defaults-surface
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/fallback-resolution.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0010-CASE-DEFAULTS-SURFACE
+    exercises:
+      - C-PROPS-0009
+    notes:
+      - Supporting module coverage for `setDefaults` as a fallback candidate source.
+  - id: module-props-resolved-watcher-surface
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/resolved-watchers.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0010-CASE-RESOLVED-WATCHER-SURFACE
+      - T-PROPS-0010-CASE-PHASE-SEPARATION
+    exercises:
+      - C-PROPS-0011
+    notes:
+      - Supporting module coverage for resolved watcher registration and setup-only guards.
+  - id: module-props-raw-watcher-surface
+    kind: module-test
+    status: passing
+    path: packages/modules/props/test/contract/watch-raw.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0010-CASE-RAW-WATCHER-SURFACE
+    exercises:
+      - C-PROPS-0012
+    notes:
+      - Supporting module coverage for raw watcher registration.
+  - id: runtime-run-props-read-surface
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/run-props-wiring.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0010-CASE-RUNTIME-READ-SURFACE
+      - T-PROPS-0010-CASE-PHASE-SEPARATION
+    exercises:
+      - C-PROPS-0008
+      - C-PROPS-0012
+      - C-PROPS-0013
+    notes:
+      - Runtime test asserts callback-time `run.props.get`, `getRaw`, and `isProvided` exist and align with watcher payloads.
+verifies:
+  contracts:
+    - id: C-PROPS-0002
+      anchors:
+        - C-PROPS-0002-A
+        - C-PROPS-0002-B
+        - C-PROPS-0002-C
+        - C-PROPS-0002-D
+        - C-PROPS-0002-E
+        - C-PROPS-0002-F
+exercises:
+  contracts:
+    - id: C-CORE-SYNTAX-0001
+      role: phase-boundary
+      coverageImpact: exercises-test-surface
+      note: '`def.props.*` exists because setup capabilities are carried by the definition handle.'
+    - id: C-CORE-SYNTAX-0002
+      role: phase-boundary
+      coverageImpact: exercises-test-surface
+      note: '`run.props.*` exists because runtime capabilities are carried by the run handle.'
+    - id: C-PROPS-0008
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: '`run.props.get()` exposes resolved snapshot access.'
+    - id: C-PROPS-0012
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: '`run.props.getRaw()` and raw watcher registration expose the raw escape hatch.'
+relates:
+  modules:
+    - M-PROPS-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added criteria-level Props API surface mapping for `C-PROPS-0002`.
+tags:
+  - props
+  - contract-test
+  - api
+  - surface

--- a/spec/tests/T-PROPS-0011.yaml
+++ b/spec/tests/T-PROPS-0011.yaml
@@ -1,0 +1,98 @@
+id: T-PROPS-0011
+type: test
+title: Runtime applyRawProps boundary tests
+status: active
+since: 0.1.0
+summary: Tests that verify `controller.applyRawProps(nextRaw)` applies raw props, dispatches props watchers, and does not implicitly trigger render commit.
+cases:
+  - id: T-PROPS-0011-CASE-CONTROLLER-ACTION
+    title: '`applyRawProps` is a runtime controller action'
+    covers:
+      - C-PROPS-0014-A
+    expectation: controller-action-not-prototype-author-api
+  - id: T-PROPS-0011-CASE-APPLIES-RAW-SNAPSHOT
+    title: '`applyRawProps(nextRaw)` applies a new raw props snapshot'
+    covers:
+      - C-PROPS-0014-B
+    expectation: next-raw-snapshot-is-applied-to-props-channel
+  - id: T-PROPS-0011-CASE-DISPATCHES-WATCHERS
+    title: '`applyRawProps` dispatches matching props watchers'
+    covers:
+      - C-PROPS-0014-C
+    expectation: matching-raw-or-resolved-watchers-fire
+  - id: T-PROPS-0011-CASE-RUN-HANDLE-BINDING
+    title: '`applyRawProps` watcher callbacks receive bound `run handle`'
+    covers:
+      - C-PROPS-0014-D
+    expectation: watcher-callback-run-handle-follows-current-dispatch-window
+  - id: T-PROPS-0011-CASE-NO-IMPLICIT-COMMIT
+    title: '`applyRawProps` does not implicitly commit or render'
+    covers:
+      - C-PROPS-0014-E
+    expectation: no-render-commit-from-apply-raw-props-itself
+implementations:
+  - id: runtime-props-integration-apply-raw-props
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/props-integration.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-PROPS-0011-CASE-CONTROLLER-ACTION
+      - T-PROPS-0011-CASE-APPLIES-RAW-SNAPSHOT
+      - T-PROPS-0011-CASE-DISPATCHES-WATCHERS
+      - T-PROPS-0011-CASE-NO-IMPLICIT-COMMIT
+    exercises:
+      - C-PROPS-0011
+      - C-PROPS-0013
+    notes:
+      - '`PROP-RT-0400` asserts `controller.applyRawProps()` fires the matching watcher and does not add a render commit.'
+  - id: runtime-run-props-wiring-apply-raw-props
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/run-props-wiring.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-PROPS-0011-CASE-APPLIES-RAW-SNAPSHOT
+      - T-PROPS-0011-CASE-DISPATCHES-WATCHERS
+      - T-PROPS-0011-CASE-RUN-HANDLE-BINDING
+    exercises:
+      - C-PROPS-0011
+      - C-PROPS-0012
+      - C-PROPS-0013
+    notes:
+      - Supporting runtime coverage verifies `applyRawProps()`-triggered resolved/raw watcher callbacks observe matching `run.props.*` state.
+verifies:
+  contracts:
+    - id: C-PROPS-0014
+      anchors:
+        - C-PROPS-0014-A
+        - C-PROPS-0014-B
+        - C-PROPS-0014-C
+        - C-PROPS-0014-D
+        - C-PROPS-0014-E
+exercises:
+  contracts:
+    - id: C-PROPS-0011
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Resolved watcher rules determine whether an `applyRawProps()` call dispatches resolved callbacks.
+    - id: C-PROPS-0012
+      role: test-surface
+      coverageImpact: exercises-test-surface
+      note: Raw watcher rules determine whether an `applyRawProps()` call dispatches raw callbacks.
+    - id: C-PROPS-0013
+      role: phase-boundary
+      coverageImpact: exercises-test-surface
+      note: Watcher callbacks triggered by `applyRawProps()` still rely on runtime `run handle` binding.
+relates:
+  modules:
+    - M-PROPS-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added criteria-level runtime `applyRawProps` test mapping for `C-PROPS-0014`.
+tags:
+  - props
+  - contract-test
+  - runtime
+  - scheduling


### PR DESCRIPTION
## 概要

这个 PR 引入了 Proto UI Semantic Workspace 的第一个可用版本，并选择 Props 作为第一条契约治理切片。

它在 `spec/` 和 `packages/spec/*` 下建立了结构化 spec 系统，新增了一个基于 React/Vite 的 Workspace 应用，用于浏览实体、关系、覆盖情况、断口和测试映射；同时补充了一组 Props 契约实体，将既有哲学、旧契约文档与真实的 module、runtime、adapter 测试连接起来。

## 主要变更

- 新增 `apps/workspace`，作为 Proto UI spec 实体的可视化工作台。
- 新增 private spec packages：
  - `@proto.ui/spec-schema`
  - `@proto.ui/spec-engine`
  - `@proto.ui/spec-graph`
  - `@proto.ui/spec-fixtures`
- 新增结构化 Props 契约 `C-PROPS-0001` 到 `C-PROPS-0014`。
- 新增 Props 测试实体 `T-PROPS-0001` 到 `T-PROPS-0011`。
- 将契约 criteria 映射到真实的 module/runtime/adapter 测试。
- 新增 JSON props value 和 resolved snapshot 行为的共享 fixtures 与 conformance helpers。
- 新增 focused Props module tests，覆盖 fallback、resolved snapshot shape、resolved watchers、raw watchers、declaration shape 和 merge safety。
- 新增 React、Vue、Web Component adapter 的 Props 行为 conformance 覆盖。
- 明确 Props enum declaration 采用 `type: "enum"` 加必填 `options` 的形状。
- 更新 release scan governance，使 private spec packages 不再被 package release 要求拦截。
- 新增阶段计划文档，记录当前 Workspace 里程碑与后续治理目标。

## Props 契约覆盖

这个 PR 收口了第一轮主要 Props 治理切片：

- JSON value boundary
- per-key semantic state classification
- declaration descriptor shape
- declaration merge safety
- failed merge atomicity
- resolved snapshot shape
- fallback behavior
- resolved watchers
- raw props escape hatch
- watcher `run handle` binding
- Props API surface
- `controller.applyRawProps` runtime boundary

已知剩余断口已通过 open questions 记录，尤其是未来需要补充 core runtime/update contracts，用于承接 `run.update()` 与 render commit scheduling 的正向规则。

## 验证

- Workspace spec dataset generation 通过。
- Focused Props module/runtime tests 通过。
- 已为新的共享 Props fixtures 增加 adapter conformance tests。
- Workspace type check 通过。


## Summary

This PR introduces the first usable version of Proto UI Semantic Workspace and uses Props as the initial contract-governance slice.

It adds a structured spec system under `spec/` and `packages/spec/*`, a React/Vite workspace app for browsing entities, relations, coverage, open questions, and test mappings, and a set of Props contract entities that connect existing philosophy/contracts to concrete module, runtime, and adapter tests.

## What Changed

- Added `apps/workspace` as the visual workspace for Proto UI spec entities.
- Added private spec packages:
  - `@proto.ui/spec-schema`
  - `@proto.ui/spec-engine`
  - `@proto.ui/spec-graph`
  - `@proto.ui/spec-fixtures`
- Added structured Props contracts `C-PROPS-0001` through `C-PROPS-0014`.
- Added Props test entities `T-PROPS-0001` through `T-PROPS-0011`.
- Mapped contract criteria to real module/runtime/adapter tests.
- Added shared fixtures and conformance helpers for JSON props values and resolved snapshot behavior.
- Added focused Props module tests for fallback, resolved snapshot shape, resolved watchers, raw watchers, declaration shape, and merge safety.
- Added adapter conformance coverage for React, Vue, and Web Component props behavior.
- Clarified Props enum declarations as `type: "enum"` plus required `options`.
- Updated release scan governance so private spec packages are excluded from package release requirements.
- Added a phase plan documenting the current Workspace milestone and next governance targets.

## Props Contract Coverage

This PR closes the first major Props governance slice:

- JSON value boundary
- per-key semantic state classification
- declaration descriptor shape
- declaration merge safety
- failed merge atomicity
- resolved snapshot shape
- fallback behavior
- resolved watchers
- raw props escape hatch
- watcher `run handle` binding
- Props API surface
- `controller.applyRawProps` runtime boundary

Known remaining gaps are documented as open questions, especially around future core runtime/update contracts for `run.update()` and render commit scheduling.

## Validation

- Workspace spec dataset generation passes.
- Focused Props module/runtime tests pass.
- Adapter conformance tests were added for the new shared props fixtures.
- Workspace type check passes.