### PR TITLE
feat：checbox 组件增暴露外界控制方法 checkedChange, 修复 space 键触发的bug

### DIFF
--- a/apps/www/scripts/example_code_generation/prototype-config.ts
+++ b/apps/www/scripts/example_code_generation/prototype-config.ts
@@ -19,6 +19,11 @@ export type PrototypeMapping = {
 };
 
 export const prototypeMappings: Record<string, PrototypeMapping> = {
+  'base-checkbox-indicator': {
+    component: 'BaseCheckboxIndicator',
+    importPath: '@prototype-libs/base',
+  },
+  'base-checkbox-root': { component: 'BaseCheckboxRoot', importPath: '@prototype-libs/base' },
   'shadcn-button': { component: 'ShadcnButton', importPath: '@prototype-libs/shadcn' },
   'shadcn-tabs-content': { component: 'ShadcnTabsContent', importPath: '@prototype-libs/shadcn' },
   'shadcn-tabs-list': { component: 'ShadcnTabsList', importPath: '@prototype-libs/shadcn' },

--- a/apps/www/src/content/docs/demo_components/base-checkbox/base-checkboxCode.ts
+++ b/apps/www/src/content/docs/demo_components/base-checkbox/base-checkboxCode.ts
@@ -1,0 +1,438 @@
+import { formatCode } from '@/utils/conversionUtils';
+import type { RuntimeId } from '@/components/PrototypePreviewer/runtimes/registry';
+
+export const codeMap: Record<RuntimeId, Record<string, string>> = {
+  wc: {
+    'demo-base-checkbox_table': formatCode(`
+<div class="flex w-full max-w-2xl flex-col gap-3">
+  <div class="text-sm font-semibold text-slate-800">Controlled table selection (checkedChange)</div>
+  <div class="text-xs text-slate-500">Selected: 1 / 4</div>
+  <div class="flex w-full flex-col">    <div class="w-full overflow-hidden rounded-lg border border-slate-200">
+      <div class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-200 bg-slate-50 text-left text-xs font-medium text-slate-500">
+        <div class="flex items-center justify-center px-2 py-2">
+          <wc-base-checkbox-root>
+            <wc-base-checkbox-indicator>
+              <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+              <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+            </wc-base-checkbox-indicator>
+          </wc-base-checkbox-root>
+        </div>
+        <div class="px-3 py-2">Name</div>
+        <div class="px-3 py-2">Email</div>
+        <div class="px-3 py-2">Role</div>
+      </div>
+      <div class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0">
+        <div class="flex items-center justify-center px-2 py-2">
+          <wc-base-checkbox-root checked>
+            <wc-base-checkbox-indicator>
+              <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+              <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+            </wc-base-checkbox-indicator>
+          </wc-base-checkbox-root>
+        </div>
+        <div class="px-3 py-2 font-medium">Sarah Chen</div>
+        <div class="px-3 py-2">sarah.chen@example.com</div>
+        <div class="px-3 py-2">Admin</div>
+      </div>
+      <div class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0">
+        <div class="flex items-center justify-center px-2 py-2">
+          <wc-base-checkbox-root>
+            <wc-base-checkbox-indicator>
+              <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+              <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+            </wc-base-checkbox-indicator>
+          </wc-base-checkbox-root>
+        </div>
+        <div class="px-3 py-2 font-medium">Marcus Rodriguez</div>
+        <div class="px-3 py-2">marcus.rodriguez@example.com</div>
+        <div class="px-3 py-2">User</div>
+      </div>
+      <div class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0">
+        <div class="flex items-center justify-center px-2 py-2">
+          <wc-base-checkbox-root>
+            <wc-base-checkbox-indicator>
+              <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+              <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+            </wc-base-checkbox-indicator>
+          </wc-base-checkbox-root>
+        </div>
+        <div class="px-3 py-2 font-medium">Priya Patel</div>
+        <div class="px-3 py-2">priya.patel@example.com</div>
+        <div class="px-3 py-2">User</div>
+      </div>
+      <div class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0">
+        <div class="flex items-center justify-center px-2 py-2">
+          <wc-base-checkbox-root>
+            <wc-base-checkbox-indicator>
+              <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+              <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+            </wc-base-checkbox-indicator>
+          </wc-base-checkbox-root>
+        </div>
+        <div class="px-3 py-2 font-medium">David Kim</div>
+        <div class="px-3 py-2">david.kim@example.com</div>
+        <div class="px-3 py-2">Editor</div>
+      </div>
+    </div></div>
+</div>
+    `),
+    'demo-base-checkbox': formatCode(`
+<div class="flex flex-col items-start gap-3">
+  <wc-base-checkbox-root>
+    <wc-base-checkbox-indicator>
+      <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+      <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+    </wc-base-checkbox-indicator>
+    <div class="flex flex-col gap-0.5">
+Unchecked
+      <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+    </div>
+  </wc-base-checkbox-root>
+  <wc-base-checkbox-root default-checked>
+    <wc-base-checkbox-indicator>
+      <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+      <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+    </wc-base-checkbox-indicator>
+    <div class="flex flex-col gap-0.5">
+Checked
+      <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+    </div>
+  </wc-base-checkbox-root>
+  <wc-base-checkbox-root default-indeterminate>
+    <wc-base-checkbox-indicator>
+      <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+      <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+    </wc-base-checkbox-indicator>
+    <div class="flex flex-col gap-0.5">
+Indeterminate
+      <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+    </div>
+  </wc-base-checkbox-root>
+  <wc-base-checkbox-root disabled>
+    <wc-base-checkbox-indicator>
+      <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+      <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+    </wc-base-checkbox-indicator>
+    <div class="flex flex-col gap-0.5">
+Disabled
+      <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+    </div>
+  </wc-base-checkbox-root>
+</div>
+    `),
+  },
+  react: {
+    'demo-base-checkbox_table': formatCode(`
+import { BaseCheckboxIndicator, BaseCheckboxRoot } from '@prototype-libs/base';
+
+export function DemoBaseCheckboxTableDemo() {
+  return (
+    <div className="flex w-full max-w-2xl flex-col gap-3">
+      <div className="text-sm font-semibold text-slate-800">
+        Controlled table selection (checkedChange)
+      </div>
+      <div className="text-xs text-slate-500">Selected: 1 / 4</div>
+      <div className="flex w-full flex-col">
+        <div className="w-full overflow-hidden rounded-lg border border-slate-200">
+          <div className="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-200 bg-slate-50 text-left text-xs font-medium text-slate-500">
+            <div className="flex items-center justify-center px-2 py-2">
+              <BaseCheckboxRoot checked={false} indeterminate={false}>
+                <BaseCheckboxIndicator>
+                  <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+                  <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+                </BaseCheckboxIndicator>
+              </BaseCheckboxRoot>
+            </div>
+            <div className="px-3 py-2">Name</div>
+            <div className="px-3 py-2">Email</div>
+            <div className="px-3 py-2">Role</div>
+          </div>
+          <div className="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0">
+            <div className="flex items-center justify-center px-2 py-2">
+              <BaseCheckboxRoot checked>
+                <BaseCheckboxIndicator>
+                  <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+                  <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+                </BaseCheckboxIndicator>
+              </BaseCheckboxRoot>
+            </div>
+            <div className="px-3 py-2 font-medium">Sarah Chen</div>
+            <div className="px-3 py-2">sarah.chen@example.com</div>
+            <div className="px-3 py-2">Admin</div>
+          </div>
+          <div className="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0">
+            <div className="flex items-center justify-center px-2 py-2">
+              <BaseCheckboxRoot checked={false}>
+                <BaseCheckboxIndicator>
+                  <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+                  <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+                </BaseCheckboxIndicator>
+              </BaseCheckboxRoot>
+            </div>
+            <div className="px-3 py-2 font-medium">Marcus Rodriguez</div>
+            <div className="px-3 py-2">marcus.rodriguez@example.com</div>
+            <div className="px-3 py-2">User</div>
+          </div>
+          <div className="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0">
+            <div className="flex items-center justify-center px-2 py-2">
+              <BaseCheckboxRoot checked={false}>
+                <BaseCheckboxIndicator>
+                  <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+                  <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+                </BaseCheckboxIndicator>
+              </BaseCheckboxRoot>
+            </div>
+            <div className="px-3 py-2 font-medium">Priya Patel</div>
+            <div className="px-3 py-2">priya.patel@example.com</div>
+            <div className="px-3 py-2">User</div>
+          </div>
+          <div className="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0">
+            <div className="flex items-center justify-center px-2 py-2">
+              <BaseCheckboxRoot checked={false}>
+                <BaseCheckboxIndicator>
+                  <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+                  <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+                </BaseCheckboxIndicator>
+              </BaseCheckboxRoot>
+            </div>
+            <div className="px-3 py-2 font-medium">David Kim</div>
+            <div className="px-3 py-2">david.kim@example.com</div>
+            <div className="px-3 py-2">Editor</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+    `),
+    'demo-base-checkbox': formatCode(`
+import { BaseCheckboxIndicator, BaseCheckboxRoot } from '@prototype-libs/base';
+
+export function DemoBaseCheckboxDemo() {
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <BaseCheckboxRoot>
+        <BaseCheckboxIndicator>
+          <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+          <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+        </BaseCheckboxIndicator>
+        <div className="flex flex-col gap-0.5">
+          Unchecked
+          <div className="text-xs text-slate-500">checked: false, indeterminate: false</div>
+        </div>
+      </BaseCheckboxRoot>
+      <BaseCheckboxRoot defaultChecked>
+        <BaseCheckboxIndicator>
+          <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+          <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+        </BaseCheckboxIndicator>
+        <div className="flex flex-col gap-0.5">
+          Checked<div className="text-xs text-slate-500">checked: false, indeterminate: false</div>
+        </div>
+      </BaseCheckboxRoot>
+      <BaseCheckboxRoot defaultIndeterminate>
+        <BaseCheckboxIndicator>
+          <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+          <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+        </BaseCheckboxIndicator>
+        <div className="flex flex-col gap-0.5">
+          Indeterminate
+          <div className="text-xs text-slate-500">checked: false, indeterminate: false</div>
+        </div>
+      </BaseCheckboxRoot>
+      <BaseCheckboxRoot disabled>
+        <BaseCheckboxIndicator>
+          <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+          <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+        </BaseCheckboxIndicator>
+        <div className="flex flex-col gap-0.5">
+          Disabled<div className="text-xs text-slate-500">checked: false, indeterminate: false</div>
+        </div>
+      </BaseCheckboxRoot>
+    </div>
+  );
+}
+    `),
+  },
+  vue: {
+    'demo-base-checkbox_table': formatCode(`
+<script setup lang="ts">
+import { BaseCheckboxIndicator, BaseCheckboxRoot } from '@prototype-libs/base';
+</script>
+
+<template>
+  <div class="flex w-full max-w-2xl flex-col gap-3">
+    <div class="text-sm font-semibold text-slate-800">
+      Controlled table selection (checkedChange)
+    </div>
+    <div class="text-xs text-slate-500">Selected: 1 / 4</div>
+    <div class="flex w-full flex-col">
+      <div class="w-full overflow-hidden rounded-lg border border-slate-200">
+        <div
+          class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-200 bg-slate-50 text-left text-xs font-medium text-slate-500"
+        >
+          <div class="flex items-center justify-center px-2 py-2">
+            <BaseCheckboxRoot checked="false" indeterminate="false">
+              <BaseCheckboxIndicator>
+                <div
+                  class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+                ></div>
+                <div
+                  class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+                ></div>
+              </BaseCheckboxIndicator>
+            </BaseCheckboxRoot>
+          </div>
+          <div class="px-3 py-2">Name</div>
+          <div class="px-3 py-2">Email</div>
+          <div class="px-3 py-2">Role</div>
+        </div>
+        <div
+          class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0"
+        >
+          <div class="flex items-center justify-center px-2 py-2">
+            <BaseCheckboxRoot checked>
+              <BaseCheckboxIndicator>
+                <div
+                  class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+                ></div>
+                <div
+                  class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+                ></div>
+              </BaseCheckboxIndicator>
+            </BaseCheckboxRoot>
+          </div>
+          <div class="px-3 py-2 font-medium">Sarah Chen</div>
+          <div class="px-3 py-2">sarah.chen@example.com</div>
+          <div class="px-3 py-2">Admin</div>
+        </div>
+        <div
+          class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0"
+        >
+          <div class="flex items-center justify-center px-2 py-2">
+            <BaseCheckboxRoot checked="false">
+              <BaseCheckboxIndicator>
+                <div
+                  class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+                ></div>
+                <div
+                  class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+                ></div>
+              </BaseCheckboxIndicator>
+            </BaseCheckboxRoot>
+          </div>
+          <div class="px-3 py-2 font-medium">Marcus Rodriguez</div>
+          <div class="px-3 py-2">marcus.rodriguez@example.com</div>
+          <div class="px-3 py-2">User</div>
+        </div>
+        <div
+          class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0"
+        >
+          <div class="flex items-center justify-center px-2 py-2">
+            <BaseCheckboxRoot checked="false">
+              <BaseCheckboxIndicator>
+                <div
+                  class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+                ></div>
+                <div
+                  class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+                ></div>
+              </BaseCheckboxIndicator>
+            </BaseCheckboxRoot>
+          </div>
+          <div class="px-3 py-2 font-medium">Priya Patel</div>
+          <div class="px-3 py-2">priya.patel@example.com</div>
+          <div class="px-3 py-2">User</div>
+        </div>
+        <div
+          class="grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0"
+        >
+          <div class="flex items-center justify-center px-2 py-2">
+            <BaseCheckboxRoot checked="false">
+              <BaseCheckboxIndicator>
+                <div
+                  class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+                ></div>
+                <div
+                  class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+                ></div>
+              </BaseCheckboxIndicator>
+            </BaseCheckboxRoot>
+          </div>
+          <div class="px-3 py-2 font-medium">David Kim</div>
+          <div class="px-3 py-2">david.kim@example.com</div>
+          <div class="px-3 py-2">Editor</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+    `),
+    'demo-base-checkbox': formatCode(`
+<script setup lang="ts">
+import { BaseCheckboxIndicator, BaseCheckboxRoot } from '@prototype-libs/base';
+</script>
+
+<template>
+  <div class="flex flex-col items-start gap-3">
+    <BaseCheckboxRoot>
+      <BaseCheckboxIndicator>
+        <div
+          class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+        ></div>
+        <div
+          class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+        ></div>
+      </BaseCheckboxIndicator>
+      <div class="flex flex-col gap-0.5">
+        Unchecked
+        <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+      </div>
+    </BaseCheckboxRoot>
+    <BaseCheckboxRoot defaultChecked>
+      <BaseCheckboxIndicator>
+        <div
+          class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+        ></div>
+        <div
+          class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+        ></div>
+      </BaseCheckboxIndicator>
+      <div class="flex flex-col gap-0.5">
+        Checked
+        <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+      </div>
+    </BaseCheckboxRoot>
+    <BaseCheckboxRoot defaultIndeterminate>
+      <BaseCheckboxIndicator>
+        <div
+          class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+        ></div>
+        <div
+          class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+        ></div>
+      </BaseCheckboxIndicator>
+      <div class="flex flex-col gap-0.5">
+        Indeterminate
+        <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+      </div>
+    </BaseCheckboxRoot>
+    <BaseCheckboxRoot disabled>
+      <BaseCheckboxIndicator>
+        <div
+          class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+        ></div>
+        <div
+          class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+        ></div>
+      </BaseCheckboxIndicator>
+      <div class="flex flex-col gap-0.5">
+        Disabled
+        <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+      </div>
+    </BaseCheckboxRoot>
+  </div>
+</template>
+    `),
+  },
+};

--- a/apps/www/src/content/docs/demo_components/base-checkbox/baseCheckboxCode.ts
+++ b/apps/www/src/content/docs/demo_components/base-checkbox/baseCheckboxCode.ts
@@ -4,33 +4,96 @@ import type { RuntimeId } from '@/components/PrototypePreviewer/runtimes/registr
 export const codeMap: Record<RuntimeId, Record<string, string>> = {
   wc: {
     'demo-base-checkbox': formatCode(`
-<wc-base-checkbox-root class="flex items-center gap-2">
-  <wc-base-checkbox-indicator class="flex h-5 w-5 items-center justify-center rounded-[4px] border">
-    <svg class="h-3 w-3" viewBox="0 0 12 12" fill="none">
-      <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" />
-    </svg>
-  </wc-base-checkbox-indicator>
-  <span>Accept terms</span>
-</wc-base-checkbox-root>
+<div class="flex flex-col items-start gap-3">
+  <wc-base-checkbox-root>
+    <wc-base-checkbox-indicator>
+      <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+      <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+    </wc-base-checkbox-indicator>
+    <div class="flex flex-col gap-0.5">
+Unchecked
+      <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+    </div>
+  </wc-base-checkbox-root>
+  <wc-base-checkbox-root default-checked>
+    <wc-base-checkbox-indicator>
+      <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+      <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+    </wc-base-checkbox-indicator>
+    <div class="flex flex-col gap-0.5">
+Checked
+      <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+    </div>
+  </wc-base-checkbox-root>
+  <wc-base-checkbox-root default-indeterminate>
+    <wc-base-checkbox-indicator>
+      <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+      <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+    </wc-base-checkbox-indicator>
+    <div class="flex flex-col gap-0.5">
+Indeterminate
+      <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+    </div>
+  </wc-base-checkbox-root>
+  <wc-base-checkbox-root disabled>
+    <wc-base-checkbox-indicator>
+      <div class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+      <div class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+    </wc-base-checkbox-indicator>
+    <div class="flex flex-col gap-0.5">
+Disabled
+      <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+    </div>
+  </wc-base-checkbox-root>
+</div>
     `),
   },
   react: {
     'demo-base-checkbox': formatCode(`
-import {
-  BaseCheckboxRoot,
-  BaseCheckboxIndicator,
-} from '@prototype-libs/base';
+import { BaseCheckboxIndicator, BaseCheckboxRoot } from '@prototype-libs/base';
 
-export function DemoBaseCheckbox() {
+export function DemoBaseCheckboxDemo() {
   return (
-    <BaseCheckboxRoot className="flex items-center gap-2">
-      <BaseCheckboxIndicator className="flex h-5 w-5 items-center justify-center rounded-[4px] border">
-        <svg className="h-3 w-3" viewBox="0 0 12 12" fill="none">
-          <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" strokeWidth={1.5} />
-        </svg>
-      </BaseCheckboxIndicator>
-      <span>Accept terms</span>
-    </BaseCheckboxRoot>
+    <div className="flex flex-col items-start gap-3">
+      <BaseCheckboxRoot>
+        <BaseCheckboxIndicator>
+          <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+          <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+        </BaseCheckboxIndicator>
+        <div className="flex flex-col gap-0.5">
+          Unchecked
+          <div className="text-xs text-slate-500">checked: false, indeterminate: false</div>
+        </div>
+      </BaseCheckboxRoot>
+      <BaseCheckboxRoot defaultChecked>
+        <BaseCheckboxIndicator>
+          <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+          <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+        </BaseCheckboxIndicator>
+        <div className="flex flex-col gap-0.5">
+          Checked<div className="text-xs text-slate-500">checked: false, indeterminate: false</div>
+        </div>
+      </BaseCheckboxRoot>
+      <BaseCheckboxRoot defaultIndeterminate>
+        <BaseCheckboxIndicator>
+          <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+          <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+        </BaseCheckboxIndicator>
+        <div className="flex flex-col gap-0.5">
+          Indeterminate
+          <div className="text-xs text-slate-500">checked: false, indeterminate: false</div>
+        </div>
+      </BaseCheckboxRoot>
+      <BaseCheckboxRoot disabled>
+        <BaseCheckboxIndicator>
+          <div className="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"></div>
+          <div className="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"></div>
+        </BaseCheckboxIndicator>
+        <div className="flex flex-col gap-0.5">
+          Disabled<div className="text-xs text-slate-500">checked: false, indeterminate: false</div>
+        </div>
+      </BaseCheckboxRoot>
+    </div>
   );
 }
     `),
@@ -38,21 +101,68 @@ export function DemoBaseCheckbox() {
   vue: {
     'demo-base-checkbox': formatCode(`
 <script setup lang="ts">
-import {
-  BaseCheckboxRoot,
-  BaseCheckboxIndicator,
-} from '@prototype-libs/base';
+import { BaseCheckboxIndicator, BaseCheckboxRoot } from '@prototype-libs/base';
 </script>
 
 <template>
-  <BaseCheckboxRoot class="flex items-center gap-2">
-    <BaseCheckboxIndicator class="flex h-5 w-5 items-center justify-center rounded-[4px] border">
-      <svg class="h-3 w-3" viewBox="0 0 12 12" fill="none">
-        <path d="M2.5 6L5 8.5L9.5 3.5" stroke="currentColor" stroke-width="1.5" />
-      </svg>
-    </BaseCheckboxIndicator>
-    <span>Accept terms</span>
-  </BaseCheckboxRoot>
+  <div class="flex flex-col items-start gap-3">
+    <BaseCheckboxRoot>
+      <BaseCheckboxIndicator>
+        <div
+          class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+        ></div>
+        <div
+          class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+        ></div>
+      </BaseCheckboxIndicator>
+      <div class="flex flex-col gap-0.5">
+        Unchecked
+        <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+      </div>
+    </BaseCheckboxRoot>
+    <BaseCheckboxRoot defaultChecked>
+      <BaseCheckboxIndicator>
+        <div
+          class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+        ></div>
+        <div
+          class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+        ></div>
+      </BaseCheckboxIndicator>
+      <div class="flex flex-col gap-0.5">
+        Checked
+        <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+      </div>
+    </BaseCheckboxRoot>
+    <BaseCheckboxRoot defaultIndeterminate>
+      <BaseCheckboxIndicator>
+        <div
+          class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+        ></div>
+        <div
+          class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+        ></div>
+      </BaseCheckboxIndicator>
+      <div class="flex flex-col gap-0.5">
+        Indeterminate
+        <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+      </div>
+    </BaseCheckboxRoot>
+    <BaseCheckboxRoot disabled>
+      <BaseCheckboxIndicator>
+        <div
+          class="h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100"
+        ></div>
+        <div
+          class="absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100"
+        ></div>
+      </BaseCheckboxIndicator>
+      <div class="flex flex-col gap-0.5">
+        Disabled
+        <div class="text-xs text-slate-500">checked: false, indeterminate: false</div>
+      </div>
+    </BaseCheckboxRoot>
+  </div>
 </template>
     `),
   },

--- a/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox_table.demo.ts
+++ b/apps/www/src/content/docs/demo_components/base-checkbox/demo-base-checkbox_table.demo.ts
@@ -1,0 +1,213 @@
+import type { DemoSetupContext } from '../../../../components/PrototypePreviewer/demo-types';
+
+const indicatorClass =
+  'group relative grid h-5 w-5 place-items-center rounded-[4px] border border-slate-400 text-white ' +
+  'data-[checked]:border-blue-600 data-[checked]:bg-blue-600 ' +
+  'data-[indeterminate]:border-blue-600 data-[indeterminate]:bg-blue-600';
+
+const checkMark = {
+  kind: 'box',
+  className: 'h-2.5 w-2.5 rounded-sm bg-current opacity-0 group-data-[checked]:opacity-100',
+};
+
+const indeterminateMark = {
+  kind: 'box',
+  className:
+    'absolute h-0.5 w-2.5 rounded bg-current opacity-0 group-data-[indeterminate]:opacity-100',
+};
+
+const tableData = [
+  { id: '1', name: 'Sarah Chen', email: 'sarah.chen@example.com', role: 'Admin' },
+  { id: '2', name: 'Marcus Rodriguez', email: 'marcus.rodriguez@example.com', role: 'User' },
+  { id: '3', name: 'Priya Patel', email: 'priya.patel@example.com', role: 'User' },
+  { id: '4', name: 'David Kim', email: 'david.kim@example.com', role: 'Editor' },
+] as const;
+
+function checkboxIndicator() {
+  return {
+    kind: 'proto',
+    prototypeId: 'base-checkbox-indicator',
+    className: indicatorClass,
+    children: [checkMark, indeterminateMark],
+  };
+}
+
+function tableCheckbox(ref: string, props?: Record<string, unknown>) {
+  return {
+    kind: 'proto',
+    prototypeId: 'base-checkbox-root',
+    ref,
+    className:
+      'inline-flex cursor-pointer select-none items-center justify-center rounded-md p-1 ' +
+      'data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
+    props,
+    children: [checkboxIndicator()],
+  };
+}
+
+function tableCell(content: string, className?: string) {
+  return {
+    kind: 'box',
+    className: className ?? 'px-3 py-2 text-sm text-slate-700',
+    children: [content],
+  };
+}
+
+export default {
+  type: 'demo',
+  root: {
+    kind: 'box',
+    className: 'flex w-full max-w-2xl flex-col gap-3',
+    children: [
+      {
+        kind: 'box',
+        className: 'text-sm font-semibold text-slate-800',
+        children: ['Controlled table selection (checkedChange)'],
+      },
+      {
+        kind: 'box',
+        ref: 'table-selection-status',
+        className: 'text-xs text-slate-500',
+        children: ['Selected: 1 / 4'],
+      },
+      {
+        kind: 'box',
+        ref: 'checkbox-group',
+        className: 'flex w-full flex-col',
+        children: [
+          {
+            kind: 'box',
+            className: 'w-full overflow-hidden rounded-lg border border-slate-200',
+            children: [
+              {
+                kind: 'box',
+                className:
+                  'grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-200 bg-slate-50 text-left text-xs font-medium text-slate-500',
+                children: [
+                  {
+                    kind: 'box',
+                    className: 'flex items-center justify-center px-2 py-2',
+                    children: [
+                      tableCheckbox('select-all', { checked: false, indeterminate: false }),
+                    ],
+                  },
+                  tableCell('Name', 'px-3 py-2'),
+                  tableCell('Email', 'px-3 py-2'),
+                  tableCell('Role', 'px-3 py-2'),
+                ],
+              },
+              ...tableData.map((row) => ({
+                kind: 'box',
+                ref: `table-row-${row.id}`,
+                className:
+                  'grid grid-cols-[2.5rem_1fr_1.4fr_5rem] border-b border-slate-100 last:border-b-0',
+                children: [
+                  {
+                    kind: 'box',
+                    className: 'flex items-center justify-center px-2 py-2',
+                    children: [
+                      tableCheckbox(`row-${row.id}`, {
+                        checked: row.id === '1',
+                      }),
+                    ],
+                  },
+                  tableCell(row.name, 'px-3 py-2 font-medium'),
+                  tableCell(row.email, 'px-3 py-2'),
+                  tableCell(row.role, 'px-3 py-2'),
+                ],
+              })),
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  setup({ refs, api }: DemoSetupContext) {
+    const cleanups: Array<() => void> = [];
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    let selectedRows = new Set<string>(['1']);
+
+    const syncTableSelection = () => {
+      const count = selectedRows.size;
+      const selectAll = count === tableData.length;
+      const partial = count > 0 && !selectAll;
+
+      api.setProps('select-all', {
+        checked: selectAll,
+        indeterminate: partial,
+      });
+
+      for (const row of tableData) {
+        api.setProps(`row-${row.id}`, {
+          checked: selectedRows.has(row.id),
+        });
+        const rowEl = refs[`table-row-${row.id}`];
+        if (rowEl) {
+          rowEl.dataset.state = selectedRows.has(row.id) ? 'selected' : '';
+        }
+      }
+
+      const status = refs['table-selection-status'];
+      if (status) {
+        status.textContent = `Selected: ${count} / ${tableData.length}`;
+      }
+    };
+
+    const onSelectAllCheckedChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ checked: boolean; indeterminate: boolean }>).detail;
+      if (detail.checked) {
+        selectedRows = new Set(tableData.map((row) => row.id));
+      } else {
+        selectedRows = new Set();
+      }
+      syncTableSelection();
+    };
+
+    const onRowCheckedChange = (rowId: string) => (event: Event) => {
+      const detail = (event as CustomEvent<{ checked: boolean; indeterminate: boolean }>).detail;
+      const next = new Set(selectedRows);
+      if (detail.checked) {
+        next.add(rowId);
+      } else {
+        next.delete(rowId);
+      }
+      selectedRows = next;
+      syncTableSelection();
+    };
+
+    const bindTableSelection = () => {
+      const selectAllRoot = refs['select-all'];
+      if (!selectAllRoot) return false;
+
+      selectAllRoot.addEventListener('checkedChange', onSelectAllCheckedChange);
+      cleanups.push(() =>
+        selectAllRoot.removeEventListener('checkedChange', onSelectAllCheckedChange)
+      );
+
+      for (const row of tableData) {
+        const rowRoot = refs[`row-${row.id}`];
+        if (!rowRoot) continue;
+        const handler = onRowCheckedChange(row.id);
+        rowRoot.addEventListener('checkedChange', handler);
+        cleanups.push(() => rowRoot.removeEventListener('checkedChange', handler));
+      }
+
+      syncTableSelection();
+      return true;
+    };
+
+    const bindTable = (attempt = 0) => {
+      if (bindTableSelection() || attempt >= 6) return;
+      const timer = setTimeout(() => bindTable(attempt + 1), 50 * (attempt + 1));
+      timers.push(timer);
+    };
+
+    requestAnimationFrame(() => requestAnimationFrame(() => bindTable()));
+
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      cleanups.forEach((cleanup) => cleanup());
+    };
+  },
+};

--- a/apps/www/src/content/docs/demo_components/tabs/tabsCode.ts
+++ b/apps/www/src/content/docs/demo_components/tabs/tabsCode.ts
@@ -7,9 +7,7 @@ export const codeMap: Record<RuntimeId, Record<string, string>> = {
 <wc-shadcn-tabs-root default-value="account">
   <wc-shadcn-tabs-list>
     <wc-shadcn-tabs-trigger value="account">Account</wc-shadcn-tabs-trigger>
-    <wc-shadcn-tabs-trigger value="password">
-      <wc-shadcn-button>Password</wc-shadcn-button>
-    </wc-shadcn-tabs-trigger>
+    <wc-shadcn-tabs-trigger value="password">Password</wc-shadcn-tabs-trigger>
     <wc-shadcn-tabs-trigger value="billing" disabled>Billing</wc-shadcn-tabs-trigger>
   </wc-shadcn-tabs-list>
   <wc-shadcn-tabs-content value="account">Make changes to your account here.</wc-shadcn-tabs-content>
@@ -21,7 +19,6 @@ export const codeMap: Record<RuntimeId, Record<string, string>> = {
   react: {
     'demo-shadcn-tabs': formatCode(`
 import {
-  ShadcnButton,
   ShadcnTabsContent,
   ShadcnTabsList,
   ShadcnTabsRoot,
@@ -33,9 +30,7 @@ export function DemoShadcnTabsDemo() {
     <ShadcnTabsRoot defaultValue="account">
       <ShadcnTabsList>
         <ShadcnTabsTrigger value="account">Account</ShadcnTabsTrigger>
-        <ShadcnTabsTrigger value="password">
-          <ShadcnButton>Password</ShadcnButton>
-        </ShadcnTabsTrigger>
+        <ShadcnTabsTrigger value="password">Password</ShadcnTabsTrigger>
         <ShadcnTabsTrigger value="billing" disabled>
           Billing
         </ShadcnTabsTrigger>
@@ -54,7 +49,6 @@ export function DemoShadcnTabsDemo() {
     'demo-shadcn-tabs': formatCode(`
 <script setup lang="ts">
 import {
-  ShadcnButton,
   ShadcnTabsContent,
   ShadcnTabsList,
   ShadcnTabsRoot,
@@ -66,9 +60,7 @@ import {
   <ShadcnTabsRoot defaultValue="account">
     <ShadcnTabsList>
       <ShadcnTabsTrigger value="account">Account</ShadcnTabsTrigger>
-      <ShadcnTabsTrigger value="password">
-        <ShadcnButton>Password</ShadcnButton>
-      </ShadcnTabsTrigger>
+      <ShadcnTabsTrigger value="password">Password</ShadcnTabsTrigger>
       <ShadcnTabsTrigger value="billing" disabled>Billing</ShadcnTabsTrigger>
     </ShadcnTabsList>
     <ShadcnTabsContent value="account">Make changes to your account here.</ShadcnTabsContent>

--- a/apps/www/src/content/docs/en/ui-libraries/base/checkbox.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/checkbox.mdx
@@ -34,9 +34,22 @@ In the Web Components preview runtime, prototype IDs are registered with a `wc-`
 
 When an enabled indeterminate checkbox is pressed:
 
-1. `checked` follows the normal `asToggle()` checked behavior and emits `checkedChange`.
+1. `checked` toggles on `press.commit` when uncontrolled, or is updated by the owner when controlled via `checkedChange` (`{ checked, indeterminate }`).
 2. The root requests `indeterminate: false` by emitting `indeterminateChange`.
 3. If `indeterminate` is uncontrolled, the root also clears its internal indeterminate state.
 4. If `indeterminate` is controlled, the external owner must handle `indeterminateChange` and pass `indeterminate={false}` back in.
 
 Disabled checkboxes do not change checked or indeterminate state on press.
+
+## Controlled table selection
+
+Sync header select-all and row checkboxes via controlled `checkedChange` (similar to Radix / shadcn table multi-select).
+
+<div>
+  <PrototypePreviewer
+    demoId="demo-base-checkbox_table"
+    initialRuntime="wc"
+    runtimes={['wc']}
+    hasCode={false}
+  />
+</div>

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/checkbox.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/checkbox.mdx
@@ -15,6 +15,12 @@ Checkbox 基础原型在 Toggle 语义之上提供 checked、unchecked、disable
     runtimes={['wc']}
     hasCode={true}
   />
+  <PrototypePreviewer
+    demoId="demo-base-checkbox_table"
+    initialRuntime="wc"
+    runtimes={['wc']}
+    hasCode={true}
+  />
 </div>
 
 ## 结构

--- a/packages/prototypes/base/src/button/button.ts
+++ b/packages/prototypes/base/src/button/button.ts
@@ -67,6 +67,14 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
   def.expose.state('pressed', pressed);
 
   def.expose.event('click', { payload: 'void' });
+  def.event.onGlobal('key.down', (_run, ev) => {
+    const detail = ev?.detail;
+    if (disabled.get()) return;
+    if (!focused.get()) return;
+    if (detail?.key !== ' ') return;
+    detail?.preventDefault?.();
+  });
+
   def.event.on('press.commit', (run) => {
     if (disabled.get()) return;
     run.expose.emit('click');

--- a/packages/prototypes/base/src/checkbox/index.ts
+++ b/packages/prototypes/base/src/checkbox/index.ts
@@ -1,4 +1,5 @@
 export type {
+  CheckboxCheckedChangeDetail,
   CheckboxRootProps,
   CheckboxRootExposes,
   CheckboxRootStateHandles,
@@ -9,6 +10,6 @@ export type {
   CheckboxIndicatorAsHookContract,
 } from './types';
 
-export { CHECKBOX_FAMILY } from './shared';
+export { CHECKBOX_FAMILY, CHECKBOX_CONTEXT } from './shared';
 export { asCheckboxRoot, default as checkboxRoot } from './root';
 export { asCheckboxIndicator, default as checkboxIndicator } from './indicator';

--- a/packages/prototypes/base/src/checkbox/root.ts
+++ b/packages/prototypes/base/src/checkbox/root.ts
@@ -1,7 +1,32 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asToggle } from '../toggle';
+import { asFocusable } from '@proto.ui/hooks';
+import { asButton } from '../button';
 import { CHECKBOX_CONTEXT, CHECKBOX_FAMILY } from './shared';
 import type { CheckboxRootAsHookContract, CheckboxRootExposes, CheckboxRootProps } from './types';
+
+function getKeyboardEventFromProtoEvent(ev: unknown): KeyboardEvent | null {
+  const detail = (ev as CustomEvent | undefined)?.detail ?? ev;
+  if (detail instanceof KeyboardEvent) return detail;
+  if (!detail || typeof detail !== 'object') return null;
+  const native = (detail as { nativeEvent?: unknown }).nativeEvent;
+  return native instanceof KeyboardEvent ? native : null;
+}
+
+function isEnterKeyboardCommit(ev: unknown): boolean {
+  const native = getKeyboardEventFromProtoEvent(ev);
+  return native?.key === 'Enter';
+}
+
+function syncHostA11y(
+  run: { host?: { get(): unknown } },
+  checked: boolean,
+  indeterminate: boolean
+) {
+  const host = run.host?.get?.() as HTMLElement | undefined;
+  if (!host) return;
+  host.setAttribute('role', 'checkbox');
+  host.setAttribute('aria-checked', indeterminate ? 'mixed' : checked ? 'true' : 'false');
+}
 
 function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes>): void {
   def.anatomy.claim(CHECKBOX_FAMILY, { role: 'root' });
@@ -19,20 +44,26 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
     defaultIndeterminate: false,
   });
 
-  asToggle();
-  const checked = def.state.fromAccessibility('checked');
-  const updateContext = def.context.provide(CHECKBOX_CONTEXT, {
-    checked: false,
-    indeterminate: false,
-    disabled: false,
-  });
+  asButton();
+  asFocusable();
 
+  const checked = def.state.fromAccessibility('checked');
+  const disabled = def.state.fromInteraction('disabled');
+  def.expose.state('checked', checked);
+  def.expose.event('checkedChange', { payload: 'json' });
   def.expose.event('indeterminateChange', { payload: 'json' });
 
   const indeterminate = def.state.bool('indeterminate', false);
   def.expose.state('indeterminate', indeterminate);
 
+  let controlledChecked = false;
   let controlledIndeterminate = false;
+
+  const updateContext = def.context.provide(CHECKBOX_CONTEXT, {
+    checked: false,
+    indeterminate: false,
+    disabled: false,
+  });
 
   const publishContext = (run: any) => {
     updateContext({
@@ -40,16 +71,37 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
       indeterminate: !!indeterminate.get(),
       disabled: !!run.props.get().disabled,
     });
+    syncHostA11y(run, !!checked.get(), !!indeterminate.get());
+  };
+
+  const emitCheckedChange = (run: any, detail: { checked: boolean; indeterminate: boolean }) => {
+    run.expose.emit('checkedChange', detail);
   };
 
   def.lifecycle.onCreated((run) => {
+    controlledChecked = run.props.isProvided('checked');
     controlledIndeterminate = run.props.isProvided('indeterminate');
+    checked.set(
+      controlledChecked ? !!run.props.get().checked : !!run.props.get().defaultChecked,
+      'reason: lifecycle.onCreated => initialize checked'
+    );
     indeterminate.set(
       controlledIndeterminate
         ? !!run.props.get().indeterminate
         : !!run.props.get().defaultIndeterminate,
       'reason: lifecycle.onCreated => initialize indeterminate'
     );
+    publishContext(run);
+  });
+
+  def.lifecycle.onMounted((run) => {
+    publishContext(run);
+  });
+
+  def.props.watch(['checked'], (run, next) => {
+    controlledChecked = run.props.isProvided('checked');
+    if (!controlledChecked) return;
+    checked.set(!!next.checked, 'reason: props.watch(checked) => controlled sync');
     publishContext(run);
   });
 
@@ -69,15 +121,30 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
     publishContext(run);
   });
 
-  def.event.on('press.commit', (run) => {
-    if (run.props.get().disabled) return;
-    if (indeterminate.get()) {
+  def.event.on('press.commit', (run, ev) => {
+    if (disabled.get()) return;
+    if (isEnterKeyboardCommit(ev)) return;
+
+    const wasIndeterminate = indeterminate.get();
+    if (wasIndeterminate) {
       if (!controlledIndeterminate) {
         indeterminate.set(false, 'reason: press.commit => clear indeterminate');
       }
       run.expose.emit('indeterminateChange', { indeterminate: false });
-      publishContext(run);
     }
+
+    const nextChecked = !checked.get();
+    const nextIndeterminate = indeterminate.get();
+
+    if (controlledChecked) {
+      emitCheckedChange(run, { checked: nextChecked, indeterminate: nextIndeterminate });
+      publishContext(run);
+      return;
+    }
+
+    checked.set(nextChecked, 'reason: press.commit => toggle checked');
+    emitCheckedChange(run, { checked: nextChecked, indeterminate: nextIndeterminate });
+    publishContext(run);
   });
 }
 

--- a/packages/prototypes/base/src/checkbox/types.ts
+++ b/packages/prototypes/base/src/checkbox/types.ts
@@ -6,13 +6,19 @@ import type {
   ToggleStateHandles,
 } from '../toggle/types';
 
+export type CheckboxCheckedChangeDetail = {
+  checked: boolean;
+  indeterminate: boolean;
+};
+
 export interface CheckboxRootProps extends ToggleProps {
   indeterminate?: boolean;
   defaultIndeterminate?: boolean;
 }
 
-export type CheckboxRootExposes = ToggleExposes & {
+export type CheckboxRootExposes = Omit<ToggleExposes, 'checkedChange'> & {
   indeterminate: ExposeState<boolean>;
+  checkedChange: ExposeEvent<CheckboxCheckedChangeDetail>;
   indeterminateChange: ExposeEvent<{ indeterminate: boolean }>;
 };
 
@@ -20,9 +26,12 @@ export type CheckboxRootStateHandles = ToggleStateHandles & {
   indeterminate: State<boolean>;
 };
 
-export type CheckboxRootAsHookContract = ToggleAsHookContract & {
-  state: { indeterminate: State<boolean> };
-  event: { indeterminateChange: { indeterminate: boolean } };
+export type CheckboxRootAsHookContract = Omit<ToggleAsHookContract, 'event'> & {
+  state: ToggleStateHandles & { indeterminate: State<boolean> };
+  event: {
+    checkedChange: CheckboxCheckedChangeDetail;
+    indeterminateChange: { indeterminate: boolean };
+  };
 };
 
 export interface CheckboxIndicatorProps {}

--- a/packages/prototypes/base/test/as-button.test.ts
+++ b/packages/prototypes/base/test/as-button.test.ts
@@ -117,4 +117,37 @@ describe('prototypes/base: asButton', () => {
     expect(exposes.pressed.get()).toBe(false);
     expect(ctx.emitted).toEqual(['click']);
   });
+
+  it('prevents Space default action when focused', () => {
+    const P: Prototype<{ disabled?: boolean }> = definePrototype({
+      name: 'x-base-as-button-space-boundary',
+      setup() {
+        asButton();
+        return (r) => r.el('button', 'ok');
+      },
+    });
+
+    const ctx = createHost({ disabled: false });
+    executeWithHost(P as any, ctx.host as any);
+    const exposes = ctx.getExposes() as any;
+
+    ctx.globalTarget.dispatchEvent(new CustomEvent('key.down'));
+    ctx.rootTarget.dispatchEvent(new CustomEvent('host:focus'));
+    expect(exposes.focused.get()).toBe(true);
+
+    let prevented = false;
+    ctx.globalTarget.dispatchEvent(
+      new CustomEvent('key.down', {
+        detail: {
+          key: ' ',
+          target: ctx.rootTarget,
+          preventDefault: () => {
+            prevented = true;
+          },
+        },
+      })
+    );
+
+    expect(prevented).toBe(true);
+  });
 });

--- a/packages/prototypes/base/test/checkbox.test.ts
+++ b/packages/prototypes/base/test/checkbox.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
-import { checkboxRoot, checkboxIndicator } from '../src/checkbox';
+import { checkboxIndicator, checkboxRoot } from '../src/checkbox';
 
 AdaptToWebComponent(checkboxRoot as any, { registerAs: 'wc-base-checkbox-root' });
 AdaptToWebComponent(checkboxIndicator as any, { registerAs: 'wc-base-checkbox-indicator' });
@@ -8,6 +8,10 @@ AdaptToWebComponent(checkboxIndicator as any, { registerAs: 'wc-base-checkbox-in
 describe('prototypes/base: checkbox', () => {
   it('checkbox-root reuses toggle semantics for checked state and checkedChange', async () => {
     const root = document.createElement('wc-base-checkbox-root') as any;
+    const checkedChanges: Array<{ checked: boolean; indeterminate: boolean }> = [];
+    root.addEventListener('checkedChange', (event: Event) => {
+      checkedChanges.push((event as CustomEvent).detail);
+    });
     document.body.appendChild(root);
 
     await Promise.resolve();
@@ -19,6 +23,47 @@ describe('prototypes/base: checkbox', () => {
     root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(exposes.checked.get()).toBe(true);
+    expect(checkedChanges).toEqual([{ checked: true, indeterminate: false }]);
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-root emits checkedChange with indeterminate on press', async () => {
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    setElementProps(root, { defaultIndeterminate: true });
+    const checkedChanges: Array<{ checked: boolean; indeterminate: boolean }> = [];
+    root.addEventListener('checkedChange', (event: Event) => {
+      checkedChanges.push((event as CustomEvent).detail);
+    });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(checkedChanges).toEqual([{ checked: true, indeterminate: false }]);
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-root controlled press emits checkedChange without mutating checked', async () => {
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    setElementProps(root, { checked: false });
+    const checkedChanges: Array<{ checked: boolean; indeterminate: boolean }> = [];
+    root.addEventListener('checkedChange', (event: Event) => {
+      checkedChanges.push((event as CustomEvent).detail);
+    });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = root.getExposes() as any;
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(exposes.checked.get()).toBe(false);
+    expect(checkedChanges).toEqual([{ checked: true, indeterminate: false }]);
     root.remove();
     await Promise.resolve();
   });
@@ -192,6 +237,57 @@ describe('prototypes/base: checkbox', () => {
 
     expect(exposes.indeterminate.get()).toBe(true);
     expect(events).toEqual([]);
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-root exposes role=checkbox and aria-checked for assistive tech', async () => {
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    setElementProps(root, { defaultChecked: true });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(root.getAttribute('role')).toBe('checkbox');
+    expect(root.getAttribute('aria-checked')).toBe('true');
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-root maps indeterminate to aria-checked=mixed', async () => {
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    setElementProps(root, { defaultIndeterminate: true });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(root.getAttribute('aria-checked')).toBe('mixed');
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('checkbox-root toggles on Space but not Enter (WAI-ARIA checkbox)', async () => {
+    const root = document.createElement('wc-base-checkbox-root') as any;
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = root.getExposes() as any;
+    root.focus();
+
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+    expect(exposes.checked.get()).toBe(false);
+
+    root.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    await Promise.resolve();
+    expect(exposes.checked.get()).toBe(true);
+
     root.remove();
     await Promise.resolve();
   });


### PR DESCRIPTION
我觉得对于这方面的控制，只用在 button 里面去进行限制皆可；没有必再去通过 boundary 去进行判断，之后在到 button 去执行。因为一个组件如果用户想要用 space 键去进行选择的话，就表示这个组件的功能一定是符合 button 的特征的。