### PR TITLE
feat: catalog feedback contracts and add runtime style patch API

### DIFF
--- a/internal/contracts/_debt/feedback.web-style-ownership.md
+++ b/internal/contracts/_debt/feedback.web-style-ownership.md
@@ -1,0 +1,34 @@
+## CONTRACT_DEBT(v0): feedback.web-style-ownership
+
+### Problem
+
+Official Web-family adapters currently realize Proto UI style tokens through a host-visible style channel such as `data-pui-style`. That channel can receive tokens from multiple sources:
+
+- setup-time `feedback.style`
+- rule-driven or future runtime feedback effects
+- adapter-owned baseline styles
+- App Maker or host-authored style tokens that coexist with Proto UI output
+
+The implementation needs an ownership model so clearing or replacing one source does not accidentally remove tokens owned by another source.
+
+### Current behavior
+
+The Web Component adapter has an owned-token implementation that tracks internal sources and rewrites `data-pui-style` without touching host `classList`.
+
+This is currently an implementation practice, not a fully cataloged contract.
+
+### Risk / tradeoff
+
+- Without an ownership contract, a future adapter or runtime style path could clear too much and break App Maker-authored styling.
+- Over-specifying this too early could leak Web-specific realization details into the feedback philosophy layer.
+
+### Desired direction
+
+Define this under an official Web adapter / CLI-governed style realization contract, not under the base feedback channel contract.
+
+The eventual contract should capture:
+
+- App Maker-authored host styling should remain usable and higher priority where the host allows it.
+- Adapter-produced style artifacts should not be written into the same ownership surface as user classes when a separate style channel is available.
+- Multiple internal style sources should be replaceable and clearable without deleting unrelated sources.
+- Hosts that cannot provide this separation should degrade gracefully and state the limitation in their adapter capability matrix.

--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -200,6 +200,8 @@ export type ContextOnChangeOptional<P extends PropsBaseType, T extends JsonObjec
 // 注意：这里不叫 run，避免和 callback-time 的 run 混淆
 export interface RenderReadHandle<Props extends PropsBaseType> {
   props: RunHandle<Props>['props'];
+  context: Pick<RunHandle<Props>['context'], 'read' | 'tryRead'>;
+  anatomy: RunHandle<Props>['anatomy'];
 }
 
 export interface ElementFactory {

--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -93,6 +93,14 @@ export interface RunHandle<Props extends PropsBaseType> {
     emit(key: string, payload?: any, options?: Record<string, unknown>): void;
   };
 
+  feedback: {
+    style: {
+      patch: (...handles: StyleHandle[]) => void;
+      suppress: (...handles: StyleHandle[]) => void;
+      clearPatch: () => void;
+    };
+  };
+
   anatomy: {
     /** runtime-only readonly anatomy query surface; unavailable during setup */
     has(family: AnatomyFamily, role: string): boolean;

--- a/packages/core/src/spec/feedback/recorder.ts
+++ b/packages/core/src/spec/feedback/recorder.ts
@@ -1,7 +1,7 @@
 // packages/core/src/spec/feedback/recorder.ts
 
 import type { StyleHandle } from './style';
-import { mergeTwTokensV0 } from './semantic-merge';
+import { getSemanticGroupKeyV0, mergeTwTokensV0 } from './semantic-merge';
 import { assertTwTokenV0 } from './tokens';
 
 export type UnUse = () => void;
@@ -12,9 +12,19 @@ type Chunk = {
   removed: boolean;
 };
 
+type PatchEntry =
+  | {
+      kind: 'patch';
+      token: string;
+    }
+  | {
+      kind: 'suppress';
+    };
+
 export class FeedbackStyleRecorder {
   private nextId = 1;
   private chunks: Chunk[] = [];
+  private runtimePatch = new Map<string, PatchEntry>();
 
   /**
    * setup-only: record style intent tokens (tw handles only)
@@ -81,16 +91,102 @@ export class FeedbackStyleRecorder {
   }
 
   /**
+   * runtime-only: write positive style patches over the current base result.
+   */
+  patch(...handles: StyleHandle[]): void {
+    for (const token of this.flattenRuntimePatchHandles(handles, 'run.feedback.style.patch')) {
+      this.runtimePatch.set(getSemanticGroupKeyV0(token), { kind: 'patch', token });
+    }
+  }
+
+  /**
+   * runtime-only: suppress semantic groups from the current base result.
+   */
+  suppress(...handles: StyleHandle[]): void {
+    for (const token of this.flattenRuntimePatchHandles(handles, 'run.feedback.style.suppress')) {
+      this.runtimePatch.set(getSemanticGroupKeyV0(token), { kind: 'suppress' });
+    }
+  }
+
+  /**
+   * runtime-only: remove every style patch entry for the current instance.
+   */
+  clearPatch(): void {
+    this.runtimePatch.clear();
+  }
+
+  /**
    * Export a semantic snapshot of merged tokens.
    *
    * v0 recommendation: export is allowed in any phase (pure snapshot).
    */
   export(): { tokens: string[] } {
+    return this.exportWithAdditional();
+  }
+
+  /**
+   * Export a semantic snapshot after appending additional base style handles,
+   * then applying the runtime patch layer.
+   *
+   * Additional handles are used by rule/runtime internals: they are still part of
+   * the pre-patch base semantic result, not host translation artifacts.
+   */
+  exportWithAdditional(...handles: StyleHandle[]): { tokens: string[] } {
+    return this.applyPatchLayer(this.exportBaseTokens(handles));
+  }
+
+  exportBase(): { tokens: string[] } {
+    return { tokens: this.exportBaseTokens() };
+  }
+
+  private exportBaseTokens(additionalHandles: StyleHandle[] = []): string[] {
     const inputs: string[] = [];
     for (const c of this.chunks) {
       if (c.removed) continue;
       inputs.push(...c.tokens);
     }
-    return mergeTwTokensV0(inputs);
+    for (const h of additionalHandles) {
+      if (!h || h.kind !== 'tw' || !Array.isArray(h.tokens)) {
+        throw new Error(`[feedback] unsupported style handle in v0`);
+      }
+      inputs.push(...h.tokens);
+    }
+    return mergeTwTokensV0(inputs).tokens;
+  }
+
+  private applyPatchLayer(baseTokens: string[]): { tokens: string[] } {
+    if (this.runtimePatch.size === 0) return { tokens: baseTokens };
+
+    const patchTokens: string[] = [];
+    const baseAfterSuppress: string[] = [];
+
+    for (const token of baseTokens) {
+      const entry = this.runtimePatch.get(getSemanticGroupKeyV0(token));
+      if (entry) continue;
+      baseAfterSuppress.push(token);
+    }
+
+    for (const entry of this.runtimePatch.values()) {
+      if (entry.kind === 'patch') patchTokens.push(entry.token);
+    }
+
+    return mergeTwTokensV0([...baseAfterSuppress, ...patchTokens]);
+  }
+
+  private flattenRuntimePatchHandles(handles: StyleHandle[], op: string): string[] {
+    const flattened: string[] = [];
+    for (const h of handles) {
+      if (!h || h.kind !== 'tw' || !Array.isArray(h.tokens)) {
+        throw new Error(`[feedback] unsupported style handle in v0`);
+      }
+      for (const t of h.tokens) {
+        assertTwTokenV0(t, op);
+        if (t === 'data-pui-style') {
+          throw new Error(`[feedback] invalid tw token (${op}): host style artifact is forbidden`);
+        }
+        flattened.push(t);
+      }
+    }
+    return flattened;
   }
 }

--- a/packages/core/test/contract/feedback.style.runtime-patch.v0.contract.test.ts
+++ b/packages/core/test/contract/feedback.style.runtime-patch.v0.contract.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { FeedbackStyleRecorder, tw } from '@proto.ui/core';
+import { FEEDBACK_STYLE_RUNTIME_PATCH_CASES } from '@proto.ui/spec-fixtures/feedback/style-runtime-patch';
+
+describe('core: feedback.style runtime patch v0 contract', () => {
+  it('keeps fixture coverage aligned with the runtime patch cases', () => {
+    expect(FEEDBACK_STYLE_RUNTIME_PATCH_CASES.map((testCase) => testCase.specCase)).toEqual([
+      'T-FEEDBACK-STYLE-0002-CASE-PATCH',
+      'T-FEEDBACK-STYLE-0002-CASE-SUPPRESS',
+      'T-FEEDBACK-STYLE-0002-CASE-CLEAR-PATCH',
+      'T-FEEDBACK-STYLE-0002-CASE-PATCH-TOKEN-PURITY',
+      'T-FEEDBACK-STYLE-0002-CASE-NO-RENDER',
+    ]);
+  });
+
+  it('applies patch after the base semantic result, with same-group last write winning', () => {
+    const recorder = new FeedbackStyleRecorder();
+
+    recorder.use(tw('opacity-50 bg-blue-500 text-white'));
+    recorder.patch(tw('opacity-100'));
+
+    expect(recorder.export().tokens).toEqual(['bg-blue-500', 'text-white', 'opacity-100']);
+
+    recorder.patch(tw('opacity-25'));
+    expect(recorder.export().tokens).toEqual(['bg-blue-500', 'text-white', 'opacity-25']);
+  });
+
+  it('suppresses a semantic group from the base result without undoing historical patches', () => {
+    const recorder = new FeedbackStyleRecorder();
+
+    recorder.use(tw('opacity-50 bg-blue-500 text-white'));
+    recorder.patch(tw('opacity-100'));
+    recorder.suppress(tw('opacity-50'));
+
+    expect(recorder.export().tokens).toEqual(['bg-blue-500', 'text-white']);
+
+    recorder.patch(tw('opacity-25'));
+    expect(recorder.export().tokens).toEqual(['bg-blue-500', 'text-white', 'opacity-25']);
+  });
+
+  it('keeps different semantic groups independent and clearPatch restores the base result', () => {
+    const recorder = new FeedbackStyleRecorder();
+
+    recorder.use(tw('opacity-50 bg-blue-500 text-white'));
+    recorder.patch(tw('opacity-100 bg-red-500'));
+    recorder.suppress(tw('text-white'));
+
+    expect(recorder.export().tokens).toEqual(['opacity-100', 'bg-red-500']);
+
+    recorder.clearPatch();
+    expect(recorder.export().tokens).toEqual(['opacity-50', 'bg-blue-500', 'text-white']);
+  });
+
+  it('validates runtime patch inputs as author-side feedback.style token handles', () => {
+    const recorder = new FeedbackStyleRecorder();
+
+    expect(() => recorder.patch(tw('hover:opacity-100'))).toThrow();
+    expect(() => recorder.suppress(tw('data-[disabled]:opacity-50'))).toThrow();
+    expect(() => recorder.patch({ kind: 'tw', tokens: ['data-pui-style'] })).toThrow();
+  });
+});

--- a/packages/modules/context/src/impl.ts
+++ b/packages/modules/context/src/impl.ts
@@ -198,7 +198,7 @@ export class ContextModuleImpl extends ModuleBase {
   // -------------------------
 
   read<T extends JsonObject>(key: ContextKey<T>): T {
-    this.guardCallbackOnly('run.context.read');
+    this.guardRuntimeOnly('run.context.read');
 
     const self = this.getSelfToken();
     this.ensureSubscribed(self, key, 'required', 'read');
@@ -224,7 +224,7 @@ export class ContextModuleImpl extends ModuleBase {
   }
 
   tryRead<T extends JsonObject>(key: ContextKey<T>): T | null {
-    this.guardCallbackOnly('run.context.tryRead');
+    this.guardRuntimeOnly('run.context.tryRead');
 
     const self = this.getSelfToken();
     this.ensureSubscribed(self, key, 'optional', 'tryRead');
@@ -337,6 +337,14 @@ export class ContextModuleImpl extends ModuleBase {
 
   private guardCallbackOnly(op: string) {
     if (this.sys.execPhase() !== 'callback') {
+      throw contextError(ERR.PHASE, `[Context] illegal phase for ${op}: ${this.sys.execPhase()}`);
+    }
+  }
+
+  private guardRuntimeOnly(op: string) {
+    try {
+      this.sys.ensureRuntime(op);
+    } catch {
       throw contextError(ERR.PHASE, `[Context] illegal phase for ${op}: ${this.sys.execPhase()}`);
     }
   }

--- a/packages/modules/feedback/src/create.ts
+++ b/packages/modules/feedback/src/create.ts
@@ -6,7 +6,6 @@ import { createModule, defineModule, ModuleBase } from '@proto.ui/module-base';
 import type { ModuleFactoryArgs } from '@proto.ui/module-base';
 
 import type { FeedbackFacade, FeedbackModule, FeedbackPort } from './types';
-import { mergeTwTokensV0 } from '@proto.ui/core';
 import { EFFECTS_CAP } from './caps';
 
 export function createFeedbackModule(ctx: ModuleFactoryArgs): FeedbackModule {
@@ -45,9 +44,9 @@ export function createFeedbackModule(ctx: ModuleFactoryArgs): FeedbackModule {
           };
         }
 
-        /** runtime-only */
+        /** internal runtime base style contribution, used by rule execution */
         useStyleRuntime(handles: StyleHandle[]): () => void {
-          const op = 'run.feedback.style.use';
+          const op = 'rule.feedback.style.use';
           if (this.protoPhase === 'setup') {
             throw illegalPhase(op, this.protoPhase, {
               prototypeName: init.prototypeName,
@@ -64,6 +63,33 @@ export function createFeedbackModule(ctx: ModuleFactoryArgs): FeedbackModule {
             this.dirty = true;
             this.flushIfPossible();
           };
+        }
+
+        /** runtime-only public patch API */
+        patchStyle(handles: StyleHandle[]): void {
+          const op = 'run.feedback.style.patch';
+          this.ensureRuntime(op);
+          this.recorder.patch(...handles);
+          this.dirty = true;
+          this.flushIfPossible();
+        }
+
+        /** runtime-only public suppress API */
+        suppressStyle(handles: StyleHandle[]): void {
+          const op = 'run.feedback.style.suppress';
+          this.ensureRuntime(op);
+          this.recorder.suppress(...handles);
+          this.dirty = true;
+          this.flushIfPossible();
+        }
+
+        /** runtime-only public clear API */
+        clearStylePatch(): void {
+          const op = 'run.feedback.style.clearPatch';
+          this.ensureRuntime(op);
+          this.recorder.clearPatch();
+          this.dirty = true;
+          this.flushIfPossible();
         }
 
         /** internal: record tokens without v0 validation (setup or runtime) */
@@ -122,9 +148,7 @@ export function createFeedbackModule(ctx: ModuleFactoryArgs): FeedbackModule {
             return;
           }
           const effects = this.caps.get(EFFECTS_CAP);
-          // merge with existing recorded styles to preserve setup styles
-          const base = this.exportMerged();
-          const merged = mergeTwTokensV0([...base.tokens, ...(handle?.tokens ?? [])]);
+          const merged = this.recorder.exportWithAdditional(handle);
           effects.queueStyle({ kind: 'tw', tokens: merged.tokens });
           effects.requestFlush();
           this.flushRequested = true;
@@ -149,6 +173,16 @@ export function createFeedbackModule(ctx: ModuleFactoryArgs): FeedbackModule {
             this.flushRequested = true;
           }
         }
+
+        private ensureRuntime(op: string): void {
+          this.sys?.ensureRuntime(op);
+          if (!this.sys && this.protoPhase === 'setup') {
+            throw illegalPhase(op, this.protoPhase, {
+              prototypeName: init.prototypeName,
+              hint: `Use 'run' only after setup.`,
+            });
+          }
+        }
       }
 
       const impl = new Impl(caps);
@@ -156,6 +190,9 @@ export function createFeedbackModule(ctx: ModuleFactoryArgs): FeedbackModule {
       const facade: FeedbackFacade = {
         style: {
           use: (...handles) => impl.useStyle(handles),
+          patch: (...handles) => impl.patchStyle(handles),
+          suppress: (...handles) => impl.suppressStyle(handles),
+          clearPatch: () => impl.clearStylePatch(),
           exportMerged: () => impl.exportMerged(),
         },
       };
@@ -165,6 +202,9 @@ export function createFeedbackModule(ctx: ModuleFactoryArgs): FeedbackModule {
         port: {
           applyMergedStyle: (h) => impl.applyMergedStyle(h),
           useStyleRuntime: (...handles) => impl.useStyleRuntime(handles),
+          patchStyle: (...handles) => impl.patchStyle(handles),
+          suppressStyle: (...handles) => impl.suppressStyle(handles),
+          clearStylePatch: () => impl.clearStylePatch(),
           useStyleUnsafe: (...handles) => impl.useStyleUnsafe(handles),
         } satisfies FeedbackPort,
         hooks: {

--- a/packages/modules/feedback/src/types.ts
+++ b/packages/modules/feedback/src/types.ts
@@ -6,6 +6,15 @@ export interface FeedbackFacade extends ModuleFacade {
     /** setup-only */
     use: (...handles: StyleHandle[]) => () => void;
 
+    /** runtime-only */
+    patch: (...handles: StyleHandle[]) => void;
+
+    /** runtime-only */
+    suppress: (...handles: StyleHandle[]) => void;
+
+    /** runtime-only */
+    clearPatch: () => void;
+
     /** pure snapshot: allowed in any phase */
     exportMerged: () => StyleHandle;
   };
@@ -18,11 +27,17 @@ export type FeedbackPort = {
    */
   applyMergedStyle(handle: StyleHandle): void;
 
-  /**
-   * Runtime-only: record a style use (returns unUse).
-   * Preserves ordering semantics (later use wins by position).
-   */
+  /** Internal: record a rule-produced base style use (returns unUse). */
   useStyleRuntime: (...handles: StyleHandle[]) => () => void;
+
+  /** Runtime-only public feedback.style patch surface. */
+  patchStyle: (...handles: StyleHandle[]) => void;
+
+  /** Runtime-only public feedback.style suppress surface. */
+  suppressStyle: (...handles: StyleHandle[]) => void;
+
+  /** Runtime-only public feedback.style patch reset surface. */
+  clearStylePatch: () => void;
 
   /**
    * Internal: record style tokens without v0 token validation.

--- a/packages/runtime/src/kernel/handles/run.ts
+++ b/packages/runtime/src/kernel/handles/run.ts
@@ -6,6 +6,7 @@ import { PropsFacade } from '@proto.ui/module-props';
 import { ContextFacade } from '@proto.ui/module-context';
 import { EventFacade } from '@proto.ui/module-event';
 import { AnatomyFacade } from '@proto.ui/module-anatomy';
+import { FeedbackFacade } from '@proto.ui/module-feedback';
 
 export const createRunHandle = <P extends PropsBaseType>(
   update: RunHandle<P>['update'],
@@ -16,6 +17,7 @@ export const createRunHandle = <P extends PropsBaseType>(
   const context = facades['context'] as ContextFacade;
   const event = facades['event'] as EventFacade;
   const anatomy = facades['anatomy'] as AnatomyFacade | undefined;
+  const feedback = facades['feedback'] as FeedbackFacade;
 
   return {
     update,
@@ -32,6 +34,13 @@ export const createRunHandle = <P extends PropsBaseType>(
     },
     event: {
       emit: (key, payload, options) => event.emit(key, payload, options),
+    },
+    feedback: {
+      style: {
+        patch: (...handles) => feedback.style.patch(...handles),
+        suppress: (...handles) => feedback.style.suppress(...handles),
+        clearPatch: () => feedback.style.clearPatch(),
+      },
     },
     anatomy: {
       has: (family, role) => {

--- a/packages/runtime/src/kernel/kernel.ts
+++ b/packages/runtime/src/kernel/kernel.ts
@@ -21,6 +21,8 @@ import {
 import type { RuleFacade } from '@proto.ui/module-rule';
 import type { ModuleOrchestratorFacadeView } from '../orchestrator/module-orchestrator/types';
 import type { PropsFacade } from '@proto.ui/module-props';
+import type { ContextFacade } from '@proto.ui/module-context';
+import type { AnatomyFacade } from '@proto.ui/module-anatomy';
 import type { ExecPhase } from '@proto.ui/module-base';
 import { attachAsHookRuntime } from './as-hook';
 
@@ -86,6 +88,10 @@ export function createKernel<P extends PropsBaseType>(
   let renderFn: RenderFn = defaultRender;
   if (typeof maybeRender === 'function') {
     renderFn = maybeRender;
+  } else if (typeof maybeRender !== 'undefined') {
+    throw new Error(
+      `[Prototype] setup() must return render function or void, got: ${typeof maybeRender}.`
+    );
   }
   setPhase('unknown');
 
@@ -112,9 +118,55 @@ export function createKernel<P extends PropsBaseType>(
   // ----------------
   const facades = modules.getFacades();
   const propsFacade = facades['props'] as PropsFacade<P>;
+  const contextFacade = facades['context'] as ContextFacade;
+  const anatomyFacade = facades['anatomy'] as AnatomyFacade | undefined;
 
   const read: RenderReadHandle<P> = {
     props: propsFacade as any,
+    context: {
+      read: (key) => contextFacade.read(key),
+      tryRead: (key) => contextFacade.tryRead(key),
+    },
+    anatomy: {
+      has: (family, role) => {
+        if (!anatomyFacade) throw new Error(`[Anatomy] module unavailable`);
+        return anatomyFacade.has(family, role);
+      },
+      parts: ((family: any, options: any) => {
+        if (!anatomyFacade) throw new Error(`[Anatomy] module unavailable`);
+        return anatomyFacade.parts(family, options as any);
+      }) as RenderReadHandle<P>['anatomy']['parts'],
+      partsOf: ((family: any, role: any, options: any) => {
+        if (!anatomyFacade) throw new Error(`[Anatomy] module unavailable`);
+        return anatomyFacade.partsOf(family, role, options as any);
+      }) as RenderReadHandle<P>['anatomy']['partsOf'],
+      order: {
+        version: ((family, options) => {
+          if (!anatomyFacade) throw new Error(`[Anatomy] module unavailable`);
+          return anatomyFacade.order.version(family, options as any);
+        }) as RenderReadHandle<P>['anatomy']['order']['version'],
+        parts: ((family, options) => {
+          if (!anatomyFacade) throw new Error(`[Anatomy] module unavailable`);
+          return anatomyFacade.order.parts(family, options as any);
+        }) as RenderReadHandle<P>['anatomy']['order']['parts'],
+        partsOf: ((family, role, options) => {
+          if (!anatomyFacade) throw new Error(`[Anatomy] module unavailable`);
+          return anatomyFacade.order.partsOf(family, role, options as any);
+        }) as RenderReadHandle<P>['anatomy']['order']['partsOf'],
+        indexOfSelf: ((family, role, options) => {
+          if (!anatomyFacade) throw new Error(`[Anatomy] module unavailable`);
+          return anatomyFacade.order.indexOfSelf(family, role, options as any);
+        }) as RenderReadHandle<P>['anatomy']['order']['indexOfSelf'],
+        prevOfSelf: ((family, role, options) => {
+          if (!anatomyFacade) throw new Error(`[Anatomy] module unavailable`);
+          return anatomyFacade.order.prevOfSelf(family, role, options as any);
+        }) as RenderReadHandle<P>['anatomy']['order']['prevOfSelf'],
+        nextOfSelf: ((family, role, options) => {
+          if (!anatomyFacade) throw new Error(`[Anatomy] module unavailable`);
+          return anatomyFacade.order.nextOfSelf(family, role, options as any);
+        }) as RenderReadHandle<P>['anatomy']['order']['nextOfSelf'],
+      },
+    },
   };
 
   const { el, slot, r, svg } = createRendererPrimitives();

--- a/packages/runtime/test/contract/feedback.style.runtime-patch.v0.contract.test.ts
+++ b/packages/runtime/test/contract/feedback.style.runtime-patch.v0.contract.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { EffectsPort, Prototype, StyleHandle } from '@proto.ui/core';
+import { tw } from '@proto.ui/core';
+import { EFFECTS_CAP } from '@proto.ui/module-feedback';
+import { executeWithHost, type RuntimeHost } from '../../src';
+
+describe('runtime: feedback.style runtime patch v0', () => {
+  it('exposes patch/suppress/clearPatch on the runtime feedback style handle', () => {
+    const styles: StyleHandle[] = [];
+    const proto: Prototype = {
+      name: 'feedback-style-runtime-patch-surface',
+      setup(def: any) {
+        def.feedback.style.use(tw('opacity-50 bg-blue-500'));
+        def.lifecycle.onMounted((run: any) => {
+          expect(typeof run.feedback.style.patch).toBe('function');
+          expect(typeof run.feedback.style.suppress).toBe('function');
+          expect(typeof run.feedback.style.clearPatch).toBe('function');
+
+          run.feedback.style.patch(tw('opacity-100'));
+          run.feedback.style.suppress(tw('bg-blue-500'));
+          run.feedback.style.clearPatch();
+        });
+        return (r: any) => [r.el('div', 'ok')];
+      },
+    } as any;
+
+    executeWithHost(proto, makeHost(proto.name, styles));
+
+    expect(lastTokens(styles)).toEqual(['opacity-50', 'bg-blue-500']);
+  });
+
+  it('applies patch and suppress over setup style without structural render', () => {
+    const styles: StyleHandle[] = [];
+    let renderCount = 0;
+    let commitCount = 0;
+
+    const proto: Prototype = {
+      name: 'feedback-style-runtime-patch-no-render',
+      setup(def: any) {
+        def.feedback.style.use(tw('opacity-50 bg-blue-500 text-white'));
+        def.lifecycle.onMounted((run: any) => {
+          run.feedback.style.patch(tw('opacity-100'));
+          run.feedback.style.suppress(tw('bg-blue-500'));
+        });
+        return (r: any) => {
+          renderCount += 1;
+          return [r.el('div', 'ok')];
+        };
+      },
+    } as any;
+
+    executeWithHost(
+      proto,
+      makeHost(proto.name, styles, {
+        onCommit: () => {
+          commitCount += 1;
+        },
+      })
+    );
+
+    expect(lastTokens(styles)).toEqual(['text-white', 'opacity-100']);
+    expect(renderCount).toBe(1);
+    expect(commitCount).toBe(1);
+  });
+
+  it('applies the patch layer after rule-produced style intents and before style translation', () => {
+    const styles: StyleHandle[] = [];
+
+    const proto: Prototype<{ active?: boolean }> = {
+      name: 'feedback-style-runtime-patch-after-rule',
+      setup(def: any) {
+        def.props.define({ active: { type: 'boolean', default: true } } as any);
+        def.rule({
+          when: (w: any) => w.prop('active').eq(true),
+          intent: (i: any) => i.feedback.style.use(tw('opacity-50 bg-blue-500')),
+        });
+        def.lifecycle.onMounted((run: any) => {
+          run.feedback.style.patch(tw('opacity-100'));
+          run.feedback.style.suppress(tw('bg-blue-500'));
+        });
+        return (r: any) => [r.el('div', 'ok')];
+      },
+    } as any;
+
+    executeWithHost(
+      proto,
+      makeHost(proto.name, styles, {
+        rawProps: { active: true },
+      })
+    );
+
+    expect(lastTokens(styles)).toEqual(['opacity-100']);
+  });
+
+  it('rejects runtime patch inputs that are not author-side style tokens', () => {
+    const proto: Prototype = {
+      name: 'feedback-style-runtime-patch-token-purity',
+      setup(def: any) {
+        def.lifecycle.onMounted((run: any) => {
+          run.feedback.style.patch(tw('hover:opacity-100'));
+        });
+        return (r: any) => [r.el('div', 'ok')];
+      },
+    } as any;
+
+    expect(() => executeWithHost(proto, makeHost(proto.name, []))).toThrow();
+  });
+});
+
+function makeHost(
+  prototypeName: string,
+  styles: StyleHandle[],
+  options: {
+    rawProps?: Record<string, any>;
+    onCommit?: () => void;
+  } = {}
+): RuntimeHost<any> {
+  const effects: EffectsPort = {
+    queueStyle(handle) {
+      styles.push({ kind: handle.kind, tokens: [...handle.tokens] });
+    },
+    requestFlush() {},
+  };
+
+  return {
+    prototypeName,
+    getRawProps: () => options.rawProps ?? {},
+    commit(_children, signal) {
+      options.onCommit?.();
+      signal?.done();
+    },
+    schedule(task) {
+      task();
+    },
+    onRuntimeReady(wiring) {
+      wiring.attach('feedback', [[EFFECTS_CAP, effects]]);
+    },
+  };
+}
+
+function lastTokens(styles: StyleHandle[]): string[] {
+  return styles[styles.length - 1]?.tokens ?? [];
+}

--- a/packages/runtime/test/contract/prototype.render-syntax.v0.contract.test.ts
+++ b/packages/runtime/test/contract/prototype.render-syntax.v0.contract.test.ts
@@ -1,5 +1,13 @@
 import { PROTOTYPE_RENDER_SYNTAX_CASES } from '@proto.ui/spec-fixtures/core/prototype-render-syntax';
-import type { Prototype } from '@proto.ui/core';
+import { createAnatomyFamily, type Prototype } from '@proto.ui/core';
+import type { ContextKey } from '@proto.ui/types';
+import {
+  ANATOMY_GET_PROTO_CAP,
+  ANATOMY_INSTANCE_TOKEN_CAP,
+  ANATOMY_PARENT_CAP,
+  ANATOMY_ROOT_TARGET_CAP,
+} from '@proto.ui/module-anatomy';
+import { CONTEXT_INSTANCE_TOKEN_CAP, CONTEXT_PARENT_CAP } from '@proto.ui/module-context';
 import { describe, expect, it } from 'vitest';
 import { createRuntimeInstance, executeWithHost, type RuntimeHost } from '../../src';
 
@@ -73,6 +81,25 @@ describe('contract: runtime / prototype render syntax (v0)', () => {
 
   it(
     caseTitle(
+      'T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-INVALID',
+      'setup rejects non-render non-void returns'
+    ),
+    () => {
+      const proto: Prototype = {
+        name: 'x-runtime-invalid-setup-return',
+        setup() {
+          return 1 as any;
+        },
+      };
+
+      expect(() => createRuntimeInstance(proto)).toThrow(
+        /\[Prototype\] setup\(\) must return render function or void/
+      );
+    }
+  );
+
+  it(
+    caseTitle(
       'T-CORE-SYNTAX-0001-CASE-RENDER-HANDLE',
       'render receives renderer handle and returns TemplateChildren'
     ),
@@ -105,10 +132,20 @@ describe('contract: runtime / prototype render syntax (v0)', () => {
   it(
     caseTitle(
       'T-CORE-SYNTAX-0001-CASE-RENDER-READ',
-      'renderer read exposes current props without update entry'
+      'renderer read exposes current runtime input without write entries'
     ),
     () => {
       const commits: unknown[] = [];
+      const REQUIRED_KEY = {
+        __brand: 'ContextKey',
+        debugName: 'render-read-required-context',
+      } as ContextKey<{ value: string }>;
+      const OPTIONAL_KEY = {
+        __brand: 'ContextKey',
+        debugName: 'render-read-optional-context',
+      } as ContextKey<{ value: string }>;
+      const family = createAnatomyFamily('render-read-anatomy');
+      const target = { id: 'render-read-target' };
       const host: RuntimeHost<{ label: string }> = {
         prototypeName: 'x-runtime-render-read',
         getRawProps() {
@@ -117,6 +154,18 @@ describe('contract: runtime / prototype render syntax (v0)', () => {
         commit(children, signal) {
           commits.push(children);
           signal?.done();
+        },
+        onRuntimeReady(wiring) {
+          wiring.attach('context', [
+            [CONTEXT_INSTANCE_TOKEN_CAP, target],
+            [CONTEXT_PARENT_CAP, () => null],
+          ]);
+          wiring.attach('anatomy', [
+            [ANATOMY_INSTANCE_TOKEN_CAP, target],
+            [ANATOMY_PARENT_CAP, () => null],
+            [ANATOMY_GET_PROTO_CAP, () => proto],
+            [ANATOMY_ROOT_TARGET_CAP, () => target],
+          ]);
         },
         schedule(task) {
           task();
@@ -127,22 +176,53 @@ describe('contract: runtime / prototype render syntax (v0)', () => {
         name: 'x-runtime-render-read',
         setup(def) {
           def.props.define({ label: { type: 'string', default: 'fallback' } });
+          def.context.provide(REQUIRED_KEY, { value: 'from-context' });
+          def.context.provide(OPTIONAL_KEY, { value: 'from-optional-context' });
+          def.context.subscribe(REQUIRED_KEY);
+          def.context.trySubscribe(OPTIONAL_KEY);
+          def.anatomy.family(family, {
+            roles: {
+              root: { cardinality: { min: 1, max: 1 } },
+            },
+          });
+          def.anatomy.claim(family, { role: 'root' });
 
           return (renderer: any) => {
             expect(typeof renderer.read.props.get).toBe('function');
             expect(typeof renderer.read.props.getRaw).toBe('function');
             expect(typeof renderer.read.props.isProvided).toBe('function');
+            expect(typeof renderer.read.context.read).toBe('function');
+            expect(typeof renderer.read.context.tryRead).toBe('function');
+            expect(typeof renderer.read.context.update).toBe('undefined');
+            expect(typeof renderer.read.context.tryUpdate).toBe('undefined');
+            expect(typeof renderer.read.anatomy.has).toBe('function');
+            expect(typeof renderer.read.anatomy.partsOf).toBe('function');
             expect(typeof renderer.update).toBe('undefined');
+
             expect(renderer.read.props.get()).toEqual({ label: 'from-host' });
             expect(renderer.read.props.isProvided('label')).toBe(true);
-            return renderer.el('div', renderer.read.props.get().label);
+            expect(renderer.read.context.read(REQUIRED_KEY)).toEqual({ value: 'from-context' });
+            expect(renderer.read.context.tryRead(OPTIONAL_KEY)).toEqual({
+              value: 'from-optional-context',
+            });
+            expect(renderer.read.anatomy.has(family, 'root')).toBe(true);
+            expect(renderer.read.anatomy.partsOf(family, 'root')).toHaveLength(1);
+
+            return renderer.el(
+              'div',
+              `${renderer.read.props.get().label}:${renderer.read.context.read(REQUIRED_KEY).value}:${
+                renderer.read.anatomy.partsOf(family, 'root').length
+              }`
+            );
           };
         },
       };
 
       executeWithHost(proto, host);
 
-      expect(commits).toEqual([{ type: 'div', style: undefined, children: 'from-host' }]);
+      expect(commits).toEqual([
+        { type: 'div', style: undefined, children: 'from-host:from-context:1' },
+      ]);
     }
   );
 });

--- a/packages/spec/fixtures/package.json
+++ b/packages/spec/fixtures/package.json
@@ -28,6 +28,14 @@
     "./template/authoring": {
       "types": "./src/template/authoring.ts",
       "default": "./src/template/authoring.ts"
+    },
+    "./feedback/style-authoring": {
+      "types": "./src/feedback/style-authoring.ts",
+      "default": "./src/feedback/style-authoring.ts"
+    },
+    "./feedback/style-runtime-patch": {
+      "types": "./src/feedback/style-runtime-patch.ts",
+      "default": "./src/feedback/style-runtime-patch.ts"
     }
   },
   "description": "Shared semantic test fixtures for Proto UI spec contracts."

--- a/packages/spec/fixtures/src/core/prototype-render-syntax.ts
+++ b/packages/spec/fixtures/src/core/prototype-render-syntax.ts
@@ -3,8 +3,9 @@ export type PrototypeRenderSyntaxExpectation =
   | 'setup-receives-definition-handle'
   | 'setup-returned-render-is-executed'
   | 'void-setup-uses-default-slot-render'
+  | 'invalid-setup-return-fails-fast'
   | 'render-receives-renderer-handle-and-returns-template-children'
-  | 'renderer-read-props-without-update-entry';
+  | 'renderer-read-runtime-input-without-write-entry';
 
 export type PrototypeRenderSyntaxCase = {
   id: string;
@@ -43,7 +44,14 @@ export const PROTOTYPE_RENDER_SYNTAX_CASES = [
     specCase: 'T-CORE-SYNTAX-0001-CASE-SETUP-VOID-DEFAULT',
     covers: ['C-CORE-SYNTAX-0004-C'],
     expectation: 'void-setup-uses-default-slot-render',
-    notes: ['This records the current v0 runtime behavior and its open-question boundary.'],
+    notes: ['Default slot render is a stable v0 contract.'],
+  },
+  {
+    id: 'setup-invalid-return',
+    title: 'setup rejects non-render non-void returns',
+    specCase: 'T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-INVALID',
+    covers: ['C-CORE-SYNTAX-0004-D'],
+    expectation: 'invalid-setup-return-fails-fast',
   },
   {
     id: 'render-receives-renderer',
@@ -53,17 +61,19 @@ export const PROTOTYPE_RENDER_SYNTAX_CASES = [
     expectation: 'render-receives-renderer-handle-and-returns-template-children',
   },
   {
-    id: 'renderer-read-props-no-update',
-    title: 'renderer read exposes props and no update entry',
+    id: 'renderer-read-runtime-input-no-write',
+    title: 'renderer read exposes props, context, and anatomy without write entries',
     specCase: 'T-CORE-SYNTAX-0001-CASE-RENDER-READ',
     covers: [
       'C-CORE-SYNTAX-0006-B',
       'C-CORE-SYNTAX-0006-C',
       'C-CORE-SYNTAX-0006-D',
+      'C-CORE-SYNTAX-0006-E',
+      'C-CORE-SYNTAX-0006-F',
       'C-LIFECYCLE-0003-D',
       'C-LIFECYCLE-0003-E',
     ],
-    expectation: 'renderer-read-props-without-update-entry',
+    expectation: 'renderer-read-runtime-input-without-write-entry',
   },
 ] as const satisfies readonly PrototypeRenderSyntaxCase[];
 

--- a/packages/spec/fixtures/src/feedback/style-authoring.ts
+++ b/packages/spec/fixtures/src/feedback/style-authoring.ts
@@ -1,0 +1,53 @@
+export type FeedbackStyleAuthoringExpectation =
+  | 'setup-style-plan-recorded'
+  | 'setup-style-plan-unused'
+  | 'author-token-accepted'
+  | 'author-token-rejected';
+
+export type FeedbackStyleAuthoringCase = {
+  id: string;
+  title: string;
+  specCase: string;
+  covers: readonly string[];
+  tokens: readonly string[];
+  expectation: FeedbackStyleAuthoringExpectation;
+};
+
+export const FEEDBACK_STYLE_AUTHORING_CASES = [
+  {
+    id: 'setup-use-records-style-plan',
+    title: 'setup use records a visual style plan',
+    specCase: 'T-FEEDBACK-STYLE-0001-CASE-SETUP-USE',
+    covers: ['C-FEEDBACK-STYLE-0001-A', 'C-FEEDBACK-STYLE-0001-B', 'C-FEEDBACK-STYLE-0002-A'],
+    tokens: ['bg-blue-500', 'text-white'],
+    expectation: 'setup-style-plan-recorded',
+  },
+  {
+    id: 'setup-unuse-removes-exact-contribution',
+    title: 'setup unUse removes only the use contribution it came from',
+    specCase: 'T-FEEDBACK-STYLE-0001-CASE-SETUP-UNUSE',
+    covers: ['C-FEEDBACK-STYLE-0002-C', 'C-FEEDBACK-STYLE-0002-D'],
+    tokens: ['bg-red-500', 'text-white'],
+    expectation: 'setup-style-plan-unused',
+  },
+  {
+    id: 'author-token-subset-accepted',
+    title: 'author-side style tokens are accepted as Proto UI feedback.style tokens',
+    specCase: 'T-FEEDBACK-STYLE-0001-CASE-AUTHOR-TOKENS',
+    covers: ['C-FEEDBACK-STYLE-0003-A', 'C-FEEDBACK-STYLE-0003-B'],
+    tokens: ['opacity-50', 'px-2.5', 'text-[0.8rem]'],
+    expectation: 'author-token-accepted',
+  },
+  {
+    id: 'variant-token-rejected',
+    title: 'stateful variant syntax is rejected from author-side style tokens',
+    specCase: 'T-FEEDBACK-STYLE-0001-CASE-TOKEN-PURITY',
+    covers: ['C-FEEDBACK-STYLE-0004-A', 'C-FEEDBACK-STYLE-0004-B'],
+    tokens: ['hover:bg-white', 'data-[disabled]:opacity-50'],
+    expectation: 'author-token-rejected',
+  },
+] as const satisfies readonly FeedbackStyleAuthoringCase[];
+
+export const FEEDBACK_STYLE_AUTHORING_SPEC_CASES = [
+  ...new Set(FEEDBACK_STYLE_AUTHORING_CASES.map((testCase) => testCase.specCase)),
+] as const;

--- a/packages/spec/fixtures/src/feedback/style-runtime-patch.ts
+++ b/packages/spec/fixtures/src/feedback/style-runtime-patch.ts
@@ -1,0 +1,69 @@
+export type FeedbackStyleRuntimePatchExpectation =
+  | 'runtime-patch-applied'
+  | 'runtime-suppress-applied'
+  | 'runtime-patch-layer-cleared'
+  | 'runtime-patch-token-rejected'
+  | 'style-flush-without-render';
+
+export type FeedbackStyleRuntimePatchCase = {
+  id: string;
+  title: string;
+  specCase: string;
+  covers: readonly string[];
+  baseTokens: readonly string[];
+  patchTokens?: readonly string[];
+  suppressTokens?: readonly string[];
+  expectation: FeedbackStyleRuntimePatchExpectation;
+};
+
+export const FEEDBACK_STYLE_RUNTIME_PATCH_CASES = [
+  {
+    id: 'patch-overrides-base-semantic-group',
+    title: 'patch writes a positive runtime patch over the base semantic result',
+    specCase: 'T-FEEDBACK-STYLE-0002-CASE-PATCH',
+    covers: ['C-FEEDBACK-STYLE-0005-A', 'C-FEEDBACK-STYLE-0005-D', 'C-FEEDBACK-STYLE-0005-E'],
+    baseTokens: ['opacity-50', 'bg-blue-500'],
+    patchTokens: ['opacity-100'],
+    expectation: 'runtime-patch-applied',
+  },
+  {
+    id: 'suppress-removes-base-semantic-group',
+    title: 'suppress writes a negative runtime patch for a semantic group',
+    specCase: 'T-FEEDBACK-STYLE-0002-CASE-SUPPRESS',
+    covers: ['C-FEEDBACK-STYLE-0005-D', 'C-FEEDBACK-STYLE-0005-E'],
+    baseTokens: ['opacity-50', 'bg-blue-500'],
+    suppressTokens: ['opacity-50'],
+    expectation: 'runtime-suppress-applied',
+  },
+  {
+    id: 'clear-patch-restores-base',
+    title: 'clearPatch removes the runtime patch layer and restores the base semantic result',
+    specCase: 'T-FEEDBACK-STYLE-0002-CASE-CLEAR-PATCH',
+    covers: ['C-FEEDBACK-STYLE-0005-F'],
+    baseTokens: ['opacity-50', 'bg-blue-500'],
+    patchTokens: ['opacity-100'],
+    expectation: 'runtime-patch-layer-cleared',
+  },
+  {
+    id: 'patch-rejects-host-or-stateful-token',
+    title: 'patch and suppress reject stateful or host-realization tokens',
+    specCase: 'T-FEEDBACK-STYLE-0002-CASE-PATCH-TOKEN-PURITY',
+    covers: ['C-FEEDBACK-STYLE-0005-C', 'C-FEEDBACK-STYLE-0004-A'],
+    baseTokens: ['opacity-50'],
+    patchTokens: ['data-pui-style', 'hover:opacity-100'],
+    expectation: 'runtime-patch-token-rejected',
+  },
+  {
+    id: 'patch-flushes-style-without-render',
+    title: 'runtime style patch triggers style flush without render',
+    specCase: 'T-FEEDBACK-STYLE-0002-CASE-NO-RENDER',
+    covers: ['C-FEEDBACK-STYLE-0005-G', 'C-FEEDBACK-STYLE-0005-H', 'C-FEEDBACK-0002-E'],
+    baseTokens: ['opacity-50'],
+    patchTokens: ['opacity-100'],
+    expectation: 'style-flush-without-render',
+  },
+] as const satisfies readonly FeedbackStyleRuntimePatchCase[];
+
+export const FEEDBACK_STYLE_RUNTIME_PATCH_SPEC_CASES = [
+  ...new Set(FEEDBACK_STYLE_RUNTIME_PATCH_CASES.map((testCase) => testCase.specCase)),
+] as const;

--- a/packages/spec/fixtures/src/index.ts
+++ b/packages/spec/fixtures/src/index.ts
@@ -2,3 +2,5 @@ export * from './props/json-value-boundary';
 export * from './lifecycle/callback-order';
 export * from './core/prototype-render-syntax';
 export * from './template/authoring';
+export * from './feedback/style-authoring';
+export * from './feedback/style-runtime-patch';

--- a/packages/spec/fixtures/test/feedback-style-authoring.test.ts
+++ b/packages/spec/fixtures/test/feedback-style-authoring.test.ts
@@ -1,0 +1,50 @@
+import path from 'node:path';
+
+import { loadSpecWorkspaceFromDirectory } from '@proto.ui/spec-engine/node';
+import { FEEDBACK_STYLE_AUTHORING_CASES } from '@proto.ui/spec-fixtures/feedback/style-authoring';
+import { describe, expect, it } from 'vitest';
+
+describe('spec fixtures: feedback style authoring', () => {
+  it('stays aligned with T-FEEDBACK-STYLE-0001', async () => {
+    const workspace = await loadSpecWorkspaceFromDirectory(path.resolve(process.cwd(), 'spec'));
+    expect(workspace.issues).toEqual([]);
+
+    const testSpec = workspace.entities.find((entity) => entity.id === 'T-FEEDBACK-STYLE-0001');
+    expect(testSpec).toBeDefined();
+    expect(testSpec?.type).toBe('test');
+
+    const specCaseIds = new Set<string>(testSpec?.cases.map((testCase) => testCase.id));
+    const fixtureSpecCases = new Set<string>(
+      FEEDBACK_STYLE_AUTHORING_CASES.map((testCase) => testCase.specCase)
+    );
+
+    for (const testCase of FEEDBACK_STYLE_AUTHORING_CASES) {
+      expect(
+        specCaseIds.has(testCase.specCase),
+        `${testCase.id} references ${testCase.specCase}`
+      ).toBe(true);
+
+      for (const criterionId of testCase.covers) {
+        const contractId = criterionId.replace(/-[A-Z]$/, '');
+        const contract = workspace.entities.find((entity) => entity.id === contractId);
+        expect(contract, `${testCase.id} references ${contractId}`).toBeDefined();
+        expect(
+          contract?.criteria.some((criterion) => criterion.id === criterionId),
+          `${testCase.id} covers ${criterionId}`
+        ).toBe(true);
+      }
+    }
+
+    expect(fixtureSpecCases).toEqual(specCaseIds);
+
+    const fixtureImplementation = testSpec?.implementations.find(
+      (implementation) => implementation.id === 'feedback-style-authoring-fixture'
+    );
+
+    expect(fixtureImplementation?.status).toBe('active');
+    expect(fixtureImplementation?.path).toBe(
+      'packages/spec/fixtures/src/feedback/style-authoring.ts'
+    );
+    expect(new Set(fixtureImplementation?.consumesCases ?? [])).toEqual(specCaseIds);
+  });
+});

--- a/packages/spec/fixtures/test/feedback-style-runtime-patch.test.ts
+++ b/packages/spec/fixtures/test/feedback-style-runtime-patch.test.ts
@@ -1,0 +1,50 @@
+import path from 'node:path';
+
+import { loadSpecWorkspaceFromDirectory } from '@proto.ui/spec-engine/node';
+import { FEEDBACK_STYLE_RUNTIME_PATCH_CASES } from '@proto.ui/spec-fixtures/feedback/style-runtime-patch';
+import { describe, expect, it } from 'vitest';
+
+describe('spec fixtures: feedback style runtime patch', () => {
+  it('stays aligned with T-FEEDBACK-STYLE-0002', async () => {
+    const workspace = await loadSpecWorkspaceFromDirectory(path.resolve(process.cwd(), 'spec'));
+    expect(workspace.issues).toEqual([]);
+
+    const testSpec = workspace.entities.find((entity) => entity.id === 'T-FEEDBACK-STYLE-0002');
+    expect(testSpec).toBeDefined();
+    expect(testSpec?.type).toBe('test');
+
+    const specCaseIds = new Set<string>(testSpec?.cases.map((testCase) => testCase.id));
+    const fixtureSpecCases = new Set<string>(
+      FEEDBACK_STYLE_RUNTIME_PATCH_CASES.map((testCase) => testCase.specCase)
+    );
+
+    for (const testCase of FEEDBACK_STYLE_RUNTIME_PATCH_CASES) {
+      expect(
+        specCaseIds.has(testCase.specCase),
+        `${testCase.id} references ${testCase.specCase}`
+      ).toBe(true);
+
+      for (const criterionId of testCase.covers) {
+        const contractId = criterionId.replace(/-[A-Z]$/, '');
+        const contract = workspace.entities.find((entity) => entity.id === contractId);
+        expect(contract, `${testCase.id} references ${contractId}`).toBeDefined();
+        expect(
+          contract?.criteria.some((criterion) => criterion.id === criterionId),
+          `${testCase.id} covers ${criterionId}`
+        ).toBe(true);
+      }
+    }
+
+    expect(fixtureSpecCases).toEqual(specCaseIds);
+
+    const fixtureImplementation = testSpec?.implementations.find(
+      (implementation) => implementation.id === 'feedback-style-runtime-patch-fixture'
+    );
+
+    expect(fixtureImplementation?.status).toBe('active');
+    expect(fixtureImplementation?.path).toBe(
+      'packages/spec/fixtures/src/feedback/style-runtime-patch.ts'
+    );
+    expect(new Set(fixtureImplementation?.consumesCases ?? [])).toEqual(specCaseIds);
+  });
+});

--- a/spec/contracts/C-CORE-SYNTAX-0004.yaml
+++ b/spec/contracts/C-CORE-SYNTAX-0004.yaml
@@ -43,20 +43,13 @@ dependsOn:
   contracts:
     - C-CORE-SYNTAX-0001
     - C-CORE-SYNTAX-0003
-openQuestions:
-  - id: C-CORE-SYNTAX-0004-Q-DEFAULT-SLOT
-    question:
-      zh-CN: '`setup` 返回 `void` 时的默认 slot render 是否应长期作为 public contract，而不是仅作为当前 runtime 的 v0 默认实现？'
-      en: Should the default slot render for `setup` returning `void` remain a long-term public contract rather than only the current runtime's v0 default implementation?
-    context:
-      zh-CN: 当前 runtime 已实现默认 slot render，且大量无 render 的测试原型依赖该行为；后续若要收紧为必须显式返回 render，需要迁移这一路径。
-      en: The current runtime implements default slot render, and many render-less test prototypes rely on it; if future versions require explicit render returns, this path will need migration.
-    blocks:
-      - C-CORE-SYNTAX-0004-C
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured setup argument and return-shape semantics, including current default slot render behavior.
+  - version: 0.1.0
+    change: revised
+    summary: Resolved default slot render as stable v0 contract and added fail-fast behavior for invalid setup returns.
 tags:
   - core
   - syntax

--- a/spec/contracts/C-CORE-SYNTAX-0006.yaml
+++ b/spec/contracts/C-CORE-SYNTAX-0006.yaml
@@ -24,9 +24,17 @@ criteria:
       en: The renderer handle must provide a render-time read view so render can read current runtime input needed to build the template.
   - id: C-CORE-SYNTAX-0006-C
     text:
-      zh-CN: 当前 v0 renderer read view 至少必须提供 props 的 `get()`、`getRaw()` 与 `isProvided()` 读取入口。
-      en: The current v0 renderer read view must at least provide props `get()`, `getRaw()`, and `isProvided()` read entries.
+      zh-CN: 当前 v0 renderer read view 必须提供 props 的 `get()`、`getRaw()` 与 `isProvided()` 读取入口。
+      en: The current v0 renderer read view must provide props `get()`, `getRaw()`, and `isProvided()` read entries.
   - id: C-CORE-SYNTAX-0006-D
+    text:
+      zh-CN: 当前 v0 renderer read view 必须提供 context 的 `read()` 与 `tryRead()` 读取入口，但不得提供 context write/update 入口。
+      en: The current v0 renderer read view must provide context `read()` and `tryRead()` entries, but must not provide context write/update entries.
+  - id: C-CORE-SYNTAX-0006-E
+    text:
+      zh-CN: 当前 v0 renderer read view 必须提供 anatomy 的只读 query surface。
+      en: The current v0 renderer read view must provide the anatomy read-only query surface.
+  - id: C-CORE-SYNTAX-0006-F
     text:
       zh-CN: Renderer handle 不得暴露 `run.update()` 或等价 update entry。
       en: The renderer handle must not expose `run.update()` or an equivalent update entry.
@@ -42,20 +50,13 @@ dependsOn:
   contracts:
     - C-CORE-SYNTAX-0005
     - C-LIFECYCLE-0003
-openQuestions:
-  - id: C-CORE-SYNTAX-0006-Q-CONTEXT-READ
-    question:
-      zh-CN: Renderer read view 是否应扩展到 context/anatomy 等 read-only runtime input？
-      en: Should the renderer read view expand to context, anatomy, and other read-only runtime input?
-    context:
-      zh-CN: 旧讨论认为 render 读取当前 runtime input 是必要能力；当前实现主要稳定覆盖 props read，context read 更像后续实现缺口。
-      en: Older discussion treats reading current runtime input during render as necessary; the current implementation primarily stabilizes props read, while context read looks like a follow-up implementation gap.
-    blocks:
-      - C-CORE-SYNTAX-0006-B
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured the render-time renderer handle syntax surface and read/update boundary.
+  - version: 0.1.0
+    change: revised
+    summary: Added context and anatomy read-only entries to renderer read view.
 tags:
   - core
   - syntax

--- a/spec/contracts/C-FEEDBACK-0001.yaml
+++ b/spec/contracts/C-FEEDBACK-0001.yaml
@@ -1,0 +1,66 @@
+id: C-FEEDBACK-0001
+type: contract
+title: Feedback is the component-to-user information channel
+status: draft
+since: 0.1.0
+summary: Feedback is the Component-to-User channel that carries perceivable information.
+statement:
+  zh-CN: >-
+    Feedback 是 Proto UI 中 Component → User 方向、且仅属于该方向的信息通路。它承载组件向 User 传递的可感知信息，使 User 能感知组件的存在、状态、变化与交互结果。
+
+
+  en: >-
+    Feedback is the Component → User information channel in Proto UI, and belongs only to that direction. It carries perceivable information from a component to the User so the User can perceive the component's existence, state, changes, and interaction results.
+
+
+criteria:
+  - id: C-FEEDBACK-0001-A
+    text:
+      zh-CN: Feedback 必须被识别为 Component → User 方向的信息通路。
+      en: Feedback must be identified as the Component → User information channel.
+  - id: C-FEEDBACK-0001-B
+    text:
+      zh-CN: Feedback 不得被解释为 App Maker → Component、Component → App Maker、Other Component ↔ Component 或 host/environment 相关通路。
+      en: Feedback must not be interpreted as an App Maker → Component, Component → App Maker, Other Component ↔ Component, or host/environment-related channel.
+  - id: C-FEEDBACK-0001-C
+    text:
+      zh-CN: Feedback 必须承载 User 可感知的信息，而不是 App Maker 配置、其他组件协作或宿主环境信息。
+      en: Feedback must carry information perceivable by the User, not App Maker configuration, other-component collaboration, or host-environment information.
+  - id: C-FEEDBACK-0001-D
+    text:
+      zh-CN: 没有 feedback 通路时，User 完全无法通过 Proto UI 的可移植语义感知组件的存在、状态、变化或交互结果。
+      en: Without the feedback channel, the User cannot perceive a component's existence, state, changes, or interaction results at all through Proto UI's portable semantics.
+  - id: C-FEEDBACK-0001-E
+    text:
+      zh-CN: Feedback 的具体媒介可以是视觉、听觉、触觉或其他可感知形式；具体媒介的宿主翻译不由本契约定义。
+      en: Feedback can be carried through visual, auditory, tactile, or other perceivable forms; host translation for a concrete medium is not defined by this contract.
+sources:
+  - path: apps/www/src/content/docs/zh-cn/whitepaper/information-flow-model.md
+    sections:
+      - User
+      - User ↔ Component
+  - path: apps/www/src/content/docs/en/whitepaper/information-flow-model.md
+    sections:
+      - User
+      - User ↔ Component
+refines:
+  contracts:
+    - id: C-CORE-CHANNEL-0001
+      anchors:
+        - C-CORE-CHANNEL-0001-A
+        - C-CORE-CHANNEL-0001-C
+      note: Feedback is the Component-to-User perceivable-information channel currently admitted into Proto UI's portable channel model.
+dependsOn:
+  knowledge:
+    - K-INFORMATION-CHANNEL-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured the top-level channel identity for feedback.
+  - version: 0.1.0
+    change: revised
+    summary: Clarified Feedback as exactly the Component-to-User channel and strengthened the no-feedback perception boundary.
+tags:
+  - feedback
+  - channel
+  - user

--- a/spec/contracts/C-FEEDBACK-0002.yaml
+++ b/spec/contracts/C-FEEDBACK-0002.yaml
@@ -1,0 +1,72 @@
+id: C-FEEDBACK-0002
+type: contract
+title: Feedback separates setup planning from runtime effects
+status: draft
+since: 0.1.0
+summary: Feedback APIs must distinguish setup-time feedback planning from runtime feedback effects.
+statement:
+  zh-CN: >-
+    Feedback 通路必须回应 `setup`/`runtime` 分离：setup 阶段 API 用于计划组件将如何产生反馈；runtime 阶段 API 如果被公开提供，则应表达运行期反馈副作用，而不得重新打开 setup-time 计划 API。公开 runtime API 的具体形态仍是 v0 断口。
+
+
+  en: >-
+    The Feedback channel must reflect `setup`/`runtime` separation: setup-time APIs plan how a component can produce feedback; runtime APIs, if publicly provided, should express runtime feedback effects and must not reopen setup-time planning APIs. The concrete shape of a public runtime API remains a v0 decision gap.
+
+
+criteria:
+  - id: C-FEEDBACK-0002-A
+    text:
+      zh-CN: Feedback 的 setup-time API 必须用于声明或计划反馈能力。
+      en: Feedback setup-time APIs must be used to declare or plan feedback capabilities.
+  - id: C-FEEDBACK-0002-B
+    text:
+      zh-CN: 进入 runtime 后，setup-time feedback planning API 不得继续可用。
+      en: After entering runtime, setup-time feedback planning APIs must no longer be available.
+  - id: C-FEEDBACK-0002-C
+    text:
+      zh-CN: 如果 Feedback 提供公开 runtime API，该 API 必须被视为带副作用的 runtime feedback effect 入口，而不是 setup plan 的延续。
+      en: If Feedback provides a public runtime API, that API must be treated as a side-effecting runtime feedback-effect entry, not as a continuation of the setup plan.
+  - id: C-FEEDBACK-0002-D
+    text:
+      zh-CN: Feedback runtime effect 不得改变 template 逻辑结构或内容；结构和内容变化必须通过 render/update 相关机制表达。
+      en: Feedback runtime effects must not change template logic structure or content; structural and content changes must be expressed through render/update-related mechanisms.
+  - id: C-FEEDBACK-0002-E
+    text:
+      zh-CN: Feedback runtime effect 应能够在不触发 render 的情况下更新反馈；最差情况下宿主可以用与 render 等价的开销实现该能力，但这属于宿主实现成本。
+      en: Feedback runtime effects should be able to update feedback without triggering render; in the worst case, a host can implement this with render-equivalent cost, but that is a host implementation cost.
+openQuestions:
+  - id: C-FEEDBACK-0002-Q-RUNTIME-API
+    question:
+      zh-CN: v0 是否应公开 feedback runtime API；若公开，它是否应表现为 add/remove 一组 style token 的副作用入口？
+      en: Should v0 expose a public feedback runtime API; if so, should it behave as a side-effecting entry for adding/removing a set of style tokens?
+    context:
+      zh-CN: 长期治理方向倾向提供 feedback runtime API，以便让 rule 的边界更清晰。当前可通过 `def.rule` 动态添加/去除样式并获得自动副作用管理；但如果 feedback 完全没有 runtime API，rule 在某些动态样式场景会从推荐路径变成必选路径。具体 API 形态仍需进一步讨论。
+      en: The long-term governance direction leans toward providing a feedback runtime API so rule boundaries stay clearer. Today, `def.rule` can dynamically add/remove styles with automatic side-effect management; however, if feedback has no runtime API at all, rule becomes required rather than merely recommended for some dynamic-style scenarios. The concrete API shape still needs further discussion.
+    blocks:
+      - C-FEEDBACK-0002-C
+sources:
+  - path: internal/contracts/feedback/style.use.setup-only.v0.md
+    sections:
+      - Setup-only Constraint
+      - unUse Semantics (setup-only)
+  - path: packages/modules/feedback/src/create.ts
+    sections:
+      - useStyle
+      - useStyleRuntime
+dependsOn:
+  contracts:
+    - C-FEEDBACK-0001
+    - C-LIFECYCLE-0001
+    - C-CORE-SYNTAX-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured feedback setup/runtime surface separation and the public runtime API decision point.
+  - version: 0.1.0
+    change: revised
+    summary: Clarified public runtime API as a decision gap and recorded no-render feedback update as the target runtime effect boundary.
+tags:
+  - feedback
+  - api
+  - setup
+  - runtime

--- a/spec/contracts/C-FEEDBACK-0002.yaml
+++ b/spec/contracts/C-FEEDBACK-0002.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: Feedback APIs must distinguish setup-time feedback planning from runtime feedback effects.
 statement:
   zh-CN: >-
-    Feedback 通路必须回应 `setup`/`runtime` 分离：setup 阶段 API 用于计划组件将如何产生反馈；runtime 阶段 API 如果被公开提供，则应表达运行期反馈副作用，而不得重新打开 setup-time 计划 API。公开 runtime API 的具体形态仍是 v0 断口。
+    Feedback 通路必须回应 `setup`/`runtime` 分离：setup 阶段 API 用于计划组件将如何产生反馈；runtime 阶段 API 如果被公开提供，则应表达运行期反馈副作用，而不得重新打开 setup-time 计划 API。v0 已先为 `feedback.style` 固化 runtime patch escape hatch；其他 feedback 子 surface 的 runtime API 可在各自契约中继续细化。
 
 
   en: >-
-    The Feedback channel must reflect `setup`/`runtime` separation: setup-time APIs plan how a component can produce feedback; runtime APIs, if publicly provided, should express runtime feedback effects and must not reopen setup-time planning APIs. The concrete shape of a public runtime API remains a v0 decision gap.
+    The Feedback channel must reflect `setup`/`runtime` separation: setup-time APIs plan how a component can produce feedback; runtime APIs, if publicly provided, should express runtime feedback effects and must not reopen setup-time planning APIs. v0 has stabilized a runtime patch escape hatch for `feedback.style`; runtime APIs for other feedback subsurfaces can be refined in their own contracts.
 
 
 criteria:
@@ -34,16 +34,6 @@ criteria:
     text:
       zh-CN: Feedback runtime effect 应能够在不触发 render 的情况下更新反馈；最差情况下宿主可以用与 render 等价的开销实现该能力，但这属于宿主实现成本。
       en: Feedback runtime effects should be able to update feedback without triggering render; in the worst case, a host can implement this with render-equivalent cost, but that is a host implementation cost.
-openQuestions:
-  - id: C-FEEDBACK-0002-Q-RUNTIME-API
-    question:
-      zh-CN: v0 是否应公开 feedback runtime API；若公开，它是否应表现为 add/remove 一组 style token 的副作用入口？
-      en: Should v0 expose a public feedback runtime API; if so, should it behave as a side-effecting entry for adding/removing a set of style tokens?
-    context:
-      zh-CN: 长期治理方向倾向提供 feedback runtime API，以便让 rule 的边界更清晰。当前可通过 `def.rule` 动态添加/去除样式并获得自动副作用管理；但如果 feedback 完全没有 runtime API，rule 在某些动态样式场景会从推荐路径变成必选路径。具体 API 形态仍需进一步讨论。
-      en: The long-term governance direction leans toward providing a feedback runtime API so rule boundaries stay clearer. Today, `def.rule` can dynamically add/remove styles with automatic side-effect management; however, if feedback has no runtime API at all, rule becomes required rather than merely recommended for some dynamic-style scenarios. The concrete API shape still needs further discussion.
-    blocks:
-      - C-FEEDBACK-0002-C
 sources:
   - path: internal/contracts/feedback/style.use.setup-only.v0.md
     sections:
@@ -52,7 +42,13 @@ sources:
   - path: packages/modules/feedback/src/create.ts
     sections:
       - useStyle
-      - useStyleRuntime
+      - patchStyle
+      - suppressStyle
+      - clearStylePatch
+  - path: spec/contracts/C-FEEDBACK-STYLE-0005.yaml
+    sections:
+      - C-FEEDBACK-STYLE-0005-A
+      - C-FEEDBACK-STYLE-0005-H
 dependsOn:
   contracts:
     - C-FEEDBACK-0001
@@ -65,6 +61,9 @@ revisions:
   - version: 0.1.0
     change: revised
     summary: Clarified public runtime API as a decision gap and recorded no-render feedback update as the target runtime effect boundary.
+  - version: 0.1.0
+    change: revised
+    summary: Resolved the feedback.style runtime API gap through C-FEEDBACK-STYLE-0005 while keeping other feedback subsurfaces open.
 tags:
   - feedback
   - api

--- a/spec/contracts/C-FEEDBACK-STYLE-0001.yaml
+++ b/spec/contracts/C-FEEDBACK-STYLE-0001.yaml
@@ -1,0 +1,66 @@
+id: C-FEEDBACK-STYLE-0001
+type: contract
+title: feedback.style is the visual feedback surface
+status: draft
+since: 0.1.0
+summary: '`feedback.style` describes visual feedback that can change component appearance without changing template structure.'
+statement:
+  zh-CN: >-
+    `feedback.style` 是 Feedback 通路中仅负责视觉反馈的 surface。它描述组件应如何改变自身样貌，使 User 感知组件的存在、状态或变化；它不负责改变 template 的逻辑结构或内容。
+
+
+  en: >-
+    `feedback.style` is the visual-feedback-only surface within the Feedback channel. It describes how a component should change its appearance so the User can perceive the component's existence, state, or changes; it does not change template logic structure or content.
+
+
+criteria:
+  - id: C-FEEDBACK-STYLE-0001-A
+    text:
+      zh-CN: '`feedback.style` 必须被识别为 Feedback 通路下的视觉反馈 surface，且只覆盖视觉反馈。'
+      en: '`feedback.style` must be identified as a visual-feedback surface under the Feedback channel, and covers visual feedback only.'
+  - id: C-FEEDBACK-STYLE-0001-B
+    text:
+      zh-CN: '`feedback.style` 可以改变组件的视觉样貌。'
+      en: '`feedback.style` can change component visual appearance.'
+  - id: C-FEEDBACK-STYLE-0001-C
+    text:
+      zh-CN: '`feedback.style` 不得表达 template 逻辑树、结构或内容的变化；即使某些样式能影响布局或可见性，也不得改变组件的逻辑树。'
+      en: '`feedback.style` must not express changes to the template logic tree, structure, or content; even when styles affect layout or visibility, they must not change the component logic tree.'
+  - id: C-FEEDBACK-STYLE-0001-D
+    text:
+      zh-CN: '`feedback.style` 的宿主实现方式不由本契约指定；它可能由 adapter 或翻译层映射到宿主支持的样式机制。'
+      en: The host realization strategy for `feedback.style` is not specified by this contract; adapters or translation layers can map it to style mechanisms supported by the host.
+openQuestions:
+  - id: C-FEEDBACK-STYLE-0001-Q-NON-VISUAL
+    question:
+      zh-CN: 非视觉反馈（例如听觉、触觉等）应如何作为未来的 `feedback.*` 子 surface 被接纳？
+      en: How should non-visual feedback, such as auditory or tactile feedback, be admitted as future `feedback.*` subsurfaces?
+    context:
+      zh-CN: v0 当前只编目 `feedback.style`。Feedback 通路本身允许视觉、听觉、触觉或其他可感知媒介，但非视觉 surface 暂未进入当前实现重点。
+      en: v0 currently catalogs only `feedback.style`. The Feedback channel itself allows visual, auditory, tactile, or other perceivable media, but non-visual surfaces are not part of the current implementation focus.
+sources:
+  - path: internal/contracts/feedback/README.md
+    sections:
+      - Purpose
+      - Scope (v0)
+      - Separation of Concerns
+  - path: apps/www/src/content/docs/zh-cn/whitepaper/translation-layer.md
+    sections:
+      - 样式与反馈
+  - path: apps/www/src/content/docs/en/whitepaper/translation-layer.md
+    sections:
+      - Styling and feedback
+dependsOn:
+  contracts:
+    - C-FEEDBACK-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured `feedback.style` as the visual feedback surface and separated it from template structure/content changes.
+  - version: 0.1.0
+    change: revised
+    summary: Clarified `feedback.style` as visual-only and strengthened the logical-tree boundary.
+tags:
+  - feedback
+  - style
+  - visual

--- a/spec/contracts/C-FEEDBACK-STYLE-0002.yaml
+++ b/spec/contracts/C-FEEDBACK-STYLE-0002.yaml
@@ -1,0 +1,58 @@
+id: C-FEEDBACK-STYLE-0002
+type: contract
+title: Setup style plans are setup-only and reversible during setup
+status: draft
+since: 0.1.0
+summary: Setup-time `feedback.style` records style plans, and each setup plan contribution can be removed only during setup.
+statement:
+  zh-CN: >-
+    `def.feedback.style.use(...)` 必须在 setup 阶段登记 style plan；它返回的 `unUse` 只用于 setup 阶段撤销对应贡献。一旦进入 runtime，setup style plan API 不再可用，也不得作为 runtime 更新机制使用。
+
+
+  en: >-
+    `def.feedback.style.use(...)` must record a style plan during setup; the returned `unUse` is only for removing that contribution during setup. Once runtime begins, setup style-plan APIs are no longer available and must not be used as runtime update mechanisms.
+
+
+criteria:
+  - id: C-FEEDBACK-STYLE-0002-A
+    text:
+      zh-CN: Setup-time style plan 必须通过 `def.feedback.style.use(...handles)` 登记。
+      en: Setup-time style plans must be recorded through `def.feedback.style.use(...handles)`.
+  - id: C-FEEDBACK-STYLE-0002-B
+    text:
+      zh-CN: '`def.feedback.style.use` 必须是 setup-only；在 runtime callback、event handler、effect 或其他 post-setup 执行上下文中调用必须抛错。'
+      en: '`def.feedback.style.use` must be setup-only; calling it from runtime callbacks, event handlers, effects, or other post-setup execution contexts must throw.'
+  - id: C-FEEDBACK-STYLE-0002-C
+    text:
+      zh-CN: '`def.feedback.style.use` 返回的 `unUse` 必须只移除该次 `use` 调用登记的 style plan 贡献。'
+      en: The `unUse` returned by `def.feedback.style.use` must remove only the style-plan contribution recorded by that `use` call.
+  - id: C-FEEDBACK-STYLE-0002-D
+    text:
+      zh-CN: '`unUse` 必须是 setup-only；进入 runtime 后调用必须抛错。'
+      en: '`unUse` must be setup-only; calling it after entering runtime must throw.'
+  - id: C-FEEDBACK-STYLE-0002-E
+    text:
+      zh-CN: '`unUse` 不是 runtime update 机制，也不是 lifecycle disposer。'
+      en: '`unUse` is not a runtime update mechanism and not a lifecycle disposer.'
+sources:
+  - path: internal/contracts/feedback/style.use.setup-only.v0.md
+    sections:
+      - API Shape
+      - Setup-only Constraint
+      - unUse Semantics (setup-only)
+  - path: packages/runtime/test/contract/feedback.style.setup-only.v0.contract.test.ts
+    sections:
+      - 'runtime: feedback.style.setup-only v0'
+dependsOn:
+  contracts:
+    - C-FEEDBACK-0002
+    - C-FEEDBACK-STYLE-0001
+    - C-CORE-SYNTAX-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured setup-only style planning and setup-only `unUse` semantics.
+tags:
+  - feedback
+  - style
+  - setup

--- a/spec/contracts/C-FEEDBACK-STYLE-0003.yaml
+++ b/spec/contracts/C-FEEDBACK-STYLE-0003.yaml
@@ -1,0 +1,70 @@
+id: C-FEEDBACK-STYLE-0003
+type: contract
+title: feedback.style values are style token sets
+status: draft
+since: 0.1.0
+summary: '`feedback.style` values are sets of author-side Proto UI style tokens, currently based on a subset of Tailwind atomic-class syntax.'
+statement:
+  zh-CN: >-
+    `feedback.style` 的 value 必须被表示为原型作者侧 style token 的集合。现阶段 Proto UI style token 搬用 Tailwind CSS 原子类语法的子集，但这些 token 表达的是原型内部的视觉意图，不等同于最终宿主样式 token、宿主 class 或其他翻译层产物。
+
+
+  en: >-
+    A `feedback.style` value must be represented as a set of prototype-author-side style tokens. In the current stage, Proto UI style tokens borrow a subset of Tailwind CSS atomic-class syntax, but these tokens express prototype-internal visual intent and are not equivalent to final host style tokens, host classes, or other translation-layer artifacts.
+
+
+criteria:
+  - id: C-FEEDBACK-STYLE-0003-A
+    text:
+      zh-CN: '`feedback.style` value 必须由原型作者侧 style token 集合表达。'
+      en: '`feedback.style` values must be expressed as sets of prototype-author-side style tokens.'
+  - id: C-FEEDBACK-STYLE-0003-B
+    text:
+      zh-CN: 当前 v0 style token 语法必须被视为 Tailwind CSS 原子类语法的子集。
+      en: The current v0 style-token syntax must be treated as a subset of Tailwind CSS atomic-class syntax.
+  - id: C-FEEDBACK-STYLE-0003-C
+    text:
+      zh-CN: Proto UI style token 表达原型内部视觉意图；不得要求它与最终宿主样式 token、DOM attribute、CSS class、CSS rule 或其他宿主产物一一对应。
+      en: Proto UI style tokens express prototype-internal visual intent; they must not be required to correspond one-to-one with final host style tokens, DOM attributes, CSS classes, CSS rules, or other host artifacts.
+  - id: C-FEEDBACK-STYLE-0003-D
+    text:
+      zh-CN: 翻译层可以将 style token 翻译成 CSS、attribute、样式装饰器、宿主私有结构或其他完全不同的宿主产物，只要保持 `feedback.style` 的语义意图。
+      en: A translation layer can translate style tokens into CSS, attributes, style decorators, host-private structures, or other completely different host artifacts as long as it preserves the semantic intent of `feedback.style`.
+openQuestions:
+  - id: C-FEEDBACK-STYLE-0003-Q-ARBITRARY-VALUE
+    question:
+      zh-CN: v0 是否应继续允许 Tailwind arbitrary value；若允许，边界如何避免与具体 Web/CSS 实现过度耦合？
+      en: Should v0 continue allowing Tailwind arbitrary values; if so, how should their boundary avoid over-coupling to concrete Web/CSS implementation details?
+    context:
+      zh-CN: 当前实现允许受控 arbitrary value，但长期治理方向倾向规避这类与具体实现耦合的表达，或引入更中立的尺寸和值体系。某些场景可能仍需要类似能力。
+      en: The current implementation allows controlled arbitrary values, but the long-term governance direction leans toward avoiding expressions coupled to concrete implementations, or introducing a more neutral size/value system. Some scenarios may still need similar capability.
+  - id: C-FEEDBACK-STYLE-0003-Q-TEMPLATE-STYLE
+    question:
+      zh-CN: Template `style` 属性应如何反向引用 `feedback.style` token，并明确其只激活纯静态 feedback-only 能力？
+      en: How should the Template `style` attribute reference `feedback.style` tokens back, and clarify that it only activates pure static feedback-only capability?
+    context:
+      zh-CN: Template 允许 `style` 属性，是 feedback-only 子结构可不拆的体现之一。后续 template 契约应引用 feedback style；若未补齐，需要保留断口。
+      en: Template allowing a `style` attribute is one expression of feedback-only substructure not requiring extraction. Future template contracts should reference feedback style; if not completed, this gap should remain visible.
+sources:
+  - path: internal/contracts/feedback/style.use.setup-only.v0.md
+    sections:
+      - Accepted Style Handles (v0)
+      - Token Syntax Rules (`tw.tokens`)
+  - path: packages/core/src/spec/feedback/style.ts
+    sections:
+      - StyleHandle
+      - tw
+dependsOn:
+  contracts:
+    - C-FEEDBACK-STYLE-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured style token sets as the value shape for `feedback.style`.
+  - version: 0.1.0
+    change: revised
+    summary: Clarified style tokens as author-side intent tokens, separated translation artifacts, and recorded arbitrary-value and template-style gaps.
+tags:
+  - feedback
+  - style
+  - tokens

--- a/spec/contracts/C-FEEDBACK-STYLE-0004.yaml
+++ b/spec/contracts/C-FEEDBACK-STYLE-0004.yaml
@@ -1,0 +1,63 @@
+id: C-FEEDBACK-STYLE-0004
+type: contract
+title: Author style tokens must not carry state or selector logic
+status: draft
+since: 0.1.0
+summary: Prototype-author-side `feedback.style` tokens must describe style only and must not encode state, event, selector, or host-realization dependencies.
+statement:
+  zh-CN: >-
+    原型作者写入 `feedback.style` 的 style token 必须只表达样式意图，不得混入状态、事件、selector 或宿主实现依赖。特别地，当前 v0 作者侧 style token 不允许包含 `:`；`hover:bg-white` 或 `data-[x]:opacity-50` 这类状态化或 selector 化表达不得进入原型内部 style token。禁止 `:` 是通路纯度要求，而不只是实现限制。
+
+
+  en: >-
+    Style tokens authored into `feedback.style` must express style intent only and must not mix in state, event, selector, or host-realization dependencies. In particular, current v0 author-side style tokens must not contain `:`; stateful or selector-like expressions such as `hover:bg-white` or `data-[x]:opacity-50` must not enter prototype-internal style tokens. Forbidding `:` is a channel-purity requirement, not merely an implementation limitation.
+
+
+criteria:
+  - id: C-FEEDBACK-STYLE-0004-A
+    text:
+      zh-CN: 作者侧 style token 不得包含 `:`；这一限制来自 feedback 通路纯度，而不只是当前 parser 或 adapter 能力。
+      en: Author-side style tokens must not contain `:`; this limitation comes from feedback channel purity, not merely from current parser or adapter capability.
+  - id: C-FEEDBACK-STYLE-0004-B
+    text:
+      zh-CN: 作者侧 style token 不得直接表达 hover、active、focus、data attribute selector、ARIA selector 或其他状态/事件/selector 依赖。
+      en: Author-side style tokens must not directly express hover, active, focus, data-attribute selectors, ARIA selectors, or other state/event/selector dependencies.
+  - id: C-FEEDBACK-STYLE-0004-C
+    text:
+      zh-CN: 状态化视觉反馈应通过状态、上下文、props 或其他信息通路与 rule 等独立 API 组合表达，而不是让 style token 自带状态。
+      en: Stateful visual feedback should be expressed by composing state, context, props, or other information channels with independent APIs such as rule, rather than by making style tokens carry state themselves.
+  - id: C-FEEDBACK-STYLE-0004-D
+    text:
+      zh-CN: Adapter 或翻译层可以生成带状态、selector 或平台特定结构的最终样式产物；这些最终产物不受作者侧 style token 语法约束，也不等同于原型内部作者侧 style token。
+      en: Adapters or translation layers can generate final style artifacts with state, selectors, or platform-specific structure; those final artifacts are not constrained by author-side style-token syntax and are not equivalent to prototype-internal author-side style tokens.
+  - id: C-FEEDBACK-STYLE-0004-E
+    text:
+      zh-CN: 因非法 token 语法导致的失败必须同步、确定性地抛错。
+      en: Failures caused by illegal token syntax must throw synchronously and deterministically.
+sources:
+  - path: internal/contracts/feedback/style.use.setup-only.v0.md
+    sections:
+      - Token Syntax Rules (`tw.tokens`)
+      - Explicitly Unsupported Handle Kinds
+  - path: packages/core/src/spec/feedback/tokens.ts
+    sections:
+      - assertTwTokenV0
+  - path: packages/modules/rule-expose-state-web/src/create.ts
+    sections:
+      - buildVariant
+      - useStyleUnsafe
+dependsOn:
+  contracts:
+    - C-FEEDBACK-STYLE-0003
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Captured purity constraints for author-side style tokens and separated them from translation-layer style artifacts.
+  - version: 0.1.0
+    change: revised
+    summary: Clarified the colon ban as a feedback-channel purity requirement and separated author tokens from translation-layer artifacts.
+tags:
+  - feedback
+  - style
+  - tokens
+  - purity

--- a/spec/contracts/C-FEEDBACK-STYLE-0005.yaml
+++ b/spec/contracts/C-FEEDBACK-STYLE-0005.yaml
@@ -1,0 +1,88 @@
+id: C-FEEDBACK-STYLE-0005
+type: contract
+title: Runtime style patch is the final pre-translation feedback.style escape hatch
+status: draft
+since: 0.1.0
+summary: '`run.feedback.style.patch`, `suppress`, and `clearPatch` modify the current runtime style patch layer before style translation.'
+statement:
+  zh-CN: >-
+    `run.feedback.style.patch(...)`、`run.feedback.style.suppress(...)` 与 `run.feedback.style.clearPatch()` 是 `feedback.style` 的 runtime-only escape hatch。它们不参与 setup style plan，也不替代 rule 的声明式副作用管理；它们以增量方式修改当前实例唯一的 runtime style patch layer，并在 setup 与 rule 产生的 style 语义结果之后、进入翻译层之前，对 `feedback.style` 的最终可翻译结果执行最后修补。
+
+
+  en: >-
+    `run.feedback.style.patch(...)`, `run.feedback.style.suppress(...)`, and `run.feedback.style.clearPatch()` are the runtime-only escape hatch for `feedback.style`. They do not participate in setup style plans and do not replace rule's declarative side-effect management; they incrementally modify the current instance's single runtime style patch layer and apply the final repair to the final translatable `feedback.style` result after setup and rule have produced their style semantic result and before that result enters the translation layer.
+
+
+criteria:
+  - id: C-FEEDBACK-STYLE-0005-A
+    text:
+      zh-CN: Runtime style patch API 必须通过 `run.feedback.style.patch(...handles)`、`run.feedback.style.suppress(...handles)` 与 `run.feedback.style.clearPatch()` 暴露，并且必须是 runtime-only API，不得在 setup 阶段可用。
+      en: The runtime style patch API must be exposed through `run.feedback.style.patch(...handles)`, `run.feedback.style.suppress(...handles)`, and `run.feedback.style.clearPatch()`, and must be runtime-only rather than available during setup.
+  - id: C-FEEDBACK-STYLE-0005-B
+    text:
+      zh-CN: Runtime style patch API 是 escape hatch，不是推荐的动态样式表达路径；推荐路径仍是 rule 与 feedback、props、state、context 等信息通路或能力的组合。
+      en: The runtime style patch API is an escape hatch, not the recommended path for dynamic style expression; the recommended path remains composing rule with feedback, props, state, context, and related channels or capabilities.
+  - id: C-FEEDBACK-STYLE-0005-C
+    text:
+      zh-CN: '`patch` 与 `suppress` 的输入仍必须是原型作者侧 `feedback.style` token handle，并遵守 `C-FEEDBACK-STYLE-0003` 与 `C-FEEDBACK-STYLE-0004`；它们不得接收 DOM attribute、CSS class、CSS rule、`data-pui-style` token 或其他宿主产物作为输入。'
+      en: Inputs to `patch` and `suppress` must remain prototype-author-side `feedback.style` token handles and must follow `C-FEEDBACK-STYLE-0003` and `C-FEEDBACK-STYLE-0004`; they must not accept DOM attributes, CSS classes, CSS rules, `data-pui-style` tokens, or other host artifacts as inputs.
+  - id: C-FEEDBACK-STYLE-0005-D
+    text:
+      zh-CN: 当前实例必须只有一份 runtime style patch layer；`patch` 与 `suppress` 必须增量修改该 layer，同一 semantic group 内后写覆盖前写，不同 semantic group 互不影响。
+      en: Each instance must have a single runtime style patch layer; `patch` and `suppress` must incrementally modify that layer, later writes must override earlier writes within the same semantic group, and different semantic groups must remain independent.
+  - id: C-FEEDBACK-STYLE-0005-E
+    text:
+      zh-CN: '`patch(...handles)` 必须为输入 token 所属 semantic group 写入正向 runtime patch，并取消同组已有的 `suppress`；`suppress(...handles)` 必须为输入 token 所属 semantic group 写入负向 runtime patch，并取消同组已有的 `patch`。`suppress` 不得被解释为撤销某一次历史 `patch` 调用。'
+      en: '`patch(...handles)` must write positive runtime patches for the semantic groups represented by its input tokens and cancel existing `suppress` entries in the same groups; `suppress(...handles)` must write negative runtime patches for the semantic groups represented by its input tokens and cancel existing `patch` entries in the same groups. `suppress` must not be interpreted as undoing a historical `patch` call.'
+  - id: C-FEEDBACK-STYLE-0005-F
+    text:
+      zh-CN: '`clearPatch()` 必须清空当前实例的 runtime style patch layer，使最终可翻译结果回到 setup、rule 等基础 style 语义结果。'
+      en: "`clearPatch()` must clear the current instance's runtime style patch layer, returning the final translatable result to the base style semantic result produced by setup, rule, and related sources."
+  - id: C-FEEDBACK-STYLE-0005-G
+    text:
+      zh-CN: Runtime style patch layer 必须在 setup style plan 与 rule style intent 产生的基础 style 语义结果之后、翻译层之前生效；翻译层必须消费应用 patch 后的最终 `feedback.style` 语义结果，不得绕过 patch layer 直接消费 setup 或 rule 的中间结果。
+      en: The runtime style patch layer must apply after the base style semantic result produced by setup style plans and rule style intents, and before translation; the translation layer must consume the final `feedback.style` semantic result after patch has been applied and must not bypass the patch layer by consuming intermediate setup or rule results directly.
+  - id: C-FEEDBACK-STYLE-0005-H
+    text:
+      zh-CN: Runtime style patch API 必须只触发 style flush，不应触发 render；它不得改变 setup style plan、rule declaration、state machine、template 逻辑树、template 结构或 template 内容，并且当前实例销毁时 runtime style patch layer 必须随实例清理。
+      en: Runtime style patch APIs must trigger only style flush and should not trigger render; they must not change setup style plans, rule declarations, state machines, the template logic tree, template structure, or template content, and the runtime style patch layer must be cleaned up when the current instance is disposed.
+openQuestions:
+  - id: C-FEEDBACK-STYLE-0005-Q-CALL-PHASE
+    question:
+      zh-CN: Runtime style patch API 是否应只允许在 callback/effect/lifecycle 等 side-effect runtime 上下文中调用，并显式禁止 render-time 调用？
+      en: Should runtime style patch APIs be allowed only in side-effecting runtime contexts such as callbacks, effects, and lifecycle callbacks, and explicitly forbidden during render-time?
+    context:
+      zh-CN: render function 当前通过 renderer handle 表达 template 产出，原则上应保持无 side-effect；但 exec-phase 术语和 runtime side-effect 子阶段仍需更细的统一契约。
+      en: The render function currently produces templates through the renderer handle and should generally remain side-effect-free; however, exec-phase terminology and runtime side-effect subphases still need a more detailed shared contract.
+sources:
+  - path: spec/contracts/C-FEEDBACK-0002.yaml
+    sections:
+      - C-FEEDBACK-0002-C
+      - C-FEEDBACK-0002-E
+      - C-FEEDBACK-0002-Q-RUNTIME-API
+  - path: spec/contracts/C-FEEDBACK-STYLE-0003.yaml
+    sections:
+      - C-FEEDBACK-STYLE-0003-A
+      - C-FEEDBACK-STYLE-0003-C
+  - path: spec/contracts/C-FEEDBACK-STYLE-0004.yaml
+    sections:
+      - C-FEEDBACK-STYLE-0004-A
+      - C-FEEDBACK-STYLE-0004-D
+dependsOn:
+  contracts:
+    - C-FEEDBACK-0002
+    - C-FEEDBACK-STYLE-0001
+    - C-FEEDBACK-STYLE-0003
+    - C-FEEDBACK-STYLE-0004
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Drafted runtime style patch as the final `feedback.style` escape hatch with `patch`, `suppress`, and `clearPatch`.
+  - version: 0.1.0
+    change: revised
+    summary: Clarified runtime style patch as the final pre-translation semantic repair layer, not a post-translation artifact override.
+tags:
+  - feedback
+  - style
+  - runtime
+  - patch

--- a/spec/contracts/C-PROPS-0001.md
+++ b/spec/contracts/C-PROPS-0001.md
@@ -1,3 +1,3 @@
-# Props is the app-maker-to-prototype configuration channel
+# Props is the app-maker-to-component configuration channel
 
-Props is the information channel used by the app maker to configure a prototype. Serialization and value-shape restrictions are defined by narrower contracts that build on this channel identity.
+Props is the information channel used by the App Maker to configure a Component. Serialization and value-shape restrictions are defined by narrower contracts that build on this channel identity.

--- a/spec/contracts/C-PROPS-0001.yaml
+++ b/spec/contracts/C-PROPS-0001.yaml
@@ -1,9 +1,9 @@
 id: C-PROPS-0001
 type: contract
-title: Props is the app-maker-to-prototype configuration channel
+title: Props is the app-maker-to-component configuration channel
 status: active
 since: 0.1.0
-summary: Props carries configuration data from the app maker into a prototype.
+summary: Props carries configuration data from the App Maker into a Component.
 notes: ./C-PROPS-0001.md
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
@@ -21,11 +21,14 @@ refines:
       anchors:
         - C-CORE-CHANNEL-0001-A
         - C-CORE-CHANNEL-0001-C
-      note: Props is the Maker-to-component configuration channel currently admitted into Proto UI's portable channel model.
+      note: Props is the App-Maker-to-Component configuration channel currently admitted into Proto UI's portable channel model.
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured the top-level channel identity for props.
+  - version: 0.1.0
+    change: revised
+    summary: Corrected the channel endpoint from Prototype to Component and aligned App Maker terminology.
 tags:
   - props
   - channel

--- a/spec/tests/T-CORE-SYNTAX-0001.yaml
+++ b/spec/tests/T-CORE-SYNTAX-0001.yaml
@@ -29,6 +29,11 @@ cases:
     covers:
       - C-CORE-SYNTAX-0004-C
     expectation: void-setup-uses-default-slot-render
+  - id: T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-INVALID
+    title: Setup rejects non-render non-void returns
+    covers:
+      - C-CORE-SYNTAX-0004-D
+    expectation: invalid-setup-return-fails-fast
   - id: T-CORE-SYNTAX-0001-CASE-RENDER-HANDLE
     title: Render receives a renderer handle and returns TemplateChildren
     covers:
@@ -37,14 +42,16 @@ cases:
       - C-CORE-SYNTAX-0006-A
     expectation: render-receives-renderer-handle-and-returns-template-children
   - id: T-CORE-SYNTAX-0001-CASE-RENDER-READ
-    title: Renderer read exposes current runtime props without update entry
+    title: Renderer read exposes current runtime input without write entries
     covers:
       - C-CORE-SYNTAX-0006-B
       - C-CORE-SYNTAX-0006-C
       - C-CORE-SYNTAX-0006-D
+      - C-CORE-SYNTAX-0006-E
+      - C-CORE-SYNTAX-0006-F
       - C-LIFECYCLE-0003-D
       - C-LIFECYCLE-0003-E
-    expectation: renderer-read-props-without-update-entry
+    expectation: renderer-read-runtime-input-without-write-entry
 implementations:
   - id: core-prototype-render-syntax-fixture
     kind: fixture
@@ -56,6 +63,7 @@ implementations:
       - T-CORE-SYNTAX-0001-CASE-SETUP-DEF
       - T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-RENDER
       - T-CORE-SYNTAX-0001-CASE-SETUP-VOID-DEFAULT
+      - T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-INVALID
       - T-CORE-SYNTAX-0001-CASE-RENDER-HANDLE
       - T-CORE-SYNTAX-0001-CASE-RENDER-READ
     notes:
@@ -76,6 +84,7 @@ implementations:
       - T-CORE-SYNTAX-0001-CASE-SETUP-DEF
       - T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-RENDER
       - T-CORE-SYNTAX-0001-CASE-SETUP-VOID-DEFAULT
+      - T-CORE-SYNTAX-0001-CASE-SETUP-RETURN-INVALID
       - T-CORE-SYNTAX-0001-CASE-RENDER-HANDLE
       - T-CORE-SYNTAX-0001-CASE-RENDER-READ
 verifies:
@@ -91,6 +100,7 @@ verifies:
         - C-CORE-SYNTAX-0004-A
         - C-CORE-SYNTAX-0004-B
         - C-CORE-SYNTAX-0004-C
+        - C-CORE-SYNTAX-0004-D
     - id: C-CORE-SYNTAX-0005
       anchors:
         - C-CORE-SYNTAX-0005-A
@@ -102,6 +112,8 @@ verifies:
         - C-CORE-SYNTAX-0006-B
         - C-CORE-SYNTAX-0006-C
         - C-CORE-SYNTAX-0006-D
+        - C-CORE-SYNTAX-0006-E
+        - C-CORE-SYNTAX-0006-F
 exercises:
   contracts:
     - id: C-LIFECYCLE-0003
@@ -112,6 +124,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added shared fixture and contract tests for prototype setup/render syntax.
+  - version: 0.1.0
+    change: revised
+    summary: Added invalid setup return coverage and context/anatomy render read coverage.
 tags:
   - core
   - syntax

--- a/spec/tests/T-FEEDBACK-STYLE-0001.yaml
+++ b/spec/tests/T-FEEDBACK-STYLE-0001.yaml
@@ -1,0 +1,88 @@
+id: T-FEEDBACK-STYLE-0001
+type: test
+title: Feedback style authoring tests
+status: draft
+since: 0.1.0
+summary: Shared fixture and contract tests for setup-time feedback.style authoring, token values, and token purity.
+cases:
+  - id: T-FEEDBACK-STYLE-0001-CASE-SETUP-USE
+    title: Setup feedback.style use records a visual style plan
+    covers:
+      - C-FEEDBACK-STYLE-0001-A
+      - C-FEEDBACK-STYLE-0001-B
+      - C-FEEDBACK-STYLE-0002-A
+    expectation: setup-style-plan-recorded
+  - id: T-FEEDBACK-STYLE-0001-CASE-SETUP-UNUSE
+    title: Setup feedback.style unUse removes only its own contribution
+    covers:
+      - C-FEEDBACK-STYLE-0002-C
+      - C-FEEDBACK-STYLE-0002-D
+    expectation: setup-style-plan-unused
+  - id: T-FEEDBACK-STYLE-0001-CASE-AUTHOR-TOKENS
+    title: feedback.style values are author-side Proto UI style token sets
+    covers:
+      - C-FEEDBACK-STYLE-0003-A
+      - C-FEEDBACK-STYLE-0003-B
+    expectation: author-token-accepted
+  - id: T-FEEDBACK-STYLE-0001-CASE-TOKEN-PURITY
+    title: Author-side feedback.style tokens cannot encode state, event, selector, or host-realization dependencies
+    covers:
+      - C-FEEDBACK-STYLE-0004-A
+      - C-FEEDBACK-STYLE-0004-B
+    expectation: author-token-rejected
+implementations:
+  - id: feedback-style-authoring-fixture
+    kind: fixture
+    status: active
+    path: packages/spec/fixtures/src/feedback/style-authoring.ts
+    required: true
+    consumesCases:
+      - T-FEEDBACK-STYLE-0001-CASE-SETUP-USE
+      - T-FEEDBACK-STYLE-0001-CASE-SETUP-UNUSE
+      - T-FEEDBACK-STYLE-0001-CASE-AUTHOR-TOKENS
+      - T-FEEDBACK-STYLE-0001-CASE-TOKEN-PURITY
+  - id: core-feedback-style-authoring-contract
+    kind: module-test
+    status: passing
+    path: packages/core/test/contract/feedback.style.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-FEEDBACK-STYLE-0001-CASE-SETUP-USE
+      - T-FEEDBACK-STYLE-0001-CASE-SETUP-UNUSE
+      - T-FEEDBACK-STYLE-0001-CASE-AUTHOR-TOKENS
+      - T-FEEDBACK-STYLE-0001-CASE-TOKEN-PURITY
+  - id: runtime-feedback-style-setup-only-contract
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/feedback.style.setup-only.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-FEEDBACK-STYLE-0001-CASE-SETUP-USE
+      - T-FEEDBACK-STYLE-0001-CASE-SETUP-UNUSE
+verifies:
+  contracts:
+    - id: C-FEEDBACK-STYLE-0001
+      anchors:
+        - C-FEEDBACK-STYLE-0001-A
+        - C-FEEDBACK-STYLE-0001-B
+    - id: C-FEEDBACK-STYLE-0002
+      anchors:
+        - C-FEEDBACK-STYLE-0002-A
+        - C-FEEDBACK-STYLE-0002-C
+        - C-FEEDBACK-STYLE-0002-D
+    - id: C-FEEDBACK-STYLE-0003
+      anchors:
+        - C-FEEDBACK-STYLE-0003-A
+        - C-FEEDBACK-STYLE-0003-B
+    - id: C-FEEDBACK-STYLE-0004
+      anchors:
+        - C-FEEDBACK-STYLE-0004-A
+        - C-FEEDBACK-STYLE-0004-B
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added feedback.style authoring test entity and shared fixture mapping.
+tags:
+  - feedback
+  - style
+  - contract-test

--- a/spec/tests/T-FEEDBACK-STYLE-0002.yaml
+++ b/spec/tests/T-FEEDBACK-STYLE-0002.yaml
@@ -1,0 +1,102 @@
+id: T-FEEDBACK-STYLE-0002
+type: test
+title: Feedback style runtime patch tests
+status: draft
+since: 0.1.0
+summary: Shared fixture, core tests, and runtime tests for run.feedback.style.patch, suppress, and clearPatch.
+cases:
+  - id: T-FEEDBACK-STYLE-0002-CASE-PATCH
+    title: Runtime patch writes positive style tokens over the base semantic result
+    covers:
+      - C-FEEDBACK-STYLE-0005-A
+      - C-FEEDBACK-STYLE-0005-D
+      - C-FEEDBACK-STYLE-0005-E
+    expectation: runtime-patch-applied
+  - id: T-FEEDBACK-STYLE-0002-CASE-SUPPRESS
+    title: Runtime suppress removes a semantic group from the base semantic result
+    covers:
+      - C-FEEDBACK-STYLE-0005-D
+      - C-FEEDBACK-STYLE-0005-E
+    expectation: runtime-suppress-applied
+  - id: T-FEEDBACK-STYLE-0002-CASE-CLEAR-PATCH
+    title: Runtime clearPatch restores the setup and rule base semantic result
+    covers:
+      - C-FEEDBACK-STYLE-0005-F
+    expectation: runtime-patch-layer-cleared
+  - id: T-FEEDBACK-STYLE-0002-CASE-PATCH-TOKEN-PURITY
+    title: Runtime patch inputs remain author-side feedback.style token handles
+    covers:
+      - C-FEEDBACK-STYLE-0005-C
+      - C-FEEDBACK-STYLE-0004-A
+    expectation: runtime-patch-token-rejected
+  - id: T-FEEDBACK-STYLE-0002-CASE-NO-RENDER
+    title: Runtime patch triggers style flush without render or template mutation
+    covers:
+      - C-FEEDBACK-STYLE-0005-G
+      - C-FEEDBACK-STYLE-0005-H
+      - C-FEEDBACK-0002-E
+    expectation: style-flush-without-render
+implementations:
+  - id: feedback-style-runtime-patch-fixture
+    kind: fixture
+    status: active
+    path: packages/spec/fixtures/src/feedback/style-runtime-patch.ts
+    required: true
+    consumesCases:
+      - T-FEEDBACK-STYLE-0002-CASE-PATCH
+      - T-FEEDBACK-STYLE-0002-CASE-SUPPRESS
+      - T-FEEDBACK-STYLE-0002-CASE-CLEAR-PATCH
+      - T-FEEDBACK-STYLE-0002-CASE-PATCH-TOKEN-PURITY
+      - T-FEEDBACK-STYLE-0002-CASE-NO-RENDER
+  - id: core-feedback-style-runtime-patch-contract
+    kind: module-test
+    status: passing
+    path: packages/core/test/contract/feedback.style.runtime-patch.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-FEEDBACK-STYLE-0002-CASE-PATCH
+      - T-FEEDBACK-STYLE-0002-CASE-SUPPRESS
+      - T-FEEDBACK-STYLE-0002-CASE-CLEAR-PATCH
+      - T-FEEDBACK-STYLE-0002-CASE-PATCH-TOKEN-PURITY
+  - id: runtime-feedback-style-runtime-patch-contract
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/feedback.style.runtime-patch.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-FEEDBACK-STYLE-0002-CASE-PATCH
+      - T-FEEDBACK-STYLE-0002-CASE-SUPPRESS
+      - T-FEEDBACK-STYLE-0002-CASE-CLEAR-PATCH
+      - T-FEEDBACK-STYLE-0002-CASE-PATCH-TOKEN-PURITY
+      - T-FEEDBACK-STYLE-0002-CASE-NO-RENDER
+verifies:
+  contracts:
+    - id: C-FEEDBACK-STYLE-0005
+      anchors:
+        - C-FEEDBACK-STYLE-0005-A
+        - C-FEEDBACK-STYLE-0005-C
+        - C-FEEDBACK-STYLE-0005-D
+        - C-FEEDBACK-STYLE-0005-E
+        - C-FEEDBACK-STYLE-0005-F
+        - C-FEEDBACK-STYLE-0005-G
+        - C-FEEDBACK-STYLE-0005-H
+exercises:
+  contracts:
+    - id: C-FEEDBACK-0002
+      role: phase-boundary
+      coverageImpact: exercises-test-surface
+      note: Exercises runtime feedback effects and no-render style flush behavior.
+    - id: C-FEEDBACK-STYLE-0004
+      role: value-boundary
+      coverageImpact: exercises-test-surface
+      note: Exercises author-side token purity for runtime patch inputs.
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added feedback.style runtime patch test entity and shared fixture mapping.
+tags:
+  - feedback
+  - style
+  - runtime
+  - patch
+  - contract-test


### PR DESCRIPTION
## 概要

本 PR 完成 feedback 相关契约的编目，并新增 `feedback.style` 的首个公开 runtime API。

契约部分明确了 feedback 是 `Component -> User` 的信息通路，`feedback.style` 是其中负责视觉反馈的 surface，并区分 setup 阶段的样式计划与 runtime 阶段的反馈副作用。同时，本 PR 明确了作者侧 style token 的边界：Proto UI style token 是进入翻译层之前的语义 token，不等同于宿主 class、DOM attribute 或 adapter 产物。

在此基础上，本 PR 新增 runtime style patch API：

- `run.feedback.style.patch(...handles)`
- `run.feedback.style.suppress(...handles)`
- `run.feedback.style.clearPatch()`

该 API 被定位为逃生舱 API。它在 setup style plan 和 rule style intent 产生基础样式语义结果之后生效，并在进入 adapter/style 翻译层之前完成最终语义修补。

## 变更内容

- 新增 feedback 契约实体：
  - `C-FEEDBACK-0001`
  - `C-FEEDBACK-0002`
  - `C-FEEDBACK-STYLE-0001` 至 `C-FEEDBACK-STYLE-0005`
- 新增 feedback style 测试实体：
  - `T-FEEDBACK-STYLE-0001`
  - `T-FEEDBACK-STYLE-0002`
- 新增 feedback style authoring 与 runtime patch 的公共 spec fixture。
- 在 `FeedbackStyleRecorder` 中实现 runtime style patch layer。
- 通过 runtime handle 暴露 `run.feedback.style.patch/suppress/clearPatch`。
- 确保 rule 产出的 style intent 仍属于 patch 前的基础语义结果。
- 更新 `C-FEEDBACK-0002`，将 `feedback.style` runtime API 断口收敛到 `C-FEEDBACK-STYLE-0005`。

## Runtime 语义

runtime patch layer 是实例级、增量式的：

- `patch()` 按 semantic group 写入正向 style token。
- `suppress()` 从当前基础结果中移除某个 semantic group。
- 同一 semantic group 后写覆盖前写。
- 不同 semantic group 互不影响。
- `clearPatch()` 恢复到 setup/rule 产生的基础样式语义结果。
- patch 操作只触发 style flush，不触发 render。

## 验证

- feedback core/runtime/spec fixture 相关 `pnpm vitest run`
- `pnpm check:types:workspace`
- rule/style 相关回归测试
- `git diff --check`

---

## Summary

This PR catalogs the feedback channel contracts and adds the first public runtime API for `feedback.style`.

The contract work clarifies feedback as the `Component -> User` information channel, defines `feedback.style` as the visual feedback surface, and separates setup-time style planning from runtime feedback effects. It also records the author-side style token boundary: Proto UI style tokens are pre-translation semantic tokens, not host classes, DOM attributes, or final adapter artifacts.

On top of that, this PR introduces the runtime style patch API:

- `run.feedback.style.patch(...handles)`
- `run.feedback.style.suppress(...handles)`
- `run.feedback.style.clearPatch()`

This API is modeled as an escape hatch. It applies after setup style plans and rule style intents have produced the base semantic style result, but before adapter/style translation.

## Changes

- Added feedback contract entities:
  - `C-FEEDBACK-0001`
  - `C-FEEDBACK-0002`
  - `C-FEEDBACK-STYLE-0001` to `C-FEEDBACK-STYLE-0005`
- Added feedback style test entities:
  - `T-FEEDBACK-STYLE-0001`
  - `T-FEEDBACK-STYLE-0002`
- Added shared spec fixtures for feedback style authoring and runtime patch behavior.
- Implemented runtime style patch support in `FeedbackStyleRecorder`.
- Exposed `run.feedback.style.patch/suppress/clearPatch` through the runtime handle.
- Ensured rule-produced style intents remain part of the pre-patch base result.
- Updated `C-FEEDBACK-0002` to resolve the `feedback.style` runtime API gap through `C-FEEDBACK-STYLE-0005`.

## Runtime Semantics

The runtime patch layer is instance-local and incremental:

- `patch()` writes positive style tokens by semantic group.
- `suppress()` removes a semantic group from the current base result.
- same semantic group writes are last-write-wins.
- different semantic groups remain independent.
- `clearPatch()` restores the setup/rule base semantic result.
- patch operations trigger style flush only and do not trigger render.

## Validation

- `pnpm vitest run` for feedback core/runtime/spec fixture tests
- `pnpm check:types:workspace`
- rule/style regression tests
- `git diff --check`