### PR TITLE
feat(workspace): Lifecycle 相关旧契约梳理

### DIFF
--- a/internal/records/2026-05-22-spec-entity-scope-governance.zh-CN.md
+++ b/internal/records/2026-05-22-spec-entity-scope-governance.zh-CN.md
@@ -1,0 +1,291 @@
+# 2026-05-22 spec 实体类型与 scope 治理记录
+
+> Internal record. Not normative. 本文记录一次关于 Adapter、Compiler、Prototype interaction 约束如何进入 spec 体系的日常工程讨论。它包含临时判断、候选方案与后续 todo，不等同于 `spec/decisions/D-*` 决策实体。
+
+---
+
+## 1）背景
+
+当前 spec 体系已经有较稳定的实体类型，例如：
+
+- `contract`
+- `module`
+- `test`
+- `decision`
+- `host-cap`
+- `knowledge`
+
+在整理 lifecycle 契约时，出现了一个新的治理问题：
+
+- core lifecycle 只定义通用 runtime 顺序与 checkpoint。
+- Adapter 需要把具体 host 生命周期映射到这些 core lifecycle 语义。
+- Compiler 虽然不是 v0 正式发布目标，但在 Proto UI 的哲学模型中与 Adapter 一样，都是 translation layer 的工程落地方式。
+- 官方原型库中的每个 prototype 也会有独立交互规范，约束某个组件该有哪些交互、不该有哪些交互；这类规范与 translation layer 独立演进，更接近 component / interaction layer。
+
+因此需要判断：
+
+1. Adapter / Compiler 是否需要独立实体类型？
+2. 官方 prototype interaction 规范是否需要独立实体类型？
+3. 哪些内容应进入 spec `D-*` 决策，哪些只适合放在 `internal/records`？
+
+---
+
+## 2）当前记录形式判断
+
+本次讨论暂时放在 `internal/records`，而不是直接进入 spec。
+
+原因：
+
+- 讨论仍夹杂候选方向、决策倾向和 todo。
+- 相关 schema 变更尚未实施。
+- 还没有与其他维护者完成正式同步。
+- 它会影响 spec 信息架构，但尚未形成稳定的 normative 约束。
+
+`internal/records` 的定位适合这类内容：
+
+- 记录为什么这样想；
+- 保留备选方案；
+- 明确哪些点还没定；
+- 为未来升级为正式 spec 决策提供材料。
+
+当某个判断稳定后，应再拆分进入：
+
+- `D-*`：记录核心治理决策；
+- `K-*`：记录概念模型或哲学分类；
+- schema 变更：新增实体类型、关系类型或字段；
+- `C-*`：记录 normative contract；
+- `T-*`：记录对应测试与 conformance mapping。
+
+---
+
+## 3）Adapter 与 Compiler 的候选定位
+
+### 3.1 Translation layer 的共同地位
+
+Adapter 与 Compiler 在 Proto UI 的哲学模型中都属于 translation layer：
+
+- Adapter：把 Proto UI runtime/prototype 语义翻译到某个 host runtime 或平台中。
+- Compiler：把 Proto UI prototype 语义编译到目标代码、目标 runtime 或目标平台结构中。
+
+二者是同一类抽象地位的不同工程落地方式。
+
+但在 v0 中：
+
+- Adapter 是真实发布与测试范围。
+- Compiler 不会作为正式发布能力进入 v0。
+
+因此短期不宜让 compiler 过早承担完整 spec 治理负担。
+
+### 3.2 Adapter 是否应是独立实体类型
+
+当前倾向：应预留或新增独立 `adapter` 实体类型。
+
+理由：
+
+- Adapter 不是一条 contract，而是被 contract 约束的工程身份。
+- 同样是 React，不同 React 主版本可以有不同 adapter profile。
+- `React 15 adapter` 与 `React 19 adapter` 可能共享一部分 baseline contract，但 host lifecycle、commit timing、props/event wiring、effect timing 等细节可能不同。
+- 测试、能力矩阵、deprecated/replacedBy、支持范围都需要一个稳定实体锚点。
+
+候选形式：
+
+- `A-WEB-COMPONENT-0001`
+- `A-REACT-19-0001`
+- `A-VUE-3-0001`
+
+这些实体表示 official adapter profile，而不是抽象 host 名称。
+
+### 3.3 Compiler 是否应是独立实体类型
+
+当前倾向：哲学上承认 compiler 与 adapter 同属 translation layer，但 v0 暂不急于新增 active compiler entity。
+
+较稳妥路径：
+
+1. 先用 `K-*` 记录 translation layer 的概念模型：Adapter 与 Compiler 是同一抽象地位下的两类实现路径。
+2. v0 只引入或预留 adapter profile 的工程治理。
+3. v1 compiler 主线启动时，再引入 compiler entity type。
+
+Compiler 前缀需另行讨论，因为 `C` 已用于 contract。候选可能是 `CMP` 或其他不冲突前缀。
+
+---
+
+## 4）Adapter 相关 contract 的层级建议
+
+如果引入 adapter entity，具体约束仍应主要使用 `contract` 实体表达。
+
+建议拆三层：
+
+### 4.1 Core contract
+
+例如：
+
+- `C-LIFECYCLE-0004`
+
+它只规定所有 runtime/adapter 必须保序映射到 canonical lifecycle checkpoint。
+
+它不关心 React、Vue、Web Component 的具体机制。
+
+### 4.2 Adapter baseline contract
+
+例如未来可能出现：
+
+- `C-ADAPTER-LIFECYCLE-0001`
+- `C-ADAPTER-PROPS-0001`
+- `C-ADAPTER-EVENT-0001`
+
+它们规定所有 Adapter profile 都应满足的翻译层基本规则。
+
+### 4.3 Adapter profile contract
+
+例如未来可能出现：
+
+- `C-ADAPTER-REACT-19-LIFECYCLE-0001`
+- `C-ADAPTER-VUE-3-PROPS-0001`
+- `C-ADAPTER-WEB-COMPONENT-EVENT-0001`
+
+它们描述某个 official adapter profile 的 host-specific 映射规则。
+
+这类 contract 比 core contract 更接近实例，但仍然不是一次构建产物；它是一个可版本化、可测试、可替换的 official profile 规范。
+
+---
+
+## 5）Prototype interaction 规范的候选定位
+
+### 5.1 问题
+
+官方 prototype library 中，每一个 prototype 都会对应一组交互约束。
+
+例如 Dialog 可能涉及：
+
+- 是否 modal；
+- focus trap；
+- Escape 行为；
+- outside interaction；
+- open/close state；
+- ARIA role 与属性；
+- 与其他 layer、portal、overlay 的交互。
+
+这些约束与 Adapter / Compiler 独立演进。
+
+它们更像 ARIA 那样的 interaction / component pattern 规范。
+
+### 5.2 是否应有独立实体类型
+
+当前倾向：应预留或新增 `prototype` 实体类型。
+
+理由：
+
+- Prototype 是被 contract 约束的官方原型身份。
+- 单纯使用 contract 无法稳定回答“Dialog 当前有哪些规范、测试、版本生命周期、替代关系”。
+- Prototype interaction 规范不是 runtime core，也不是 adapter/compiler translation layer。
+- 它需要独立承载 deprecated、replacedBy、支持矩阵、测试聚合等信息。
+
+候选形式：
+
+- `P-DIALOG-0001`
+- `P-DROPDOWN-MENU-0001`
+- `P-TOOLTIP-0001`
+
+这些实体表示 official prototype identity，而不是某条具体交互规则。
+
+### 5.3 Prototype contract 的形式
+
+具体约束仍应使用 `contract`：
+
+- `C-DIALOG-INTERACTION-0001`
+- `C-DIALOG-FOCUS-0001`
+- `C-DIALOG-KEYBOARD-0001`
+- `C-DIALOG-ARIA-0001`
+- `C-DROPDOWN-MENU-SELECTION-0001`
+
+这些 contract 通过关系指向对应 `prototype` entity。
+
+### 5.4 是否需要 interaction-pattern 实体
+
+暂不急于新增。
+
+共享交互模式可以先用：
+
+- `knowledge`
+- cross-prototype `contract`
+
+例如 modal pattern、roving tabindex pattern、composite widget navigation pattern。
+
+只有当共享 pattern 的数量和复用关系足够多，才考虑新增 `interaction-pattern` 或类似实体类型。
+
+---
+
+## 6）当前倾向性结论
+
+### 6.1 实体类型
+
+倾向预留：
+
+- `adapter`
+- `prototype`
+
+暂缓：
+
+- `compiler`
+- `interaction-pattern`
+
+### 6.2 Contract 的职责
+
+Contract 仍然表达 normative rule。
+
+新增实体类型只提供被约束对象的稳定身份锚点，不替代 contract。
+
+### 6.3 官方 Adapter 约束的地位
+
+官方 adapter 约束应定位为：
+
+> Official adapter profile 的规范。
+
+它不等同于 core protocol，也不等同于一次实现快照。
+
+### 6.4 官方 Prototype 约束的地位
+
+官方 prototype 约束应定位为：
+
+> Official prototype identity 的 component / interaction profile。
+
+它独立于 translation layer 演进，但会被 adapter/compiler 支持矩阵消费。
+
+---
+
+## 7）暂不解决的问题
+
+以下问题暂不在本记录中定案：
+
+- adapter entity 的具体 schema 字段。
+- prototype entity 的具体 schema 字段。
+- 是否立即修改 `packages/spec/schema`。
+- adapter / prototype 与 contract 的关系字段命名。
+- compiler entity type 的前缀。
+- interaction-pattern 是否最终需要独立实体。
+- workspace UI 如何展示 adapter/prototype 聚合视图。
+
+---
+
+## 8）后续动作建议
+
+1. 起草 `K-TRANSLATION-LAYER-0001`，记录 Adapter / Compiler 作为 translation layer 的概念地位。
+2. 起草 `K-PROTOTYPE-INTERACTION-PROFILE-0001`，记录 official prototype identity 与 interaction profile 的概念地位。
+3. 设计 schema 扩展草案：新增 `adapter`、`prototype` entity type，以及对应 ID prefix。
+4. 先选一个真实 profile 做试点：
+   - `A-WEB-COMPONENT-0001` 或 `A-REACT-19-0001`
+   - `P-DIALOG-0001` 或 `P-DROPDOWN-MENU-0001`
+5. 再决定是否将本记录中的稳定判断升级为 `D-*` 决策实体。
+
+---
+
+## 9）记录结论
+
+本记录不是最终 spec 决策。
+
+当前工作判断是：
+
+- 日常工程讨论、夹杂 todo 的治理想法，先放 `internal/records`。
+- 稳定且影响 schema 或长期治理边界的判断，再升级到 spec `D-*` / `K-*` / `C-*`。
+- Adapter 和 Prototype 都更适合作为独立实体锚点。
+- Compiler 的哲学地位先记录，v1 主线启动前不急于落 schema。

--- a/packages/adapters/base/src/host/adapter-host.ts
+++ b/packages/adapters/base/src/host/adapter-host.ts
@@ -12,7 +12,7 @@ export type AdapterHostHooks<P extends PropsBaseType> = {
 
 export type AdapterHostInput<P extends PropsBaseType> = Pick<
   RuntimeHost<P>,
-  'commit' | 'schedule' | 'getRawProps'
+  'commit' | 'schedule' | 'getRawProps' | 'onLifecycleCheckpoint'
 >;
 
 export type AdapterHostSession<P extends PropsBaseType> = {
@@ -35,6 +35,7 @@ export function createAdapterHost<P extends PropsBaseType>(
     getRawProps: host.getRawProps,
     commit: host.commit,
     schedule: host.schedule,
+    onLifecycleCheckpoint: host.onLifecycleCheckpoint,
     onRuntimeReady: hooks.onRuntimeReady,
     onUnmountBegin: hooks.onUnmountBegin,
   });

--- a/packages/adapters/react/src/adapt.ts
+++ b/packages/adapters/react/src/adapt.ts
@@ -1,5 +1,5 @@
 import type { Prototype } from '@proto.ui/core';
-import type { CommitSignal, RuntimeController } from '@proto.ui/runtime';
+import type { CommitSignal, RuntimeCheckpoint, RuntimeController } from '@proto.ui/runtime';
 import {
   createHostWiring,
   createEventGate,
@@ -54,6 +54,9 @@ export interface ReactAdapterOptions<Props extends PropsBaseType> {
   schedule?: (task: () => void) => void;
   getProps?: (props: ReactAdapterProps<Props>) => Partial<Props> | null | undefined;
   getMeta?: (key: string) => unknown;
+  diagnostics?: {
+    onLifecycleCheckpoint?: (cp: RuntimeCheckpoint) => void;
+  };
   exposeStateWebMode?: ExposeStateWebMode;
   autoUpdateOnPropsChange?: boolean;
   rootTag?: string;
@@ -265,6 +268,7 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
           wiring,
           eventGate,
           router,
+          onLifecycleCheckpoint: opt.diagnostics?.onLifecycleCheckpoint,
           onCommit: (children, signal) => {
             pendingCommitRef.current = true;
             pendingSignalRef.current = signal;

--- a/packages/adapters/react/src/runtime/session.ts
+++ b/packages/adapters/react/src/runtime/session.ts
@@ -1,5 +1,5 @@
 import { createAdapterHost, createHostWiring } from '@proto.ui/adapter-base';
-import type { CommitSignal } from '@proto.ui/runtime';
+import type { CommitSignal, RuntimeCheckpoint } from '@proto.ui/runtime';
 import type { Prototype } from '@proto.ui/core';
 import type { RawPropsSource } from '@proto.ui/module-props';
 import type { PropsBaseType } from '@proto.ui/types';
@@ -16,17 +16,28 @@ export function createReactHostSession<Props extends PropsBaseType>(args: {
   router: {
     dispose(): void;
   };
+  onLifecycleCheckpoint?: (cp: RuntimeCheckpoint) => void;
   onCommit: (children: any, signal: CommitSignal | null) => void;
   onAfterUnmount?: () => void;
 }) {
-  const { proto, schedule, rawPropsSource, wiring, eventGate, router, onCommit, onAfterUnmount } =
-    args;
+  const {
+    proto,
+    schedule,
+    rawPropsSource,
+    wiring,
+    eventGate,
+    router,
+    onLifecycleCheckpoint,
+    onCommit,
+    onAfterUnmount,
+  } = args;
 
   return createAdapterHost(
     proto,
     {
       getRawProps: () => rawPropsSource.get() as Readonly<Props & PropsBaseType>,
       schedule,
+      onLifecycleCheckpoint,
       commit: (children, signal) => {
         eventGate.disable();
         onCommit(children, signal ?? null);

--- a/packages/adapters/react/test/contract/lifecycle-checkpoints.v0.contract.test.ts
+++ b/packages/adapters/react/test/contract/lifecycle-checkpoints.v0.contract.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { Prototype } from '@proto.ui/core';
+import { CANONICAL_RUNTIME_CHECKPOINTS, type RuntimeCheckpoint } from '@proto.ui/runtime';
+
+import { createReactAdapter, type ReactAdapterHandle } from '../../src/adapt';
+import { createFakeReactRuntime } from '../utils/fake-react';
+
+describe('contract: adapter-react / lifecycle checkpoints (v0)', () => {
+  it('maps React host commits into canonical lifecycle checkpoints', () => {
+    const trace: RuntimeCheckpoint[] = [];
+    const callbacks: string[] = [];
+
+    const proto: Prototype = {
+      name: 'react-lifecycle-checkpoints',
+      setup(def) {
+        def.lifecycle.onCreated(() => callbacks.push('created'));
+        def.lifecycle.onMounted(() => callbacks.push('mounted'));
+        def.lifecycle.onUpdated(() => callbacks.push('updated'));
+        def.lifecycle.onUnmounted(() => callbacks.push('unmounted'));
+        return (r) => [r.el('div', 'ok')];
+      },
+    };
+
+    const fake = createFakeReactRuntime();
+    const adapter = createReactAdapter(fake.runtime);
+    const Component = adapter(proto, {
+      schedule: (task) => task(),
+      autoUpdateOnPropsChange: false,
+      diagnostics: {
+        onLifecycleCheckpoint: (cp) => trace.push(cp),
+      },
+    });
+
+    const mounted = fake.render(Component);
+
+    expect(trace).toEqual([
+      'CP0_SETUP_EXIT',
+      'CP1_CREATED_CALLBACKS',
+      'CP2_LOGICAL_TREE_READY',
+      'CP3_COMMIT_START',
+      'CP4_COMMIT_DONE',
+      'CP5_MOUNTED_CALLBACKS',
+    ]);
+    expect(callbacks).toEqual(['created', 'mounted']);
+    expect(trace.every((cp) => CANONICAL_RUNTIME_CHECKPOINTS.includes(cp))).toBe(true);
+
+    trace.length = 0;
+
+    (mounted.ref.current as ReactAdapterHandle).update();
+
+    expect(trace).toEqual(['CP6_UPDATE_RENDER']);
+    expect(callbacks).toEqual(['created', 'mounted']);
+
+    mounted.update();
+
+    expect(trace).toEqual(['CP6_UPDATE_RENDER', 'CP7_UPDATE_COMMIT_DONE', 'CP8_UPDATED_CALLBACKS']);
+    expect(callbacks).toEqual(['created', 'mounted', 'updated']);
+
+    trace.length = 0;
+    mounted.unmount();
+
+    expect(trace).toEqual(['CP9_UNMOUNT_BEGIN', 'CP10_DISPOSE_COMPLETE']);
+    expect(callbacks).toEqual(['created', 'mounted', 'updated', 'unmounted']);
+  });
+});

--- a/packages/adapters/react/test/utils/fake-react.ts
+++ b/packages/adapters/react/test/utils/fake-react.ts
@@ -21,6 +21,7 @@ type HookInstance = {
 let CURRENT: HookInstance | null = null;
 const OWNED_STYLE_KEYS = new WeakMap<HTMLElement, Set<string>>();
 const OWNED_ATTR_KEYS = new WeakMap<HTMLElement, Set<string>>();
+const WRAPPED_UPDATE = Symbol('fake-react-wrapped-update');
 
 export function createFakeReactRuntime() {
   const runtime: ReactRuntime = {
@@ -140,13 +141,7 @@ export function createMountedReactAdapter(
     ...(options as any),
   } as any);
   const mounted = fake.render(Component, props);
-  if (mounted.ref?.current && typeof mounted.ref.current.update === 'function') {
-    const rawUpdate = mounted.ref.current.update.bind(mounted.ref.current);
-    mounted.ref.current.update = () => {
-      rawUpdate();
-      mounted.update();
-    };
-  }
+  wrapAdapterUpdate(mounted);
   return { ...mounted, runtime: fake.runtime, Component };
 }
 
@@ -163,14 +158,30 @@ export function createMountedReactAdapterInto(
     ...(options as any),
   } as any);
   const mounted = fake.render(Component, props, { current: null }, hostEl);
-  if (mounted.ref?.current && typeof mounted.ref.current.update === 'function') {
-    const rawUpdate = mounted.ref.current.update.bind(mounted.ref.current);
-    mounted.ref.current.update = () => {
-      rawUpdate();
-      mounted.update();
-    };
-  }
+  wrapAdapterUpdate(mounted);
   return { ...mounted, runtime: fake.runtime, Component };
+}
+
+function wrapAdapterUpdate(
+  mounted: ReturnType<ReturnType<typeof createFakeReactRuntime>['render']>
+) {
+  const handle = mounted.ref?.current as
+    | {
+        update?: () => void;
+        [WRAPPED_UPDATE]?: true;
+      }
+    | null
+    | undefined;
+
+  if (!handle || typeof handle.update !== 'function' || handle[WRAPPED_UPDATE]) return;
+
+  const rawUpdate = handle.update.bind(handle);
+  handle.update = () => {
+    rawUpdate();
+    mounted.update();
+    wrapAdapterUpdate(mounted);
+  };
+  handle[WRAPPED_UPDATE] = true;
 }
 
 function runInstance(inst: HookInstance) {

--- a/packages/adapters/vue/src/adapt.ts
+++ b/packages/adapters/vue/src/adapt.ts
@@ -1,5 +1,5 @@
 import type { Prototype } from '@proto.ui/core';
-import type { CommitSignal, RuntimeController } from '@proto.ui/runtime';
+import type { CommitSignal, RuntimeCheckpoint, RuntimeController } from '@proto.ui/runtime';
 import {
   createHostWiring,
   createEventGate,
@@ -54,6 +54,9 @@ export interface VueAdapterOptions<Props extends PropsBaseType> {
   schedule?: (task: () => void) => void;
   getProps?: (props: VueAdapterProps<Props>) => Partial<Props> | null | undefined;
   getMeta?: (key: string) => unknown;
+  diagnostics?: {
+    onLifecycleCheckpoint?: (cp: RuntimeCheckpoint) => void;
+  };
   exposeStateWebMode?: ExposeStateWebMode;
   autoUpdateOnPropsChange?: boolean;
   rootTag?: string;
@@ -321,6 +324,7 @@ export function createVueAdapter(runtime: VueRuntime) {
             wiring,
             eventGate,
             router,
+            onLifecycleCheckpoint: opt.diagnostics?.onLifecycleCheckpoint,
             onCommit: (children, signal) => {
               pendingCommit = true;
               pendingSignal = signal;

--- a/packages/adapters/vue/src/runtime/session.ts
+++ b/packages/adapters/vue/src/runtime/session.ts
@@ -1,5 +1,5 @@
 import { createAdapterHost, createHostWiring } from '@proto.ui/adapter-base';
-import type { CommitSignal } from '@proto.ui/runtime';
+import type { CommitSignal, RuntimeCheckpoint } from '@proto.ui/runtime';
 import type { Prototype } from '@proto.ui/core';
 import type { RawPropsSource } from '@proto.ui/module-props';
 import type { PropsBaseType } from '@proto.ui/types';
@@ -16,17 +16,28 @@ export function createVueHostSession<Props extends PropsBaseType>(args: {
   router: {
     dispose(): void;
   };
+  onLifecycleCheckpoint?: (cp: RuntimeCheckpoint) => void;
   onCommit: (children: any, signal: CommitSignal | null) => void;
   onAfterUnmount?: () => void;
 }) {
-  const { proto, schedule, rawPropsSource, wiring, eventGate, router, onCommit, onAfterUnmount } =
-    args;
+  const {
+    proto,
+    schedule,
+    rawPropsSource,
+    wiring,
+    eventGate,
+    router,
+    onLifecycleCheckpoint,
+    onCommit,
+    onAfterUnmount,
+  } = args;
 
   return createAdapterHost(
     proto,
     {
       getRawProps: () => rawPropsSource.get() as Readonly<Props & PropsBaseType>,
       schedule,
+      onLifecycleCheckpoint,
       commit: (children, signal) => {
         eventGate.disable();
         onCommit(children, signal ?? null);

--- a/packages/adapters/vue/test/contract/lifecycle-checkpoints.v0.contract.test.ts
+++ b/packages/adapters/vue/test/contract/lifecycle-checkpoints.v0.contract.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { Prototype } from '@proto.ui/core';
+import { CANONICAL_RUNTIME_CHECKPOINTS, type RuntimeCheckpoint } from '@proto.ui/runtime';
+
+import { createVueAdapter, type VueAdapterHandle } from '../../src/adapt';
+import { flushVue, mountVueAdapter, VueAny } from '../utils/vue';
+
+describe('contract: adapter-vue / lifecycle checkpoints (v0)', () => {
+  it('maps Vue host commits into canonical lifecycle checkpoints', async () => {
+    const trace: RuntimeCheckpoint[] = [];
+    const callbacks: string[] = [];
+
+    const proto: Prototype = {
+      name: 'vue-lifecycle-checkpoints',
+      setup(def) {
+        def.lifecycle.onCreated(() => callbacks.push('created'));
+        def.lifecycle.onMounted(() => callbacks.push('mounted'));
+        def.lifecycle.onUpdated(() => callbacks.push('updated'));
+        def.lifecycle.onUnmounted(() => callbacks.push('unmounted'));
+        return (r) => [r.el('div', 'ok')];
+      },
+    };
+
+    const adapter = createVueAdapter(VueAny);
+    const Component = adapter(proto, {
+      schedule: (task) => task(),
+      diagnostics: {
+        onLifecycleCheckpoint: (cp) => trace.push(cp),
+      },
+    });
+
+    const mounted = mountVueAdapter(Component);
+    await flushVue();
+
+    expect(trace).toEqual([
+      'CP0_SETUP_EXIT',
+      'CP1_CREATED_CALLBACKS',
+      'CP2_LOGICAL_TREE_READY',
+      'CP3_COMMIT_START',
+      'CP4_COMMIT_DONE',
+      'CP5_MOUNTED_CALLBACKS',
+    ]);
+    expect(callbacks).toEqual(['created', 'mounted']);
+    expect(trace.every((cp) => CANONICAL_RUNTIME_CHECKPOINTS.includes(cp))).toBe(true);
+
+    trace.length = 0;
+
+    (mounted.vm as VueAdapterHandle).update();
+
+    expect(trace).toEqual(['CP6_UPDATE_RENDER']);
+    expect(callbacks).toEqual(['created', 'mounted']);
+
+    await flushVue();
+
+    expect(trace).toEqual(['CP6_UPDATE_RENDER', 'CP7_UPDATE_COMMIT_DONE', 'CP8_UPDATED_CALLBACKS']);
+    expect(callbacks).toEqual(['created', 'mounted', 'updated']);
+
+    trace.length = 0;
+    mounted.unmount();
+    await flushVue();
+
+    expect(trace).toEqual(['CP9_UNMOUNT_BEGIN', 'CP10_DISPOSE_COMPLETE']);
+    expect(callbacks).toEqual(['created', 'mounted', 'updated', 'unmounted']);
+  });
+});

--- a/packages/adapters/web-component/src/adapt.ts
+++ b/packages/adapters/web-component/src/adapt.ts
@@ -25,7 +25,7 @@ import { markProtoInstance } from './platform/instance-tree';
 import { createWebEffectsPort } from './runtime/effects-port';
 import { createWebComponentModules } from './runtime/modules';
 import { createWebComponentHostSession } from './runtime/session';
-import type { RuntimeController } from '@proto.ui/runtime';
+import type { RuntimeCheckpoint, RuntimeController } from '@proto.ui/runtime';
 
 export { __WC_DEBUG_SYS } from './debug/hooks';
 
@@ -42,6 +42,9 @@ export interface WebComponentAdapterOptions<Props extends PropsBaseType = PropsB
   getProps?: (el: HTMLElement) => Partial<Props> | null | undefined;
   schedule?: (task: () => void) => void;
   getMeta?: (key: string) => unknown;
+  diagnostics?: {
+    onLifecycleCheckpoint?: (cp: RuntimeCheckpoint) => void;
+  };
   exposeStateWebMode?: {
     allowContinuousAttr?: boolean;
     allowStringVar?: boolean;
@@ -213,6 +216,7 @@ export function AdaptToWebComponent<Props extends PropsBaseType>(
         wiring,
         eventGate,
         router,
+        onLifecycleCheckpoint: opt.diagnostics?.onLifecycleCheckpoint,
         getSlotProjector: () => this._slotProjector,
         ensureSlotProjector: () => {
           if (!this._slotProjector) this._slotProjector = new SlotProjector(thisEl);

--- a/packages/adapters/web-component/src/runtime/session.ts
+++ b/packages/adapters/web-component/src/runtime/session.ts
@@ -1,6 +1,7 @@
 import { createAdapterHost, createHostWiring } from '@proto.ui/adapter-base';
 import type { Prototype, TemplateChildren } from '@proto.ui/core';
 import { type RawPropsSource } from '@proto.ui/module-props';
+import type { RuntimeCheckpoint } from '@proto.ui/runtime';
 import { type PropsBaseType } from '@proto.ui/types';
 
 import { commitChildren } from '../commit';
@@ -23,6 +24,7 @@ export function createWebComponentHostSession<Props extends PropsBaseType>(args:
   router: {
     dispose(): void;
   };
+  onLifecycleCheckpoint?: (cp: RuntimeCheckpoint) => void;
   getSlotProjector: () => SlotProjector | null;
   ensureSlotProjector: () => SlotProjector;
   clearSlotProjector: () => void;
@@ -39,6 +41,7 @@ export function createWebComponentHostSession<Props extends PropsBaseType>(args:
     wiring,
     eventGate,
     router,
+    onLifecycleCheckpoint,
     getSlotProjector,
     ensureSlotProjector,
     clearSlotProjector,
@@ -52,6 +55,7 @@ export function createWebComponentHostSession<Props extends PropsBaseType>(args:
     {
       getRawProps: () => rawPropsSource.get() as Readonly<Props & PropsBaseType>,
       schedule,
+      onLifecycleCheckpoint,
       commit: (children, signal) => {
         commitWebComponentChildren({
           root,

--- a/packages/adapters/web-component/test/contract/lifecycle-checkpoints.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/lifecycle-checkpoints.v0.contract.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { Prototype } from '@proto.ui/core';
+import { CANONICAL_RUNTIME_CHECKPOINTS, type RuntimeCheckpoint } from '@proto.ui/runtime';
+
+import { AdaptToWebComponent, type WebComponentAdapterElement } from '../../src/adapt';
+
+async function flushWebComponentAdapter() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('contract: adapter-web-component / lifecycle checkpoints (v0)', () => {
+  it('maps Web Component host commits into canonical lifecycle checkpoints', async () => {
+    const trace: RuntimeCheckpoint[] = [];
+    const callbacks: string[] = [];
+
+    const proto: Prototype = {
+      name: 'x-wc-lifecycle-checkpoints',
+      setup(def) {
+        def.lifecycle.onCreated(() => callbacks.push('created'));
+        def.lifecycle.onMounted(() => callbacks.push('mounted'));
+        def.lifecycle.onUpdated(() => callbacks.push('updated'));
+        def.lifecycle.onUnmounted(() => callbacks.push('unmounted'));
+        return (r) => [r.el('div', 'ok')];
+      },
+    };
+
+    const Ctor = AdaptToWebComponent(proto, {
+      register: false,
+      registerAs: proto.name,
+      diagnostics: {
+        onLifecycleCheckpoint: (cp) => trace.push(cp),
+      },
+    });
+
+    if (!customElements.get(proto.name)) {
+      customElements.define(proto.name, Ctor);
+    }
+
+    const el = document.createElement(proto.name) as WebComponentAdapterElement;
+    document.body.appendChild(el);
+    await flushWebComponentAdapter();
+
+    expect(trace).toEqual([
+      'CP0_SETUP_EXIT',
+      'CP1_CREATED_CALLBACKS',
+      'CP2_LOGICAL_TREE_READY',
+      'CP3_COMMIT_START',
+      'CP4_COMMIT_DONE',
+      'CP5_MOUNTED_CALLBACKS',
+    ]);
+    expect(callbacks).toEqual(['created', 'mounted']);
+    expect(trace.every((cp) => CANONICAL_RUNTIME_CHECKPOINTS.includes(cp))).toBe(true);
+
+    trace.length = 0;
+
+    el.update();
+
+    expect(trace).toEqual(['CP6_UPDATE_RENDER', 'CP7_UPDATE_COMMIT_DONE', 'CP8_UPDATED_CALLBACKS']);
+    expect(callbacks).toEqual(['created', 'mounted', 'updated']);
+
+    trace.length = 0;
+    el.remove();
+    await flushWebComponentAdapter();
+
+    expect(trace).toEqual(['CP9_UNMOUNT_BEGIN', 'CP10_DISPOSE_COMPLETE']);
+    expect(callbacks).toEqual(['created', 'mounted', 'updated', 'unmounted']);
+  });
+});

--- a/packages/adapters/web-component/test/contract/template.adapter-boundary.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/template.adapter-boundary.v0.contract.test.ts
@@ -1,0 +1,73 @@
+import { TEMPLATE_AUTHORING_CASES } from '@proto.ui/spec-fixtures/template/authoring';
+import { asPrototypeRef } from '@proto.ui/core';
+import { describe, expect, it } from 'vitest';
+import { commitChildren, ERR_TEMPLATE_PROTOTYPE_REF_V0 } from '../../src/commit';
+
+function caseTitle(specCase: string, fallback: string): string {
+  return (
+    TEMPLATE_AUTHORING_CASES.find((testCase) => testCase.specCase === specCase)?.title ?? fallback
+  );
+}
+
+describe('contract: adapter-web-component / template adapter boundary fixture (v0)', () => {
+  it(
+    caseTitle(
+      'T-TEMPLATE-0001-CASE-ROOT-CHILDREN',
+      'template output materializes inside the host root'
+    ),
+    () => {
+      const host = document.createElement('x-template-root-boundary');
+
+      commitChildren(host, [
+        { type: 'span', children: 'a' },
+        { type: 'span', children: 'b' },
+      ] as any);
+
+      expect(host.outerHTML).toBe(
+        '<x-template-root-boundary><span>a</span><span>b</span></x-template-root-boundary>'
+      );
+    }
+  );
+
+  it(
+    caseTitle('T-TEMPLATE-0001-CASE-SLOT', 'slot is anonymous, singular, and parameterless'),
+    () => {
+      const host = document.createElement('div');
+      const slot = { type: { kind: 'slot' }, children: null } as any;
+
+      expect(() => commitChildren(host, [slot, slot] as any)).toThrow(/multiple slot/);
+      expect(() => commitChildren(host, { type: { kind: 'slot', name: 'named' } } as any)).toThrow(
+        /named slot/
+      );
+      expect(() =>
+        commitChildren(host, { type: { kind: 'slot' }, children: ['x'] } as any)
+      ).toThrow(/slot node must not have children/);
+      expect(() =>
+        commitChildren(host, { type: { kind: 'slot' }, style: { kind: 'tw', tokens: [] } } as any)
+      ).toThrow(/slot node must not have style/);
+    }
+  );
+
+  it(
+    caseTitle(
+      'T-TEMPLATE-0001-CASE-PROTOTYPE-REF',
+      'PrototypeRef template type is rejected by adapters'
+    ),
+    () => {
+      const proto = {
+        name: 'x-template-ref-target',
+        setup() {
+          return () => null;
+        },
+      } as any;
+
+      const host = document.createElement('div');
+      const bad = {
+        type: asPrototypeRef(proto),
+        children: null,
+      } as any;
+
+      expect(() => commitChildren(host, bad)).toThrowError(ERR_TEMPLATE_PROTOTYPE_REF_V0);
+    }
+  );
+});

--- a/packages/core/test/contract/prototype.definition.v0.contract.test.ts
+++ b/packages/core/test/contract/prototype.definition.v0.contract.test.ts
@@ -1,0 +1,26 @@
+import { PROTOTYPE_RENDER_SYNTAX_CASES } from '@proto.ui/spec-fixtures/core/prototype-render-syntax';
+import { definePrototype } from '../../src';
+import { describe, expect, it } from 'vitest';
+
+const DEFINITION_SHAPE_CASE = PROTOTYPE_RENDER_SYNTAX_CASES.find(
+  (testCase) => testCase.specCase === 'T-CORE-SYNTAX-0001-CASE-DEFINITION-SHAPE'
+);
+
+describe('contract: core / prototype definition syntax (v0)', () => {
+  it(DEFINITION_SHAPE_CASE?.title ?? 'prototype definitions require name and setup', () => {
+    expect(
+      definePrototype({
+        name: 'x-core-prototype-definition',
+        setup() {
+          return () => null;
+        },
+      })
+    ).toMatchObject({ name: 'x-core-prototype-definition' });
+
+    expect(() => definePrototype(null as any)).toThrow(/\[Prototype\] definePrototype/);
+    expect(() => definePrototype({ setup() {} } as any)).toThrow(/\[Prototype\] illegal name/);
+    expect(() => definePrototype({ name: 'x-missing-setup' } as any)).toThrow(
+      /\[Prototype\] setup must be a function/
+    );
+  });
+});

--- a/packages/core/test/contract/template.authoring-fixture.v0.contract.test.ts
+++ b/packages/core/test/contract/template.authoring-fixture.v0.contract.test.ts
@@ -1,0 +1,97 @@
+import { TEMPLATE_AUTHORING_CASES } from '@proto.ui/spec-fixtures/template/authoring';
+import {
+  createRendererPrimitives,
+  normalizeChildren,
+  tw,
+  type TemplateStyleHandle,
+} from '../../src';
+import { describe, expect, it } from 'vitest';
+
+function caseTitle(specCase: string, fallback: string): string {
+  return (
+    TEMPLATE_AUTHORING_CASES.find((testCase) => testCase.specCase === specCase)?.title ?? fallback
+  );
+}
+
+describe('contract: core / template authoring fixture (v0)', () => {
+  it(
+    caseTitle(
+      'T-TEMPLATE-0001-CASE-NODE-STRUCTURE',
+      'template node is structural and may carry children and style'
+    ),
+    () => {
+      const { el } = createRendererPrimitives();
+      const style = tw('inline-flex items-center') as TemplateStyleHandle;
+      const node = el('div', { style }, [el('span', 'child')]);
+
+      expect(node).toEqual({
+        type: 'div',
+        style,
+        children: { type: 'span', style: undefined, children: 'child' },
+      });
+      expect((node as any).props).toBeUndefined();
+      expect((node as any).event).toBeUndefined();
+      expect((node as any).state).toBeUndefined();
+    }
+  );
+
+  it(
+    caseTitle(
+      'T-TEMPLATE-0001-CASE-EL-DISPATCH',
+      'el dispatches children and style-only TemplateProps'
+    ),
+    () => {
+      const { el } = createRendererPrimitives();
+      const style = tw('text-sm') as TemplateStyleHandle;
+
+      expect(el('div')).toEqual({ type: 'div', style: undefined, children: null });
+      expect(el('div', {})).toEqual({ type: 'div', style: undefined, children: null });
+      expect(el('div', 'child')).toEqual({ type: 'div', style: undefined, children: 'child' });
+      expect(el('div', { style }, 'child')).toEqual({ type: 'div', style, children: 'child' });
+
+      expect(() => el('div', { id: 'x' } as any, 'child')).toThrow(/illegal template-props/);
+      expect(() => el('div', { style: { kind: 'not-style' } } as any, 'child')).toThrow(
+        /style must be a TemplateStyleHandle/
+      );
+    }
+  );
+
+  it(
+    caseTitle(
+      'T-TEMPLATE-0001-CASE-NORMALIZE',
+      'TemplateChildren normalization enforces v0 portability'
+    ),
+    () => {
+      const objectChild = { arbitrary: 'object' };
+
+      expect(normalizeChildren(undefined)).toBeNull();
+      expect(normalizeChildren(['a', null, ['b', ['c']]])).toEqual(['a', 'b', 'c']);
+      expect(normalizeChildren([null, null])).toBeNull();
+      expect(normalizeChildren(['single'])).toBe('single');
+      expect(normalizeChildren([objectChild])).toBe(objectChild);
+      expect(normalizeChildren(['a', null, 'b'], { keepNull: true })).toEqual(['a', null, 'b']);
+
+      expect(() => normalizeChildren([true as any])).toThrow(/boolean child is illegal/);
+      expect(() => normalizeChildren(['a', undefined as any])).toThrow(
+        /undefined child is illegal/
+      );
+      expect(() => normalizeChildren(['a'] as any, { flatten: 'none' })).toThrow(
+        /array children is not allowed/
+      );
+      expect(() => normalizeChildren(['a', ['b', ['c']]] as any, { flatten: 'shallow' })).toThrow(
+        /nested array children is not allowed/
+      );
+    }
+  );
+
+  it(
+    caseTitle('T-TEMPLATE-0001-CASE-SLOT', 'slot is anonymous, singular, and parameterless'),
+    () => {
+      const { r, slot } = createRendererPrimitives();
+
+      expect(slot()).toEqual({ type: { kind: 'slot' }, style: undefined, children: null });
+      expect(r.slot()).toEqual({ type: { kind: 'slot' }, style: undefined, children: null });
+      expect(() => (r as any).slot('name')).toThrow(/slot\(\) takes no arguments/);
+    }
+  );
+});

--- a/packages/runtime/src/instance/execute/with-host.ts
+++ b/packages/runtime/src/instance/execute/with-host.ts
@@ -15,7 +15,7 @@ export function executeWithHost<P extends PropsBaseType>(
   proto: Prototype<P>,
   host: RuntimeHost<P>
 ): ExecuteWithHostResult {
-  const timeline = createTimeline();
+  const timeline = createTimeline({ onMark: (cp) => host.onLifecycleCheckpoint?.(cp) });
 
   const inst = createRuntimeInstance(proto, {
     allowRunUpdate: true,
@@ -23,7 +23,7 @@ export function executeWithHost<P extends PropsBaseType>(
       host.onRuntimeReady?.(hub.getWiring());
     },
   });
-  inst.setTimeline(timeline);
+  timeline.mark('CP0_SETUP_EXIT');
 
   const { kernel, moduleHub, callbackScope } = inst;
   const { lifecycle, run } = kernel;
@@ -39,7 +39,6 @@ export function executeWithHost<P extends PropsBaseType>(
 
   // initial props hydration (before any callbacks + before initial render)
   propsPort.applyRaw({ ...(host.getRawProps?.() ?? {}) });
-  timeline.mark('host:ready');
 
   let ended = false;
 
@@ -48,8 +47,11 @@ export function executeWithHost<P extends PropsBaseType>(
     propsPort.syncFromHost();
 
     const children = inst.renderOnce();
+    timeline.mark(kind === 'initial' ? 'CP2_LOGICAL_TREE_READY' : 'CP6_UPDATE_RENDER');
 
-    timeline.mark('commit:begin');
+    if (kind === 'initial') {
+      timeline.mark('CP3_COMMIT_START');
+    }
 
     let commitDone = false;
     const afterCommit = () => {
@@ -57,9 +59,7 @@ export function executeWithHost<P extends PropsBaseType>(
       commitDone = true;
       if (ended) return;
 
-      timeline.mark('commit:done');
-
-      timeline.mark('instance:reachable');
+      timeline.mark(kind === 'initial' ? 'CP4_COMMIT_DONE' : 'CP7_UPDATE_COMMIT_DONE');
 
       // bind event dispatch
       const eventPort = moduleHub.getPort<EventPort>('event');
@@ -77,10 +77,10 @@ export function executeWithHost<P extends PropsBaseType>(
       }
 
       moduleHub.afterRenderCommit();
-      timeline.mark('afterRenderCommit');
 
       if (kind === 'update') {
         moduleHub.setProtoPhase('updated');
+        timeline.mark('CP8_UPDATED_CALLBACKS');
         // updated callbacks
         callbackScope.run(run, () => {
           for (const cb of lifecycle.updated) cb(run);
@@ -126,6 +126,7 @@ export function executeWithHost<P extends PropsBaseType>(
   (run as any).update = () => controller.update();
 
   // created callbacks: once, before first commit
+  timeline.mark('CP1_CREATED_CALLBACKS');
   callbackScope.run(run, () => {
     for (const cb of lifecycle.created) cb(run);
   });
@@ -135,11 +136,10 @@ export function executeWithHost<P extends PropsBaseType>(
   const finishMount = () => {
     if (ended) return;
     moduleHub.setProtoPhase('mounted');
-    timeline.mark('proto:mounted');
 
     host.schedule(() => {
       if (ended) return;
-      timeline.mark('mounted:callbacks');
+      timeline.mark('CP5_MOUNTED_CALLBACKS');
 
       callbackScope.run(run, () => {
         for (const cb of lifecycle.mounted) cb(run);
@@ -169,7 +169,7 @@ export function executeWithHost<P extends PropsBaseType>(
       await unmountPromise;
     }
 
-    timeline.mark('unmount:begin');
+    timeline.mark('CP9_UNMOUNT_BEGIN');
     host.onUnmountBegin?.();
 
     const eventPort = moduleHub.getPort<EventPort>('event');
@@ -182,11 +182,10 @@ export function executeWithHost<P extends PropsBaseType>(
     callbackScope.run(run, () => {
       for (const cb of lifecycle.unmounted) cb(run);
     });
-    timeline.mark('unmounted:callbacks');
 
     moduleHub.setProtoPhase('unmounted');
     inst.dispose();
-    timeline.mark('dispose:done');
+    timeline.mark('CP10_DISPOSE_COMPLETE');
   };
 
   return {

--- a/packages/runtime/src/instance/execute/with-host.ts
+++ b/packages/runtime/src/instance/execute/with-host.ts
@@ -41,7 +41,9 @@ export function executeWithHost<P extends PropsBaseType>(
   propsPort.applyRaw({ ...(host.getRawProps?.() ?? {}) });
   timeline.mark('host:ready');
 
-  const doRenderCommit = (kind: 'initial' | 'update') => {
+  let ended = false;
+
+  const doRenderCommit = (kind: 'initial' | 'update', onCommitted?: () => void) => {
     // pull latest raw before rendering
     propsPort.syncFromHost();
 
@@ -53,6 +55,7 @@ export function executeWithHost<P extends PropsBaseType>(
     const afterCommit = () => {
       if (commitDone) return;
       commitDone = true;
+      if (ended) return;
 
       timeline.mark('commit:done');
 
@@ -83,10 +86,11 @@ export function executeWithHost<P extends PropsBaseType>(
           for (const cb of lifecycle.updated) cb(run);
         });
       }
+
+      onCommitted?.();
     };
 
     host.commit(children, { done: afterCommit });
-    afterCommit();
 
     return children;
   };
@@ -128,11 +132,6 @@ export function executeWithHost<P extends PropsBaseType>(
 
   const presencePort = moduleHub.getPort<PresencePort>('presence');
 
-  // initial commit
-  const children = doRenderCommit('initial');
-
-  let ended = false;
-
   const finishMount = () => {
     if (ended) return;
     moduleHub.setProtoPhase('mounted');
@@ -151,12 +150,15 @@ export function executeWithHost<P extends PropsBaseType>(
   // presence mount is async by design, but executeWithHost must stay sync
   // to avoid breaking adapter contracts across the monorepo. We defer the
   // mounted phase via .then() so it still waits for the mount approval.
-  const mountPromise = presencePort?.awaitMount();
-  if (mountPromise) {
-    mountPromise.then(finishMount);
-  } else {
-    finishMount();
-  }
+  // initial commit
+  const children = doRenderCommit('initial', () => {
+    const mountPromise = presencePort?.awaitMount();
+    if (mountPromise) {
+      mountPromise.then(finishMount);
+    } else {
+      finishMount();
+    }
+  });
 
   const invokeUnmounted = async () => {
     if (ended) return;

--- a/packages/runtime/src/instance/execute/with-host.ts
+++ b/packages/runtime/src/instance/execute/with-host.ts
@@ -41,6 +41,8 @@ export function executeWithHost<P extends PropsBaseType>(
   propsPort.applyRaw({ ...(host.getRawProps?.() ?? {}) });
 
   let ended = false;
+  let updateInFlight = false;
+  let updateQueued = false;
 
   const doRenderCommit = (kind: 'initial' | 'update', onCommitted?: () => void) => {
     // pull latest raw before rendering
@@ -97,6 +99,28 @@ export function executeWithHost<P extends PropsBaseType>(
 
   let controller!: RuntimeController;
 
+  const startUpdate = () => {
+    updateInFlight = true;
+
+    try {
+      doRenderCommit('update', () => {
+        updateInFlight = false;
+
+        if (!updateQueued || ended) {
+          updateQueued = false;
+          return;
+        }
+
+        updateQueued = false;
+        startUpdate();
+      });
+    } catch (error) {
+      updateInFlight = false;
+      updateQueued = false;
+      throw error;
+    }
+  };
+
   const evaluateRuleStyle = () => {
     propsPort.syncFromHost();
     const current = propsFacade.get();
@@ -116,7 +140,12 @@ export function executeWithHost<P extends PropsBaseType>(
       callbackScope.runNoSync(run, () => {});
     },
     update() {
-      doRenderCommit('update');
+      if (ended) return;
+      if (updateInFlight) {
+        updateQueued = true;
+        return;
+      }
+      startUpdate();
     },
     getRuleStyleTokens() {
       return evaluateRuleStyle();

--- a/packages/runtime/src/instance/host.ts
+++ b/packages/runtime/src/instance/host.ts
@@ -11,7 +11,7 @@ export interface RuntimeHost<P extends PropsBaseType> {
   /** For diagnostics / errors */
   readonly prototypeName: string;
 
-  /** Commit HostRoot children to the host platform */
+  /** Commit HostRoot children to the host platform and call signal.done() at commit completion. */
   commit(children: TemplateChildren, signal?: CommitSignal): void;
 
   /** Scheduling hook (for microtask/macrotask decisions, adapter controls timing) */

--- a/packages/runtime/src/instance/host.ts
+++ b/packages/runtime/src/instance/host.ts
@@ -2,6 +2,7 @@
 import type { TemplateChildren } from '@proto.ui/core';
 import type { PropsBaseType } from '@proto.ui/types';
 import type { ModuleWiring } from '../orchestrator/module-orchestrator';
+import type { RuntimeCheckpoint } from '../kernel/timeline';
 
 export type CommitSignal = {
   done(): void;
@@ -16,6 +17,9 @@ export interface RuntimeHost<P extends PropsBaseType> {
 
   /** Scheduling hook (for microtask/macrotask decisions, adapter controls timing) */
   schedule(task: () => void): void;
+
+  /** Optional diagnostics hook for canonical lifecycle checkpoint traces. */
+  onLifecycleCheckpoint?(cp: RuntimeCheckpoint): void;
 
   /** host must provide raw props snapshot (may include undeclared keys) */
   getRawProps(): Readonly<P & PropsBaseType>;

--- a/packages/runtime/src/instance/instance.ts
+++ b/packages/runtime/src/instance/instance.ts
@@ -35,7 +35,6 @@ import { __RT_EVENT_CALLBACKS } from '../kernel/event';
 import { CallbackScope } from './execute/callback-scope';
 import { createKernel, type Kernel } from '../kernel';
 import { createAsHookStateProjector } from '../kernel/as-hook';
-import type { RuntimeTimeline } from '../kernel/timeline';
 
 export type RuntimeInstance<P extends PropsBaseType> = {
   kernel: Kernel<P>;
@@ -50,7 +49,6 @@ export type RuntimeInstance<P extends PropsBaseType> = {
    */
   runLifecycle(kind: keyof Kernel<P>['lifecycle']): void;
 
-  setTimeline(t: RuntimeTimeline | null): void;
   dispose(): void;
 };
 
@@ -155,10 +153,6 @@ export function createRuntimeInstance<P extends PropsBaseType>(
     });
   };
 
-  const setTimeline = (t: RuntimeTimeline | null) => {
-    kernel.setTimeline(t);
-  };
-
   const dispose = () => {
     moduleHub.dispose();
   };
@@ -169,7 +163,6 @@ export function createRuntimeInstance<P extends PropsBaseType>(
     callbackScope,
     renderOnce,
     runLifecycle,
-    setTimeline,
     dispose,
   };
 }

--- a/packages/runtime/src/kernel/kernel.ts
+++ b/packages/runtime/src/kernel/kernel.ts
@@ -22,7 +22,6 @@ import type { RuleFacade } from '@proto.ui/module-rule';
 import type { ModuleOrchestratorFacadeView } from '../orchestrator/module-orchestrator/types';
 import type { PropsFacade } from '@proto.ui/module-props';
 import type { ExecPhase } from '@proto.ui/module-base';
-import type { RuntimeTimeline } from './timeline';
 import { attachAsHookRuntime } from './as-hook';
 
 export type Kernel<P extends PropsBaseType> = {
@@ -38,8 +37,6 @@ export type Kernel<P extends PropsBaseType> = {
   renderFn: RenderFn;
 
   renderOnce(): TemplateChildren;
-
-  setTimeline(t: RuntimeTimeline | null): void;
 };
 
 export type CreateKernelOptions = {
@@ -58,8 +55,6 @@ export function createKernel<P extends PropsBaseType>(
   opt?: CreateKernelOptions & { eventSink?: EventCallbacksSink<P> }
 ): Kernel<P> {
   let phase: ExecPhase = 'unknown';
-  let timeline: RuntimeTimeline | null = null;
-
   const setPhase = (p: ExecPhase) => {
     phase = p;
     opt?.onPhaseChange?.(p);
@@ -133,7 +128,6 @@ export function createKernel<P extends PropsBaseType>(
     const children = renderFn(renderer);
     setPhase('unknown');
 
-    timeline?.mark('tree:logical-ready');
     return children;
   };
 
@@ -150,9 +144,5 @@ export function createKernel<P extends PropsBaseType>(
     renderFn,
 
     renderOnce,
-
-    setTimeline: (t) => {
-      timeline = t;
-    },
   };
 }

--- a/packages/runtime/src/kernel/timeline.ts
+++ b/packages/runtime/src/kernel/timeline.ts
@@ -1,99 +1,126 @@
 // packages/runtime/src/kernel/timeline.ts
-export type RuntimeCheckpoint =
-  | 'setup:end'
-  | 'host:ready'
-  // cycle-level (repeatable per commit)
-  | 'tree:logical-ready'
-  | 'commit:begin'
-  | 'commit:done'
-  | 'instance:reachable'
-  | 'afterRenderCommit'
-  // instance-level
-  | 'proto:mounted'
-  | 'mounted:callbacks'
-  | 'unmount:begin'
-  | 'unmounted:callbacks'
-  | 'dispose:done';
+
+export const CANONICAL_RUNTIME_CHECKPOINTS = [
+  'CP0_SETUP_EXIT',
+  'CP1_CREATED_CALLBACKS',
+  'CP2_LOGICAL_TREE_READY',
+  'CP3_COMMIT_START',
+  'CP4_COMMIT_DONE',
+  'CP5_MOUNTED_CALLBACKS',
+  'CP6_UPDATE_RENDER',
+  'CP7_UPDATE_COMMIT_DONE',
+  'CP8_UPDATED_CALLBACKS',
+  'CP9_UNMOUNT_BEGIN',
+  'CP10_DISPOSE_COMPLETE',
+] as const;
+
+export type RuntimeCheckpoint = (typeof CANONICAL_RUNTIME_CHECKPOINTS)[number];
+
+export type RuntimeTimelineOptions = {
+  onMark?: (cp: RuntimeCheckpoint) => void;
+};
 
 export type RuntimeTimeline = {
   mark(cp: RuntimeCheckpoint): void;
 };
 
-export function createTimeline(): RuntimeTimeline {
-  // instance-level monotonic order
-  const instOrder: RuntimeCheckpoint[] = [
-    'setup:end',
-    'host:ready',
-    'proto:mounted',
-    'mounted:callbacks',
-    'unmount:begin',
-    'unmounted:callbacks',
-    'dispose:done',
+export function createTimeline(options: RuntimeTimelineOptions = {}): RuntimeTimeline {
+  const instanceOrder: RuntimeCheckpoint[] = [
+    'CP0_SETUP_EXIT',
+    'CP1_CREATED_CALLBACKS',
+    'CP5_MOUNTED_CALLBACKS',
+    'CP9_UNMOUNT_BEGIN',
+    'CP10_DISPOSE_COMPLETE',
+  ];
+  const initialCycleOrder: RuntimeCheckpoint[] = [
+    'CP2_LOGICAL_TREE_READY',
+    'CP3_COMMIT_START',
+    'CP4_COMMIT_DONE',
+  ];
+  const updateCycleOrder: RuntimeCheckpoint[] = [
+    'CP6_UPDATE_RENDER',
+    'CP7_UPDATE_COMMIT_DONE',
+    'CP8_UPDATED_CALLBACKS',
   ];
 
-  // cycle-level order (repeatable)
-  const cycleOrder: RuntimeCheckpoint[] = [
-    'tree:logical-ready',
-    'commit:begin',
-    'commit:done',
-    'instance:reachable',
-    'afterRenderCommit',
-  ];
+  const instanceIndex = new Map(instanceOrder.map((k, i) => [k, i]));
+  const initialCycleIndex = new Map(initialCycleOrder.map((k, i) => [k, i]));
+  const updateCycleIndex = new Map(updateCycleOrder.map((k, i) => [k, i]));
 
-  const instIndex = new Map(instOrder.map((k, i) => [k, i]));
-  const cycleIndex = new Map(cycleOrder.map((k, i) => [k, i]));
+  let instanceLast = -1;
+  let initialCycleLast = -1;
+  let updateCycleLast = -1;
 
-  let instLast = -1;
-  let cycleLast = -1; // -1 means "not started"; 3 means "cycle completed"
-
-  const unmountBeginI = instIndex.get('unmount:begin')!;
+  const unmountBeginIndex = instanceIndex.get('CP9_UNMOUNT_BEGIN')!;
 
   return {
     mark(cp: RuntimeCheckpoint) {
-      // disallow any cycle marks after unmount begins
-      if (cycleIndex.has(cp)) {
-        if (instLast >= unmountBeginI) {
-          throw new Error(`[Lifecycle] cycle checkpoint after unmount: ${cp}`);
+      if (!isRuntimeCheckpoint(cp)) {
+        throw new Error(`[Lifecycle] unknown checkpoint: ${cp}`);
+      }
+
+      if (initialCycleIndex.has(cp)) {
+        if (instanceLast >= unmountBeginIndex) {
+          throw new Error(`[Lifecycle] initial checkpoint after unmount: ${cp}`);
         }
 
-        const i = cycleIndex.get(cp)!;
+        const i = initialCycleIndex.get(cp)!;
+        if (i <= initialCycleLast) {
+          throw new Error(
+            `[Lifecycle] checkpoint out of order (initial cycle): ${cp} after ${initialCycleOrder[initialCycleLast]}`
+          );
+        }
+        initialCycleLast = i;
+        options.onMark?.(cp);
+        return;
+      }
 
-        // starting a new cycle must happen only when previous cycle finished (or no cycle yet)
-        if (cp === 'tree:logical-ready') {
-          if (!(cycleLast === -1 || cycleLast === cycleOrder.length - 1)) {
+      if (updateCycleIndex.has(cp)) {
+        if (instanceLast >= unmountBeginIndex) {
+          throw new Error(`[Lifecycle] update checkpoint after unmount: ${cp}`);
+        }
+        if (initialCycleLast !== initialCycleOrder.length - 1) {
+          throw new Error(`[Lifecycle] update checkpoint before initial commit completion: ${cp}`);
+        }
+
+        const i = updateCycleIndex.get(cp)!;
+        if (cp === 'CP6_UPDATE_RENDER') {
+          if (!(updateCycleLast === -1 || updateCycleLast === updateCycleOrder.length - 1)) {
             throw new Error(
-              `[Lifecycle] new cycle started before previous cycle finished: ${cp} after ${cycleOrder[cycleLast]}`
+              `[Lifecycle] new update cycle started before previous cycle finished: ${cp} after ${updateCycleOrder[updateCycleLast]}`
             );
           }
-          cycleLast = -1; // reset for new cycle
+          updateCycleLast = -1;
         }
 
-        if (i <= cycleLast) {
+        if (i <= updateCycleLast) {
           throw new Error(
-            `[Lifecycle] checkpoint out of order (cycle): ${cp} after ${cycleOrder[cycleLast]}`
+            `[Lifecycle] checkpoint out of order (update cycle): ${cp} after ${updateCycleOrder[updateCycleLast]}`
           );
         }
 
-        cycleLast = i;
+        updateCycleLast = i;
+        options.onMark?.(cp);
         return;
       }
 
-      // instance-level marks
-      if (instIndex.has(cp)) {
-        const i = instIndex.get(cp)!;
+      if (instanceIndex.has(cp)) {
+        const i = instanceIndex.get(cp)!;
 
-        if (i <= instLast) {
+        if (i <= instanceLast) {
           throw new Error(
-            `[Lifecycle] checkpoint out of order (instance): ${cp} after ${instOrder[instLast]}`
+            `[Lifecycle] checkpoint out of order (instance): ${cp} after ${instanceOrder[instanceLast]}`
           );
         }
 
-        instLast = i;
+        instanceLast = i;
+        options.onMark?.(cp);
         return;
       }
-
-      // unknown checkpoint
-      throw new Error(`[Lifecycle] unknown checkpoint: ${cp}`);
     },
   };
+}
+
+function isRuntimeCheckpoint(value: string): value is RuntimeCheckpoint {
+  return (CANONICAL_RUNTIME_CHECKPOINTS as readonly string[]).includes(value);
 }

--- a/packages/runtime/test/contract/as-hook.v0.contract.test.ts
+++ b/packages/runtime/test/contract/as-hook.v0.contract.test.ts
@@ -20,8 +20,9 @@ describe('runtime contract: asHook (v0)', () => {
     const host: RuntimeHost<P> = {
       prototypeName: name,
       getRawProps: () => raw as any,
-      commit(children) {
+      commit(children, signal) {
         commits.push(children);
+        signal?.done();
       },
       schedule(task) {
         scheduled.push(task);

--- a/packages/runtime/test/contract/feedback.style.setup-only.v0.contract.test.ts
+++ b/packages/runtime/test/contract/feedback.style.setup-only.v0.contract.test.ts
@@ -47,7 +47,9 @@ function makeTestHost(prototypeName: string): RuntimeHost<any> {
   return {
     prototypeName,
     getRawProps: () => ({}),
-    commit: () => {},
+    commit: (_children, signal) => {
+      signal?.done();
+    },
     schedule: (task) => task(), // run mounted synchronously for contract
   };
 }

--- a/packages/runtime/test/contract/lifecycle-with-host.v0.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle-with-host.v0.contract.test.ts
@@ -126,6 +126,45 @@ describe('runtime contract: lifecycle-with-host (v0)', () => {
     void run; // silence unused if your TS config complains
   });
 
+  it('updated waits for host commit completion signal', async () => {
+    const calls: string[] = [];
+    const pendingDone: Array<() => void> = [];
+    const host: RuntimeHost<any> = {
+      prototypeName: 'x-runtime-life-async-commit',
+      getRawProps: () => ({}),
+      commit(_children, signal) {
+        calls.push('commit');
+        if (signal) pendingDone.push(signal.done);
+      },
+      schedule() {},
+    };
+
+    const P: Prototype = {
+      name: 'x-runtime-life-async-commit',
+      setup(def) {
+        def.lifecycle.onUpdated(() => calls.push('updated'));
+        return (r) => [r.el('div', 'v')];
+      },
+    };
+
+    const { controller } = executeWithHost(P, host);
+
+    // Complete the initial commit first; this test focuses on the update commit.
+    expect(pendingDone.length).toBe(1);
+    pendingDone.shift()!();
+
+    calls.length = 0;
+
+    controller.update();
+
+    expect(calls).toEqual(['commit']);
+    expect(pendingDone.length).toBe(1);
+
+    pendingDone.shift()!();
+
+    expect(calls).toEqual(['commit', 'updated']);
+  });
+
   it('unmounted is invoked when adapter calls invokeUnmounted()', async () => {
     const { host, calls } = createMockHost();
 
@@ -164,7 +203,9 @@ describe('runtime contract: lifecycle-with-host (v0)', () => {
     const host: RuntimeHost<any> = {
       prototypeName: proto.name,
       getRawProps: () => ({}),
-      commit: () => {},
+      commit: (_children, signal) => {
+        signal?.done();
+      },
       schedule: (task) => {
         scheduled = task;
       },

--- a/packages/runtime/test/contract/lifecycle.checkpoints.v0.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle.checkpoints.v0.contract.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import type { Prototype } from '@proto.ui/core';
+import {
+  CANONICAL_RUNTIME_CHECKPOINTS,
+  executeWithHost,
+  type RuntimeCheckpoint,
+  type RuntimeHost,
+} from '../../src';
+
+describe('contract: runtime / lifecycle canonical checkpoints (v0)', () => {
+  it('exports stable CP0-CP10 canonical checkpoint names', () => {
+    expect(CANONICAL_RUNTIME_CHECKPOINTS).toEqual([
+      'CP0_SETUP_EXIT',
+      'CP1_CREATED_CALLBACKS',
+      'CP2_LOGICAL_TREE_READY',
+      'CP3_COMMIT_START',
+      'CP4_COMMIT_DONE',
+      'CP5_MOUNTED_CALLBACKS',
+      'CP6_UPDATE_RENDER',
+      'CP7_UPDATE_COMMIT_DONE',
+      'CP8_UPDATED_CALLBACKS',
+      'CP9_UNMOUNT_BEGIN',
+      'CP10_DISPOSE_COMPLETE',
+    ]);
+  });
+
+  it('records initial, update, and dispose flow with canonical checkpoints', async () => {
+    const trace: RuntimeCheckpoint[] = [];
+    const scheduled: Array<() => void> = [];
+
+    const P: Prototype = {
+      name: 'x-lifecycle-checkpoints',
+      setup(def) {
+        def.lifecycle.onCreated(() => {});
+        def.lifecycle.onMounted(() => {});
+        def.lifecycle.onUpdated(() => {});
+        def.lifecycle.onUnmounted(() => {});
+        return (r) => [r.el('div', 'v')];
+      },
+    };
+
+    const host: RuntimeHost<any> = {
+      prototypeName: P.name,
+      getRawProps: () => ({}),
+      commit(_children, signal) {
+        signal?.done();
+      },
+      schedule(task) {
+        scheduled.push(task);
+      },
+      onLifecycleCheckpoint(cp) {
+        trace.push(cp);
+      },
+    };
+
+    const { controller, invokeUnmounted } = executeWithHost(P, host);
+
+    expect(trace).toEqual([
+      'CP0_SETUP_EXIT',
+      'CP1_CREATED_CALLBACKS',
+      'CP2_LOGICAL_TREE_READY',
+      'CP3_COMMIT_START',
+      'CP4_COMMIT_DONE',
+    ]);
+
+    expect(scheduled).toHaveLength(1);
+    scheduled.shift()!();
+    expect(trace).toEqual([
+      'CP0_SETUP_EXIT',
+      'CP1_CREATED_CALLBACKS',
+      'CP2_LOGICAL_TREE_READY',
+      'CP3_COMMIT_START',
+      'CP4_COMMIT_DONE',
+      'CP5_MOUNTED_CALLBACKS',
+    ]);
+
+    controller.update();
+    expect(trace.slice(-3)).toEqual([
+      'CP6_UPDATE_RENDER',
+      'CP7_UPDATE_COMMIT_DONE',
+      'CP8_UPDATED_CALLBACKS',
+    ]);
+
+    await invokeUnmounted();
+    expect(trace.slice(-2)).toEqual(['CP9_UNMOUNT_BEGIN', 'CP10_DISPOSE_COMPLETE']);
+  });
+
+  it('does not record update commit completion checkpoints before signal.done()', () => {
+    const trace: RuntimeCheckpoint[] = [];
+    const scheduled: Array<() => void> = [];
+    const pendingDone: Array<() => void> = [];
+
+    const P: Prototype = {
+      name: 'x-lifecycle-checkpoints-delayed',
+      setup(def) {
+        def.lifecycle.onUpdated(() => {});
+        return (r) => [r.el('div', 'v')];
+      },
+    };
+
+    const host: RuntimeHost<any> = {
+      prototypeName: P.name,
+      getRawProps: () => ({}),
+      commit(_children, signal) {
+        if (signal) pendingDone.push(signal.done);
+      },
+      schedule(task) {
+        scheduled.push(task);
+      },
+      onLifecycleCheckpoint(cp) {
+        trace.push(cp);
+      },
+    };
+
+    const { controller } = executeWithHost(P, host);
+
+    expect(pendingDone).toHaveLength(1);
+    pendingDone.shift()!();
+    scheduled.shift()?.();
+
+    trace.length = 0;
+    controller.update();
+
+    expect(trace).toEqual(['CP6_UPDATE_RENDER']);
+    expect(pendingDone).toHaveLength(1);
+
+    pendingDone.shift()!();
+
+    expect(trace).toEqual(['CP6_UPDATE_RENDER', 'CP7_UPDATE_COMMIT_DONE', 'CP8_UPDATED_CALLBACKS']);
+  });
+});

--- a/packages/runtime/test/contract/lifecycle.checkpoints.v0.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle.checkpoints.v0.contract.test.ts
@@ -128,4 +128,65 @@ describe('contract: runtime / lifecycle canonical checkpoints (v0)', () => {
 
     expect(trace).toEqual(['CP6_UPDATE_RENDER', 'CP7_UPDATE_COMMIT_DONE', 'CP8_UPDATED_CALLBACKS']);
   });
+
+  it('coalesces update intents while an async update commit is still pending', () => {
+    const trace: RuntimeCheckpoint[] = [];
+    const scheduled: Array<() => void> = [];
+    const pendingDone: Array<() => void> = [];
+
+    const P: Prototype = {
+      name: 'x-lifecycle-checkpoints-queued-update',
+      setup(def) {
+        def.lifecycle.onUpdated(() => {});
+        return (r) => [r.el('div', 'v')];
+      },
+    };
+
+    const host: RuntimeHost<any> = {
+      prototypeName: P.name,
+      getRawProps: () => ({}),
+      commit(_children, signal) {
+        if (signal) pendingDone.push(signal.done);
+      },
+      schedule(task) {
+        scheduled.push(task);
+      },
+      onLifecycleCheckpoint(cp) {
+        trace.push(cp);
+      },
+    };
+
+    const { controller } = executeWithHost(P, host);
+
+    pendingDone.shift()!();
+    scheduled.shift()?.();
+
+    trace.length = 0;
+    controller.update();
+    controller.update();
+
+    expect(trace).toEqual(['CP6_UPDATE_RENDER']);
+    expect(pendingDone).toHaveLength(1);
+
+    pendingDone.shift()!();
+
+    expect(trace).toEqual([
+      'CP6_UPDATE_RENDER',
+      'CP7_UPDATE_COMMIT_DONE',
+      'CP8_UPDATED_CALLBACKS',
+      'CP6_UPDATE_RENDER',
+    ]);
+    expect(pendingDone).toHaveLength(1);
+
+    pendingDone.shift()!();
+
+    expect(trace).toEqual([
+      'CP6_UPDATE_RENDER',
+      'CP7_UPDATE_COMMIT_DONE',
+      'CP8_UPDATED_CALLBACKS',
+      'CP6_UPDATE_RENDER',
+      'CP7_UPDATE_COMMIT_DONE',
+      'CP8_UPDATED_CALLBACKS',
+    ]);
+  });
 });

--- a/packages/runtime/test/contract/lifecycle.domain.cp0.v0.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle.domain.cp0.v0.contract.test.ts
@@ -22,7 +22,9 @@ describe('contract: runtime / domain switch at CP0 (v0)', () => {
     const host: RuntimeHost<any> = {
       prototypeName: P.name,
       getRawProps: () => ({}),
-      commit: () => {},
+      commit: (_children, signal) => {
+        signal?.done();
+      },
       schedule: () => {},
     };
 

--- a/packages/runtime/test/contract/lifecycle.registration.v0.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle.registration.v0.contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { DefHandle, Prototype } from '@proto.ui/core';
+import type { DefHandle, Prototype, RunHandle } from '@proto.ui/core';
 import { executeWithHost, type RuntimeHost } from '../../src';
 
 function createHost(): RuntimeHost<any> {
@@ -16,8 +16,10 @@ function createHost(): RuntimeHost<any> {
 }
 
 describe('runtime contract: lifecycle registration (v0)', () => {
-  it('def.lifecycle callbacks are setup-only registrations', async () => {
+  it('def.lifecycle exposes the v0 setup-only registration surface', async () => {
     const calls: string[] = [];
+    const callbackRuns: Array<RunHandle<any>> = [];
+    const registrationReturns: unknown[] = [];
     let capturedDef!: DefHandle<any>;
 
     const proto: Prototype = {
@@ -25,10 +27,42 @@ describe('runtime contract: lifecycle registration (v0)', () => {
       setup(def) {
         capturedDef = def;
 
-        expect(() => def.lifecycle.onCreated(() => calls.push('created'))).not.toThrow();
-        expect(() => def.lifecycle.onMounted(() => calls.push('mounted'))).not.toThrow();
-        expect(() => def.lifecycle.onUpdated(() => calls.push('updated'))).not.toThrow();
-        expect(() => def.lifecycle.onUnmounted(() => calls.push('unmounted'))).not.toThrow();
+        expect(Object.keys(def.lifecycle).sort()).toEqual([
+          'onCreated',
+          'onMounted',
+          'onUnmounted',
+          'onUpdated',
+        ]);
+
+        expect(() => {
+          registrationReturns.push(
+            def.lifecycle.onCreated((run) => {
+              callbackRuns.push(run);
+              calls.push('created');
+            })
+          );
+          registrationReturns.push(
+            def.lifecycle.onMounted((run) => {
+              callbackRuns.push(run);
+              calls.push('mounted');
+            })
+          );
+          registrationReturns.push(
+            def.lifecycle.onUpdated((run) => {
+              callbackRuns.push(run);
+              calls.push('updated');
+            })
+          );
+          registrationReturns.push(
+            def.lifecycle.onUnmounted((run) => {
+              callbackRuns.push(run);
+              calls.push('unmounted');
+            })
+          );
+        }).not.toThrow();
+
+        expect(calls).toEqual([]);
+        expect(registrationReturns).toEqual([undefined, undefined, undefined, undefined]);
 
         return (r) => [r.el('div', 'ok')];
       },
@@ -39,6 +73,8 @@ describe('runtime contract: lifecycle registration (v0)', () => {
 
     expect(calls).toContain('created');
     expect(calls).toContain('mounted');
+    expect(callbackRuns.length).toBeGreaterThanOrEqual(2);
+    expect(callbackRuns.every((run) => run && typeof run.update === 'function')).toBe(true);
 
     expect(() => capturedDef.lifecycle.onCreated(() => undefined)).toThrow(/phase/i);
     expect(() => capturedDef.lifecycle.onMounted(() => undefined)).toThrow(/phase/i);

--- a/packages/runtime/test/contract/lifecycle.registration.v0.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle.registration.v0.contract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { DefHandle, Prototype } from '@proto.ui/core';
+import { executeWithHost, type RuntimeHost } from '../../src';
+
+function createHost(): RuntimeHost<any> {
+  return {
+    prototypeName: 'x-lifecycle-registration',
+    getRawProps: () => ({}),
+    commit(_children, signal) {
+      signal?.done();
+    },
+    schedule(task) {
+      task();
+    },
+  };
+}
+
+describe('runtime contract: lifecycle registration (v0)', () => {
+  it('def.lifecycle callbacks are setup-only registrations', async () => {
+    const calls: string[] = [];
+    let capturedDef!: DefHandle<any>;
+
+    const proto: Prototype = {
+      name: 'x-lifecycle-registration',
+      setup(def) {
+        capturedDef = def;
+
+        expect(() => def.lifecycle.onCreated(() => calls.push('created'))).not.toThrow();
+        expect(() => def.lifecycle.onMounted(() => calls.push('mounted'))).not.toThrow();
+        expect(() => def.lifecycle.onUpdated(() => calls.push('updated'))).not.toThrow();
+        expect(() => def.lifecycle.onUnmounted(() => calls.push('unmounted'))).not.toThrow();
+
+        return (r) => [r.el('div', 'ok')];
+      },
+    };
+
+    const result = executeWithHost(proto, createHost());
+    await Promise.resolve();
+
+    expect(calls).toContain('created');
+    expect(calls).toContain('mounted');
+
+    expect(() => capturedDef.lifecycle.onCreated(() => undefined)).toThrow(/phase/i);
+    expect(() => capturedDef.lifecycle.onMounted(() => undefined)).toThrow(/phase/i);
+    expect(() => capturedDef.lifecycle.onUpdated(() => undefined)).toThrow(/phase/i);
+    expect(() => capturedDef.lifecycle.onUnmounted(() => undefined)).toThrow(/phase/i);
+
+    result.controller.update();
+    expect(calls).toContain('updated');
+
+    await result.invokeUnmounted();
+    expect(calls).toContain('unmounted');
+  });
+});

--- a/packages/runtime/test/contract/lifecycle.update-order.strict.v0.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle.update-order.strict.v0.contract.test.ts
@@ -20,8 +20,9 @@ describe('contract: runtime / update strict order (v0)', () => {
     const host: RuntimeHost<any> = {
       prototypeName: P.name,
       getRawProps: () => ({}),
-      commit: (_children: TemplateChildren) => {
+      commit: (_children: TemplateChildren, signal) => {
         calls.push('commit');
+        signal?.done();
       },
       schedule: (_task) => {},
     };

--- a/packages/runtime/test/contract/props-integration.v0.contract.test.ts
+++ b/packages/runtime/test/contract/props-integration.v0.contract.test.ts
@@ -13,8 +13,9 @@ function createMockHost<P extends PropsBaseType>(initialRaw: Record<string, any>
   const host: RuntimeHost<P> = {
     getRawProps: () => raw,
 
-    commit: (children: any) => {
+    commit: (children: any, signal) => {
       commits.push(children);
+      signal?.done();
     },
 
     schedule: (job: () => void) => {

--- a/packages/runtime/test/contract/props-integration.v0.contract.test.ts
+++ b/packages/runtime/test/contract/props-integration.v0.contract.test.ts
@@ -11,9 +11,10 @@ function createMockHost<P extends PropsBaseType>(initialRaw: Record<string, any>
   const scheduled: Array<() => void> = [];
 
   const host: RuntimeHost<P> = {
-    getRawProps: () => raw,
+    prototypeName: 'props-integration-test',
+    getRawProps: () => raw as Readonly<P & PropsBaseType>,
 
-    commit: (children: any, signal) => {
+    commit: (children, signal) => {
       commits.push(children);
       signal?.done();
     },
@@ -25,7 +26,7 @@ function createMockHost<P extends PropsBaseType>(initialRaw: Record<string, any>
     // optional hooks used by executeWithHost
     onRuntimeReady: () => {},
     onUnmountBegin: () => {},
-  } as any;
+  };
 
   const flush = () => {
     while (scheduled.length) {

--- a/packages/runtime/test/contract/prototype.render-syntax.v0.contract.test.ts
+++ b/packages/runtime/test/contract/prototype.render-syntax.v0.contract.test.ts
@@ -1,0 +1,148 @@
+import { PROTOTYPE_RENDER_SYNTAX_CASES } from '@proto.ui/spec-fixtures/core/prototype-render-syntax';
+import type { Prototype } from '@proto.ui/core';
+import { describe, expect, it } from 'vitest';
+import { createRuntimeInstance, executeWithHost, type RuntimeHost } from '../../src';
+
+function caseTitle(specCase: string, fallback: string): string {
+  return (
+    PROTOTYPE_RENDER_SYNTAX_CASES.find((testCase) => testCase.specCase === specCase)?.title ??
+    fallback
+  );
+}
+
+describe('contract: runtime / prototype render syntax (v0)', () => {
+  it(caseTitle('T-CORE-SYNTAX-0001-CASE-SETUP-DEF', 'setup receives the definition handle'), () => {
+    let seenDef: any;
+
+    const proto: Prototype = {
+      name: 'x-runtime-setup-def',
+      setup(def) {
+        seenDef = def;
+        return () => null;
+      },
+    };
+
+    createRuntimeInstance(proto);
+
+    expect(typeof seenDef.lifecycle?.onCreated).toBe('function');
+    expect(typeof seenDef.props?.define).toBe('function');
+    expect(typeof seenDef.update).toBe('undefined');
+  });
+
+  it(
+    caseTitle(
+      'T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-RENDER',
+      'setup-returned function becomes render'
+    ),
+    () => {
+      const proto: Prototype = {
+        name: 'x-runtime-return-render',
+        setup() {
+          return (renderer) => renderer.el('div', 'from-render');
+        },
+      };
+
+      const instance = createRuntimeInstance(proto);
+
+      expect(instance.renderOnce()).toEqual({
+        type: 'div',
+        style: undefined,
+        children: 'from-render',
+      });
+    }
+  );
+
+  it(
+    caseTitle(
+      'T-CORE-SYNTAX-0001-CASE-SETUP-VOID-DEFAULT',
+      'void setup return uses default slot render'
+    ),
+    () => {
+      const proto: Prototype = {
+        name: 'x-runtime-default-slot',
+        setup() {},
+      };
+
+      const instance = createRuntimeInstance(proto);
+
+      expect(instance.renderOnce()).toEqual([
+        { type: { kind: 'slot' }, style: undefined, children: null },
+      ]);
+    }
+  );
+
+  it(
+    caseTitle(
+      'T-CORE-SYNTAX-0001-CASE-RENDER-HANDLE',
+      'render receives renderer handle and returns TemplateChildren'
+    ),
+    () => {
+      let seenRenderer: any;
+
+      const proto: Prototype = {
+        name: 'x-runtime-renderer-handle',
+        setup() {
+          return (renderer) => {
+            seenRenderer = renderer;
+            return [renderer.el('span', 'a'), renderer.el('span', 'b')];
+          };
+        },
+      };
+
+      const instance = createRuntimeInstance(proto);
+
+      expect(instance.renderOnce()).toEqual([
+        { type: 'span', style: undefined, children: 'a' },
+        { type: 'span', style: undefined, children: 'b' },
+      ]);
+      expect(typeof seenRenderer.el).toBe('function');
+      expect(typeof seenRenderer.slot).toBe('function');
+      expect(typeof seenRenderer.r.slot).toBe('function');
+      expect(typeof seenRenderer.svg.root).toBe('function');
+    }
+  );
+
+  it(
+    caseTitle(
+      'T-CORE-SYNTAX-0001-CASE-RENDER-READ',
+      'renderer read exposes current props without update entry'
+    ),
+    () => {
+      const commits: unknown[] = [];
+      const host: RuntimeHost<{ label: string }> = {
+        prototypeName: 'x-runtime-render-read',
+        getRawProps() {
+          return { label: 'from-host' };
+        },
+        commit(children, signal) {
+          commits.push(children);
+          signal?.done();
+        },
+        schedule(task) {
+          task();
+        },
+      };
+
+      const proto: Prototype<{ label: string }> = {
+        name: 'x-runtime-render-read',
+        setup(def) {
+          def.props.define({ label: { type: 'string', default: 'fallback' } });
+
+          return (renderer: any) => {
+            expect(typeof renderer.read.props.get).toBe('function');
+            expect(typeof renderer.read.props.getRaw).toBe('function');
+            expect(typeof renderer.read.props.isProvided).toBe('function');
+            expect(typeof renderer.update).toBe('undefined');
+            expect(renderer.read.props.get()).toEqual({ label: 'from-host' });
+            expect(renderer.read.props.isProvided('label')).toBe(true);
+            return renderer.el('div', renderer.read.props.get().label);
+          };
+        },
+      };
+
+      executeWithHost(proto, host);
+
+      expect(commits).toEqual([{ type: 'div', style: undefined, children: 'from-host' }]);
+    }
+  );
+});

--- a/packages/spec/fixtures/package.json
+++ b/packages/spec/fixtures/package.json
@@ -16,6 +16,10 @@
     "./props/json-value-boundary": {
       "types": "./src/props/json-value-boundary.ts",
       "default": "./src/props/json-value-boundary.ts"
+    },
+    "./lifecycle/callback-order": {
+      "types": "./src/lifecycle/callback-order.ts",
+      "default": "./src/lifecycle/callback-order.ts"
     }
   },
   "description": "Shared semantic test fixtures for Proto UI spec contracts."

--- a/packages/spec/fixtures/package.json
+++ b/packages/spec/fixtures/package.json
@@ -20,6 +20,14 @@
     "./lifecycle/callback-order": {
       "types": "./src/lifecycle/callback-order.ts",
       "default": "./src/lifecycle/callback-order.ts"
+    },
+    "./core/prototype-render-syntax": {
+      "types": "./src/core/prototype-render-syntax.ts",
+      "default": "./src/core/prototype-render-syntax.ts"
+    },
+    "./template/authoring": {
+      "types": "./src/template/authoring.ts",
+      "default": "./src/template/authoring.ts"
     }
   },
   "description": "Shared semantic test fixtures for Proto UI spec contracts."

--- a/packages/spec/fixtures/src/core/prototype-render-syntax.ts
+++ b/packages/spec/fixtures/src/core/prototype-render-syntax.ts
@@ -1,0 +1,72 @@
+export type PrototypeRenderSyntaxExpectation =
+  | 'invalid-prototype-definition-fails-fast'
+  | 'setup-receives-definition-handle'
+  | 'setup-returned-render-is-executed'
+  | 'void-setup-uses-default-slot-render'
+  | 'render-receives-renderer-handle-and-returns-template-children'
+  | 'renderer-read-props-without-update-entry';
+
+export type PrototypeRenderSyntaxCase = {
+  id: string;
+  title: string;
+  specCase: string;
+  covers: readonly string[];
+  expectation: PrototypeRenderSyntaxExpectation;
+  notes?: readonly string[];
+};
+
+export const PROTOTYPE_RENDER_SYNTAX_CASES = [
+  {
+    id: 'definition-name-and-setup',
+    title: 'prototype definition requires a name and setup function',
+    specCase: 'T-CORE-SYNTAX-0001-CASE-DEFINITION-SHAPE',
+    covers: ['C-CORE-SYNTAX-0003-A', 'C-CORE-SYNTAX-0003-B', 'C-CORE-SYNTAX-0003-D'],
+    expectation: 'invalid-prototype-definition-fails-fast',
+  },
+  {
+    id: 'setup-receives-def',
+    title: 'setup receives the definition handle',
+    specCase: 'T-CORE-SYNTAX-0001-CASE-SETUP-DEF',
+    covers: ['C-CORE-SYNTAX-0003-C', 'C-CORE-SYNTAX-0004-A'],
+    expectation: 'setup-receives-definition-handle',
+  },
+  {
+    id: 'setup-returned-render',
+    title: 'setup-returned function is used as render',
+    specCase: 'T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-RENDER',
+    covers: ['C-CORE-SYNTAX-0004-B', 'C-CORE-SYNTAX-0005-A'],
+    expectation: 'setup-returned-render-is-executed',
+  },
+  {
+    id: 'setup-void-default-slot',
+    title: 'void setup return uses default slot render',
+    specCase: 'T-CORE-SYNTAX-0001-CASE-SETUP-VOID-DEFAULT',
+    covers: ['C-CORE-SYNTAX-0004-C'],
+    expectation: 'void-setup-uses-default-slot-render',
+    notes: ['This records the current v0 runtime behavior and its open-question boundary.'],
+  },
+  {
+    id: 'render-receives-renderer',
+    title: 'render receives renderer handle and returns TemplateChildren',
+    specCase: 'T-CORE-SYNTAX-0001-CASE-RENDER-HANDLE',
+    covers: ['C-CORE-SYNTAX-0005-B', 'C-CORE-SYNTAX-0005-C', 'C-CORE-SYNTAX-0006-A'],
+    expectation: 'render-receives-renderer-handle-and-returns-template-children',
+  },
+  {
+    id: 'renderer-read-props-no-update',
+    title: 'renderer read exposes props and no update entry',
+    specCase: 'T-CORE-SYNTAX-0001-CASE-RENDER-READ',
+    covers: [
+      'C-CORE-SYNTAX-0006-B',
+      'C-CORE-SYNTAX-0006-C',
+      'C-CORE-SYNTAX-0006-D',
+      'C-LIFECYCLE-0003-D',
+      'C-LIFECYCLE-0003-E',
+    ],
+    expectation: 'renderer-read-props-without-update-entry',
+  },
+] as const satisfies readonly PrototypeRenderSyntaxCase[];
+
+export const PROTOTYPE_RENDER_SYNTAX_SPEC_CASES = [
+  ...new Set(PROTOTYPE_RENDER_SYNTAX_CASES.map((testCase) => testCase.specCase)),
+] as const;

--- a/packages/spec/fixtures/src/index.ts
+++ b/packages/spec/fixtures/src/index.ts
@@ -1,1 +1,2 @@
 export * from './props/json-value-boundary';
+export * from './lifecycle/callback-order';

--- a/packages/spec/fixtures/src/index.ts
+++ b/packages/spec/fixtures/src/index.ts
@@ -1,2 +1,4 @@
 export * from './props/json-value-boundary';
 export * from './lifecycle/callback-order';
+export * from './core/prototype-render-syntax';
+export * from './template/authoring';

--- a/packages/spec/fixtures/src/lifecycle/callback-order.ts
+++ b/packages/spec/fixtures/src/lifecycle/callback-order.ts
@@ -57,11 +57,12 @@ export const LIFECYCLE_CALLBACK_ORDER_CASES = [
   },
   {
     id: 'update-render-commit-updated',
-    title: 'update lifecycle order runs updated after update commit',
+    title: 'update lifecycle order runs updated after update commit completion',
     specCase: 'T-LIFECYCLE-0001-CASE-UPDATE-CYCLE-ORDER',
     covers: ['C-LIFECYCLE-0002-E'],
     expectation: 'update-render-commit-updated',
     expectedOrder: ['update', 'update-render', 'update-commit', 'updated'],
+    notes: ['`update-commit` represents the commit completion boundary in this fixture.'],
   },
   {
     id: 'unmounted-before-dispose-availability',

--- a/packages/spec/fixtures/src/lifecycle/callback-order.ts
+++ b/packages/spec/fixtures/src/lifecycle/callback-order.ts
@@ -1,5 +1,5 @@
 export type LifecycleCallbackOrderExpectation =
-  | 'lifecycle-registration-setup-only'
+  | 'lifecycle-registration-defers-callback-invocation'
   | 'setup-created-render-commit-mounted'
   | 'queued-mounted-callback-invalidated-after-unmount'
   | 'update-render-commit-updated'
@@ -32,11 +32,11 @@ export type LifecycleCallbackOrderCase = {
 export const LIFECYCLE_CALLBACK_ORDER_CASES = [
   {
     id: 'setup-registration-setup-only',
-    title: 'lifecycle callback registration is setup-only',
+    title: 'lifecycle callback registration defers invocation to runtime flow',
     specCase: 'T-LIFECYCLE-0001-CASE-SETUP-REGISTRATION',
     covers: ['C-LIFECYCLE-0002-A'],
-    expectation: 'lifecycle-registration-setup-only',
-    notes: ['Attempts to register lifecycle callbacks after setup must fail fast.'],
+    expectation: 'lifecycle-registration-defers-callback-invocation',
+    notes: ['Registration records callbacks; runtime lifecycle flow invokes them later.'],
   },
   {
     id: 'initial-created-render-commit-mounted',

--- a/packages/spec/fixtures/src/lifecycle/callback-order.ts
+++ b/packages/spec/fixtures/src/lifecycle/callback-order.ts
@@ -1,0 +1,79 @@
+export type LifecycleCallbackOrderExpectation =
+  | 'lifecycle-registration-setup-only'
+  | 'setup-created-render-commit-mounted'
+  | 'queued-mounted-callback-invalidated-after-unmount'
+  | 'update-render-commit-updated'
+  | 'unmounted-before-dispose-availability-window';
+
+export type LifecycleTracePoint =
+  | 'setup'
+  | 'created'
+  | 'first-render'
+  | 'commit'
+  | 'mounted'
+  | 'update'
+  | 'update-render'
+  | 'update-commit'
+  | 'updated'
+  | 'unmount-begin'
+  | 'unmounted'
+  | 'dispose';
+
+export type LifecycleCallbackOrderCase = {
+  id: string;
+  title: string;
+  specCase: string;
+  covers: readonly string[];
+  expectation: LifecycleCallbackOrderExpectation;
+  expectedOrder?: readonly LifecycleTracePoint[];
+  notes?: readonly string[];
+};
+
+export const LIFECYCLE_CALLBACK_ORDER_CASES = [
+  {
+    id: 'setup-registration-setup-only',
+    title: 'lifecycle callback registration is setup-only',
+    specCase: 'T-LIFECYCLE-0001-CASE-SETUP-REGISTRATION',
+    covers: ['C-LIFECYCLE-0002-A'],
+    expectation: 'lifecycle-registration-setup-only',
+    notes: ['Attempts to register lifecycle callbacks after setup must fail fast.'],
+  },
+  {
+    id: 'initial-created-render-commit-mounted',
+    title: 'initial lifecycle order reaches mounted only after first commit',
+    specCase: 'T-LIFECYCLE-0001-CASE-INITIAL-ORDER',
+    covers: ['C-LIFECYCLE-0002-B', 'C-LIFECYCLE-0002-C', 'C-LIFECYCLE-0002-D'],
+    expectation: 'setup-created-render-commit-mounted',
+    expectedOrder: ['setup', 'created', 'first-render', 'commit', 'mounted'],
+  },
+  {
+    id: 'queued-mounted-cancelled-after-unmount',
+    title: 'queued mounted callback is invalidated when unmount wins the race',
+    specCase: 'T-LIFECYCLE-0001-CASE-MOUNTED-CANCELLED-AFTER-UNMOUNT',
+    covers: ['C-LIFECYCLE-0002-D'],
+    expectation: 'queued-mounted-callback-invalidated-after-unmount',
+    expectedOrder: ['setup', 'created', 'first-render', 'commit', 'unmount-begin', 'unmounted'],
+    notes: ['The absence of `mounted` after `unmounted` is the observable requirement.'],
+  },
+  {
+    id: 'update-render-commit-updated',
+    title: 'update lifecycle order runs updated after update commit',
+    specCase: 'T-LIFECYCLE-0001-CASE-UPDATE-CYCLE-ORDER',
+    covers: ['C-LIFECYCLE-0002-E'],
+    expectation: 'update-render-commit-updated',
+    expectedOrder: ['update', 'update-render', 'update-commit', 'updated'],
+  },
+  {
+    id: 'unmounted-before-dispose-availability',
+    title: 'unmounted callback has an availability window before dispose',
+    specCase: 'T-LIFECYCLE-0001-CASE-UNMOUNT-DISPOSAL-BOUNDARY',
+    covers: ['C-LIFECYCLE-0002-F', 'C-LIFECYCLE-0002-G'],
+    expectation: 'unmounted-before-dispose-availability-window',
+    expectedOrder: ['unmount-begin', 'unmounted', 'dispose'],
+    notes: ['Runtime-managed handles remain usable during `unmounted` and fail after `dispose`.'],
+  },
+] as const satisfies readonly LifecycleCallbackOrderCase[];
+
+export const LIFECYCLE_CALLBACK_ORDER_SPEC_CASES = [
+  ...new Set(LIFECYCLE_CALLBACK_ORDER_CASES.map((testCase) => testCase.specCase)),
+] as const;

--- a/packages/spec/fixtures/src/template/authoring.ts
+++ b/packages/spec/fixtures/src/template/authoring.ts
@@ -1,0 +1,86 @@
+export type TemplateAuthoringExpectation =
+  | 'template-output-materializes-as-root-children'
+  | 'template-node-structural-shape'
+  | 'renderer-el-dispatch-and-props-validation'
+  | 'template-children-normalize-v0'
+  | 'template-slot-protocol-v0'
+  | 'prototype-ref-template-type-rejected';
+
+export type TemplateAuthoringCase = {
+  id: string;
+  title: string;
+  specCase: string;
+  covers: readonly string[];
+  expectation: TemplateAuthoringExpectation;
+  notes?: readonly string[];
+};
+
+export const TEMPLATE_AUTHORING_CASES = [
+  {
+    id: 'root-children-output',
+    title: 'template output materializes inside the host root',
+    specCase: 'T-TEMPLATE-0001-CASE-ROOT-CHILDREN',
+    covers: ['C-TEMPLATE-0001-A', 'C-TEMPLATE-0001-B', 'C-TEMPLATE-0001-C'],
+    expectation: 'template-output-materializes-as-root-children',
+  },
+  {
+    id: 'template-node-structural-shape',
+    title: 'template node is structural and may carry children and style',
+    specCase: 'T-TEMPLATE-0001-CASE-NODE-STRUCTURE',
+    covers: ['C-TEMPLATE-0002-A', 'C-TEMPLATE-0002-B', 'C-TEMPLATE-0002-C', 'C-TEMPLATE-0002-D'],
+    expectation: 'template-node-structural-shape',
+  },
+  {
+    id: 'renderer-el-dispatch',
+    title: 'el dispatches children and style-only TemplateProps',
+    specCase: 'T-TEMPLATE-0001-CASE-EL-DISPATCH',
+    covers: [
+      'C-TEMPLATE-0003-A',
+      'C-TEMPLATE-0003-B',
+      'C-TEMPLATE-0003-C',
+      'C-TEMPLATE-0003-D',
+      'C-TEMPLATE-0003-E',
+    ],
+    expectation: 'renderer-el-dispatch-and-props-validation',
+  },
+  {
+    id: 'template-children-normalize',
+    title: 'TemplateChildren normalization enforces v0 portability',
+    specCase: 'T-TEMPLATE-0001-CASE-NORMALIZE',
+    covers: [
+      'C-TEMPLATE-0004-A',
+      'C-TEMPLATE-0004-B',
+      'C-TEMPLATE-0004-C',
+      'C-TEMPLATE-0004-D',
+      'C-TEMPLATE-0004-E',
+      'C-TEMPLATE-0004-F',
+      'C-TEMPLATE-0004-G',
+    ],
+    expectation: 'template-children-normalize-v0',
+  },
+  {
+    id: 'slot-protocol',
+    title: 'slot is anonymous, singular, and parameterless',
+    specCase: 'T-TEMPLATE-0001-CASE-SLOT',
+    covers: [
+      'C-TEMPLATE-0005-A',
+      'C-TEMPLATE-0005-B',
+      'C-TEMPLATE-0005-C',
+      'C-TEMPLATE-0005-D',
+      'C-TEMPLATE-0005-E',
+    ],
+    expectation: 'template-slot-protocol-v0',
+  },
+  {
+    id: 'prototype-ref-rejection',
+    title: 'PrototypeRef template type is rejected by adapters',
+    specCase: 'T-TEMPLATE-0001-CASE-PROTOTYPE-REF',
+    covers: ['C-TEMPLATE-0006-A', 'C-TEMPLATE-0006-B', 'C-TEMPLATE-0006-C', 'C-TEMPLATE-0006-D'],
+    expectation: 'prototype-ref-template-type-rejected',
+    notes: ['This is a negative conformance signal, not a normal authoring path.'],
+  },
+] as const satisfies readonly TemplateAuthoringCase[];
+
+export const TEMPLATE_AUTHORING_SPEC_CASES = [
+  ...new Set(TEMPLATE_AUTHORING_CASES.map((testCase) => testCase.specCase)),
+] as const;

--- a/packages/spec/fixtures/test/lifecycle-callback-order.test.ts
+++ b/packages/spec/fixtures/test/lifecycle-callback-order.test.ts
@@ -1,0 +1,54 @@
+import path from 'node:path';
+
+import { loadSpecWorkspaceFromDirectory } from '@proto.ui/spec-engine/node';
+import { LIFECYCLE_CALLBACK_ORDER_CASES } from '@proto.ui/spec-fixtures/lifecycle/callback-order';
+import { describe, expect, it } from 'vitest';
+
+describe('spec fixtures: lifecycle callback order', () => {
+  it('stays aligned with T-LIFECYCLE-0001 and C-LIFECYCLE-0002', async () => {
+    const workspace = await loadSpecWorkspaceFromDirectory(path.resolve(process.cwd(), 'spec'));
+    expect(workspace.issues).toEqual([]);
+
+    const testSpec = workspace.entities.find((entity) => entity.id === 'T-LIFECYCLE-0001');
+    const contract = workspace.entities.find((entity) => entity.id === 'C-LIFECYCLE-0002');
+
+    expect(testSpec).toBeDefined();
+    expect(contract).toBeDefined();
+    expect(testSpec?.type).toBe('test');
+    expect(contract?.type).toBe('contract');
+
+    const specCaseIds = new Set<string>(testSpec?.cases.map((testCase) => testCase.id));
+    const criteriaIds = new Set<string>(contract?.criteria.map((criterion) => criterion.id));
+    const fixtureSpecCases = new Set<string>(
+      LIFECYCLE_CALLBACK_ORDER_CASES.map((testCase) => testCase.specCase)
+    );
+
+    for (const testCase of LIFECYCLE_CALLBACK_ORDER_CASES) {
+      expect(
+        specCaseIds.has(testCase.specCase),
+        `${testCase.id} references ${testCase.specCase}`
+      ).toBe(true);
+
+      for (const criterionId of testCase.covers) {
+        expect(criteriaIds.has(criterionId), `${testCase.id} covers ${criterionId}`).toBe(true);
+      }
+    }
+
+    for (const specCaseId of specCaseIds) {
+      expect(fixtureSpecCases.has(specCaseId), `${specCaseId} should have fixture coverage`).toBe(
+        true
+      );
+    }
+
+    const fixtureImplementation = testSpec?.implementations.find(
+      (implementation) => implementation.id === 'lifecycle-callback-order-fixture'
+    );
+
+    expect(fixtureImplementation).toBeDefined();
+    expect(fixtureImplementation?.status).toBe('active');
+    expect(fixtureImplementation?.path).toBe(
+      'packages/spec/fixtures/src/lifecycle/callback-order.ts'
+    );
+    expect(new Set(fixtureImplementation?.consumesCases ?? [])).toEqual(specCaseIds);
+  });
+});

--- a/packages/spec/fixtures/test/prototype-render-syntax.test.ts
+++ b/packages/spec/fixtures/test/prototype-render-syntax.test.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+
+import { loadSpecWorkspaceFromDirectory } from '@proto.ui/spec-engine/node';
+import { PROTOTYPE_RENDER_SYNTAX_CASES } from '@proto.ui/spec-fixtures/core/prototype-render-syntax';
+import { describe, expect, it } from 'vitest';
+
+describe('spec fixtures: prototype render syntax', () => {
+  it('stays aligned with T-CORE-SYNTAX-0001 and covered contracts', async () => {
+    const workspace = await loadSpecWorkspaceFromDirectory(path.resolve(process.cwd(), 'spec'));
+    expect(workspace.issues).toEqual([]);
+
+    const testSpec = workspace.entities.find((entity) => entity.id === 'T-CORE-SYNTAX-0001');
+    expect(testSpec).toBeDefined();
+    expect(testSpec?.type).toBe('test');
+
+    const contracts = new Map(
+      workspace.entities
+        .filter((entity) => entity.type === 'contract')
+        .map((entity) => [entity.id, new Set(entity.criteria.map((criterion) => criterion.id))])
+    );
+
+    const specCaseIds = new Set<string>(testSpec?.cases.map((testCase) => testCase.id));
+    const fixtureSpecCases = new Set<string>(
+      PROTOTYPE_RENDER_SYNTAX_CASES.map((testCase) => testCase.specCase)
+    );
+
+    for (const testCase of PROTOTYPE_RENDER_SYNTAX_CASES) {
+      expect(
+        specCaseIds.has(testCase.specCase),
+        `${testCase.id} references ${testCase.specCase}`
+      ).toBe(true);
+
+      for (const criterionId of testCase.covers) {
+        const contractId = criterionId.replace(/-[A-Z]+$/, '');
+        expect(
+          contracts.get(contractId)?.has(criterionId),
+          `${testCase.id} covers ${criterionId}`
+        ).toBe(true);
+      }
+    }
+
+    for (const specCaseId of specCaseIds) {
+      expect(fixtureSpecCases.has(specCaseId), `${specCaseId} should have fixture coverage`).toBe(
+        true
+      );
+    }
+
+    const fixtureImplementation = testSpec?.implementations.find(
+      (implementation) => implementation.id === 'core-prototype-render-syntax-fixture'
+    );
+
+    expect(fixtureImplementation).toBeDefined();
+    expect(fixtureImplementation?.status).toBe('active');
+    expect(fixtureImplementation?.path).toBe(
+      'packages/spec/fixtures/src/core/prototype-render-syntax.ts'
+    );
+    expect(new Set(fixtureImplementation?.consumesCases ?? [])).toEqual(specCaseIds);
+  });
+});

--- a/packages/spec/fixtures/test/template-authoring.test.ts
+++ b/packages/spec/fixtures/test/template-authoring.test.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+
+import { loadSpecWorkspaceFromDirectory } from '@proto.ui/spec-engine/node';
+import { TEMPLATE_AUTHORING_CASES } from '@proto.ui/spec-fixtures/template/authoring';
+import { describe, expect, it } from 'vitest';
+
+describe('spec fixtures: template authoring', () => {
+  it('stays aligned with T-TEMPLATE-0001 and covered contracts', async () => {
+    const workspace = await loadSpecWorkspaceFromDirectory(path.resolve(process.cwd(), 'spec'));
+    expect(workspace.issues).toEqual([]);
+
+    const testSpec = workspace.entities.find((entity) => entity.id === 'T-TEMPLATE-0001');
+    expect(testSpec).toBeDefined();
+    expect(testSpec?.type).toBe('test');
+
+    const contracts = new Map(
+      workspace.entities
+        .filter((entity) => entity.type === 'contract')
+        .map((entity) => [entity.id, new Set(entity.criteria.map((criterion) => criterion.id))])
+    );
+
+    const specCaseIds = new Set<string>(testSpec?.cases.map((testCase) => testCase.id));
+    const fixtureSpecCases = new Set<string>(
+      TEMPLATE_AUTHORING_CASES.map((testCase) => testCase.specCase)
+    );
+
+    for (const testCase of TEMPLATE_AUTHORING_CASES) {
+      expect(
+        specCaseIds.has(testCase.specCase),
+        `${testCase.id} references ${testCase.specCase}`
+      ).toBe(true);
+
+      for (const criterionId of testCase.covers) {
+        const contractId = criterionId.replace(/-[A-Z]+$/, '');
+        expect(
+          contracts.get(contractId)?.has(criterionId),
+          `${testCase.id} covers ${criterionId}`
+        ).toBe(true);
+      }
+    }
+
+    for (const specCaseId of specCaseIds) {
+      expect(fixtureSpecCases.has(specCaseId), `${specCaseId} should have fixture coverage`).toBe(
+        true
+      );
+    }
+
+    const fixtureImplementation = testSpec?.implementations.find(
+      (implementation) => implementation.id === 'template-authoring-fixture'
+    );
+
+    expect(fixtureImplementation).toBeDefined();
+    expect(fixtureImplementation?.status).toBe('active');
+    expect(fixtureImplementation?.path).toBe('packages/spec/fixtures/src/template/authoring.ts');
+    expect(new Set(fixtureImplementation?.consumesCases ?? [])).toEqual(specCaseIds);
+  });
+});

--- a/spec/contracts/C-CORE-SYNTAX-0003.yaml
+++ b/spec/contracts/C-CORE-SYNTAX-0003.yaml
@@ -1,0 +1,52 @@
+id: C-CORE-SYNTAX-0003
+type: contract
+title: Prototype definitions expose a named setup entry
+status: draft
+since: 0.1.0
+summary: A Proto UI prototype definition is a named object whose primary executable body is `setup(def)`.
+statement:
+  zh-CN: >-
+    Proto UI 的 prototype definition 必须以稳定对象表达，其中 `name` 标识原型，`setup(def)` 是原型作者的主体执行入口。除 `setup` 之外的字段可以作为描述、元信息或未来扩展存在，但不得取代 `setup` 作为原型结构的核心入口。
+
+
+  en: >-
+    A Proto UI prototype definition must be expressed as a stable object where `name` identifies the prototype and `setup(def)` is the prototype author's primary executable entry. Fields other than `setup` may exist as description, metadata, or future extensions, but they must not replace `setup` as the structural core of the prototype.
+
+
+criteria:
+  - id: C-CORE-SYNTAX-0003-A
+    text:
+      zh-CN: Prototype definition 必须包含非空字符串 `name`。
+      en: A prototype definition must contain a non-empty string `name`.
+  - id: C-CORE-SYNTAX-0003-B
+    text:
+      zh-CN: Prototype definition 必须包含函数形态的 `setup` 字段。
+      en: A prototype definition must contain a function-valued `setup` field.
+  - id: C-CORE-SYNTAX-0003-C
+    text:
+      zh-CN: '`setup` 是原型作者声明能力、注册回调并产出 render function 的主体入口。'
+      en: '`setup` is the primary entry where prototype authors declare capabilities, register callbacks, and produce a render function.'
+  - id: C-CORE-SYNTAX-0003-D
+    text:
+      zh-CN: 官方 helper、runtime 或 adapter 在接收无效 prototype definition 时必须 fail fast，而不是静默构造不完整原型。
+      en: Official helpers, runtimes, or adapters must fail fast for invalid prototype definitions rather than silently constructing incomplete prototypes.
+sources:
+  - path: packages/core/src/prototype.ts
+    sections:
+      - Prototype
+      - definePrototype
+  - path: internal/contracts/lifecycle/README.md
+    sections:
+      - 2. Setup Phase
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured the named prototype definition shape and setup entrypoint.
+tags:
+  - core
+  - syntax
+  - prototype
+  - setup

--- a/spec/contracts/C-CORE-SYNTAX-0004.yaml
+++ b/spec/contracts/C-CORE-SYNTAX-0004.yaml
@@ -1,0 +1,64 @@
+id: C-CORE-SYNTAX-0004
+type: contract
+title: Setup receives `def` and may produce render
+status: draft
+since: 0.1.0
+summary: Prototype `setup` receives the definition handle and returns either a render function or `void`.
+statement:
+  zh-CN: >-
+    Prototype `setup` 必须在 setup 阶段以 `def` 句柄作为参数执行。`setup` 的 portable 返回值形态是 render function 或 `void`：返回函数时，该函数成为该实例的 render function；返回 `void` 时，当前 v0 runtime 将其解释为默认 slot render。
+
+
+  en: >-
+    Prototype `setup` must run during setup with the `def` handle as its argument. The portable return shape of `setup` is either a render function or `void`: when it returns a function, that function becomes the instance render function; when it returns `void`, the current v0 runtime interprets it as the default slot render.
+
+
+criteria:
+  - id: C-CORE-SYNTAX-0004-A
+    text:
+      zh-CN: '`setup` 调用必须接收 `definition handle`，并遵守 `C-CORE-SYNTAX-0001` 的 setup-time 能力边界。'
+      en: '`setup` invocation must receive the `definition handle` and follow the setup-time capability boundary in `C-CORE-SYNTAX-0001`.'
+  - id: C-CORE-SYNTAX-0004-B
+    text:
+      zh-CN: '`setup` 返回函数时，该函数必须被 runtime 视为当前实例的 render function。'
+      en: When `setup` returns a function, the runtime must treat that function as the current instance's render function.
+  - id: C-CORE-SYNTAX-0004-C
+    text:
+      zh-CN: '`setup` 返回 `void` 时，当前 v0 runtime 必须提供默认 render，输出一个匿名 slot。'
+      en: When `setup` returns `void`, the current v0 runtime must provide a default render that outputs one anonymous slot.
+  - id: C-CORE-SYNTAX-0004-D
+    text:
+      zh-CN: '`setup` 不得返回除 render function 或 `void` 之外的 portable 值形态。'
+      en: '`setup` must not return a portable value shape other than a render function or `void`.'
+sources:
+  - path: packages/core/src/prototype.ts
+    sections:
+      - Prototype
+      - RenderFn
+  - path: packages/runtime/src/kernel/kernel.ts
+    sections:
+      - setup
+      - render
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0001
+    - C-CORE-SYNTAX-0003
+openQuestions:
+  - id: C-CORE-SYNTAX-0004-Q-DEFAULT-SLOT
+    question:
+      zh-CN: '`setup` 返回 `void` 时的默认 slot render 是否应长期作为 public contract，而不是仅作为当前 runtime 的 v0 默认实现？'
+      en: Should the default slot render for `setup` returning `void` remain a long-term public contract rather than only the current runtime's v0 default implementation?
+    context:
+      zh-CN: 当前 runtime 已实现默认 slot render，且大量无 render 的测试原型依赖该行为；后续若要收紧为必须显式返回 render，需要迁移这一路径。
+      en: The current runtime implements default slot render, and many render-less test prototypes rely on it; if future versions require explicit render returns, this path will need migration.
+    blocks:
+      - C-CORE-SYNTAX-0004-C
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured setup argument and return-shape semantics, including current default slot render behavior.
+tags:
+  - core
+  - syntax
+  - setup
+  - render

--- a/spec/contracts/C-CORE-SYNTAX-0005.yaml
+++ b/spec/contracts/C-CORE-SYNTAX-0005.yaml
@@ -1,0 +1,56 @@
+id: C-CORE-SYNTAX-0005
+type: contract
+title: Render functions return TemplateChildren
+status: draft
+since: 0.1.0
+summary: A render function is the setup-produced runtime function that receives a renderer handle and returns `TemplateChildren`.
+statement:
+  zh-CN: >-
+    Render function 是由 `setup` 产出、在 runtime render 阶段执行的函数。它必须接收 renderer handle，并返回 `TemplateChildren` 作为当前 render 输出；该输出随后由 runtime/adapter 的 render/commit flow 消费。
+
+
+  en: >-
+    A render function is the function produced by `setup` and executed during the runtime render phase. It must receive a renderer handle and return `TemplateChildren` as the current render output; that output is then consumed by the runtime/adapter render/commit flow.
+
+
+criteria:
+  - id: C-CORE-SYNTAX-0005-A
+    text:
+      zh-CN: Render function 必须由 `setup` 返回值或 runtime 默认 render 产生，而不是由 adapter 任意发明。
+      en: A render function must come from the `setup` return value or the runtime default render, not be invented arbitrarily by adapters.
+  - id: C-CORE-SYNTAX-0005-B
+    text:
+      zh-CN: Render function 调用时必须接收 renderer handle，而不是 `def handle` 或 lifecycle callback 的 `run handle`。
+      en: Render function invocation must receive the renderer handle, not the `def handle` or the lifecycle callback `run handle`.
+  - id: C-CORE-SYNTAX-0005-C
+    text:
+      zh-CN: Render function 的返回值必须被解释为 `TemplateChildren`。
+      en: A render function return value must be interpreted as `TemplateChildren`.
+  - id: C-CORE-SYNTAX-0005-D
+    text:
+      zh-CN: Render function 执行属于 runtime render 阶段，并必须接入 `C-LIFECYCLE-0002` 与 `C-LIFECYCLE-0003` 描述的 render/commit flow。
+      en: Render function execution belongs to the runtime render phase and must enter the render/commit flow described by `C-LIFECYCLE-0002` and `C-LIFECYCLE-0003`.
+sources:
+  - path: packages/core/src/prototype.ts
+    sections:
+      - RenderFn
+  - path: packages/core/src/handles.ts
+    sections:
+      - RendererHandle
+  - path: packages/runtime/src/kernel/kernel.ts
+    sections:
+      - render
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0004
+    - C-LIFECYCLE-0002
+    - C-LIFECYCLE-0003
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured render function invocation and return-shape semantics.
+tags:
+  - core
+  - syntax
+  - render
+  - template

--- a/spec/contracts/C-CORE-SYNTAX-0006.yaml
+++ b/spec/contracts/C-CORE-SYNTAX-0006.yaml
@@ -1,0 +1,63 @@
+id: C-CORE-SYNTAX-0006
+type: contract
+title: Renderer handle is the render-time syntax surface
+status: draft
+since: 0.1.0
+summary: Render-time template construction and render input reads are exposed through the renderer handle.
+statement:
+  zh-CN: >-
+    Render function 内的 portable 语法入口必须由 renderer handle 承载。renderer handle 提供 template authoring primitives（例如 `el`、`slot`、`r`、`svg`）以及 render-time read view；它不是 `run handle`，不得成为递归进入 update flow 的入口。
+
+
+  en: >-
+    Portable syntax inside render functions must be carried by the renderer handle. The renderer handle provides template authoring primitives such as `el`, `slot`, `r`, and `svg`, plus a render-time read view; it is not the `run handle` and must not become an entry point for recursive update flow.
+
+
+criteria:
+  - id: C-CORE-SYNTAX-0006-A
+    text:
+      zh-CN: Renderer handle 必须暴露 template authoring primitives，用于构建 `TemplateChildren`。
+      en: The renderer handle must expose template authoring primitives used to build `TemplateChildren`.
+  - id: C-CORE-SYNTAX-0006-B
+    text:
+      zh-CN: Renderer handle 必须提供 render-time read view，使 render 可以读取构建 template 所需的当前 runtime input。
+      en: The renderer handle must provide a render-time read view so render can read current runtime input needed to build the template.
+  - id: C-CORE-SYNTAX-0006-C
+    text:
+      zh-CN: 当前 v0 renderer read view 至少必须提供 props 的 `get()`、`getRaw()` 与 `isProvided()` 读取入口。
+      en: The current v0 renderer read view must at least provide props `get()`, `getRaw()`, and `isProvided()` read entries.
+  - id: C-CORE-SYNTAX-0006-D
+    text:
+      zh-CN: Renderer handle 不得暴露 `run.update()` 或等价 update entry。
+      en: The renderer handle must not expose `run.update()` or an equivalent update entry.
+sources:
+  - path: packages/core/src/handles.ts
+    sections:
+      - RendererHandle
+      - RenderReadHandle
+  - path: packages/runtime/src/kernel/kernel.ts
+    sections:
+      - read / renderer
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0005
+    - C-LIFECYCLE-0003
+openQuestions:
+  - id: C-CORE-SYNTAX-0006-Q-CONTEXT-READ
+    question:
+      zh-CN: Renderer read view 是否应扩展到 context/anatomy 等 read-only runtime input？
+      en: Should the renderer read view expand to context, anatomy, and other read-only runtime input?
+    context:
+      zh-CN: 旧讨论认为 render 读取当前 runtime input 是必要能力；当前实现主要稳定覆盖 props read，context read 更像后续实现缺口。
+      en: Older discussion treats reading current runtime input during render as necessary; the current implementation primarily stabilizes props read, while context read looks like a follow-up implementation gap.
+    blocks:
+      - C-CORE-SYNTAX-0006-B
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured the render-time renderer handle syntax surface and read/update boundary.
+tags:
+  - core
+  - syntax
+  - renderer
+  - render

--- a/spec/contracts/C-LIFECYCLE-0001.yaml
+++ b/spec/contracts/C-LIFECYCLE-0001.yaml
@@ -3,42 +3,70 @@ type: contract
 title: Prototype execution separates setup-time planning from runtime execution
 status: draft
 since: 0.1.0
-summary: '`Setup`-time planning and `runtime` execution are distinct phases with different semantic responsibilities.'
+summary: '`setup` and `runtime` are the coarse execution periods shared by all Proto UI lifecycle models.'
 statement:
-  zh-CN: Proto UI 原型的生命周期早于组件生命周期，并分为 `setup-time planning` 与 `runtime execution` 两个语义阶段。
-  en: A Proto UI prototype lifecycle starts before the component lifecycle and separates `setup-time planning` from `runtime execution`.
+  zh-CN: >-
+    Proto UI 的生命周期模型首先被粗略划分为 `setup` 与 `runtime` 两个执行时期：`setup` 期间具体组件实例尚不存在，原型作者只能声明、注册或计划能力；`runtime` 期间具体组件实例已经存在，runtime callback、render 与 host 驱动路径可以服务于某次真实运行。更细的生命周期 callback 模型与 CP checkpoint 模型都共享同一个 `setup` 语义，只是对 `runtime` 时期进行不同粒度的细化。
+
+
+  en: >-
+    Proto UI first separates lifecycle execution into the coarse `setup` and `runtime` periods. During `setup`, no concrete component instance exists and prototype authors may only declare, register, or plan capabilities. During `runtime`, a concrete component instance exists and runtime callbacks, render execution, and host-driven paths serve a real invocation. The finer lifecycle callback model and CP checkpoint model share the same `setup` semantics and only refine the `runtime` period at different granularities.
+
+
 criteria:
   - id: C-LIFECYCLE-0001-A
     text:
-      zh-CN: 原型生命周期的起点早于组件生命周期，因为原型可以作为 DSL 通过适配器或编译器生成组件。
-      en: The prototype lifecycle starts before the component lifecycle because a prototype can be adapted or compiled into a component.
+      zh-CN: '`setup` 时期必须表示具体组件实例尚不存在的阶段。'
+      en: The `setup` period must represent the stage before a concrete component instance exists.
   - id: C-LIFECYCLE-0001-B
     text:
-      zh-CN: '`setup` 阶段覆盖从原型被创建到组件被创建之前的时间段。'
-      en: The `setup` phase spans from prototype creation to before component creation.
+      zh-CN: '`setup` 时期的原型 API 语义必须是声明、注册、配置或计划，而不是针对某次真实运行立即执行。'
+      en: Prototype APIs in the `setup` period must describe declarations, registrations, configuration, or plans rather than immediate execution for a real invocation.
   - id: C-LIFECYCLE-0001-C
     text:
-      zh-CN: '`runtime` 阶段覆盖从组件被创建到组件被销毁的时间段。'
-      en: The `runtime` phase spans from component creation to component destruction.
+      zh-CN: '`runtime` 时期必须表示具体组件实例已经存在，直到该实例完成 unmount/dispose 的阶段。'
+      en: The `runtime` period must represent the stage where a concrete component instance exists until that instance completes unmount/dispose.
   - id: C-LIFECYCLE-0001-D
     text:
-      zh-CN: '`setup` 阶段的语法语义是计划、声明、注册或预演，而不是具体某次调用的执行。'
-      en: '`Setup`-time syntax describes plans, declarations, registrations, or previews rather than execution for a concrete invocation.'
+      zh-CN: '`runtime` 时期的原型 API 可以观察或作用于当前实例的运行输入、状态、上下文与 host 驱动 callback。'
+      en: Prototype APIs in the `runtime` period may observe or act on the current instance's runtime input, state, context, and host-driven callbacks.
   - id: C-LIFECYCLE-0001-E
     text:
-      zh-CN: '`runtime` 阶段的语法语义服务于具体某次调用，可以观察或作用于当前运行输入与状态。'
-      en: '`Runtime` syntax serves a concrete invocation and may observe or act on current runtime input and state.'
+      zh-CN: 生命周期 callback 模型与 CP checkpoint 模型不得重新定义 `setup` 语义，只能对 `runtime` 时期进行更细粒度的划分。
+      en: The lifecycle callback model and CP checkpoint model must not redefine `setup` semantics; they may only refine the `runtime` period at finer granularity.
+  - id: C-LIFECYCLE-0001-F
+    text:
+      zh-CN: 用于 API 可用性判断的 execution guard 必须至少能区分 `setup` 与 `runtime` 两个时期。
+      en: Execution guards used for API availability must at least distinguish the `setup` and `runtime` periods.
 sources:
-  - path: internal/contracts/props/base-text/01.define-merge.v0.zh-CN.md
+  - path: internal/contracts/lifecycle/component-lifecycle.v0.md
     sections:
-      - '1. 范围与术语'
-  - path: internal/contracts/props/base-text/02.resolve-fallback.v0.zh-CN.md
+      - Execution Domain Mapping (v0)
+  - path: internal/contracts/lifecycle/exec-phase-guard.v0.md
     sections:
-      - '2. 公共运行时 API'
+      - 1. Terminology
+      - 3. Semantics
+openQuestions:
+  - id: C-LIFECYCLE-0001-Q-EXEC-PHASE-INTERNAL
+    question:
+      zh-CN: '`SystemCaps.execPhase()` 是否应被视为纯实现层守卫，而不进入公开 lifecycle 模型？'
+      en: Should `SystemCaps.execPhase()` be treated as a purely implementation-level guard rather than part of the public lifecycle model?
+    context:
+      zh-CN: >-
+        `setup/runtime` 是契约层的粗粒度时期；当前实现还使用 `setup/render/callback/unknown` 作为 `execPhase`。其中 `render/callback` 更像 API guard 与 callback context 的实现细节，`unknown` 更像 runtime idle marker，后续可以考虑收敛或隐藏。
+
+      en: >-
+        `setup/runtime` is the coarse contract-level period model. The current implementation also uses `setup/render/callback/unknown` as `execPhase`; `render/callback` look more like API-guard and callback-context implementation details, while `unknown` looks like a runtime idle marker that could be collapsed or hidden later.
+
+    blocks:
+      - C-LIFECYCLE-0001-F
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted the upstream lifecycle model used by setup-time props declarations.
+  - version: 0.1.0
+    change: revised
+    summary: Reframed the entity around the shared setup/runtime execution-period model.
 tags:
   - lifecycle
   - setup

--- a/spec/contracts/C-LIFECYCLE-0002.yaml
+++ b/spec/contracts/C-LIFECYCLE-0002.yaml
@@ -16,8 +16,8 @@ statement:
 criteria:
   - id: C-LIFECYCLE-0002-A
     text:
-      zh-CN: '`def.lifecycle.onCreated/onMounted/onUpdated/onUnmounted` 必须只能在 `setup` 时期注册。'
-      en: '`def.lifecycle.onCreated/onMounted/onUpdated/onUnmounted` must only be registered during the `setup` period.'
+      zh-CN: 通过 `C-LIFECYCLE-0005` 定义的 prototype-visible lifecycle API 注册的 callback，必须由 runtime 生命周期流程调用，而不是在注册时立即执行。
+      en: Callbacks registered through the prototype-visible lifecycle API defined by `C-LIFECYCLE-0005` must be invoked by runtime lifecycle flow rather than immediately during registration.
   - id: C-LIFECYCLE-0002-B
     text:
       zh-CN: '`created` callback 必须在 `setup` 完成之后、首次 render 与首次 commit 之前执行。'
@@ -63,6 +63,7 @@ sources:
 dependsOn:
   contracts:
     - C-LIFECYCLE-0001
+    - C-LIFECYCLE-0005
 openQuestions:
   - id: C-LIFECYCLE-0002-Q-CALLBACK-ERRORS
     question:
@@ -83,6 +84,9 @@ revisions:
   - version: 0.1.0
     change: revised
     summary: Clarified that lifecycle commit ordering is based on host commit completion rather than synchronous function-call completion.
+  - version: 0.1.0
+    change: revised
+    summary: Moved lifecycle API surface syntax ownership to `C-LIFECYCLE-0005` while keeping callback invocation ordering here.
 tags:
   - lifecycle
   - callbacks

--- a/spec/contracts/C-LIFECYCLE-0002.yaml
+++ b/spec/contracts/C-LIFECYCLE-0002.yaml
@@ -1,0 +1,87 @@
+id: C-LIFECYCLE-0002
+type: contract
+title: Prototype-visible lifecycle callbacks follow canonical runtime order
+status: draft
+since: 0.1.0
+summary: Proto UI exposes lifecycle callbacks over the canonical runtime order `created -> first render -> commit -> mounted -> update cycles -> unmounted/dispose`.
+statement:
+  zh-CN: >-
+    Proto UI 的原型可见生命周期 API 必须映射到同一条 runtime 顺序：`setup -> created -> first render -> commit -> mounted -> (update -> render -> commit -> updated)*n -> unmounted/dispose`。`created`、`mounted`、`updated` 与 `unmounted` 是 setup 阶段注册、runtime 阶段调用的 callback；runtime 必须保证它们相对 render、commit、update 与 dispose 的顺序稳定，adapter 不得通过 host 生命周期重排这些语义。
+
+
+  en: >-
+    Proto UI's prototype-visible lifecycle API must map to one runtime order: `setup -> created -> first render -> commit -> mounted -> (update -> render -> commit -> updated)*n -> unmounted/dispose`. `created`, `mounted`, `updated`, and `unmounted` are callbacks registered during setup and invoked during runtime. The runtime must keep their ordering relative to render, commit, update, and dispose stable, and adapters must not reorder these semantics through host lifecycles.
+
+
+criteria:
+  - id: C-LIFECYCLE-0002-A
+    text:
+      zh-CN: '`def.lifecycle.onCreated/onMounted/onUpdated/onUnmounted` 必须只能在 `setup` 时期注册。'
+      en: '`def.lifecycle.onCreated/onMounted/onUpdated/onUnmounted` must only be registered during the `setup` period.'
+  - id: C-LIFECYCLE-0002-B
+    text:
+      zh-CN: '`created` callback 必须在 `setup` 完成之后、首次 render 与首次 commit 之前执行。'
+      en: '`created` callbacks must run after `setup` completes and before the first render and first commit.'
+  - id: C-LIFECYCLE-0002-C
+    text:
+      zh-CN: 首次 render 必须在 `created` 之后执行，并且首次 commit 必须应用该 render 的输出。
+      en: The first render must run after `created`, and the first commit must apply that render output.
+  - id: C-LIFECYCLE-0002-D
+    text:
+      zh-CN: '`mounted` callback 必须在首次 commit 完成之后执行；若实例在 mounted callback 执行前已经 unmount，已排队的 mounted callback 必须失效。'
+      en: '`mounted` callbacks must run after the first commit completes; if the instance unmounts before a mounted callback runs, the queued mounted callback must become ineffective.'
+  - id: C-LIFECYCLE-0002-E
+    text:
+      zh-CN: 每个 update cycle 必须按照 `update -> render -> commit -> updated` 的顺序执行；`updated` callback 不得早于对应 update commit。
+      en: Each update cycle must execute in `update -> render -> commit -> updated` order; `updated` callbacks must not run before the corresponding update commit.
+  - id: C-LIFECYCLE-0002-F
+    text:
+      zh-CN: '`unmounted` callback 必须在实例 dispose 之前执行；在 `unmounted` callback 执行期间，runtime handle 与受 lifecycle 管理的模块 handle 仍处于可用窗口。'
+      en: '`unmounted` callbacks must run before instance disposal; while `unmounted` callbacks execute, runtime handles and lifecycle-managed module handles are still in their availability window.'
+  - id: C-LIFECYCLE-0002-G
+    text:
+      zh-CN: dispose 完成后，受 runtime lifecycle 管理的 module facade、port 或 handle 必须被视为失效，后续操作必须失败而不是继续产生 runtime 行为。
+      en: After disposal completes, module facades, ports, or handles governed by the runtime lifecycle must be considered invalid, and later operations must fail rather than keep producing runtime behavior.
+sources:
+  - path: internal/contracts/lifecycle/component-lifecycle.v0.md
+    sections:
+      - Lifecycle Callbacks
+      - Ordering Guarantees
+      - Update Cycle
+      - Unmount & Disposal Semantics
+  - path: internal/contracts/runtime/lifecycle-with-host.v0.md
+    sections:
+      - 'Contract: Lifecycle Semantics (cross-host)'
+      - Ordering Constraints (cross-host)
+  - path: internal/contracts/lifecycle/README.md
+    sections:
+      - 1. Canonical Lifecycle Timeline (v0)
+      - 3. Created Callback
+      - 6. Mounted Callback
+      - 7. Update Cycle (v0)
+      - 8. Unmounted Callback & Disposal
+dependsOn:
+  contracts:
+    - C-LIFECYCLE-0001
+openQuestions:
+  - id: C-LIFECYCLE-0002-Q-CALLBACK-ERRORS
+    question:
+      zh-CN: lifecycle callback 抛错后的传播、后续 callback 是否继续执行、以及是否进入 dispose 是否应由本契约定义？
+      en: Should this contract define error propagation, whether later lifecycle callbacks continue, and whether disposal proceeds after a lifecycle callback throws?
+    context:
+      zh-CN: 旧契约只要求不能重排 canonical timeline，错误恢复仍是 adapter/runtime 断口。
+      en: Older contracts only require that the canonical timeline not be reordered; error recovery remains a runtime/adapter gap.
+    blocks:
+      - C-LIFECYCLE-0002
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Drafted the prototype-visible lifecycle callback ordering contract.
+  - version: 0.1.0
+    change: revised
+    summary: Resolved the `created` protoPhase exposure gap as an implementation follow-up without changing the callback ordering criteria.
+tags:
+  - lifecycle
+  - callbacks
+  - runtime
+  - dispose

--- a/spec/contracts/C-LIFECYCLE-0002.yaml
+++ b/spec/contracts/C-LIFECYCLE-0002.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: Proto UI exposes lifecycle callbacks over the canonical runtime order `created -> first render -> commit -> mounted -> update cycles -> unmounted/dispose`.
 statement:
   zh-CN: >-
-    Proto UI 的原型可见生命周期 API 必须映射到同一条 runtime 顺序：`setup -> created -> first render -> commit -> mounted -> (update -> render -> commit -> updated)*n -> unmounted/dispose`。`created`、`mounted`、`updated` 与 `unmounted` 是 setup 阶段注册、runtime 阶段调用的 callback；runtime 必须保证它们相对 render、commit、update 与 dispose 的顺序稳定，adapter 不得通过 host 生命周期重排这些语义。
+    Proto UI 的原型可见生命周期 API 必须映射到同一条 runtime 顺序：`setup -> created -> first render -> commit -> mounted -> (update -> render -> commit -> updated)*n -> unmounted/dispose`。这里的 `commit` 指对应 host commit 被 runtime/adapter 认定完成的语义边界，而不是必须同步完成的函数调用。`created`、`mounted`、`updated` 与 `unmounted` 是 setup 阶段注册、runtime 阶段调用的 callback；runtime 必须保证它们相对 render、commit completion、update 与 dispose 的顺序稳定，adapter 不得通过 host 生命周期重排这些语义。
 
 
   en: >-
-    Proto UI's prototype-visible lifecycle API must map to one runtime order: `setup -> created -> first render -> commit -> mounted -> (update -> render -> commit -> updated)*n -> unmounted/dispose`. `created`, `mounted`, `updated`, and `unmounted` are callbacks registered during setup and invoked during runtime. The runtime must keep their ordering relative to render, commit, update, and dispose stable, and adapters must not reorder these semantics through host lifecycles.
+    Proto UI's prototype-visible lifecycle API must map to one runtime order: `setup -> created -> first render -> commit -> mounted -> (update -> render -> commit -> updated)*n -> unmounted/dispose`. Here `commit` means the semantic boundary where the corresponding host commit is considered complete by the runtime/adapter, not necessarily a synchronously completed function call. `created`, `mounted`, `updated`, and `unmounted` are callbacks registered during setup and invoked during runtime. The runtime must keep their ordering relative to render, commit completion, update, and dispose stable, and adapters must not reorder these semantics through host lifecycles.
 
 
 criteria:
@@ -32,8 +32,8 @@ criteria:
       en: '`mounted` callbacks must run after the first commit completes; if the instance unmounts before a mounted callback runs, the queued mounted callback must become ineffective.'
   - id: C-LIFECYCLE-0002-E
     text:
-      zh-CN: 每个 update cycle 必须按照 `update -> render -> commit -> updated` 的顺序执行；`updated` callback 不得早于对应 update commit。
-      en: Each update cycle must execute in `update -> render -> commit -> updated` order; `updated` callbacks must not run before the corresponding update commit.
+      zh-CN: 每个被接受的 update cycle 必须按照 `update intent -> render -> commit completion -> updated` 的顺序执行；`updated` callback 不得早于对应 update commit completion。
+      en: Each accepted update cycle must execute in `update intent -> render -> commit completion -> updated` order; `updated` callbacks must not run before the corresponding update commit completion.
   - id: C-LIFECYCLE-0002-F
     text:
       zh-CN: '`unmounted` callback 必须在实例 dispose 之前执行；在 `unmounted` callback 执行期间，runtime handle 与受 lifecycle 管理的模块 handle 仍处于可用窗口。'
@@ -80,6 +80,9 @@ revisions:
   - version: 0.1.0
     change: revised
     summary: Resolved the `created` protoPhase exposure gap as an implementation follow-up without changing the callback ordering criteria.
+  - version: 0.1.0
+    change: revised
+    summary: Clarified that lifecycle commit ordering is based on host commit completion rather than synchronous function-call completion.
 tags:
   - lifecycle
   - callbacks

--- a/spec/contracts/C-LIFECYCLE-0003.yaml
+++ b/spec/contracts/C-LIFECYCLE-0003.yaml
@@ -6,18 +6,18 @@ since: 0.1.0
 summary: Render and commit are runtime-owned effects that may only be entered through explicit lifecycle update paths.
 statement:
   zh-CN: >-
-    Proto UI 必须把 render/commit 视为 runtime-owned flow，而不是任意模块 API 的隐式副作用。原型作者侧只有 `run.update()` 表达“请求进入 update flow”的意图；runtime/controller 或 adapter 可以拥有显式 update 入口，但 props、state、context、event、feedback 等通路 API 不得自行、隐式或旁路触发 render/commit。进入 update flow 后，其顺序必须继续遵守 `C-LIFECYCLE-0002` 的 `update -> render -> commit -> updated` 模型。
+    Proto UI 必须把 render/commit 视为 runtime-owned flow，而不是任意模块 API 的隐式副作用。原型作者侧只有 `run.update()` 表达“请求进入 update flow”的意图；该意图可以由 runtime/host 同步执行、调度执行、批处理或合并，不承诺调用返回时 host view 已经更新。runtime/controller 或 adapter 可以拥有显式 update 入口，但 props、state、context、event、feedback 等通路 API 不得自行、隐式或旁路触发 render/commit。一旦某个 update intent 被接受为 update cycle，其顺序必须继续遵守 `C-LIFECYCLE-0002` 的 `update intent -> render -> commit completion -> updated` 模型。
 
 
   en: >-
-    Proto UI must treat render/commit as runtime-owned flow rather than an implicit side effect of arbitrary module APIs. On the prototype-author surface, only `run.update()` expresses intent to enter update flow. Runtime/controller or adapter layers may own explicit update entry points, but props, state, context, event, feedback, and similar channel APIs must not trigger render/commit by themselves, implicitly, or through a side path. Once update flow begins, it must still follow the `update -> render -> commit -> updated` model defined by `C-LIFECYCLE-0002`.
+    Proto UI must treat render/commit as runtime-owned flow rather than an implicit side effect of arbitrary module APIs. On the prototype-author surface, only `run.update()` expresses intent to enter update flow. That intent may be executed synchronously, scheduled, batched, or coalesced by the runtime/host, and it does not guarantee that the host view has changed when the call returns. Runtime/controller or adapter layers may own explicit update entry points, but props, state, context, event, feedback, and similar channel APIs must not trigger render/commit by themselves, implicitly, or through a side path. Once an update intent is accepted as an update cycle, it must still follow the `update intent -> render -> commit completion -> updated` model defined by `C-LIFECYCLE-0002`.
 
 
 criteria:
   - id: C-LIFECYCLE-0003-A
     text:
-      zh-CN: '`run.update()` 必须被建模为原型作者可访问的显式 update intent，而不是普通 module API 的副作用。'
-      en: '`run.update()` must be modeled as the explicit update intent available to prototype authors, not as a side effect of ordinary module APIs.'
+      zh-CN: '`run.update()` 必须被建模为原型作者可访问的显式 update intent，而不是普通 module API 的副作用或同步 view update 保证。'
+      en: '`run.update()` must be modeled as the explicit update intent available to prototype authors, not as a side effect of ordinary module APIs or a synchronous view-update guarantee.'
   - id: C-LIFECYCLE-0003-B
     text:
       zh-CN: runtime/controller 或 adapter 可以提供显式 update 入口，但这些入口必须被标注为 runtime/host 层能力，而不是 channel API 的隐式行为。
@@ -36,8 +36,16 @@ criteria:
       en: During render function execution, even if a `run handle` or equivalent runtime view is available, it must not be possible to enter recursive update flow through `run.update()` or an equivalent entry point.
   - id: C-LIFECYCLE-0003-F
     text:
-      zh-CN: 一旦显式 update 入口被接受，runtime 必须按 `C-LIFECYCLE-0002` 的 update cycle 顺序执行 render、commit 与 `updated` callback。
-      en: Once an explicit update entry point is accepted, the runtime must execute render, commit, and `updated` callbacks according to the update-cycle order in `C-LIFECYCLE-0002`.
+      zh-CN: 一旦显式 update 入口被接受为 update cycle，runtime/host 必须按 `C-LIFECYCLE-0002` 的 update cycle 顺序完成 render、host commit completion 与 `updated` callback。
+      en: Once an explicit update entry point is accepted as an update cycle, the runtime/host must complete render, host commit completion, and `updated` callbacks according to the update-cycle order in `C-LIFECYCLE-0002`.
+  - id: C-LIFECYCLE-0003-G
+    text:
+      zh-CN: runtime/host 可以调度、批处理或合并多个 update intent；原型作者不得依赖 `run.update()` 调用返回后立即观察到 host view 变化。
+      en: The runtime/host may schedule, batch, or coalesce multiple update intents; prototype authors must not rely on host-view changes being observable immediately after `run.update()` returns.
+  - id: C-LIFECYCLE-0003-H
+    text:
+      zh-CN: 当多个 update intent 被合并为一次 update commit 时，`updated` callback 必须按实际完成的 update commit 执行一次，而不是按 intent 次数执行。
+      en: When multiple update intents are coalesced into one update commit, `updated` callbacks must run once for the completed update commit rather than once per intent.
 sources:
   - path: internal/contracts/runtime/lifecycle-with-host.v0.md
     sections:
@@ -58,16 +66,6 @@ refines:
   contracts:
     - C-PROPS-0014
 openQuestions:
-  - id: C-LIFECYCLE-0003-Q-SYNC-OR-SCHEDULED-UPDATE
-    question:
-      zh-CN: '`run.update()`/controller update 在 v0 中是否必须同步 render+commit，还是只承诺 update intent 并允许 host 调度、批处理或合并？'
-      en: In v0, must `run.update()` or controller update synchronously render and commit, or should it only guarantee update intent while allowing host scheduling, batching, or coalescing?
-    context:
-      zh-CN: 当前 `executeWithHost` 实现同步执行 update render/commit，但旧 runtime-with-host 契约允许 host 把 update 解释为 intent。
-      en: The current `executeWithHost` implementation performs update render/commit synchronously, while the older runtime-with-host contract allows hosts to interpret update as intent.
-    blocks:
-      - C-LIFECYCLE-0003-A
-      - C-LIFECYCLE-0003-F
   - id: C-LIFECYCLE-0003-Q-RENDER-RUN-WRITE-SURFACE
     question:
       zh-CN: render 函数执行期间的 `run handle` 是否应包含 state/context/event 等 write 相关 API，还是只暴露 read API 并禁用所有 write API？
@@ -76,8 +74,10 @@ openQuestions:
       zh-CN: >-
         render 期间读取 props/context 等 runtime input 是构建 template 的必要能力；当前只能通过 `renderer.read.props` 读取 props，不能读取 context 更像实现缺口。真正的权衡在 write API：若 render-time `run` 不含 write API，可能限制某些需求；若包含 write API，write 可能触发 watcher，并在当前 update 尚未完成时再次进入 update flow，风险接近直接在 render 中调用 `run.update()`。
 
+
       en: >-
         Reading runtime input such as props and context during render is necessary for template construction; the current `renderer.read.props`-only surface makes context reads look like an implementation gap. The real tradeoff is write APIs: excluding write APIs from render-time `run` may block some use cases, while including them may trigger watchers and re-enter update flow before the current update completes, with risks similar to calling `run.update()` during render.
+
 
     blocks:
       - C-LIFECYCLE-0003-C
@@ -87,6 +87,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted the lifecycle-owned explicit update/render entry-point boundary.
+  - version: 0.1.0
+    change: revised
+    summary: Resolved update scheduling semantics by treating `run.update()` as intent and preserving host-controlled scheduling, batching, coalescing, and commit-completion ordering.
 tags:
   - lifecycle
   - runtime

--- a/spec/contracts/C-LIFECYCLE-0003.yaml
+++ b/spec/contracts/C-LIFECYCLE-0003.yaml
@@ -1,0 +1,95 @@
+id: C-LIFECYCLE-0003
+type: contract
+title: Runtime update flow has explicit render entry points
+status: draft
+since: 0.1.0
+summary: Render and commit are runtime-owned effects that may only be entered through explicit lifecycle update paths.
+statement:
+  zh-CN: >-
+    Proto UI 必须把 render/commit 视为 runtime-owned flow，而不是任意模块 API 的隐式副作用。原型作者侧只有 `run.update()` 表达“请求进入 update flow”的意图；runtime/controller 或 adapter 可以拥有显式 update 入口，但 props、state、context、event、feedback 等通路 API 不得自行、隐式或旁路触发 render/commit。进入 update flow 后，其顺序必须继续遵守 `C-LIFECYCLE-0002` 的 `update -> render -> commit -> updated` 模型。
+
+
+  en: >-
+    Proto UI must treat render/commit as runtime-owned flow rather than an implicit side effect of arbitrary module APIs. On the prototype-author surface, only `run.update()` expresses intent to enter update flow. Runtime/controller or adapter layers may own explicit update entry points, but props, state, context, event, feedback, and similar channel APIs must not trigger render/commit by themselves, implicitly, or through a side path. Once update flow begins, it must still follow the `update -> render -> commit -> updated` model defined by `C-LIFECYCLE-0002`.
+
+
+criteria:
+  - id: C-LIFECYCLE-0003-A
+    text:
+      zh-CN: '`run.update()` 必须被建模为原型作者可访问的显式 update intent，而不是普通 module API 的副作用。'
+      en: '`run.update()` must be modeled as the explicit update intent available to prototype authors, not as a side effect of ordinary module APIs.'
+  - id: C-LIFECYCLE-0003-B
+    text:
+      zh-CN: runtime/controller 或 adapter 可以提供显式 update 入口，但这些入口必须被标注为 runtime/host 层能力，而不是 channel API 的隐式行为。
+      en: Runtime/controller or adapter layers may provide explicit update entry points, but those entry points must be identified as runtime/host-layer capabilities rather than implicit channel API behavior.
+  - id: C-LIFECYCLE-0003-C
+    text:
+      zh-CN: props、state、context、event、feedback 等模块 API 的调用不得自动触发 render 或 commit。
+      en: Calls to module APIs such as props, state, context, event, or feedback must not automatically trigger render or commit.
+  - id: C-LIFECYCLE-0003-D
+    text:
+      zh-CN: render 函数执行期间必须能够读取构建 template 所需的当前 runtime input；runtime 可以通过完整 `run handle`、render-time view 或等价机制提供 props、context 等 read API。
+      en: During render function execution, the current runtime input needed to build the template must be readable; the runtime may provide props, context, and other read APIs through a full `run handle`, a render-time view, or an equivalent mechanism.
+  - id: C-LIFECYCLE-0003-E
+    text:
+      zh-CN: render 函数执行期间即使可以获得 `run handle` 或等价 runtime view，也不得通过 `run.update()` 或等价入口进入递归 update flow。
+      en: During render function execution, even if a `run handle` or equivalent runtime view is available, it must not be possible to enter recursive update flow through `run.update()` or an equivalent entry point.
+  - id: C-LIFECYCLE-0003-F
+    text:
+      zh-CN: 一旦显式 update 入口被接受，runtime 必须按 `C-LIFECYCLE-0002` 的 update cycle 顺序执行 render、commit 与 `updated` callback。
+      en: Once an explicit update entry point is accepted, the runtime must execute render, commit, and `updated` callbacks according to the update-cycle order in `C-LIFECYCLE-0002`.
+sources:
+  - path: internal/contracts/runtime/lifecycle-with-host.v0.md
+    sections:
+      - update intent
+      - updated
+      - Ordering Constraints (cross-host)
+  - path: internal/contracts/lifecycle/README.md
+    sections:
+      - 7. Update Cycle (v0)
+  - path: internal/contracts/props/base-text/05.runtime-integration.v0.zh-CN.md
+    sections:
+      - '5. applyRawProps 不触发渲染'
+dependsOn:
+  contracts:
+    - C-LIFECYCLE-0001
+    - C-LIFECYCLE-0002
+refines:
+  contracts:
+    - C-PROPS-0014
+openQuestions:
+  - id: C-LIFECYCLE-0003-Q-SYNC-OR-SCHEDULED-UPDATE
+    question:
+      zh-CN: '`run.update()`/controller update 在 v0 中是否必须同步 render+commit，还是只承诺 update intent 并允许 host 调度、批处理或合并？'
+      en: In v0, must `run.update()` or controller update synchronously render and commit, or should it only guarantee update intent while allowing host scheduling, batching, or coalescing?
+    context:
+      zh-CN: 当前 `executeWithHost` 实现同步执行 update render/commit，但旧 runtime-with-host 契约允许 host 把 update 解释为 intent。
+      en: The current `executeWithHost` implementation performs update render/commit synchronously, while the older runtime-with-host contract allows hosts to interpret update as intent.
+    blocks:
+      - C-LIFECYCLE-0003-A
+      - C-LIFECYCLE-0003-F
+  - id: C-LIFECYCLE-0003-Q-RENDER-RUN-WRITE-SURFACE
+    question:
+      zh-CN: render 函数执行期间的 `run handle` 是否应包含 state/context/event 等 write 相关 API，还是只暴露 read API 并禁用所有 write API？
+      en: During render function execution, should the `run handle` include write-capable APIs such as state, context, and event APIs, or expose only read APIs and disable all write APIs?
+    context:
+      zh-CN: >-
+        render 期间读取 props/context 等 runtime input 是构建 template 的必要能力；当前只能通过 `renderer.read.props` 读取 props，不能读取 context 更像实现缺口。真正的权衡在 write API：若 render-time `run` 不含 write API，可能限制某些需求；若包含 write API，write 可能触发 watcher，并在当前 update 尚未完成时再次进入 update flow，风险接近直接在 render 中调用 `run.update()`。
+
+      en: >-
+        Reading runtime input such as props and context during render is necessary for template construction; the current `renderer.read.props`-only surface makes context reads look like an implementation gap. The real tradeoff is write APIs: excluding write APIs from render-time `run` may block some use cases, while including them may trigger watchers and re-enter update flow before the current update completes, with risks similar to calling `run.update()` during render.
+
+    blocks:
+      - C-LIFECYCLE-0003-C
+      - C-LIFECYCLE-0003-D
+      - C-LIFECYCLE-0003-E
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Drafted the lifecycle-owned explicit update/render entry-point boundary.
+tags:
+  - lifecycle
+  - runtime
+  - update
+  - render
+  - scheduling

--- a/spec/contracts/C-LIFECYCLE-0004.yaml
+++ b/spec/contracts/C-LIFECYCLE-0004.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: The CP0-CP10 checkpoint model refines runtime lifecycle ordering for runtime and adapter design without becoming prototype API.
 statement:
   zh-CN: >-
-    Proto UI runtime 与 adapter 必须把 host 行为映射到同一组不可重排的 lifecycle checkpoints：CP0 setup exit、CP1 created callbacks、CP2 logical tree ready、CP3 commit start、CP4 commit done、CP5 mounted callbacks、CP6 update render、CP7 update commit done、CP8 updated callbacks、CP9 unmount begin、CP10 dispose complete。该 checkpoint 模型是 runtime/adapter 设计约束，不是原型作者可见 API；它只把 `C-LIFECYCLE-0002` 的 runtime 顺序细化为可实现、可测试的边界。CP4 与 CP7 均表示 host commit completion，可以由同步或异步 host profile 达成。
+    Proto UI runtime 与 adapter 必须把 host 行为映射到同一组不可重排的 lifecycle checkpoints：CP0 setup exit、CP1 created callbacks、CP2 logical tree ready、CP3 commit start、CP4 commit done、CP5 mounted callbacks、CP6 update render、CP7 update commit done、CP8 updated callbacks、CP9 unmount begin、CP10 dispose complete。该 checkpoint 模型是 runtime/adapter 设计约束，不是原型作者可见 API；它只把 `C-LIFECYCLE-0002` 的 runtime 顺序细化为可实现、可测试的边界。CP0-CP10 的编号、canonical name 与语义定义是 runtime timeline 与 test trace 的 source of truth；实现可以保留内部 mark 名称，但必须能无损映射到 canonical checkpoint。CP4 与 CP7 均表示 host commit completion，可以由同步或异步 host profile 达成。
 
 
   en: >-
-    Proto UI runtime and adapters must map host behavior into one non-reorderable set of lifecycle checkpoints: CP0 setup exit, CP1 created callbacks, CP2 logical tree ready, CP3 commit start, CP4 commit done, CP5 mounted callbacks, CP6 update render, CP7 update commit done, CP8 updated callbacks, CP9 unmount begin, and CP10 dispose complete. This checkpoint model constrains runtime and adapter design; it is not a prototype-author API. It only refines the runtime order in `C-LIFECYCLE-0002` into implementable and testable boundaries. CP4 and CP7 both represent host commit completion, which may be reached by either synchronous or asynchronous host profiles.
+    Proto UI runtime and adapters must map host behavior into one non-reorderable set of lifecycle checkpoints: CP0 setup exit, CP1 created callbacks, CP2 logical tree ready, CP3 commit start, CP4 commit done, CP5 mounted callbacks, CP6 update render, CP7 update commit done, CP8 updated callbacks, CP9 unmount begin, and CP10 dispose complete. This checkpoint model constrains runtime and adapter design; it is not a prototype-author API. It only refines the runtime order in `C-LIFECYCLE-0002` into implementable and testable boundaries. The CP0-CP10 numbers, canonical names, and semantic definitions are the source of truth for runtime timelines and test traces; implementations may keep internal mark names, but they must map losslessly to the canonical checkpoints. CP4 and CP7 both represent host commit completion, which may be reached by either synchronous or asynchronous host profiles.
 
 
 criteria:
@@ -42,6 +42,14 @@ criteria:
     text:
       zh-CN: CP checkpoint 名称与编号不得作为原型作者 API 暴露；原型作者只依赖 `C-LIFECYCLE-0002` 定义的 callback 顺序与可用性。
       en: CP checkpoint names and numbers must not be exposed as prototype-author APIs; prototype authors only rely on the callback ordering and availability defined by `C-LIFECYCLE-0002`.
+  - id: C-LIFECYCLE-0004-H
+    text:
+      zh-CN: runtime timeline、test trace、adapter conformance trace 若需要记录 lifecycle checkpoint，必须使用 canonical checkpoint name，或提供到 canonical checkpoint name 的无损映射。
+      en: Runtime timelines, test traces, and adapter conformance traces that record lifecycle checkpoints must use canonical checkpoint names or provide a lossless mapping to canonical checkpoint names.
+  - id: C-LIFECYCLE-0004-I
+    text:
+      zh-CN: canonical checkpoint names 必须固定为 `CP0_SETUP_EXIT`、`CP1_CREATED_CALLBACKS`、`CP2_LOGICAL_TREE_READY`、`CP3_COMMIT_START`、`CP4_COMMIT_DONE`、`CP5_MOUNTED_CALLBACKS`、`CP6_UPDATE_RENDER`、`CP7_UPDATE_COMMIT_DONE`、`CP8_UPDATED_CALLBACKS`、`CP9_UNMOUNT_BEGIN` 与 `CP10_DISPOSE_COMPLETE`。
+      en: Canonical checkpoint names must be fixed as `CP0_SETUP_EXIT`, `CP1_CREATED_CALLBACKS`, `CP2_LOGICAL_TREE_READY`, `CP3_COMMIT_START`, `CP4_COMMIT_DONE`, `CP5_MOUNTED_CALLBACKS`, `CP6_UPDATE_RENDER`, `CP7_UPDATE_COMMIT_DONE`, `CP8_UPDATED_CALLBACKS`, `CP9_UNMOUNT_BEGIN`, and `CP10_DISPOSE_COMPLETE`.
 sources:
   - path: internal/contracts/lifecycle/adapter-lifecycle.v0.md
     sections:
@@ -59,15 +67,6 @@ dependsOn:
     - C-LIFECYCLE-0002
     - C-LIFECYCLE-0003
 openQuestions:
-  - id: C-LIFECYCLE-0004-Q-CP-SOURCE-OF-TRUTH
-    question:
-      zh-CN: CP0-CP10 是否应成为 runtime timeline/test trace 的稳定命名，还是只作为契约文档中的语义 checkpoint？
-      en: Should CP0-CP10 become stable names in runtime timeline/test traces, or remain only semantic checkpoints in contract documents?
-    context:
-      zh-CN: 当前实现已有 runtime timeline mark，但名称与 CP 编号不完全一一对应。
-      en: The current implementation has runtime timeline marks, but their names do not map one-to-one to CP numbers.
-    blocks:
-      - C-LIFECYCLE-0004
   - id: C-LIFECYCLE-0004-Q-ADAPTER-PROFILES
     question:
       zh-CN: React、Vue、Web Component 等 host-specific 生命周期映射是否应分别建立 adapter profile 契约，而不是继续扩展 core lifecycle 契约？
@@ -84,6 +83,9 @@ revisions:
   - version: 0.1.0
     change: revised
     summary: Clarified CP7 as update commit completion so checkpoint ordering supports synchronous and asynchronous host profiles.
+  - version: 0.1.0
+    change: revised
+    summary: Resolved CP source-of-truth semantics by defining stable canonical checkpoint names for runtime timelines and test traces.
 tags:
   - lifecycle
   - checkpoint

--- a/spec/contracts/C-LIFECYCLE-0004.yaml
+++ b/spec/contracts/C-LIFECYCLE-0004.yaml
@@ -1,0 +1,88 @@
+id: C-LIFECYCLE-0004
+type: contract
+title: Runtime and adapters preserve canonical lifecycle checkpoints
+status: draft
+since: 0.1.0
+summary: The CP0-CP10 checkpoint model refines runtime lifecycle ordering for runtime and adapter design without becoming prototype API.
+statement:
+  zh-CN: >-
+    Proto UI runtime 与 adapter 必须把 host 行为映射到同一组不可重排的 lifecycle checkpoints：CP0 setup exit、CP1 created callbacks、CP2 logical tree ready、CP3 commit start、CP4 commit done、CP5 mounted callbacks、CP6 update render、CP7 update commit、CP8 updated callbacks、CP9 unmount begin、CP10 dispose complete。该 checkpoint 模型是 runtime/adapter 设计约束，不是原型作者可见 API；它只把 `C-LIFECYCLE-0002` 的 runtime 顺序细化为可实现、可测试的边界。
+
+
+  en: >-
+    Proto UI runtime and adapters must map host behavior into one non-reorderable set of lifecycle checkpoints: CP0 setup exit, CP1 created callbacks, CP2 logical tree ready, CP3 commit start, CP4 commit done, CP5 mounted callbacks, CP6 update render, CP7 update commit, CP8 updated callbacks, CP9 unmount begin, and CP10 dispose complete. This checkpoint model constrains runtime and adapter design; it is not a prototype-author API. It only refines the runtime order in `C-LIFECYCLE-0002` into implementable and testable boundaries.
+
+
+criteria:
+  - id: C-LIFECYCLE-0004-A
+    text:
+      zh-CN: CP0 必须表示 `proto.setup(def)` 已经返回，且 `setup` 时期已经退出，但任何 lifecycle callback 尚未执行。
+      en: CP0 must represent that `proto.setup(def)` has returned and the `setup` period has exited, while no lifecycle callback has run yet.
+  - id: C-LIFECYCLE-0004-B
+    text:
+      zh-CN: CP1 到 CP5 必须按 `created callbacks -> logical tree ready -> commit start -> commit done -> mounted callbacks` 的顺序发生。
+      en: CP1 through CP5 must occur in `created callbacks -> logical tree ready -> commit start -> commit done -> mounted callbacks` order.
+  - id: C-LIFECYCLE-0004-C
+    text:
+      zh-CN: 每个 update cycle 的 CP6 到 CP8 必须按 `update render -> update commit -> updated callbacks` 的顺序发生。
+      en: For each update cycle, CP6 through CP8 must occur in `update render -> update commit -> updated callbacks` order.
+  - id: C-LIFECYCLE-0004-D
+    text:
+      zh-CN: CP9 必须表示实例进入 unmount/disconnect 流程且 `unmounted` callback 即将或正在执行；此时受 runtime 管理的 module handle 仍不得被提前 dispose。
+      en: CP9 must represent that the instance has entered unmount/disconnect flow and `unmounted` callbacks are about to run or are running; runtime-managed module handles must not be disposed early at this point.
+  - id: C-LIFECYCLE-0004-E
+    text:
+      zh-CN: CP10 必须表示实例 dispose 完成；CP10 之后受 `SystemCaps` 或 runtime lifecycle 管理的 handle 访问必须失败。
+      en: CP10 must represent completed instance disposal; after CP10, access to handles governed by `SystemCaps` or runtime lifecycle must fail.
+  - id: C-LIFECYCLE-0004-F
+    text:
+      zh-CN: adapter 必须把 host-specific lifecycle 映射到 CP0-CP10，不得引入与 canonical checkpoint 顺序竞争或平行的生命周期模型。
+      en: Adapters must map host-specific lifecycles into CP0-CP10 and must not introduce a competing or parallel lifecycle model.
+  - id: C-LIFECYCLE-0004-G
+    text:
+      zh-CN: CP checkpoint 名称与编号不得作为原型作者 API 暴露；原型作者只依赖 `C-LIFECYCLE-0002` 定义的 callback 顺序与可用性。
+      en: CP checkpoint names and numbers must not be exposed as prototype-author APIs; prototype authors only rely on the callback ordering and availability defined by `C-LIFECYCLE-0002`.
+sources:
+  - path: internal/contracts/lifecycle/adapter-lifecycle.v0.md
+    sections:
+      - Canonical Timeline
+      - Checkpoints
+      - Mandatory Rules
+  - path: internal/contracts/lifecycle/component-lifecycle.v0.md
+    sections:
+      - Execution Domain Mapping (v0)
+      - Ordering Guarantees
+      - Unmount & Disposal Semantics
+dependsOn:
+  contracts:
+    - C-LIFECYCLE-0001
+    - C-LIFECYCLE-0002
+    - C-LIFECYCLE-0003
+openQuestions:
+  - id: C-LIFECYCLE-0004-Q-CP-SOURCE-OF-TRUTH
+    question:
+      zh-CN: CP0-CP10 是否应成为 runtime timeline/test trace 的稳定命名，还是只作为契约文档中的语义 checkpoint？
+      en: Should CP0-CP10 become stable names in runtime timeline/test traces, or remain only semantic checkpoints in contract documents?
+    context:
+      zh-CN: 当前实现已有 runtime timeline mark，但名称与 CP 编号不完全一一对应。
+      en: The current implementation has runtime timeline marks, but their names do not map one-to-one to CP numbers.
+    blocks:
+      - C-LIFECYCLE-0004
+  - id: C-LIFECYCLE-0004-Q-ADAPTER-PROFILES
+    question:
+      zh-CN: React、Vue、Web Component 等 host-specific 生命周期映射是否应分别建立 adapter profile 契约，而不是继续扩展 core lifecycle 契约？
+      en: Should React, Vue, Web Component, and other host-specific lifecycle mappings be governed by separate adapter profile contracts rather than expanding core lifecycle contracts?
+    context:
+      zh-CN: core lifecycle 只约束 adapter 必须保序映射到 CP 模型；具体 connected/disconnected、framework next tick、DOM move 等行为属于 host profile。
+      en: Core lifecycle only requires adapters to preserve ordering into the CP model; concrete connected/disconnected, framework next tick, DOM move, and similar behavior belongs to host profiles.
+    blocks:
+      - C-LIFECYCLE-0004-F
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Drafted the runtime/adapter checkpoint model for lifecycle governance.
+tags:
+  - lifecycle
+  - checkpoint
+  - runtime
+  - adapter

--- a/spec/contracts/C-LIFECYCLE-0004.yaml
+++ b/spec/contracts/C-LIFECYCLE-0004.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: The CP0-CP10 checkpoint model refines runtime lifecycle ordering for runtime and adapter design without becoming prototype API.
 statement:
   zh-CN: >-
-    Proto UI runtime 与 adapter 必须把 host 行为映射到同一组不可重排的 lifecycle checkpoints：CP0 setup exit、CP1 created callbacks、CP2 logical tree ready、CP3 commit start、CP4 commit done、CP5 mounted callbacks、CP6 update render、CP7 update commit、CP8 updated callbacks、CP9 unmount begin、CP10 dispose complete。该 checkpoint 模型是 runtime/adapter 设计约束，不是原型作者可见 API；它只把 `C-LIFECYCLE-0002` 的 runtime 顺序细化为可实现、可测试的边界。
+    Proto UI runtime 与 adapter 必须把 host 行为映射到同一组不可重排的 lifecycle checkpoints：CP0 setup exit、CP1 created callbacks、CP2 logical tree ready、CP3 commit start、CP4 commit done、CP5 mounted callbacks、CP6 update render、CP7 update commit done、CP8 updated callbacks、CP9 unmount begin、CP10 dispose complete。该 checkpoint 模型是 runtime/adapter 设计约束，不是原型作者可见 API；它只把 `C-LIFECYCLE-0002` 的 runtime 顺序细化为可实现、可测试的边界。CP4 与 CP7 均表示 host commit completion，可以由同步或异步 host profile 达成。
 
 
   en: >-
-    Proto UI runtime and adapters must map host behavior into one non-reorderable set of lifecycle checkpoints: CP0 setup exit, CP1 created callbacks, CP2 logical tree ready, CP3 commit start, CP4 commit done, CP5 mounted callbacks, CP6 update render, CP7 update commit, CP8 updated callbacks, CP9 unmount begin, and CP10 dispose complete. This checkpoint model constrains runtime and adapter design; it is not a prototype-author API. It only refines the runtime order in `C-LIFECYCLE-0002` into implementable and testable boundaries.
+    Proto UI runtime and adapters must map host behavior into one non-reorderable set of lifecycle checkpoints: CP0 setup exit, CP1 created callbacks, CP2 logical tree ready, CP3 commit start, CP4 commit done, CP5 mounted callbacks, CP6 update render, CP7 update commit done, CP8 updated callbacks, CP9 unmount begin, and CP10 dispose complete. This checkpoint model constrains runtime and adapter design; it is not a prototype-author API. It only refines the runtime order in `C-LIFECYCLE-0002` into implementable and testable boundaries. CP4 and CP7 both represent host commit completion, which may be reached by either synchronous or asynchronous host profiles.
 
 
 criteria:
@@ -24,8 +24,8 @@ criteria:
       en: CP1 through CP5 must occur in `created callbacks -> logical tree ready -> commit start -> commit done -> mounted callbacks` order.
   - id: C-LIFECYCLE-0004-C
     text:
-      zh-CN: 每个 update cycle 的 CP6 到 CP8 必须按 `update render -> update commit -> updated callbacks` 的顺序发生。
-      en: For each update cycle, CP6 through CP8 must occur in `update render -> update commit -> updated callbacks` order.
+      zh-CN: 每个被接受的 update cycle 的 CP6 到 CP8 必须按 `update render -> update commit done -> updated callbacks` 的顺序发生；CP8 不得早于 CP7。
+      en: For each accepted update cycle, CP6 through CP8 must occur in `update render -> update commit done -> updated callbacks` order; CP8 must not occur before CP7.
   - id: C-LIFECYCLE-0004-D
     text:
       zh-CN: CP9 必须表示实例进入 unmount/disconnect 流程且 `unmounted` callback 即将或正在执行；此时受 runtime 管理的 module handle 仍不得被提前 dispose。
@@ -81,6 +81,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Drafted the runtime/adapter checkpoint model for lifecycle governance.
+  - version: 0.1.0
+    change: revised
+    summary: Clarified CP7 as update commit completion so checkpoint ordering supports synchronous and asynchronous host profiles.
 tags:
   - lifecycle
   - checkpoint

--- a/spec/contracts/C-LIFECYCLE-0005.yaml
+++ b/spec/contracts/C-LIFECYCLE-0005.yaml
@@ -1,0 +1,65 @@
+id: C-LIFECYCLE-0005
+type: contract
+title: Prototype lifecycle API surface uses setup-time callback registration
+status: draft
+since: 0.1.0
+summary: Prototype-visible lifecycle syntax is the setup-time `def.lifecycle` callback registration surface for `created`, `mounted`, `updated`, and `unmounted`.
+statement:
+  zh-CN: >-
+    Proto UI 的 prototype-visible lifecycle API 必须通过 setup 阶段的 `def.lifecycle` surface 注册 runtime callback。v0 的 portable lifecycle entry 固定为 `def.lifecycle.onCreated(cb)`、`def.lifecycle.onMounted(cb)`、`def.lifecycle.onUpdated(cb)` 与 `def.lifecycle.onUnmounted(cb)`；这些 entry 只负责注册 callback，不会在注册时立即执行 callback，也不提供 portable unsubscribe/revoke handle。被注册的 callback 在 runtime 阶段执行，并必须接收绑定到当前 callback invocation 的 `run handle`。CP checkpoint、host-specific lifecycle hook、adapter diagnostics hook 与 runtime internal lifecycle marker 不得作为 prototype-visible lifecycle API 暴露。
+
+
+  en: >-
+    Proto UI's prototype-visible lifecycle API must register runtime callbacks through the setup-time `def.lifecycle` surface. The v0 portable lifecycle entries are fixed as `def.lifecycle.onCreated(cb)`, `def.lifecycle.onMounted(cb)`, `def.lifecycle.onUpdated(cb)`, and `def.lifecycle.onUnmounted(cb)`. These entries only register callbacks; they must not invoke callbacks during registration and must not provide a portable unsubscribe or revoke handle. Registered callbacks execute during runtime and must receive a `run handle` bound to the current callback invocation. CP checkpoints, host-specific lifecycle hooks, adapter diagnostics hooks, and runtime-internal lifecycle markers must not be exposed as prototype-visible lifecycle APIs.
+
+
+criteria:
+  - id: C-LIFECYCLE-0005-A
+    text:
+      zh-CN: lifecycle setup API 必须由 `def.lifecycle` 承载，而不是由 `run handle`、renderer、adapter option 或 host-specific hook 承载。
+      en: The lifecycle setup API must be carried by `def.lifecycle`, not by the `run handle`, renderer, adapter options, or host-specific hooks.
+  - id: C-LIFECYCLE-0005-B
+    text:
+      zh-CN: v0 portable lifecycle registration entries 必须固定为 `onCreated`、`onMounted`、`onUpdated` 与 `onUnmounted`。
+      en: The v0 portable lifecycle registration entries must be fixed as `onCreated`, `onMounted`, `onUpdated`, and `onUnmounted`.
+  - id: C-LIFECYCLE-0005-C
+    text:
+      zh-CN: '`def.lifecycle.onCreated/onMounted/onUpdated/onUnmounted` 必须是 setup-only registration API；setup 结束后调用必须失败。'
+      en: '`def.lifecycle.onCreated/onMounted/onUpdated/onUnmounted` must be setup-only registration APIs; calls after setup exits must fail.'
+  - id: C-LIFECYCLE-0005-D
+    text:
+      zh-CN: lifecycle registration API 不得在注册时立即执行 callback；callback 只能由 runtime 生命周期流程调用。
+      en: Lifecycle registration APIs must not invoke callbacks during registration; callbacks may only be invoked by runtime lifecycle flow.
+  - id: C-LIFECYCLE-0005-E
+    text:
+      zh-CN: lifecycle callback 执行时必须接收绑定当前 callback invocation 的 `run handle`，并遵守 `C-CORE-SYNTAX-0002`。
+      en: Lifecycle callbacks must receive a `run handle` bound to the current callback invocation and must follow `C-CORE-SYNTAX-0002`.
+  - id: C-LIFECYCLE-0005-F
+    text:
+      zh-CN: lifecycle registration API 的返回值不得被解释为 portable unsubscribe、revoke 或 lifecycle handle 能力。
+      en: Return values from lifecycle registration APIs must not be interpreted as portable unsubscribe, revoke, or lifecycle-handle capabilities.
+  - id: C-LIFECYCLE-0005-G
+    text:
+      zh-CN: CP checkpoint、host-specific lifecycle hook、adapter diagnostics hook 与 runtime internal lifecycle marker 不得作为 prototype-visible lifecycle API 暴露。
+      en: CP checkpoints, host-specific lifecycle hooks, adapter diagnostics hooks, and runtime-internal lifecycle markers must not be exposed as prototype-visible lifecycle APIs.
+sources:
+  - path: internal/contracts/lifecycle/component-lifecycle.v0.md
+    sections:
+      - Lifecycle Callbacks
+  - path: packages/core/src/handles.ts
+    sections:
+      - DefHandle.lifecycle
+dependsOn:
+  contracts:
+    - C-LIFECYCLE-0001
+    - C-CORE-SYNTAX-0001
+    - C-CORE-SYNTAX-0002
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Split prototype lifecycle API surface syntax from lifecycle callback ordering.
+tags:
+  - lifecycle
+  - syntax
+  - setup
+  - run-handle

--- a/spec/contracts/C-TEMPLATE-0001.yaml
+++ b/spec/contracts/C-TEMPLATE-0001.yaml
@@ -1,0 +1,48 @@
+id: C-TEMPLATE-0001
+type: contract
+title: Template output describes root children
+status: draft
+since: 0.1.0
+summary: Template output describes the structural children rendered inside the host root, not the host root itself.
+statement:
+  zh-CN: >-
+    Proto UI template 的 render 输出描述的是 Root Node 内部应渲染的 `TemplateChildren`。Root Node 由 runtime/adapter/host 创建并承载组件级通路；template 不声明 Root Node，template 返回的最外层节点也不得被解释为 Root Node。
+
+
+  en: >-
+    Proto UI template render output describes the `TemplateChildren` to render inside the Root Node. The Root Node is created by the runtime/adapter/host and carries component-level channels; template does not declare the Root Node, and the outermost returned template node must not be interpreted as the Root Node.
+
+
+criteria:
+  - id: C-TEMPLATE-0001-A
+    text:
+      zh-CN: Template render 输出必须被消费为 Root Node 内部 children。
+      en: Template render output must be consumed as children inside the Root Node.
+  - id: C-TEMPLATE-0001-B
+    text:
+      zh-CN: Template 不得声明、替换或升级为组件 Root Node。
+      en: Template must not declare, replace, or upgrade into the component Root Node.
+  - id: C-TEMPLATE-0001-C
+    text:
+      zh-CN: Template 返回数组时，数组项必须按顺序展开为同一个 Root Node 内部的 sibling children。
+      en: When template returns an array, its items must expand in order as sibling children inside the same Root Node.
+sources:
+  - path: internal/contracts/template/template-node.md
+    sections:
+      - 2. Root Node (Host Root Container) and Template Nodes
+      - 5. Basic Template Authoring and Structural Illustration
+  - path: packages/adapters/web-component/test/commit.test.ts
+    sections:
+      - basic
+      - array expansion
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0005
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured the Root Node versus TemplateChildren boundary.
+tags:
+  - template
+  - root-node
+  - render-output

--- a/spec/contracts/C-TEMPLATE-0002.yaml
+++ b/spec/contracts/C-TEMPLATE-0002.yaml
@@ -1,0 +1,51 @@
+id: C-TEMPLATE-0002
+type: contract
+title: Template nodes are structural nodes
+status: draft
+since: 0.1.0
+summary: Template nodes are structural units that may compose children and carry style, but do not carry component-level channels.
+statement:
+  zh-CN: >-
+    Template Node 是 template 语法产出的结构节点单位。v0 中它可以参与树结构组合，可以承载 style 相关表达；props、state、event、expose、feedback 等组件级通路的锚点由 Root Node 与对应模块契约负责，不由普通 Template Node 直接承载。
+
+
+  en: >-
+    A Template Node is the structural node unit produced by template syntax. In v0 it may participate in tree composition and carry style expressions; component-level channels such as props, state, event, expose, and feedback are anchored by the Root Node and their module contracts, not directly by ordinary Template Nodes.
+
+
+criteria:
+  - id: C-TEMPLATE-0002-A
+    text:
+      zh-CN: Template Node 必须被视为结构节点，而不是组件实例、Root Node 或宿主生命周期实体。
+      en: A Template Node must be treated as a structural node, not as a component instance, Root Node, or host lifecycle entity.
+  - id: C-TEMPLATE-0002-B
+    text:
+      zh-CN: Template Node 可以拥有 `children` 并参与树结构组合。
+      en: A Template Node may have `children` and participate in tree composition.
+  - id: C-TEMPLATE-0002-C
+    text:
+      zh-CN: Template Node 可以携带 style 表达；style 的语义由 feedback/style 子系统定义。
+      en: A Template Node may carry style expressions; style semantics are defined by the feedback/style subsystem.
+  - id: C-TEMPLATE-0002-D
+    text:
+      zh-CN: v0 不要求 Template Node 直接承载 props、state、event、expose 或 feedback 的组件级通路能力。
+      en: v0 does not require Template Nodes to directly carry component-level props, state, event, expose, or feedback channel capabilities.
+sources:
+  - path: internal/contracts/template/template-node.md
+    sections:
+      - 1. Conceptual Positioning
+      - 3. Capability Boundaries of Template Nodes (v0)
+  - path: packages/core/src/spec/template.ts
+    sections:
+      - TemplateNode
+dependsOn:
+  contracts:
+    - C-TEMPLATE-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured the structural capability boundary for Template Nodes.
+tags:
+  - template
+  - template-node
+  - structure

--- a/spec/contracts/C-TEMPLATE-0003.yaml
+++ b/spec/contracts/C-TEMPLATE-0003.yaml
@@ -1,0 +1,57 @@
+id: C-TEMPLATE-0003
+type: contract
+title: '`el()` constructs TemplateNodes with style-only props'
+status: draft
+since: 0.1.0
+summary: Renderer `el()` constructs TemplateNodes using fixed argument dispatch and a minimal `TemplateProps` shape.
+statement:
+  zh-CN: >-
+    Renderer `el(type, [props], [children])` 必须按固定分派规则构造 `TemplateNode`。v0 的 `TemplateProps` 只允许空对象或 `{ style?: TemplateStyleHandle }`，除此之外的字段不得进入 template props 通道。
+
+
+  en: >-
+    Renderer `el(type, [props], [children])` must construct `TemplateNode`s using fixed dispatch rules. v0 `TemplateProps` only permits an empty object or `{ style?: TemplateStyleHandle }`; no other fields may enter the template props channel.
+
+
+criteria:
+  - id: C-TEMPLATE-0003-A
+    text:
+      zh-CN: '`el(type)` 必须将 children 输入视为 `null`。'
+      en: '`el(type)` must treat children input as `null`.'
+  - id: C-TEMPLATE-0003-B
+    text:
+      zh-CN: '`el(type, a)` 中若 `a` 是合法 `TemplateProps`，必须将其解释为 props；否则必须将其解释为 children 输入。'
+      en: In `el(type, a)`, if `a` is valid `TemplateProps`, it must be interpreted as props; otherwise it must be interpreted as children input.
+  - id: C-TEMPLATE-0003-C
+    text:
+      zh-CN: '`el(type, props, children)` 的第二参数必须是合法 `TemplateProps`，否则必须抛错。'
+      en: In `el(type, props, children)`, the second argument must be valid `TemplateProps`, otherwise an error must be thrown.
+  - id: C-TEMPLATE-0003-D
+    text:
+      zh-CN: v0 `TemplateProps` 的允许键集合必须为空或仅包含 `style`。
+      en: The allowed key set of v0 `TemplateProps` must be empty or contain only `style`.
+  - id: C-TEMPLATE-0003-E
+    text:
+      zh-CN: 若 `style` 存在，它必须是合法 `TemplateStyleHandle`。
+      en: If `style` is present, it must be a valid `TemplateStyleHandle`.
+sources:
+  - path: internal/contracts/template/renderer-primitives.v0.md
+    sections:
+      - 4. `el()` Argument Dispatch Rules (Normative)
+      - 5. TemplateProps Validation (Normative)
+  - path: packages/core/src/spec/template.ts
+    sections:
+      - createRendererPrimitives
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0006
+    - C-TEMPLATE-0002
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured `el()` argument dispatch and TemplateProps validation.
+tags:
+  - template
+  - renderer
+  - syntax
+  - style

--- a/spec/contracts/C-TEMPLATE-0004.yaml
+++ b/spec/contracts/C-TEMPLATE-0004.yaml
@@ -1,0 +1,64 @@
+id: C-TEMPLATE-0004
+type: contract
+title: Template children normalize to a portable shape
+status: draft
+since: 0.1.0
+summary: '`TemplateChildren` normalization uses deep flattening, `null` as empty, and rejects boolean or nested `undefined` children.'
+statement:
+  zh-CN: >-
+    Proto UI v0 必须将 `TemplateChildren` 规范化为跨宿主可移植、可调试的稳定形态。默认策略是 deep flatten、`keepNull=false`；顶层 `undefined` 归一为 `null`，数组内 `null` 默认移除，boolean 与作为 child 出现的 `undefined` 必须抛错。
+
+
+  en: >-
+    Proto UI v0 must normalize `TemplateChildren` into a stable shape that is portable and debuggable across hosts. The default policy is deep flatten with `keepNull=false`; top-level `undefined` canonicalizes to `null`, `null` inside arrays is removed by default, and boolean or child-position `undefined` must throw.
+
+
+criteria:
+  - id: C-TEMPLATE-0004-A
+    text:
+      zh-CN: 默认 normalize 策略必须是 `flatten="deep"` 且 `keepNull=false`。
+      en: The default normalize policy must be `flatten="deep"` and `keepNull=false`.
+  - id: C-TEMPLATE-0004-B
+    text:
+      zh-CN: 顶层 `undefined` 输入必须归一为 `null`。
+      en: Top-level `undefined` input must canonicalize to `null`.
+  - id: C-TEMPLATE-0004-C
+    text:
+      zh-CN: 默认策略下，children 数组中的 `null` 必须作为 empty 被移除；全空结果必须归一为 `null`。
+      en: Under the default policy, `null` in children arrays must be removed as empty; an all-empty result must canonicalize to `null`.
+  - id: C-TEMPLATE-0004-D
+    text:
+      zh-CN: boolean child 必须抛错。
+      en: Boolean children must throw.
+  - id: C-TEMPLATE-0004-E
+    text:
+      zh-CN: child 位置的 `undefined` 必须抛错。
+      en: '`undefined` in child position must throw.'
+  - id: C-TEMPLATE-0004-F
+    text:
+      zh-CN: 默认 deep flatten 必须将嵌套数组展开为单层 children；结果为单个 child 时必须返回该 child 而不是数组。
+      en: Default deep flatten must flatten nested arrays into one children level; when the result is one child, that child must be returned rather than an array.
+  - id: C-TEMPLATE-0004-G
+    text:
+      zh-CN: v0 normalize 不负责验证非空 object child 是否为合法 `TemplateNode`。
+      en: v0 normalization is not responsible for validating whether non-null object children are valid `TemplateNode`s.
+sources:
+  - path: internal/contracts/template/normalize.v0.md
+    sections:
+      - 'Contract: Default Normalize Policy'
+      - Validation boundary (important)
+  - path: packages/core/src/spec/template.ts
+    sections:
+      - normalizeChildren
+dependsOn:
+  contracts:
+    - C-CORE-VALUE-0001
+    - C-TEMPLATE-0002
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured TemplateChildren normalization rules and validation boundary.
+tags:
+  - template
+  - normalize
+  - portability

--- a/spec/contracts/C-TEMPLATE-0005.yaml
+++ b/spec/contracts/C-TEMPLATE-0005.yaml
@@ -1,0 +1,61 @@
+id: C-TEMPLATE-0005
+type: contract
+title: Template slot is anonymous and singular
+status: draft
+since: 0.1.0
+summary: The v0 template slot is an anonymous reserved node, appears at most once, and carries no params or props.
+statement:
+  zh-CN: >-
+    Proto UI v0 的 slot 是 template 层的保留节点，表达来自宿主/外部组合的 children 插入点。它必须匿名、最多出现一次、不得携带参数、props、style 或 fallback 语义；更丰富的 slot API 属于上层框架或编译层，而不是 core template 协议。
+
+
+  en: >-
+    The Proto UI v0 slot is a reserved template node that marks the insertion point for children from host or external composition. It must be anonymous, appear at most once, and carry no params, props, style, or fallback semantics; richer slot APIs belong to upper frameworks or compilation layers, not the core template protocol.
+
+
+criteria:
+  - id: C-TEMPLATE-0005-A
+    text:
+      zh-CN: >-
+        Slot 在 template 层必须表达为 `type = { kind: "slot" }` 的 reserved node。
+
+
+      en: >-
+        Slot must be expressed at the template layer as a reserved node with `type = { kind: "slot" }`.
+
+
+  - id: C-TEMPLATE-0005-B
+    text:
+      zh-CN: '`r.slot()` 或等价入口不得接收任何参数。'
+      en: '`r.slot()` or equivalent entries must not accept any arguments.'
+  - id: C-TEMPLATE-0005-C
+    text:
+      zh-CN: 单次 render 输出中必须只允许 0 或 1 个 slot。
+      en: One render output must allow only 0 or 1 slot.
+  - id: C-TEMPLATE-0005-D
+    text:
+      zh-CN: Slot 不得携带 name、props、params、style、children 或 fallback。
+      en: Slot must not carry name, props, params, style, children, or fallback.
+  - id: C-TEMPLATE-0005-E
+    text:
+      zh-CN: Adapter/compiler 可以依赖 slot 匿名、单一、无参数的结构事实进行宿主映射。
+      en: Adapters and compilers may rely on the structural fact that slot is anonymous, singular, and parameterless when mapping to hosts.
+sources:
+  - path: internal/contracts/template/slot.md
+    sections:
+      - Protocol Constraints (MUST)
+      - What adapters can assume
+  - path: packages/core/src/spec/template.ts
+    sections:
+      - createRendererPrimitives
+dependsOn:
+  contracts:
+    - C-TEMPLATE-0002
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured v0 slot reserved-node semantics and constraints.
+tags:
+  - template
+  - slot
+  - protocol

--- a/spec/contracts/C-TEMPLATE-0006.yaml
+++ b/spec/contracts/C-TEMPLATE-0006.yaml
@@ -1,0 +1,54 @@
+id: C-TEMPLATE-0006
+type: contract
+title: Adapters reject PrototypeRef template types
+status: draft
+since: 0.1.0
+summary: Official adapters and compilers must actively reject `PrototypeRef` when it appears as a template node type.
+statement:
+  zh-CN: >-
+    虽然正常原型作者路径不应产生 `PrototypeRef` template type，官方 adapter/compiler 在处理 template 时若遇到 `TemplateNode.type` 为 `PrototypeRef`，仍必须主动抛错。这是对 `K-PROTOTYPE-COMPOSITION-0001` 的负向合规信号：adapter 不得私自支持或容忍 core template protocol 不提供的 prototype-level composition。
+
+
+  en: >-
+    Although normal prototype authoring paths should not produce a `PrototypeRef` template type, official adapters and compilers must still actively throw when processing a template whose `TemplateNode.type` is `PrototypeRef`. This is a negative conformance signal for `K-PROTOTYPE-COMPOSITION-0001`: adapters must not privately support or tolerate prototype-level composition that the core template protocol does not provide.
+
+
+criteria:
+  - id: C-TEMPLATE-0006-A
+    text:
+      zh-CN: Adapter/compiler 遇到 `TemplateNode.type` 为 `PrototypeRef` 时必须抛错。
+      en: Adapters and compilers must throw when encountering `TemplateNode.type` as `PrototypeRef`.
+  - id: C-TEMPLATE-0006-B
+    text:
+      zh-CN: 官方 adapter/compiler 不得将 `PrototypeRef` 降级、包裹、转译或当作普通 host element 支持。
+      en: Official adapters and compilers must not downgrade, wrap, translate, or support `PrototypeRef` as an ordinary host element.
+  - id: C-TEMPLATE-0006-C
+    text:
+      zh-CN: v0 主动拒绝时的错误消息必须为 `[Template] PrototypeRef is not allowed in Template v0.`。
+      en: The v0 active-rejection error message must be `[Template] PrototypeRef is not allowed in Template v0.`.
+  - id: C-TEMPLATE-0006-D
+    text:
+      zh-CN: 该拒绝语义是 adapter/compiler 服从 template 边界的合规信号，不表示正常 authoring path 应可构造 `PrototypeRef`。
+      en: This rejection semantic is a conformance signal that adapters and compilers obey the template boundary; it does not mean normal authoring paths should be able to construct `PrototypeRef`.
+sources:
+  - path: internal/contracts/template/no-prototype-composition.v0.md
+    sections:
+      - Required Adapter Behavior (Normative)
+      - Required Error Signature (v0)
+  - path: packages/adapters/web-component/src/commit.ts
+    sections:
+      - ERR_TEMPLATE_PROTOTYPE_REF_V0
+dependsOn:
+  contracts:
+    - C-TEMPLATE-0001
+  knowledge:
+    - K-PROTOTYPE-COMPOSITION-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured adapter/compiler negative conformance behavior for PrototypeRef template types.
+tags:
+  - template
+  - adapter
+  - prototype-ref
+  - conformance

--- a/spec/knowledge/K-PROTOTYPE-COMPOSITION-0001.yaml
+++ b/spec/knowledge/K-PROTOTYPE-COMPOSITION-0001.yaml
@@ -1,0 +1,52 @@
+id: K-PROTOTYPE-COMPOSITION-0001
+type: knowledge
+title: Proto UI excludes prototype-level template composition
+status: draft
+since: 0.1.0
+summary: Proto UI keeps prototype composition outside the core template language to preserve protocol boundaries.
+statement:
+  zh-CN: >-
+    Proto UI 不把“在 template 中嵌套另一个 prototype”作为 core template language 的能力。Prototype 生态负责编写交互主体与语义，Adapter/Compiler 生态负责宿主映射；组件间组合应发生在宿主层或上层框架/编译层，而不是通过 template 直接引用其他 prototype。
+
+
+  en: >-
+    Proto UI does not treat "nest another prototype inside template" as a capability of the core template language. The Prototype ecosystem authors interactive subjects and semantics, while the Adapter/Compiler ecosystem maps them to hosts; component composition should happen at the host layer or in upper framework/compilation layers, not by directly referencing other prototypes inside template.
+
+
+criteria:
+  - id: K-PROTOTYPE-COMPOSITION-0001-A
+    text:
+      zh-CN: Template language 描述 Root Node 内部结构，不描述 prototype-to-prototype composition。
+      en: The template language describes structure inside a Root Node, not prototype-to-prototype composition.
+  - id: K-PROTOTYPE-COMPOSITION-0001-B
+    text:
+      zh-CN: 允许 template 直接嵌套 prototype 会模糊 Prototype 生态与 Adapter/Compiler 生态的边界。
+      en: Allowing template to nest prototypes directly would blur the boundary between the Prototype ecosystem and the Adapter/Compiler ecosystem.
+  - id: K-PROTOTYPE-COMPOSITION-0001-C
+    text:
+      zh-CN: 若上层框架提供更方便的组件组合语法，该语法必须在框架/编译/宿主层解决，而不是扩展 core template protocol。
+      en: If an upper framework provides more convenient component composition syntax, that syntax must be resolved at the framework, compilation, or host layer rather than by extending the core template protocol.
+sources:
+  - path: internal/contracts/template/no-prototype-composition.v0.md
+    sections:
+      - Summary
+      - Rationale
+  - path: internal/contracts/template/template-node.md
+    sections:
+      - 2. Root Node (Host Root Container) and Template Nodes
+explains:
+  contracts:
+    - C-TEMPLATE-0001
+dependsOn:
+  knowledge:
+    - K-DESIGN-TRADEOFF-0001
+    - K-COMPONENT-INTERACTION-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured the design rationale behind excluding prototype-level template composition.
+tags:
+  - philosophy
+  - prototype
+  - composition
+  - template

--- a/spec/tests/T-CORE-SYNTAX-0001.yaml
+++ b/spec/tests/T-CORE-SYNTAX-0001.yaml
@@ -1,0 +1,119 @@
+id: T-CORE-SYNTAX-0001
+type: test
+title: Prototype setup and render syntax tests
+status: draft
+since: 0.1.0
+summary: Shared fixture, core tests, and runtime tests for prototype definition, setup return, render function, and renderer handle syntax.
+cases:
+  - id: T-CORE-SYNTAX-0001-CASE-DEFINITION-SHAPE
+    title: Prototype definitions require a name and setup function
+    covers:
+      - C-CORE-SYNTAX-0003-A
+      - C-CORE-SYNTAX-0003-B
+      - C-CORE-SYNTAX-0003-D
+    expectation: invalid-prototype-definition-fails-fast
+  - id: T-CORE-SYNTAX-0001-CASE-SETUP-DEF
+    title: Setup is invoked with the definition handle
+    covers:
+      - C-CORE-SYNTAX-0003-C
+      - C-CORE-SYNTAX-0004-A
+    expectation: setup-receives-definition-handle
+  - id: T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-RENDER
+    title: Setup-returned function becomes the render function
+    covers:
+      - C-CORE-SYNTAX-0004-B
+      - C-CORE-SYNTAX-0005-A
+    expectation: setup-returned-render-is-executed
+  - id: T-CORE-SYNTAX-0001-CASE-SETUP-VOID-DEFAULT
+    title: Void setup return uses the v0 default slot render
+    covers:
+      - C-CORE-SYNTAX-0004-C
+    expectation: void-setup-uses-default-slot-render
+  - id: T-CORE-SYNTAX-0001-CASE-RENDER-HANDLE
+    title: Render receives a renderer handle and returns TemplateChildren
+    covers:
+      - C-CORE-SYNTAX-0005-B
+      - C-CORE-SYNTAX-0005-C
+      - C-CORE-SYNTAX-0006-A
+    expectation: render-receives-renderer-handle-and-returns-template-children
+  - id: T-CORE-SYNTAX-0001-CASE-RENDER-READ
+    title: Renderer read exposes current runtime props without update entry
+    covers:
+      - C-CORE-SYNTAX-0006-B
+      - C-CORE-SYNTAX-0006-C
+      - C-CORE-SYNTAX-0006-D
+      - C-LIFECYCLE-0003-D
+      - C-LIFECYCLE-0003-E
+    expectation: renderer-read-props-without-update-entry
+implementations:
+  - id: core-prototype-render-syntax-fixture
+    kind: fixture
+    status: active
+    path: packages/spec/fixtures/src/core/prototype-render-syntax.ts
+    required: true
+    consumesCases:
+      - T-CORE-SYNTAX-0001-CASE-DEFINITION-SHAPE
+      - T-CORE-SYNTAX-0001-CASE-SETUP-DEF
+      - T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-RENDER
+      - T-CORE-SYNTAX-0001-CASE-SETUP-VOID-DEFAULT
+      - T-CORE-SYNTAX-0001-CASE-RENDER-HANDLE
+      - T-CORE-SYNTAX-0001-CASE-RENDER-READ
+    notes:
+      - Shared fixture records the case-to-criteria mapping used by core and runtime tests.
+  - id: core-prototype-definition-shape
+    kind: module-test
+    status: passing
+    path: packages/core/test/contract/prototype.definition.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-CORE-SYNTAX-0001-CASE-DEFINITION-SHAPE
+  - id: runtime-prototype-render-syntax
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/prototype.render-syntax.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-CORE-SYNTAX-0001-CASE-SETUP-DEF
+      - T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-RENDER
+      - T-CORE-SYNTAX-0001-CASE-SETUP-VOID-DEFAULT
+      - T-CORE-SYNTAX-0001-CASE-RENDER-HANDLE
+      - T-CORE-SYNTAX-0001-CASE-RENDER-READ
+verifies:
+  contracts:
+    - id: C-CORE-SYNTAX-0003
+      anchors:
+        - C-CORE-SYNTAX-0003-A
+        - C-CORE-SYNTAX-0003-B
+        - C-CORE-SYNTAX-0003-C
+        - C-CORE-SYNTAX-0003-D
+    - id: C-CORE-SYNTAX-0004
+      anchors:
+        - C-CORE-SYNTAX-0004-A
+        - C-CORE-SYNTAX-0004-B
+        - C-CORE-SYNTAX-0004-C
+    - id: C-CORE-SYNTAX-0005
+      anchors:
+        - C-CORE-SYNTAX-0005-A
+        - C-CORE-SYNTAX-0005-B
+        - C-CORE-SYNTAX-0005-C
+    - id: C-CORE-SYNTAX-0006
+      anchors:
+        - C-CORE-SYNTAX-0006-A
+        - C-CORE-SYNTAX-0006-B
+        - C-CORE-SYNTAX-0006-C
+        - C-CORE-SYNTAX-0006-D
+exercises:
+  contracts:
+    - id: C-LIFECYCLE-0003
+      role: execution-order
+      coverageImpact: exercises-test-surface
+      note: Render read and no-update-entry cases exercise the render-time input and no recursive update-flow boundary.
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added shared fixture and contract tests for prototype setup/render syntax.
+tags:
+  - core
+  - syntax
+  - render
+  - contract-test

--- a/spec/tests/T-LIFECYCLE-0001.yaml
+++ b/spec/tests/T-LIFECYCLE-0001.yaml
@@ -29,12 +29,13 @@ cases:
     notes:
       - Covers hosts that schedule `mounted` asynchronously and then unmount before the scheduled task runs.
   - id: T-LIFECYCLE-0001-CASE-UPDATE-CYCLE-ORDER
-    title: Update cycle runs render, commit, then updated callbacks
+    title: Update cycle runs render, commit completion, then updated callbacks
     covers:
       - C-LIFECYCLE-0002-E
     expectation: update-render-commit-updated
     notes:
       - The fixture models ordering, not whether the host performs the update synchronously or schedules it.
+      - The `commit` trace point represents the commit completion boundary for this fixture.
   - id: T-LIFECYCLE-0001-CASE-UNMOUNT-DISPOSAL-BOUNDARY
     title: Unmounted runs before dispose and handles are invalid after dispose
     covers:

--- a/spec/tests/T-LIFECYCLE-0001.yaml
+++ b/spec/tests/T-LIFECYCLE-0001.yaml
@@ -6,12 +6,12 @@ since: 0.1.0
 summary: Shared fixture and runtime test mapping for the lifecycle callback ordering and disposal guarantees in `C-LIFECYCLE-0002`.
 cases:
   - id: T-LIFECYCLE-0001-CASE-SETUP-REGISTRATION
-    title: Lifecycle callbacks are registered during setup only
+    title: Registered lifecycle callbacks are invoked by runtime lifecycle flow
     covers:
       - C-LIFECYCLE-0002-A
-    expectation: lifecycle-registration-setup-only
+    expectation: lifecycle-registration-defers-callback-invocation
     notes:
-      - Verifies that `def.lifecycle.*` registrations are setup-time declarations, not runtime mutations.
+      - Verifies that lifecycle registration records callbacks for runtime lifecycle flow rather than invoking them immediately.
   - id: T-LIFECYCLE-0001-CASE-INITIAL-ORDER
     title: Initial lifecycle order is setup, created, first render, commit, mounted
     covers:
@@ -96,7 +96,7 @@ implementations:
     consumesCases:
       - T-LIFECYCLE-0001-CASE-SETUP-REGISTRATION
     notes:
-      - Focused coverage for `def.lifecycle.*` setup-only registration guards.
+      - Focused coverage that `def.lifecycle.*` registers callbacks without immediate invocation; setup-only API surface coverage is owned by `T-LIFECYCLE-0004`.
 verifies:
   contracts:
     - id: C-LIFECYCLE-0002
@@ -114,10 +114,17 @@ exercises:
       role: lifecycle-model
       coverageImpact: exercises-test-surface
       note: Callback ordering relies on the shared setup/runtime period model but does not directly test `C-LIFECYCLE-0001`.
+    - id: C-LIFECYCLE-0005
+      role: api-surface
+      coverageImpact: exercises-test-surface
+      note: Callback ordering uses the lifecycle API surface but does not own lifecycle syntax coverage.
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Added lifecycle callback ordering test cases and the shared fixture mapping for `C-LIFECYCLE-0002`.
+  - version: 0.1.0
+    change: revised
+    summary: Moved lifecycle API surface coverage to `T-LIFECYCLE-0004` while keeping callback invocation flow coverage here.
 tags:
   - lifecycle
   - contract-test

--- a/spec/tests/T-LIFECYCLE-0001.yaml
+++ b/spec/tests/T-LIFECYCLE-0001.yaml
@@ -1,0 +1,124 @@
+id: T-LIFECYCLE-0001
+type: test
+title: Prototype-visible lifecycle callback order tests
+status: draft
+since: 0.1.0
+summary: Shared fixture and runtime test mapping for the lifecycle callback ordering and disposal guarantees in `C-LIFECYCLE-0002`.
+cases:
+  - id: T-LIFECYCLE-0001-CASE-SETUP-REGISTRATION
+    title: Lifecycle callbacks are registered during setup only
+    covers:
+      - C-LIFECYCLE-0002-A
+    expectation: lifecycle-registration-setup-only
+    notes:
+      - Verifies that `def.lifecycle.*` registrations are setup-time declarations, not runtime mutations.
+  - id: T-LIFECYCLE-0001-CASE-INITIAL-ORDER
+    title: Initial lifecycle order is setup, created, first render, commit, mounted
+    covers:
+      - C-LIFECYCLE-0002-B
+      - C-LIFECYCLE-0002-C
+      - C-LIFECYCLE-0002-D
+    expectation: setup-created-render-commit-mounted
+    notes:
+      - '`mounted` may be host-scheduled, but it must not run before the first commit has completed.'
+  - id: T-LIFECYCLE-0001-CASE-MOUNTED-CANCELLED-AFTER-UNMOUNT
+    title: Queued mounted callbacks do not run after unmount
+    covers:
+      - C-LIFECYCLE-0002-D
+    expectation: queued-mounted-callback-invalidated-after-unmount
+    notes:
+      - Covers hosts that schedule `mounted` asynchronously and then unmount before the scheduled task runs.
+  - id: T-LIFECYCLE-0001-CASE-UPDATE-CYCLE-ORDER
+    title: Update cycle runs render, commit, then updated callbacks
+    covers:
+      - C-LIFECYCLE-0002-E
+    expectation: update-render-commit-updated
+    notes:
+      - The fixture models ordering, not whether the host performs the update synchronously or schedules it.
+  - id: T-LIFECYCLE-0001-CASE-UNMOUNT-DISPOSAL-BOUNDARY
+    title: Unmounted runs before dispose and handles are invalid after dispose
+    covers:
+      - C-LIFECYCLE-0002-F
+      - C-LIFECYCLE-0002-G
+    expectation: unmounted-before-dispose-availability-window
+    notes:
+      - Verifies the availability window during `unmounted` and invalidation after disposal.
+implementations:
+  - id: lifecycle-callback-order-fixture
+    kind: fixture
+    status: active
+    path: packages/spec/fixtures/src/lifecycle/callback-order.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0001-CASE-SETUP-REGISTRATION
+      - T-LIFECYCLE-0001-CASE-INITIAL-ORDER
+      - T-LIFECYCLE-0001-CASE-MOUNTED-CANCELLED-AFTER-UNMOUNT
+      - T-LIFECYCLE-0001-CASE-UPDATE-CYCLE-ORDER
+      - T-LIFECYCLE-0001-CASE-UNMOUNT-DISPOSAL-BOUNDARY
+    notes:
+      - Shared lifecycle ordering fixture for runtime tests, adapter conformance tests, and future host profile test harnesses.
+  - id: runtime-lifecycle-with-host-order
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/lifecycle-with-host.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0001-CASE-INITIAL-ORDER
+      - T-LIFECYCLE-0001-CASE-MOUNTED-CANCELLED-AFTER-UNMOUNT
+      - T-LIFECYCLE-0001-CASE-UPDATE-CYCLE-ORDER
+      - T-LIFECYCLE-0001-CASE-UNMOUNT-DISPOSAL-BOUNDARY
+    notes:
+      - Existing runtime coverage verifies initial ordering, update ordering, unmounted invocation, and mounted callback invalidation after unmount.
+  - id: runtime-lifecycle-update-strict-order
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/lifecycle.update-order.strict.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0001-CASE-UPDATE-CYCLE-ORDER
+    notes:
+      - Focused strict-order coverage for render before commit and updated after commit.
+  - id: runtime-exec-phase-disposal-boundary
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/exec-phase-guard.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0001-CASE-UNMOUNT-DISPOSAL-BOUNDARY
+    notes:
+      - Uses state handles as probes for the unmounted availability window and post-dispose invalidation.
+  - id: runtime-lifecycle-registration-setup-only
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/lifecycle.registration.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0001-CASE-SETUP-REGISTRATION
+    notes:
+      - Focused coverage for `def.lifecycle.*` setup-only registration guards.
+verifies:
+  contracts:
+    - id: C-LIFECYCLE-0002
+      anchors:
+        - C-LIFECYCLE-0002-A
+        - C-LIFECYCLE-0002-B
+        - C-LIFECYCLE-0002-C
+        - C-LIFECYCLE-0002-D
+        - C-LIFECYCLE-0002-E
+        - C-LIFECYCLE-0002-F
+        - C-LIFECYCLE-0002-G
+exercises:
+  contracts:
+    - id: C-LIFECYCLE-0001
+      role: lifecycle-model
+      coverageImpact: exercises-test-surface
+      note: Callback ordering relies on the shared setup/runtime period model but does not directly test `C-LIFECYCLE-0001`.
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added lifecycle callback ordering test cases and the shared fixture mapping for `C-LIFECYCLE-0002`.
+tags:
+  - lifecycle
+  - contract-test
+  - runtime
+  - fixture

--- a/spec/tests/T-LIFECYCLE-0002.yaml
+++ b/spec/tests/T-LIFECYCLE-0002.yaml
@@ -1,0 +1,149 @@
+id: T-LIFECYCLE-0002
+type: test
+title: Explicit update flow and host scheduling tests
+status: draft
+since: 0.1.0
+summary: Test mapping for the explicit update intent boundary and host-controlled update scheduling semantics in `C-LIFECYCLE-0003`.
+openQuestions:
+  - id: T-LIFECYCLE-0002-Q-ASYNC-HOST-PROFILES
+    question:
+      zh-CN: 是否需要为 React/Vue 等异步 host profile 建立独立 adapter conformance fixture，用于验证 commit completion 之后才触发 `updated`？
+      en: Should React, Vue, and other asynchronous host profiles get a dedicated adapter conformance fixture that verifies `updated` runs only after commit completion?
+    context:
+      zh-CN: core runtime 已覆盖延迟 `CommitSignal.done()` 时 `updated` 不会提前运行；React/Vue 等 adapter profile 仍需要独立验证它们在正确的 host commit completion 边界调用 `done()`。
+      en: Core runtime coverage now verifies that `updated` does not run before a delayed `CommitSignal.done()`; React, Vue, and other adapter profiles still need independent tests proving that they call `done()` at the correct host commit completion boundary.
+    blocks:
+      - C-LIFECYCLE-0003-F
+      - C-LIFECYCLE-0003-G
+  - id: T-LIFECYCLE-0002-Q-COALESCED-UPDATE-CYCLE
+    question:
+      zh-CN: 若未来 runtime/adapter 实现 update intent 合并，是否需要新增 fake host scheduler fixture 来验证多个 intent 合并为一次 commit 时 `updated` 只执行一次？
+      en: If a future runtime or adapter implements update-intent coalescing, should a fake host scheduler fixture verify that multiple intents coalesced into one commit produce only one `updated` callback?
+    context:
+      zh-CN: 当前实现未合并 update intent；本测试断口只保留合并语义的未来验证位置。
+      en: The current implementation does not coalesce update intents; this test gap only preserves the future verification point for coalescing semantics.
+    blocks:
+      - C-LIFECYCLE-0003-H
+cases:
+  - id: T-LIFECYCLE-0002-CASE-EXPLICIT-UPDATE-INTENT
+    title: '`run.update()` and controller update are explicit update intents'
+    covers:
+      - C-LIFECYCLE-0003-A
+      - C-LIFECYCLE-0003-B
+      - C-LIFECYCLE-0003-F
+    expectation: explicit-update-intent-enters-update-cycle
+    notes:
+      - Existing runtime ordering tests use explicit controller update as the observable update entry point.
+  - id: T-LIFECYCLE-0002-CASE-MODULE-APIS-NO-IMPLICIT-RENDER
+    title: Module APIs do not implicitly trigger render or commit
+    covers:
+      - C-LIFECYCLE-0003-C
+    expectation: module-api-calls-do-not-auto-render
+    notes:
+      - Existing props and state tests verify that channel mutations may dispatch watchers but do not automatically render or commit.
+  - id: T-LIFECYCLE-0002-CASE-RENDER-RUNTIME-INPUT
+    title: Render can read runtime input without entering recursive update flow
+    covers:
+      - C-LIFECYCLE-0003-D
+      - C-LIFECYCLE-0003-E
+    expectation: render-read-surface-without-recursive-update
+    notes:
+      - The exact render-time read/write surface remains governed by `C-LIFECYCLE-0003-Q-RENDER-RUN-WRITE-SURFACE`.
+  - id: T-LIFECYCLE-0002-CASE-HOST-SCHEDULED-UPDATE
+    title: Host scheduling does not create a synchronous view-update guarantee
+    covers:
+      - C-LIFECYCLE-0003-G
+    expectation: update-intent-does-not-guarantee-immediate-host-view-change
+    notes:
+      - This is a host profile conformance case; synchronous WC behavior may be stronger than the core contract.
+  - id: T-LIFECYCLE-0002-CASE-COALESCED-UPDATE
+    title: Coalesced update intents produce one updated callback per completed commit
+    covers:
+      - C-LIFECYCLE-0003-H
+    expectation: coalesced-update-intents-run-updated-once-per-commit
+    notes:
+      - This case becomes executable only for runtimes or adapters that implement update coalescing.
+implementations:
+  - id: runtime-lifecycle-update-strict-order
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/lifecycle.update-order.strict.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0002-CASE-EXPLICIT-UPDATE-INTENT
+    notes:
+      - Existing coverage verifies render before commit and updated after commit for an explicit update entry point.
+  - id: runtime-lifecycle-with-host-update-order
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/lifecycle-with-host.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0002-CASE-EXPLICIT-UPDATE-INTENT
+      - T-LIFECYCLE-0002-CASE-HOST-SCHEDULED-UPDATE
+    notes:
+      - Existing coverage verifies that explicit controller update enters the update cycle and reaches `updated` after commit.
+      - Delayed `CommitSignal.done()` coverage verifies that `updated` waits for commit completion rather than the `host.commit()` call itself.
+  - id: runtime-state-no-auto-render
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/state-basic.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0002-CASE-MODULE-APIS-NO-IMPLICIT-RENDER
+    notes:
+      - Existing coverage verifies that state mutation does not re-render until an explicit update entry point is used.
+  - id: runtime-props-apply-raw-no-render
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/props-integration.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0002-CASE-MODULE-APIS-NO-IMPLICIT-RENDER
+    notes:
+      - Existing coverage verifies that `controller.applyRawProps()` dispatches watchers but does not render or commit.
+  - id: adapter-web-component-state-no-auto-render
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/state-no-auto-render.v0.test.ts
+    required: false
+    consumesCases:
+      - T-LIFECYCLE-0002-CASE-MODULE-APIS-NO-IMPLICIT-RENDER
+    notes:
+      - Web Component adapter coverage verifies the same no-auto-render rule through the adapter surface.
+  - id: adapter-web-component-props-reprovide-no-auto-render
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/props-reprovide.test.ts
+    required: false
+    consumesCases:
+      - T-LIFECYCLE-0002-CASE-MODULE-APIS-NO-IMPLICIT-RENDER
+    notes:
+      - Web Component adapter coverage verifies props re-provision dispatch behavior without implicit render.
+verifies:
+  contracts:
+    - id: C-LIFECYCLE-0003
+      anchors:
+        - C-LIFECYCLE-0003-A
+        - C-LIFECYCLE-0003-B
+        - C-LIFECYCLE-0003-C
+        - C-LIFECYCLE-0003-D
+        - C-LIFECYCLE-0003-E
+        - C-LIFECYCLE-0003-F
+        - C-LIFECYCLE-0003-G
+        - C-LIFECYCLE-0003-H
+exercises:
+  contracts:
+    - id: C-LIFECYCLE-0002
+      role: execution-order
+      coverageImpact: exercises-test-surface
+      note: Explicit update flow tests rely on the callback ordering model defined by `C-LIFECYCLE-0002`.
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added explicit update flow test mapping and preserved future gaps for async host profiles and update coalescing.
+tags:
+  - lifecycle
+  - update
+  - scheduling
+  - contract-test

--- a/spec/tests/T-LIFECYCLE-0003.yaml
+++ b/spec/tests/T-LIFECYCLE-0003.yaml
@@ -3,7 +3,7 @@ type: test
 title: Canonical lifecycle checkpoint trace tests
 status: draft
 since: 0.1.0
-summary: Runtime tests that verify the CP0-CP10 canonical checkpoint names and trace boundaries required by `C-LIFECYCLE-0004`.
+summary: Runtime and adapter tests that verify the CP0-CP10 canonical checkpoint names and trace boundaries required by `C-LIFECYCLE-0004`.
 cases:
   - id: T-LIFECYCLE-0003-CASE-CANONICAL-NAMES
     title: CP0-CP10 canonical checkpoint names are stable
@@ -31,6 +31,27 @@ cases:
       - C-LIFECYCLE-0004-E
       - C-LIFECYCLE-0004-H
     expectation: unmount-dispose-cp9-before-cp10
+  - id: T-LIFECYCLE-0003-CASE-ADAPTER-CANONICAL-TRACE
+    title: Official adapters expose conformance traces with canonical checkpoint names
+    covers:
+      - C-LIFECYCLE-0004-F
+      - C-LIFECYCLE-0004-H
+      - C-LIFECYCLE-0004-I
+    expectation: adapter-trace-uses-canonical-checkpoint-names
+  - id: T-LIFECYCLE-0003-CASE-ADAPTER-COMMIT-COMPLETION
+    title: Official adapters record CP4 and CP7 only after host commit completion
+    covers:
+      - C-LIFECYCLE-0004-B
+      - C-LIFECYCLE-0004-C
+      - C-LIFECYCLE-0004-F
+    expectation: adapter-checkpoint-trace-respects-host-commit-completion
+  - id: T-LIFECYCLE-0003-CASE-ADAPTER-DISPOSE-BOUNDARY
+    title: Official adapters map host unmount or disconnect into CP9 and CP10
+    covers:
+      - C-LIFECYCLE-0004-D
+      - C-LIFECYCLE-0004-E
+      - C-LIFECYCLE-0004-F
+    expectation: adapter-unmount-disconnect-maps-to-cp9-cp10
 implementations:
   - id: runtime-lifecycle-canonical-checkpoints
     kind: runtime-test
@@ -45,6 +66,42 @@ implementations:
     notes:
       - Uses `RuntimeHost.onLifecycleCheckpoint` to observe canonical runtime checkpoints without exposing them as prototype-author APIs.
       - Includes delayed `CommitSignal.done()` coverage so CP7/CP8 are tied to update commit completion.
+  - id: adapter-react-lifecycle-canonical-checkpoints
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/contract/lifecycle-checkpoints.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0003-CASE-ADAPTER-CANONICAL-TRACE
+      - T-LIFECYCLE-0003-CASE-ADAPTER-COMMIT-COMPLETION
+      - T-LIFECYCLE-0003-CASE-ADAPTER-DISPOSE-BOUNDARY
+    notes:
+      - Uses the React adapter diagnostics hook to observe canonical runtime checkpoints without exposing checkpoint names as prototype-author APIs.
+      - Verifies CP7 and CP8 are not recorded until the fake React host has performed the follow-up render/layout-effect commit completion step.
+  - id: adapter-vue-lifecycle-canonical-checkpoints
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/contract/lifecycle-checkpoints.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0003-CASE-ADAPTER-CANONICAL-TRACE
+      - T-LIFECYCLE-0003-CASE-ADAPTER-COMMIT-COMPLETION
+      - T-LIFECYCLE-0003-CASE-ADAPTER-DISPOSE-BOUNDARY
+    notes:
+      - Uses the Vue adapter diagnostics hook to observe canonical runtime checkpoints without exposing checkpoint names as prototype-author APIs.
+      - Verifies CP7 and CP8 are not recorded until Vue post-flush/nextTick commit completion has settled.
+  - id: adapter-web-component-lifecycle-canonical-checkpoints
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/contract/lifecycle-checkpoints.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0003-CASE-ADAPTER-CANONICAL-TRACE
+      - T-LIFECYCLE-0003-CASE-ADAPTER-COMMIT-COMPLETION
+      - T-LIFECYCLE-0003-CASE-ADAPTER-DISPOSE-BOUNDARY
+    notes:
+      - Uses the Web Component adapter diagnostics hook to observe canonical runtime checkpoints without exposing checkpoint names as prototype-author APIs.
+      - Verifies the synchronous DOM commit path records CP7 and CP8 before `update()` returns.
 verifies:
   contracts:
     - id: C-LIFECYCLE-0004
@@ -54,6 +111,7 @@ verifies:
         - C-LIFECYCLE-0004-C
         - C-LIFECYCLE-0004-D
         - C-LIFECYCLE-0004-E
+        - C-LIFECYCLE-0004-F
         - C-LIFECYCLE-0004-H
         - C-LIFECYCLE-0004-I
 exercises:
@@ -66,8 +124,12 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added canonical lifecycle checkpoint trace coverage for `C-LIFECYCLE-0004`.
+  - version: 0.1.0
+    change: revised
+    summary: Added official adapter conformance coverage for canonical checkpoint traces and host commit completion boundaries.
 tags:
   - lifecycle
   - checkpoint
   - runtime
+  - adapter
   - contract-test

--- a/spec/tests/T-LIFECYCLE-0003.yaml
+++ b/spec/tests/T-LIFECYCLE-0003.yaml
@@ -1,0 +1,73 @@
+id: T-LIFECYCLE-0003
+type: test
+title: Canonical lifecycle checkpoint trace tests
+status: draft
+since: 0.1.0
+summary: Runtime tests that verify the CP0-CP10 canonical checkpoint names and trace boundaries required by `C-LIFECYCLE-0004`.
+cases:
+  - id: T-LIFECYCLE-0003-CASE-CANONICAL-NAMES
+    title: CP0-CP10 canonical checkpoint names are stable
+    covers:
+      - C-LIFECYCLE-0004-H
+      - C-LIFECYCLE-0004-I
+    expectation: stable-canonical-checkpoint-names
+  - id: T-LIFECYCLE-0003-CASE-INITIAL-CHECKPOINTS
+    title: Initial runtime flow records CP0 through CP5 in canonical order
+    covers:
+      - C-LIFECYCLE-0004-A
+      - C-LIFECYCLE-0004-B
+      - C-LIFECYCLE-0004-H
+    expectation: initial-flow-cp0-through-cp5
+  - id: T-LIFECYCLE-0003-CASE-UPDATE-CHECKPOINTS
+    title: Accepted update cycles record CP6 through CP8 in canonical order
+    covers:
+      - C-LIFECYCLE-0004-C
+      - C-LIFECYCLE-0004-H
+    expectation: update-flow-cp6-through-cp8
+  - id: T-LIFECYCLE-0003-CASE-DISPOSE-CHECKPOINTS
+    title: Unmount and dispose record CP9 before CP10
+    covers:
+      - C-LIFECYCLE-0004-D
+      - C-LIFECYCLE-0004-E
+      - C-LIFECYCLE-0004-H
+    expectation: unmount-dispose-cp9-before-cp10
+implementations:
+  - id: runtime-lifecycle-canonical-checkpoints
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/lifecycle.checkpoints.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0003-CASE-CANONICAL-NAMES
+      - T-LIFECYCLE-0003-CASE-INITIAL-CHECKPOINTS
+      - T-LIFECYCLE-0003-CASE-UPDATE-CHECKPOINTS
+      - T-LIFECYCLE-0003-CASE-DISPOSE-CHECKPOINTS
+    notes:
+      - Uses `RuntimeHost.onLifecycleCheckpoint` to observe canonical runtime checkpoints without exposing them as prototype-author APIs.
+      - Includes delayed `CommitSignal.done()` coverage so CP7/CP8 are tied to update commit completion.
+verifies:
+  contracts:
+    - id: C-LIFECYCLE-0004
+      anchors:
+        - C-LIFECYCLE-0004-A
+        - C-LIFECYCLE-0004-B
+        - C-LIFECYCLE-0004-C
+        - C-LIFECYCLE-0004-D
+        - C-LIFECYCLE-0004-E
+        - C-LIFECYCLE-0004-H
+        - C-LIFECYCLE-0004-I
+exercises:
+  contracts:
+    - id: C-LIFECYCLE-0002
+      role: execution-order
+      coverageImpact: exercises-test-surface
+      note: Canonical checkpoint tests exercise the lifecycle callback ordering model at runtime trace boundaries.
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added canonical lifecycle checkpoint trace coverage for `C-LIFECYCLE-0004`.
+tags:
+  - lifecycle
+  - checkpoint
+  - runtime
+  - contract-test

--- a/spec/tests/T-LIFECYCLE-0003.yaml
+++ b/spec/tests/T-LIFECYCLE-0003.yaml
@@ -24,6 +24,12 @@ cases:
       - C-LIFECYCLE-0004-C
       - C-LIFECYCLE-0004-H
     expectation: update-flow-cp6-through-cp8
+  - id: T-LIFECYCLE-0003-CASE-ASYNC-UPDATE-COALESCING
+    title: Update intents during pending async commit are coalesced into a later update cycle
+    covers:
+      - C-LIFECYCLE-0004-C
+      - C-LIFECYCLE-0004-H
+    expectation: async-update-intents-queue-until-previous-cp8
   - id: T-LIFECYCLE-0003-CASE-DISPOSE-CHECKPOINTS
     title: Unmount and dispose record CP9 before CP10
     covers:
@@ -62,10 +68,12 @@ implementations:
       - T-LIFECYCLE-0003-CASE-CANONICAL-NAMES
       - T-LIFECYCLE-0003-CASE-INITIAL-CHECKPOINTS
       - T-LIFECYCLE-0003-CASE-UPDATE-CHECKPOINTS
+      - T-LIFECYCLE-0003-CASE-ASYNC-UPDATE-COALESCING
       - T-LIFECYCLE-0003-CASE-DISPOSE-CHECKPOINTS
     notes:
       - Uses `RuntimeHost.onLifecycleCheckpoint` to observe canonical runtime checkpoints without exposing them as prototype-author APIs.
       - Includes delayed `CommitSignal.done()` coverage so CP7/CP8 are tied to update commit completion.
+      - Verifies repeated update intents during a pending async commit are accepted as a queued/coalesced update cycle after the previous cycle reaches CP8.
   - id: adapter-react-lifecycle-canonical-checkpoints
     kind: adapter-test
     status: passing
@@ -127,6 +135,9 @@ revisions:
   - version: 0.1.0
     change: revised
     summary: Added official adapter conformance coverage for canonical checkpoint traces and host commit completion boundaries.
+  - version: 0.1.0
+    change: revised
+    summary: Added queued async update intent coverage for runtime checkpoint traces.
 tags:
   - lifecycle
   - checkpoint

--- a/spec/tests/T-LIFECYCLE-0004.yaml
+++ b/spec/tests/T-LIFECYCLE-0004.yaml
@@ -1,0 +1,84 @@
+id: T-LIFECYCLE-0004
+type: test
+title: Prototype lifecycle API surface tests
+status: draft
+since: 0.1.0
+summary: Runtime tests that verify the setup-time `def.lifecycle` API surface required by `C-LIFECYCLE-0005`.
+cases:
+  - id: T-LIFECYCLE-0004-CASE-ENTRY-SURFACE
+    title: '`def.lifecycle` exposes only the portable v0 registration entries'
+    covers:
+      - C-LIFECYCLE-0005-A
+      - C-LIFECYCLE-0005-B
+      - C-LIFECYCLE-0005-G
+    expectation: lifecycle-registration-entry-surface
+  - id: T-LIFECYCLE-0004-CASE-SETUP-ONLY
+    title: Lifecycle callback registration is setup-only
+    covers:
+      - C-LIFECYCLE-0005-C
+    expectation: lifecycle-registration-setup-only
+  - id: T-LIFECYCLE-0004-CASE-REGISTRATION-DOES-NOT-INVOKE
+    title: Registration does not invoke lifecycle callbacks immediately
+    covers:
+      - C-LIFECYCLE-0005-D
+      - C-LIFECYCLE-0002-A
+    expectation: lifecycle-registration-defers-callback-invocation
+  - id: T-LIFECYCLE-0004-CASE-RUN-HANDLE-BINDING
+    title: Lifecycle callbacks receive a runtime `run handle`
+    covers:
+      - C-LIFECYCLE-0005-E
+    expectation: lifecycle-callback-run-handle-binding
+  - id: T-LIFECYCLE-0004-CASE-NO-PORTABLE-REVOKE
+    title: Registration return values do not define portable revoke handles
+    covers:
+      - C-LIFECYCLE-0005-F
+    expectation: lifecycle-registration-has-no-portable-revoke-handle
+implementations:
+  - id: runtime-lifecycle-api-surface
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/lifecycle.registration.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0004-CASE-ENTRY-SURFACE
+      - T-LIFECYCLE-0004-CASE-SETUP-ONLY
+      - T-LIFECYCLE-0004-CASE-REGISTRATION-DOES-NOT-INVOKE
+      - T-LIFECYCLE-0004-CASE-RUN-HANDLE-BINDING
+      - T-LIFECYCLE-0004-CASE-NO-PORTABLE-REVOKE
+    notes:
+      - Verifies the concrete `def.lifecycle` registration surface and setup-only guards through runtime execution.
+      - Uses callback invocation as a runtime probe, not as an ordering test; callback ordering remains owned by `T-LIFECYCLE-0001`.
+verifies:
+  contracts:
+    - id: C-LIFECYCLE-0005
+      anchors:
+        - C-LIFECYCLE-0005-A
+        - C-LIFECYCLE-0005-B
+        - C-LIFECYCLE-0005-C
+        - C-LIFECYCLE-0005-D
+        - C-LIFECYCLE-0005-E
+        - C-LIFECYCLE-0005-F
+        - C-LIFECYCLE-0005-G
+exercises:
+  contracts:
+    - id: C-LIFECYCLE-0002
+      role: execution-order
+      coverageImpact: exercises-test-surface
+      note: API surface tests use runtime lifecycle invocation to prove callbacks are registered rather than called immediately.
+    - id: C-CORE-SYNTAX-0001
+      role: api-surface
+      coverageImpact: exercises-test-surface
+      note: Lifecycle setup APIs are exposed through `def`.
+    - id: C-CORE-SYNTAX-0002
+      role: api-surface
+      coverageImpact: exercises-test-surface
+      note: Lifecycle callbacks receive `run` during runtime invocation.
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added lifecycle API surface coverage for `C-LIFECYCLE-0005`.
+tags:
+  - lifecycle
+  - syntax
+  - contract-test
+  - runtime

--- a/spec/tests/T-TEMPLATE-0001.yaml
+++ b/spec/tests/T-TEMPLATE-0001.yaml
@@ -1,0 +1,173 @@
+id: T-TEMPLATE-0001
+type: test
+title: Template authoring and adapter boundary tests
+status: draft
+since: 0.1.0
+summary: Shared fixture and contract tests for template root-child boundaries, renderer primitives, normalization, slot protocol, and PrototypeRef rejection.
+cases:
+  - id: T-TEMPLATE-0001-CASE-ROOT-CHILDREN
+    title: Template output is rendered as host-root children
+    covers:
+      - C-TEMPLATE-0001-A
+      - C-TEMPLATE-0001-B
+      - C-TEMPLATE-0001-C
+    expectation: template-output-materializes-as-root-children
+  - id: T-TEMPLATE-0001-CASE-NODE-STRUCTURE
+    title: Template nodes are structural nodes with children and optional style
+    covers:
+      - C-TEMPLATE-0002-A
+      - C-TEMPLATE-0002-B
+      - C-TEMPLATE-0002-C
+      - C-TEMPLATE-0002-D
+    expectation: template-node-structural-shape
+  - id: T-TEMPLATE-0001-CASE-EL-DISPATCH
+    title: Renderer `el()` uses fixed dispatch and style-only TemplateProps
+    covers:
+      - C-TEMPLATE-0003-A
+      - C-TEMPLATE-0003-B
+      - C-TEMPLATE-0003-C
+      - C-TEMPLATE-0003-D
+      - C-TEMPLATE-0003-E
+    expectation: renderer-el-dispatch-and-props-validation
+  - id: T-TEMPLATE-0001-CASE-NORMALIZE
+    title: TemplateChildren normalization enforces the portable v0 shape
+    covers:
+      - C-TEMPLATE-0004-A
+      - C-TEMPLATE-0004-B
+      - C-TEMPLATE-0004-C
+      - C-TEMPLATE-0004-D
+      - C-TEMPLATE-0004-E
+      - C-TEMPLATE-0004-F
+      - C-TEMPLATE-0004-G
+    expectation: template-children-normalize-v0
+  - id: T-TEMPLATE-0001-CASE-SLOT
+    title: Template slot is anonymous, singular, and parameterless
+    covers:
+      - C-TEMPLATE-0005-A
+      - C-TEMPLATE-0005-B
+      - C-TEMPLATE-0005-C
+      - C-TEMPLATE-0005-D
+      - C-TEMPLATE-0005-E
+    expectation: template-slot-protocol-v0
+  - id: T-TEMPLATE-0001-CASE-PROTOTYPE-REF
+    title: Adapter rejects PrototypeRef template types with the v0 error
+    covers:
+      - C-TEMPLATE-0006-A
+      - C-TEMPLATE-0006-B
+      - C-TEMPLATE-0006-C
+      - C-TEMPLATE-0006-D
+    expectation: prototype-ref-template-type-rejected
+implementations:
+  - id: template-authoring-fixture
+    kind: fixture
+    status: active
+    path: packages/spec/fixtures/src/template/authoring.ts
+    required: true
+    consumesCases:
+      - T-TEMPLATE-0001-CASE-ROOT-CHILDREN
+      - T-TEMPLATE-0001-CASE-NODE-STRUCTURE
+      - T-TEMPLATE-0001-CASE-EL-DISPATCH
+      - T-TEMPLATE-0001-CASE-NORMALIZE
+      - T-TEMPLATE-0001-CASE-SLOT
+      - T-TEMPLATE-0001-CASE-PROTOTYPE-REF
+    notes:
+      - Shared fixture records the template case-to-criteria mapping used by new core and adapter tests.
+  - id: core-template-authoring-fixture
+    kind: module-test
+    status: passing
+    path: packages/core/test/contract/template.authoring-fixture.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-TEMPLATE-0001-CASE-NODE-STRUCTURE
+      - T-TEMPLATE-0001-CASE-EL-DISPATCH
+      - T-TEMPLATE-0001-CASE-NORMALIZE
+      - T-TEMPLATE-0001-CASE-SLOT
+  - id: adapter-web-component-template-boundary-fixture
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/contract/template.adapter-boundary.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-TEMPLATE-0001-CASE-ROOT-CHILDREN
+      - T-TEMPLATE-0001-CASE-SLOT
+      - T-TEMPLATE-0001-CASE-PROTOTYPE-REF
+  - id: core-template-normalize-existing
+    kind: module-test
+    status: passing
+    path: packages/core/test/contract/template.normalize.contract.test.ts
+    required: false
+    consumesCases:
+      - T-TEMPLATE-0001-CASE-NORMALIZE
+    notes:
+      - Existing normalize contract test remains valid but is secondary to the shared fixture-based test mapping.
+  - id: core-template-renderer-primitives-existing
+    kind: module-test
+    status: passing
+    path: packages/core/test/contract/template.renderer-primitives.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-TEMPLATE-0001-CASE-EL-DISPATCH
+    notes:
+      - Existing renderer primitive coverage remains valid but is secondary to the shared fixture-based test mapping.
+  - id: adapter-web-component-prototype-ref-existing
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/contract/template.no-prototype-composition.v0.contract.test.ts
+    required: false
+    consumesCases:
+      - T-TEMPLATE-0001-CASE-PROTOTYPE-REF
+    notes:
+      - Existing targeted PrototypeRef rejection test remains valid.
+verifies:
+  contracts:
+    - id: C-TEMPLATE-0001
+      anchors:
+        - C-TEMPLATE-0001-A
+        - C-TEMPLATE-0001-B
+        - C-TEMPLATE-0001-C
+    - id: C-TEMPLATE-0002
+      anchors:
+        - C-TEMPLATE-0002-A
+        - C-TEMPLATE-0002-B
+        - C-TEMPLATE-0002-C
+        - C-TEMPLATE-0002-D
+    - id: C-TEMPLATE-0003
+      anchors:
+        - C-TEMPLATE-0003-A
+        - C-TEMPLATE-0003-B
+        - C-TEMPLATE-0003-C
+        - C-TEMPLATE-0003-D
+        - C-TEMPLATE-0003-E
+    - id: C-TEMPLATE-0004
+      anchors:
+        - C-TEMPLATE-0004-A
+        - C-TEMPLATE-0004-B
+        - C-TEMPLATE-0004-C
+        - C-TEMPLATE-0004-D
+        - C-TEMPLATE-0004-E
+        - C-TEMPLATE-0004-F
+        - C-TEMPLATE-0004-G
+    - id: C-TEMPLATE-0005
+      anchors:
+        - C-TEMPLATE-0005-A
+        - C-TEMPLATE-0005-B
+        - C-TEMPLATE-0005-C
+        - C-TEMPLATE-0005-D
+        - C-TEMPLATE-0005-E
+    - id: C-TEMPLATE-0006
+      anchors:
+        - C-TEMPLATE-0006-A
+        - C-TEMPLATE-0006-B
+        - C-TEMPLATE-0006-C
+        - C-TEMPLATE-0006-D
+explains:
+  knowledge:
+    - K-PROTOTYPE-COMPOSITION-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added shared fixture and contract tests for template authoring and adapter boundary semantics.
+tags:
+  - template
+  - contract-test
+  - fixture


### PR DESCRIPTION
## Summary

本 PR 将 Lifecycle 相关旧契约梳理进 spec 体系，建立 `C-LIFECYCLE-*` 契约实体、对应测试实体与必要的 runtime/adapter conformance 覆盖。

## Scope

- 新增并整理 Lifecycle 契约实体：
  - `C-LIFECYCLE-0001`: setup/runtime 执行时期模型
  - `C-LIFECYCLE-0002`: prototype-visible lifecycle callback 顺序
  - `C-LIFECYCLE-0003`: update/render/commit 入口与触发边界
  - `C-LIFECYCLE-0004`: runtime/adapter canonical checkpoint 模型
  - `C-LIFECYCLE-0005`: prototype lifecycle API surface 语法
- 新增/更新 Lifecycle 测试实体：
  - callback order 与 disposal boundary
  - explicit update / no implicit render
  - canonical CP0-CP10 checkpoint trace
  - lifecycle API surface
- 补充 runtime 与 adapter 侧测试，覆盖 React/Vue/Web Component adapter 对 canonical checkpoint 的映射。
- 增加 adapter diagnostics checkpoint observer 透传，用于 conformance trace，不作为 prototype API 暴露。
- 记录 spec entity scope / adapter / compiler / prototype-family 相关治理讨论。

## Validation

- Lifecycle runtime contract tests passed.
- React/Vue/Web Component adapter lifecycle checkpoint conformance tests passed.
- `pnpm run check:types:workspace` passed.
- Spec dataset generation passed via `node --import tsx apps/workspace/scripts/generate-spec-dataset.ts`.
- Prettier checks passed for touched files.