### PR TITLE
[codex] Type rule authoring builders

### DIFF
--- a/internal/contracts/types/rule.contract.v0.type-test.ts
+++ b/internal/contracts/types/rule.contract.v0.type-test.ts
@@ -1,0 +1,54 @@
+import { tw, type DefHandle, type OwnedStateHandle, type StyleHandle } from '@proto.ui/core';
+
+type ButtonProps = {
+  active: boolean;
+  tone: 'primary' | 'secondary';
+  count: number;
+  nullable: boolean | null;
+  data: { label: string };
+};
+
+declare const def: DefHandle<ButtonProps>;
+declare const open: OwnedStateHandle<boolean>;
+declare const tone: OwnedStateHandle<'primary' | 'secondary'>;
+declare const style: StyleHandle;
+
+def.rule({
+  when: (w) =>
+    w.all(
+      w.prop('active').eq(true),
+      w.prop('tone').eq('primary'),
+      w.prop('count').eq(1),
+      w.prop('nullable').eq(null),
+      w.state(open).eq(false),
+      w.state(tone).eq('secondary'),
+      w.meta('colorScheme').eq('dark')
+    ),
+  intent: (i) => {
+    i.feedback.style.use(tw('opacity-50'), style);
+    i.state(open).be(true);
+    i.state(tone).be('primary');
+  },
+});
+
+def.rule({
+  when: (w) => {
+    // @ts-expect-error prop keys must come from the prototype props shape
+    w.prop('missing');
+    // @ts-expect-error boolean prop comparisons reject string literals
+    w.prop('active').eq('true');
+    // @ts-expect-error string literal prop comparisons preserve the declared union
+    w.prop('tone').eq('danger');
+    // @ts-expect-error object props are not comparable by v0 rule.eq
+    w.prop('data').eq({ label: 'Save' });
+    // @ts-expect-error state comparisons preserve the state value type
+    w.state(open).eq('false');
+    return w.t();
+  },
+  intent: (i) => {
+    // @ts-expect-error feedback.style.use accepts StyleHandle values, not raw strings
+    i.feedback.style.use('opacity-50');
+    // @ts-expect-error state intent values must match the state handle value type
+    i.state(open).be('true');
+  },
+});

--- a/packages/adapters/react/test/rule-props-style.test.ts
+++ b/packages/adapters/react/test/rule-props-style.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { tw, type Prototype } from '@proto.ui/core';
+import { tw, type DefHandle, type Prototype } from '@proto.ui/core';
 
 import { createMountedReactAdapter } from './utils/fake-react';
 
@@ -7,14 +7,14 @@ describe('adapter-react: rule props -> style', () => {
   it('applies rule style on prop change and removes it on deactivate', () => {
     const proto: Prototype<{ active?: boolean }> = {
       name: 'react-rule-props-style',
-      setup(def: any) {
+      setup(def: DefHandle<{ active?: boolean }>) {
         def.props.define({
           active: { type: 'boolean', default: false },
         });
 
         def.rule({
-          when: (w: any) => w.prop('active').eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.prop('active').eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
 
         return (r: any) => [r.el('div', {}, ['ok'])];

--- a/packages/adapters/vue/test/rule-state-style.test.ts
+++ b/packages/adapters/vue/test/rule-state-style.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { tw, type Prototype } from '@proto.ui/core';
+import { tw, type DefHandle, type Prototype } from '@proto.ui/core';
 
 import { createMountedVueAdapter, flushVue } from './utils/vue';
 
@@ -7,12 +7,12 @@ describe('adapter-vue: rule state -> style', () => {
   it('applies rule style on state change and removes it on deactivate', async () => {
     const proto: Prototype = {
       name: 'vue-rule-state-style',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         const pressed = def.state.bool('pressed', false);
 
         def.rule({
-          when: (w: any) => w.state(pressed).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.state(pressed).eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
 
         def.lifecycle.onUpdated(() => {

--- a/packages/adapters/web-component/test/contract/rule.expose-state-web.optimize.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/rule.expose-state-web.optimize.v0.contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { Prototype } from '@proto.ui/core';
+import type { DefHandle, Prototype } from '@proto.ui/core';
 import { tw } from '@proto.ui/core';
 import { AdaptToWebComponent } from '../../src/adapt';
 
@@ -7,13 +7,13 @@ describe('adapter-web-component: rule expose-state-web optimization (v0)', () =>
   it('short-circuits to selector token when state is exposed and non-continuous', async () => {
     const proto: Prototype = {
       name: 'x-rule-esw-opt',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         const disabled = def.state.bool('btn.disabled', false);
         def.expose('disabled', disabled);
 
         def.rule({
-          when: (w: any) => w.state(disabled).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.state(disabled).eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
 
         def.lifecycle.onMounted(() => {
@@ -45,7 +45,7 @@ describe('adapter-web-component: rule expose-state-web optimization (v0)', () =>
   it('does not optimize when state is continuous number (number.range)', async () => {
     const proto: Prototype = {
       name: 'x-rule-esw-range',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         const value = def.state.numberRange('slider.value', 0.5, {
           min: 0,
           max: 1,
@@ -53,8 +53,8 @@ describe('adapter-web-component: rule expose-state-web optimization (v0)', () =>
         def.expose('value', value);
 
         def.rule({
-          when: (w: any) => w.state(value).eq(0.5),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.state(value).eq(0.5),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
 
         return (r: any) => [r.el('div', {}, ['ok'])];
@@ -80,13 +80,13 @@ describe('adapter-web-component: rule expose-state-web optimization (v0)', () =>
   it('optimizes state+meta(colorScheme=dark) rule into dark:* selector tokens', async () => {
     const proto: Prototype = {
       name: 'x-rule-meta-dark-opt',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         const disabled = def.state.bool('btn.disabled', false);
         def.expose('disabled', disabled);
 
         def.rule({
-          when: (w: any) => w.all(w.state(disabled).eq(true), w.meta('colorScheme').eq('dark')),
-          intent: (i: any) => i.feedback.style.use(tw('bg-zinc-950')),
+          when: (w) => w.all(w.state(disabled).eq(true), w.meta('colorScheme').eq('dark')),
+          intent: (i) => i.feedback.style.use(tw('bg-zinc-950')),
         });
 
         def.lifecycle.onMounted(() => {
@@ -114,7 +114,7 @@ describe('adapter-web-component: rule expose-state-web optimization (v0)', () =>
   it('maps supported official semantics to standard web variants', async () => {
     const proto: Prototype = {
       name: 'x-rule-esw-semantic-opt',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         const hovered = def.state.fromInteraction('hovered');
         const pressed = def.state.fromInteraction('pressed');
         const invalid = def.state.fromAccessibility('invalid');
@@ -124,16 +124,16 @@ describe('adapter-web-component: rule expose-state-web optimization (v0)', () =>
         def.expose('invalid', invalid);
 
         def.rule({
-          when: (w: any) => w.state(hovered).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.state(hovered).eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
         def.rule({
-          when: (w: any) => w.state(pressed).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('ring-2')),
+          when: (w) => w.state(pressed).eq(true),
+          intent: (i) => i.feedback.style.use(tw('ring-2')),
         });
         def.rule({
-          when: (w: any) => w.state(invalid).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('border-destructive')),
+          when: (w) => w.state(invalid).eq(true),
+          intent: (i) => i.feedback.style.use(tw('border-destructive')),
         });
 
         def.lifecycle.onMounted(() => {
@@ -166,7 +166,7 @@ describe('adapter-web-component: rule expose-state-web optimization (v0)', () =>
   it('can fall back to data-* selectors when host policy disallows native variants', async () => {
     const proto: Prototype = {
       name: 'x-rule-esw-semantic-fallback',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         const disabled = def.state.fromInteraction('disabled');
         const focusVisible = def.state.fromInteraction('focusVisible');
 
@@ -174,12 +174,12 @@ describe('adapter-web-component: rule expose-state-web optimization (v0)', () =>
         def.expose('focusVisible', focusVisible);
 
         def.rule({
-          when: (w: any) => w.state(disabled).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.state(disabled).eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
         def.rule({
-          when: (w: any) => w.state(focusVisible).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('ring-2')),
+          when: (w) => w.state(focusVisible).eq(true),
+          intent: (i) => i.feedback.style.use(tw('ring-2')),
         });
 
         def.lifecycle.onMounted(() => {

--- a/packages/adapters/web-component/test/contract/rule.state-style.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/rule.state-style.v0.contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { Prototype } from '@proto.ui/core';
+import type { DefHandle, Prototype } from '@proto.ui/core';
 import { tw } from '@proto.ui/core';
 import { AdaptToWebComponent } from '../../src/adapt';
 
@@ -9,12 +9,12 @@ describe('adapter-web-component: rule state -> style (v0)', () => {
   it('applies rule style on state change and removes it on deactivate', async () => {
     const proto: Prototype = {
       name: 'rule-state-style-wc',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         const pressed = def.state.bool('pressed', false);
 
         def.rule({
-          when: (w: any) => w.state(pressed).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.state(pressed).eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
 
         def.lifecycle.onUpdated(() => {

--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -20,7 +20,7 @@ import {
   SvgFactories,
 } from './spec';
 import type { AnatomyClaimDecl, AnatomyFamily, AnatomyOrderView, AnatomyPartView } from './anatomy';
-import { State, StateDefAPI } from './state';
+import { State, StateDefAPI, type BorrowedStateHandle, type OwnedStateHandle } from './state';
 import type { Unsubscribe } from './state';
 
 // 统一错误上下文，方便在 runtime 做 phase guard 时给出可诊断信息
@@ -51,6 +51,87 @@ export type ExposeMap = Record<
   string,
   ExposeEvent<any> | ExposeMethod<any> | ExposeValue<any> | ExposeState<any>
 >;
+
+export type RuleHandle = {
+  readonly id: number;
+  dispose(): void;
+};
+
+export type RuleDep<Props extends PropsBaseType> =
+  | { kind: 'prop'; key: keyof Props }
+  | { kind: 'state'; id: unknown }
+  | { kind: 'context'; key: unknown }
+  | { kind: 'meta'; key: string };
+
+export type WhenLiteral = string | number | boolean | null;
+export type WhenComparable<T> =
+  Extract<T, WhenLiteral> extends never ? WhenLiteral : Extract<T, WhenLiteral>;
+
+export type WhenValue<Props extends PropsBaseType> =
+  | { type: 'prop'; key: keyof Props }
+  | { type: 'state'; id: unknown }
+  | { type: 'context'; key: unknown }
+  | { type: 'meta'; key: string };
+
+export type WhenExpr<Props extends PropsBaseType> =
+  | { type: 'true' }
+  | { type: 'false' }
+  | { type: 'eq'; left: WhenValue<Props>; right: WhenLiteral }
+  | { type: 'not'; expr: WhenExpr<Props> }
+  | { type: 'all'; exprs: WhenExpr<Props>[] }
+  | { type: 'any'; exprs: WhenExpr<Props>[] };
+
+export interface WhenSignal<Props extends PropsBaseType, T> {
+  eq(lit: WhenComparable<T>): WhenExpr<Props>;
+}
+
+export interface WhenBuilder<Props extends PropsBaseType> {
+  prop<K extends keyof Props & string>(key: K): WhenSignal<Props, Props[K]>;
+  state<T>(state: State<T>): WhenSignal<Props, T>;
+  ctx<T extends JsonObject>(key: ContextKey<T>): WhenSignal<Props, unknown>;
+  meta(key: string): WhenSignal<Props, unknown>;
+
+  all(...exprs: WhenExpr<Props>[]): WhenExpr<Props>;
+  any(...exprs: WhenExpr<Props>[]): WhenExpr<Props>;
+  not(expr: WhenExpr<Props>): WhenExpr<Props>;
+
+  t(): WhenExpr<Props>;
+  f(): WhenExpr<Props>;
+}
+
+export type RuleOp<Props extends PropsBaseType = PropsBaseType> =
+  | { kind: 'feedback.style.use'; handles: StyleHandle[] }
+  | {
+      kind: 'state.set';
+      handle: OwnedStateHandle<any> | BorrowedStateHandle<any, Props>;
+      value: any;
+      reason?: any;
+    };
+
+export type RuleIntent<Props extends PropsBaseType = PropsBaseType> = {
+  kind: 'ops';
+  ops: RuleOp<Props>[];
+};
+
+export interface StateIntentBuilder<T> {
+  be(value: T): void;
+}
+
+export interface IntentBuilder<Props extends PropsBaseType = PropsBaseType> {
+  feedback: {
+    style: {
+      use(...handles: StyleHandle[]): void;
+    };
+  };
+  state: <T>(handle: OwnedStateHandle<T> | BorrowedStateHandle<T, Props>) => StateIntentBuilder<T>;
+}
+
+export type RuleSpec<Props extends PropsBaseType> = {
+  label?: string;
+  note?: string;
+  when: (w: WhenBuilder<Props>) => WhenExpr<Props>;
+  intent: (i: IntentBuilder<Props>) => void;
+};
 
 /**
  * Handles are how we strictly separate phases:
@@ -148,7 +229,7 @@ export interface DefHandle<Props extends PropsBaseType, Exposes = Record<string,
     ) => void;
   };
 
-  rule: (spec: any) => { readonly id: number; dispose(): void };
+  rule: (spec: RuleSpec<Props>) => RuleHandle;
 
   event: {
     on(

--- a/packages/modules/context/test/contract/context.with-tree.v0.contract.test.ts
+++ b/packages/modules/context/test/contract/context.with-tree.v0.contract.test.ts
@@ -23,7 +23,7 @@ describe('context-module: contract v0 (with-tree)', () => {
 
   it('CTX-MOD-V0-1000: subscribe requires provider at setup', () => {
     const parentMap = new Map<any, any>();
-    const getParent = (i: any) => parentMap.get(i) ?? null;
+    const getParent = (i: unknown) => parentMap.get(i) ?? null;
 
     const sys = createSysCaps();
     sys.__setExecPhase('setup');
@@ -37,7 +37,7 @@ describe('context-module: contract v0 (with-tree)', () => {
 
   it('CTX-MOD-V0-1100: provide + subscribe + update triggers callback', () => {
     const parentMap = new Map<any, any>();
-    const getParent = (i: any) => parentMap.get(i) ?? null;
+    const getParent = (i: unknown) => parentMap.get(i) ?? null;
 
     const providerToken = { id: 'provider' };
     const consumerToken = { id: 'consumer' };
@@ -85,7 +85,7 @@ describe('context-module: contract v0 (with-tree)', () => {
 
   it('CTX-MOD-V0-1120: provider can update its provided context without subscribing', () => {
     const parentMap = new Map<any, any>();
-    const getParent = (i: any) => parentMap.get(i) ?? null;
+    const getParent = (i: unknown) => parentMap.get(i) ?? null;
 
     const providerToken = { id: 'provider' };
     const consumerToken = { id: 'consumer' };
@@ -132,7 +132,7 @@ describe('context-module: contract v0 (with-tree)', () => {
 
   it('CTX-MOD-V0-1150: subscribe returns unsubscribe that deactivates callback', () => {
     const parentMap = new Map<any, any>();
-    const getParent = (i: any) => parentMap.get(i) ?? null;
+    const getParent = (i: unknown) => parentMap.get(i) ?? null;
 
     const providerToken = { id: 'provider' };
     const consumerToken = { id: 'consumer' };
@@ -170,7 +170,7 @@ describe('context-module: contract v0 (with-tree)', () => {
 
   it('CTX-MOD-V0-1200: update requires prior subscription', () => {
     const parentMap = new Map<any, any>();
-    const getParent = (i: any) => parentMap.get(i) ?? null;
+    const getParent = (i: unknown) => parentMap.get(i) ?? null;
 
     const providerToken = { id: 'provider' };
     const consumerToken = { id: 'consumer' };
@@ -199,7 +199,7 @@ describe('context-module: contract v0 (with-tree)', () => {
 
   it('CTX-MOD-V0-1300: tryUpdate returns false when provider missing', () => {
     const parentMap = new Map<any, any>();
-    const getParent = (i: any) => parentMap.get(i) ?? null;
+    const getParent = (i: unknown) => parentMap.get(i) ?? null;
 
     const consumerToken = { id: 'consumer' };
 
@@ -221,7 +221,7 @@ describe('context-module: contract v0 (with-tree)', () => {
 
   it('CTX-MOD-V0-1400: T-CONTEXT-0001-CASE-PROVIDE-VALUE rejects invalid context values', () => {
     const parentMap = new Map<any, any>();
-    const getParent = (i: any) => parentMap.get(i) ?? null;
+    const getParent = (i: unknown) => parentMap.get(i) ?? null;
 
     const sys = createSysCaps();
     sys.__setExecPhase('setup');
@@ -247,7 +247,7 @@ describe('context-module: contract v0 (with-tree)', () => {
 
   it('CTX-MOD-V0-1500: consumer can rebind to a new provider via tree change', () => {
     const parentMap = new Map<any, any>();
-    const getParent = (i: any) => parentMap.get(i) ?? null;
+    const getParent = (i: unknown) => parentMap.get(i) ?? null;
 
     const providerAToken = { id: 'provider-A' };
     const providerBToken = { id: 'provider-B' };
@@ -291,7 +291,7 @@ describe('context-module: contract v0 (with-tree)', () => {
 
   it('CTX-MOD-V0-1600: provider removal leads to disconnected reads', () => {
     const parentMap = new Map<any, any>();
-    const getParent = (i: any) => parentMap.get(i) ?? null;
+    const getParent = (i: unknown) => parentMap.get(i) ?? null;
 
     const providerToken = { id: 'provider' };
     const consumerToken = { id: 'consumer' };

--- a/packages/modules/rule/src/compile.ts
+++ b/packages/modules/rule/src/compile.ts
@@ -2,8 +2,12 @@
 import type { RuleIR, RuleSpec, RuleOp } from './types';
 import { createWhenBuilder } from './when-builder';
 import { createIntentBuilder } from './intent-builder';
+import type { PropsBaseType } from '@proto.ui/types';
 
-function attachDefaultReasons(ops: RuleOp[], spec: RuleSpec<any>): RuleOp[] {
+function attachDefaultReasons<Props extends PropsBaseType>(
+  ops: RuleOp<Props>[],
+  spec: RuleSpec<Props>
+): RuleOp<Props>[] {
   return ops.map((op, idx) => {
     if (op.kind !== 'state.set') return op;
     if (op.reason !== undefined) return op;
@@ -23,7 +27,7 @@ function attachDefaultReasons(ops: RuleOp[], spec: RuleSpec<any>): RuleOp[] {
  * Compile a RuleSpec into pure-data RuleIR.
  * v0: must be called during setup by runtime's def.rule.
  */
-export function compileRule<Props extends {}>(
+export function compileRule<Props extends PropsBaseType>(
   spec: RuleSpec<Props>,
   opt?: {
     registerStateHandle?: (id: any, handle: any) => void;
@@ -34,7 +38,7 @@ export function compileRule<Props extends {}>(
   });
   const when = spec.when(w);
 
-  const { builder, exportIntent } = createIntentBuilder();
+  const { builder, exportIntent } = createIntentBuilder<Props>();
   spec.intent(builder);
 
   const intent = exportIntent();

--- a/packages/modules/rule/src/create.ts
+++ b/packages/modules/rule/src/create.ts
@@ -36,7 +36,7 @@ export function createRuleModule<Props extends PropsBaseType>(
 
       return {
         facade: {
-          rule: (spec) => impl.define(spec as any),
+          rule: (spec) => impl.define(spec),
         },
         port: {
           exportIR: () => impl.exportIR(),

--- a/packages/modules/rule/src/eval.ts
+++ b/packages/modules/rule/src/eval.ts
@@ -1,8 +1,9 @@
 // packages/modules/rule/src/eval.ts
 import type { RuleIR, RulePlanV0, RuleEvalCtx, WhenExpr, WhenValue } from './types';
 import { mergeTwTokensV0 } from '@proto.ui/core';
+import type { PropsBaseType } from '@proto.ui/types';
 
-function evalValue<Props extends {}>(v: WhenValue<Props>, ctx: RuleEvalCtx<Props>): any {
+function evalValue<Props extends PropsBaseType>(v: WhenValue<Props>, ctx: RuleEvalCtx<Props>): any {
   switch (v.type) {
     case 'prop':
       return (ctx.props as any)[v.key];
@@ -15,7 +16,10 @@ function evalValue<Props extends {}>(v: WhenValue<Props>, ctx: RuleEvalCtx<Props
   }
 }
 
-function evalExpr<Props extends {}>(e: WhenExpr<Props>, ctx: RuleEvalCtx<Props>): boolean {
+function evalExpr<Props extends PropsBaseType>(
+  e: WhenExpr<Props>,
+  ctx: RuleEvalCtx<Props>
+): boolean {
   switch (e.type) {
     case 'true':
       return true;
@@ -39,7 +43,7 @@ function evalExpr<Props extends {}>(e: WhenExpr<Props>, ctx: RuleEvalCtx<Props>)
  * - Deterministic ordering: declaration order
  * - Collect ops, concatenate tokens in order, semantic-merge -> tokens
  */
-export function evaluateRulesToPlan<Props extends {}>(
+export function evaluateRulesToPlan<Props extends PropsBaseType>(
   rules: RuleIR<Props>[],
   ctx: RuleEvalCtx<Props>
 ): RulePlanV0 {

--- a/packages/modules/rule/src/intent-builder.ts
+++ b/packages/modules/rule/src/intent-builder.ts
@@ -3,10 +3,10 @@ import type { IntentBuilder, RuleIntent, RuleOp, StateIntentBuilder } from './ty
 import type { StyleHandle, OwnedStateHandle, BorrowedStateHandle } from '@proto.ui/core';
 import type { PropsBaseType } from '@proto.ui/types';
 
-export function createIntentBuilder() {
-  const ops: RuleOp[] = [];
+export function createIntentBuilder<Props extends PropsBaseType = PropsBaseType>() {
+  const ops: RuleOp<Props>[] = [];
 
-  const builder: IntentBuilder = {
+  const builder: IntentBuilder<Props> = {
     feedback: {
       style: {
         use: (...handles: StyleHandle[]) => {
@@ -15,19 +15,19 @@ export function createIntentBuilder() {
       },
     },
     state: <T>(
-      handle: OwnedStateHandle<T> | BorrowedStateHandle<T, PropsBaseType>
+      handle: OwnedStateHandle<T> | BorrowedStateHandle<T, Props>
     ): StateIntentBuilder<T> => ({
       be(value: T) {
         ops.push({
           kind: 'state.set',
-          handle: handle as any,
+          handle,
           value,
         });
       },
     }),
   };
 
-  const exportIntent = (): RuleIntent => ({ kind: 'ops', ops: ops.slice() });
+  const exportIntent = (): RuleIntent<Props> => ({ kind: 'ops', ops: ops.slice() });
 
   return { builder, exportIntent };
 }

--- a/packages/modules/rule/src/types.ts
+++ b/packages/modules/rule/src/types.ts
@@ -4,105 +4,36 @@ import type {
   ModuleInstance,
   ModuleFacade,
   ModuleScope,
-  StyleHandle,
-  OwnedStateHandle,
-  BorrowedStateHandle,
+  IntentBuilder,
+  RuleDep,
+  RuleHandle,
+  RuleIntent,
+  RuleOp,
+  RuleSpec,
+  StateIntentBuilder,
+  WhenBuilder,
+  WhenExpr,
+  WhenLiteral,
+  WhenSignal,
+  WhenValue,
 } from '@proto.ui/core';
 
-export type RuleHandle = {
-  readonly id: number;
-  dispose(): void;
-};
-
-export type RuleDep<Props> =
-  | { kind: 'prop'; key: keyof Props }
-  | { kind: 'state'; id: any }
-  | { kind: 'context'; key: any }
-  | { kind: 'meta'; key: string };
-
-export type WhenLiteral = string | number | boolean | null;
-
-export type WhenValue<Props> =
-  | { type: 'prop'; key: keyof Props }
-  | { type: 'state'; id: any }
-  | { type: 'context'; key: any }
-  | { type: 'meta'; key: string };
-
-export type WhenExpr<Props> =
-  | { type: 'true' }
-  | { type: 'false' }
-  | { type: 'eq'; left: WhenValue<Props>; right: WhenLiteral }
-  | { type: 'not'; expr: WhenExpr<Props> }
-  | { type: 'all'; exprs: WhenExpr<Props>[] }
-  | { type: 'any'; exprs: WhenExpr<Props>[] };
-
-export interface WhenSignal<Props, T> {
-  eq(lit: WhenLiteral): WhenExpr<Props>;
-}
-
-export interface WhenBuilder<Props extends {}> {
-  prop<K extends keyof Props>(key: K): WhenSignal<Props, Props[K]>;
-  state(_s: any): WhenSignal<Props, any>;
-  ctx<T>(_key: any): WhenSignal<Props, T>;
-  meta(key: string): WhenSignal<Props, unknown>;
-
-  all(...exprs: WhenExpr<Props>[]): WhenExpr<Props>;
-  any(...exprs: WhenExpr<Props>[]): WhenExpr<Props>;
-  not(expr: WhenExpr<Props>): WhenExpr<Props>;
-
-  t(): WhenExpr<Props>;
-  f(): WhenExpr<Props>;
-}
-
-export type RuleOp =
-  | { kind: 'feedback.style.use'; handles: StyleHandle[] }
-  | {
-      kind: 'state.set';
-      handle: OwnedStateHandle<any> | BorrowedStateHandle<any, any>;
-      value: any;
-      reason?: any;
-    };
-
-export type RuleIntent = { kind: 'ops'; ops: RuleOp[] };
-
-export type RuleIR<Props extends {}> = {
+export type RuleIR<Props extends PropsBaseType> = {
   id: number;
   label?: string;
   note?: string;
 
   deps: RuleDep<Props>[];
   when: WhenExpr<Props>;
-  intent: RuleIntent;
+  intent: RuleIntent<Props>;
 };
-
-export type RuleSpec<Props extends {}> = {
-  label?: string;
-  note?: string;
-  when: (w: WhenBuilder<Props>) => WhenExpr<Props>;
-  intent: (i: IntentBuilder) => void;
-};
-
-export interface StateIntentBuilder<T> {
-  be(value: T): void;
-}
-
-export interface IntentBuilder {
-  feedback: {
-    style: {
-      use(...handles: StyleHandle[]): void;
-    };
-  };
-  state: <T>(
-    handle: OwnedStateHandle<T> | BorrowedStateHandle<T, PropsBaseType>
-  ) => StateIntentBuilder<T>;
-}
 
 export type RulePlanV0 = {
   kind: 'style.tokens';
   tokens: string[];
 };
 
-export type RuleEvalCtx<Props extends {}> = {
+export type RuleEvalCtx<Props extends PropsBaseType> = {
   props: Readonly<Props>;
   readState?: (id: any) => any;
   readContext?: (key: any, path?: string[]) => any;
@@ -113,7 +44,7 @@ export type RuleEvalResult =
   | { kind: 'plan'; plan: RulePlanV0 }
   | { kind: 'short-circuit'; executed: boolean };
 
-export type RuleExtension<Props extends {}> = {
+export type RuleExtension<Props extends PropsBaseType> = {
   transformRules?: (rules: RuleIR<Props>[], ctx: RuleEvalCtx<Props>) => RuleIR<Props>[];
   beforePlan?: (
     ctx: RuleEvalCtx<Props>
@@ -123,20 +54,35 @@ export type RuleExtension<Props extends {}> = {
   afterPlan?: (plan: RulePlanV0, ctx: RuleEvalCtx<Props>) => RulePlanV0;
 };
 
-export type RulePort<Props extends {}> = {
+export type RulePort<Props extends PropsBaseType> = {
   exportIR(): RuleIR<Props>[];
   resolveStateHandle(id: any): { get(): any } | undefined;
   evaluate(ctx: RuleEvalCtx<Props>): RuleEvalResult;
   registerExtension(ext: RuleExtension<Props>): void;
 };
 
-export type RuleFacade<Props extends {}> = ModuleFacade & {
+export type RuleFacade<Props extends PropsBaseType> = ModuleFacade & {
   // setup-only: def.rule
   rule: (spec: RuleSpec<Props>) => RuleHandle;
 };
 
-export type RuleModule<Props extends {}> = ModuleInstance<RuleFacade<Props>> & {
+export type RuleModule<Props extends PropsBaseType> = ModuleInstance<RuleFacade<Props>> & {
   name: 'rule';
   scope: ModuleScope; // normally "instance"
   port: RulePort<Props>;
+};
+
+export type {
+  IntentBuilder,
+  RuleDep,
+  RuleHandle,
+  RuleIntent,
+  RuleOp,
+  RuleSpec,
+  StateIntentBuilder,
+  WhenBuilder,
+  WhenExpr,
+  WhenLiteral,
+  WhenSignal,
+  WhenValue,
 };

--- a/packages/modules/rule/src/when-builder.ts
+++ b/packages/modules/rule/src/when-builder.ts
@@ -1,5 +1,6 @@
 // packages/modules/rule/src/when-builder.ts
 import type { RuleDep, WhenBuilder, WhenExpr, WhenLiteral, WhenSignal } from './types';
+import type { PropsBaseType } from '@proto.ui/types';
 
 function stateIdOf(s: any): string {
   const id = s?.__stateId ?? s?.id ?? s;
@@ -7,7 +8,7 @@ function stateIdOf(s: any): string {
   return `obj:${String(id)}`;
 }
 
-export function createWhenBuilder<Props extends {}>(opts?: {
+export function createWhenBuilder<Props extends PropsBaseType>(opts?: {
   onStateHandle?: (id: any, handle: any) => void;
 }) {
   const deps: RuleDep<Props>[] = [];
@@ -30,7 +31,7 @@ export function createWhenBuilder<Props extends {}>(opts?: {
 
   const makeSignal = (left: any): WhenSignal<Props, any> => ({
     eq(lit: WhenLiteral): WhenExpr<Props> {
-      return { type: 'eq', left, right: lit } as any;
+      return { type: 'eq', left, right: lit };
     },
   });
 
@@ -55,20 +56,20 @@ export function createWhenBuilder<Props extends {}>(opts?: {
     },
 
     all(...exprs: WhenExpr<Props>[]): WhenExpr<Props> {
-      return { type: 'all', exprs } as any;
+      return { type: 'all', exprs };
     },
     any(...exprs: WhenExpr<Props>[]): WhenExpr<Props> {
-      return { type: 'any', exprs } as any;
+      return { type: 'any', exprs };
     },
     not(expr: WhenExpr<Props>): WhenExpr<Props> {
-      return { type: 'not', expr } as any;
+      return { type: 'not', expr };
     },
 
     t(): WhenExpr<Props> {
-      return { type: 'true' } as any;
+      return { type: 'true' };
     },
     f(): WhenExpr<Props> {
-      return { type: 'false' } as any;
+      return { type: 'false' };
     },
   };
 

--- a/packages/prototypes/base/src/dialog/content.ts
+++ b/packages/prototypes/base/src/dialog/content.ts
@@ -127,8 +127,8 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   });
 
   def.rule({
-    when: (w: any) => w.state(open).eq(false),
-    intent: (i: any) => i.feedback.style.use(tw('hidden')),
+    when: (w) => w.state(open).eq(false),
+    intent: (i) => i.feedback.style.use(tw('hidden')),
   });
 }
 

--- a/packages/prototypes/base/src/dialog/overlay.ts
+++ b/packages/prototypes/base/src/dialog/overlay.ts
@@ -101,8 +101,8 @@ function setupDialogMask(def: DefHandle<DialogMaskProps, DialogMaskExposes>): vo
   });
 
   def.rule({
-    when: (w: any) => w.state(open).eq(false),
-    intent: (i: any) => i.feedback.style.use(tw('hidden')),
+    when: (w) => w.state(open).eq(false),
+    intent: (i) => i.feedback.style.use(tw('hidden')),
   });
 }
 

--- a/packages/prototypes/base/src/dropdown/content.ts
+++ b/packages/prototypes/base/src/dropdown/content.ts
@@ -219,8 +219,8 @@ function setupDropdownContent(
   });
 
   def.rule({
-    when: (w: any) => w.state(open).eq(false),
-    intent: (i: any) => i.feedback.style.use(tw('hidden')),
+    when: (w) => w.state(open).eq(false),
+    intent: (i) => i.feedback.style.use(tw('hidden')),
   });
 }
 

--- a/packages/prototypes/base/src/hover-card/content.ts
+++ b/packages/prototypes/base/src/hover-card/content.ts
@@ -82,8 +82,8 @@ function setupHoverCardContent(
   });
 
   def.rule({
-    when: (w: any) => w.state(open).eq(false),
-    intent: (i: any) => i.feedback.style.use(tw('hidden')),
+    when: (w) => w.state(open).eq(false),
+    intent: (i) => i.feedback.style.use(tw('hidden')),
   });
 }
 

--- a/packages/prototypes/base/src/select/content.ts
+++ b/packages/prototypes/base/src/select/content.ts
@@ -174,8 +174,8 @@ function setupSelectContent(def: DefHandle<SelectContentProps, SelectContentExpo
   });
 
   def.rule({
-    when: (w: any) => w.state(open).eq(false),
-    intent: (i: any) => i.feedback.style.use(tw('hidden')),
+    when: (w) => w.state(open).eq(false),
+    intent: (i) => i.feedback.style.use(tw('hidden')),
   });
 
   def.lifecycle.onUnmounted(() => {

--- a/packages/prototypes/base/src/tabs/content.ts
+++ b/packages/prototypes/base/src/tabs/content.ts
@@ -41,8 +41,8 @@ function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>):
   });
 
   def.rule({
-    when: (w: any) => w.state(current).eq(false),
-    intent: (i: any) => i.feedback.style.use(tw('hidden')),
+    when: (w) => w.state(current).eq(false),
+    intent: (i) => i.feedback.style.use(tw('hidden')),
   });
 }
 

--- a/packages/prototypes/shadcn/src/button/index.ts
+++ b/packages/prototypes/shadcn/src/button/index.ts
@@ -82,8 +82,8 @@ const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
     // Variant surface rules map the public `variant` prop to visual tokens.
     (Object.keys(VARIANT_TOKENS) as ShadcnButtonVariant[]).forEach((variant) => {
       def.rule({
-        when: (w: any) => w.prop('variant').eq(variant),
-        intent: (i: any) => i.feedback.style.use(tw(VARIANT_TOKENS[variant])),
+        when: (w) => w.prop('variant').eq(variant),
+        intent: (i) => i.feedback.style.use(tw(VARIANT_TOKENS[variant])),
       });
     });
 
@@ -91,8 +91,8 @@ const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
     // top without re-encoding every variant.
     (Object.keys(SIZE_TOKENS) as ShadcnButtonSize[]).forEach((size) => {
       def.rule({
-        when: (w: any) => w.prop('size').eq(size),
-        intent: (i: any) => i.feedback.style.use(tw(SIZE_TOKENS[size])),
+        when: (w) => w.prop('size').eq(size),
+        intent: (i) => i.feedback.style.use(tw(SIZE_TOKENS[size])),
       });
     });
 
@@ -100,113 +100,112 @@ const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
     // shadcn styling can stay inside rule semantics instead of hard-coding
     // host-specific pseudo selectors.
     def.rule({
-      when: (w: any) => w.state(focusVisible).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('border-ring ring-3 ring-ring/50')),
+      when: (w) => w.state(focusVisible).eq(true),
+      intent: (i) => i.feedback.style.use(tw('border-ring ring-3 ring-ring/50')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.state(focusVisible).eq(true), w.prop('variant').eq('destructive')),
-      intent: (i: any) => i.feedback.style.use(tw('border-destructive/40 ring-destructive/20')),
+      when: (w) => w.all(w.state(focusVisible).eq(true), w.prop('variant').eq('destructive')),
+      intent: (i) => i.feedback.style.use(tw('border-destructive/40 ring-destructive/20')),
     });
 
     def.rule({
-      when: (w: any) => w.state(pressed).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('translate-y-px')),
+      when: (w) => w.state(pressed).eq(true),
+      intent: (i) => i.feedback.style.use(tw('translate-y-px')),
     });
 
     // Hovered surface rules are split by variant so later dark/meta branches
     // can replace them cleanly without duplicating the base variant tokens.
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('default')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-primary/80')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('default')),
+      intent: (i) => i.feedback.style.use(tw('bg-primary/80')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('secondary')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-secondary/80')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('secondary')),
+      intent: (i) => i.feedback.style.use(tw('bg-secondary/80')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('outline')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('outline')),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('ghost')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('ghost')),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('link')),
-      intent: (i: any) => i.feedback.style.use(tw('underline')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('link')),
+      intent: (i) => i.feedback.style.use(tw('underline')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('destructive')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-destructive/20')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('destructive')),
+      intent: (i) => i.feedback.style.use(tw('bg-destructive/20')),
     });
 
     // Accessibility semantics stay in the official shared state lane. This
     // keeps button-compatible semantics like `expanded` / `invalid` reusable
     // by higher-level triggers instead of reintroducing ad-hoc aria props here.
     def.rule({
-      when: (w: any) => w.all(w.state(expanded).eq(true), w.prop('variant').eq('outline')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.all(w.state(expanded).eq(true), w.prop('variant').eq('outline')),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(expanded).eq(true), w.prop('variant').eq('secondary')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-secondary text-secondary-foreground')),
+      when: (w) => w.all(w.state(expanded).eq(true), w.prop('variant').eq('secondary')),
+      intent: (i) => i.feedback.style.use(tw('bg-secondary text-secondary-foreground')),
     });
 
     def.rule({
-      when: (w: any) => w.state(invalid).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('border-destructive ring-3 ring-destructive/20')),
+      when: (w) => w.state(invalid).eq(true),
+      intent: (i) => i.feedback.style.use(tw('border-destructive ring-3 ring-destructive/20')),
     });
 
     // Dark mode stays in meta so the prototype remains host-agnostic while web
     // adapters still have a clean place to optimize to `dark:*`.
     def.rule({
-      when: (w: any) => w.all(w.meta('colorScheme').eq('dark'), w.prop('variant').eq('outline')),
-      intent: (i: any) => i.feedback.style.use(tw('border-input bg-input/30')),
+      when: (w) => w.all(w.meta('colorScheme').eq('dark'), w.prop('variant').eq('outline')),
+      intent: (i) => i.feedback.style.use(tw('border-input bg-input/30')),
     });
     def.rule({
-      when: (w: any) =>
+      when: (w) =>
         w.all(
           w.meta('colorScheme').eq('dark'),
           w.state(hovered).eq(true),
           w.prop('variant').eq('outline')
         ),
-      intent: (i: any) => i.feedback.style.use(tw('bg-input/50')),
+      intent: (i) => i.feedback.style.use(tw('bg-input/50')),
     });
     def.rule({
-      when: (w: any) =>
-        w.all(w.meta('colorScheme').eq('dark'), w.prop('variant').eq('destructive')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-destructive/20')),
+      when: (w) => w.all(w.meta('colorScheme').eq('dark'), w.prop('variant').eq('destructive')),
+      intent: (i) => i.feedback.style.use(tw('bg-destructive/20')),
     });
     def.rule({
-      when: (w: any) =>
+      when: (w) =>
         w.all(
           w.meta('colorScheme').eq('dark'),
           w.state(hovered).eq(true),
           w.prop('variant').eq('destructive')
         ),
-      intent: (i: any) => i.feedback.style.use(tw('bg-destructive/30')),
+      intent: (i) => i.feedback.style.use(tw('bg-destructive/30')),
     });
     def.rule({
-      when: (w: any) =>
+      when: (w) =>
         w.all(
           w.meta('colorScheme').eq('dark'),
           w.state(focusVisible).eq(true),
           w.prop('variant').eq('destructive')
         ),
-      intent: (i: any) => i.feedback.style.use(tw('ring-destructive/40')),
+      intent: (i) => i.feedback.style.use(tw('ring-destructive/40')),
     });
     def.rule({
-      when: (w: any) => w.all(w.meta('colorScheme').eq('dark'), w.state(invalid).eq(true)),
-      intent: (i: any) => i.feedback.style.use(tw('border-destructive/50 ring-destructive/40')),
+      when: (w) => w.all(w.meta('colorScheme').eq('dark'), w.state(invalid).eq(true)),
+      intent: (i) => i.feedback.style.use(tw('border-destructive/50 ring-destructive/40')),
     });
 
     // Disabled remains a standalone rule because it semantically cuts across
     // every variant and size, and we now source it from the shared button
     // behavior instead of duplicating prop semantics locally.
     def.rule({
-      when: (w: any) => w.state(disabled).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
+      when: (w) => w.state(disabled).eq(true),
+      intent: (i) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
     });
   },
 });

--- a/packages/prototypes/shadcn/src/dialog/close.ts
+++ b/packages/prototypes/shadcn/src/dialog/close.ts
@@ -65,49 +65,49 @@ const dialogClose = definePrototype<ShadcnDialogCloseProps, ShadcnDialogCloseExp
 
     (Object.keys(VARIANT_TOKENS) as ShadcnDialogCloseVariant[]).forEach((variant) => {
       def.rule({
-        when: (w: any) => w.prop('variant').eq(variant),
-        intent: (i: any) => i.feedback.style.use(tw(VARIANT_TOKENS[variant])),
+        when: (w) => w.prop('variant').eq(variant),
+        intent: (i) => i.feedback.style.use(tw(VARIANT_TOKENS[variant])),
       });
     });
 
     def.rule({
-      when: (w: any) => w.state(focusVisible).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('border-ring ring-3 ring-ring/50')),
+      when: (w) => w.state(focusVisible).eq(true),
+      intent: (i) => i.feedback.style.use(tw('border-ring ring-3 ring-ring/50')),
     });
 
     def.rule({
-      when: (w: any) => w.state(pressed).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('translate-y-px')),
+      when: (w) => w.state(pressed).eq(true),
+      intent: (i) => i.feedback.style.use(tw('translate-y-px')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('default')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-primary/80')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('default')),
+      intent: (i) => i.feedback.style.use(tw('bg-primary/80')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('secondary')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-secondary/80')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('secondary')),
+      intent: (i) => i.feedback.style.use(tw('bg-secondary/80')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('outline')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('outline')),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('ghost')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('ghost')),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('link')),
-      intent: (i: any) => i.feedback.style.use(tw('underline')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('link')),
+      intent: (i) => i.feedback.style.use(tw('underline')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('destructive')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-destructive/20')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('destructive')),
+      intent: (i) => i.feedback.style.use(tw('bg-destructive/20')),
     });
 
     def.rule({
-      when: (w: any) => w.state(disabled).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
+      when: (w) => w.state(disabled).eq(true),
+      intent: (i) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
     });
   },
 });

--- a/packages/prototypes/shadcn/src/dialog/trigger.ts
+++ b/packages/prototypes/shadcn/src/dialog/trigger.ts
@@ -67,68 +67,68 @@ const dialogTrigger = definePrototype<ShadcnDialogTriggerProps, ShadcnDialogTrig
 
     (Object.keys(VARIANT_TOKENS) as ShadcnDialogTriggerVariant[]).forEach((variant) => {
       def.rule({
-        when: (w: any) => w.prop('variant').eq(variant),
-        intent: (i: any) => i.feedback.style.use(tw(VARIANT_TOKENS[variant])),
+        when: (w) => w.prop('variant').eq(variant),
+        intent: (i) => i.feedback.style.use(tw(VARIANT_TOKENS[variant])),
       });
     });
 
     def.rule({
-      when: (w: any) => w.state(focusVisible).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('border-ring ring-3 ring-ring/50')),
+      when: (w) => w.state(focusVisible).eq(true),
+      intent: (i) => i.feedback.style.use(tw('border-ring ring-3 ring-ring/50')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.state(focusVisible).eq(true), w.prop('variant').eq('destructive')),
-      intent: (i: any) => i.feedback.style.use(tw('border-destructive/40 ring-destructive/20')),
+      when: (w) => w.all(w.state(focusVisible).eq(true), w.prop('variant').eq('destructive')),
+      intent: (i) => i.feedback.style.use(tw('border-destructive/40 ring-destructive/20')),
     });
 
     def.rule({
-      when: (w: any) => w.state(pressed).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('translate-y-px')),
+      when: (w) => w.state(pressed).eq(true),
+      intent: (i) => i.feedback.style.use(tw('translate-y-px')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('default')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-primary/80')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('default')),
+      intent: (i) => i.feedback.style.use(tw('bg-primary/80')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('secondary')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-secondary/80')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('secondary')),
+      intent: (i) => i.feedback.style.use(tw('bg-secondary/80')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('outline')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('outline')),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('ghost')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('ghost')),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('link')),
-      intent: (i: any) => i.feedback.style.use(tw('underline')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('link')),
+      intent: (i) => i.feedback.style.use(tw('underline')),
     });
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('destructive')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-destructive/20')),
-    });
-
-    def.rule({
-      when: (w: any) => w.all(w.state(expanded).eq(true), w.prop('variant').eq('outline')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
-    });
-    def.rule({
-      when: (w: any) => w.all(w.state(expanded).eq(true), w.prop('variant').eq('secondary')),
-      intent: (i: any) => i.feedback.style.use(tw('bg-secondary text-secondary-foreground')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.prop('variant').eq('destructive')),
+      intent: (i) => i.feedback.style.use(tw('bg-destructive/20')),
     });
 
     def.rule({
-      when: (w: any) => w.state(invalid).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('border-destructive ring-3 ring-destructive/20')),
+      when: (w) => w.all(w.state(expanded).eq(true), w.prop('variant').eq('outline')),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
+    });
+    def.rule({
+      when: (w) => w.all(w.state(expanded).eq(true), w.prop('variant').eq('secondary')),
+      intent: (i) => i.feedback.style.use(tw('bg-secondary text-secondary-foreground')),
     });
 
     def.rule({
-      when: (w: any) => w.state(disabled).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
+      when: (w) => w.state(invalid).eq(true),
+      intent: (i) => i.feedback.style.use(tw('border-destructive ring-3 ring-destructive/20')),
+    });
+
+    def.rule({
+      when: (w) => w.state(disabled).eq(true),
+      intent: (i) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
     });
   },
 });

--- a/packages/prototypes/shadcn/src/dropdown/item.ts
+++ b/packages/prototypes/shadcn/src/dropdown/item.ts
@@ -34,24 +34,24 @@ const dropdownItem = definePrototype<ShadcnDropdownItemProps, ShadcnDropdownItem
     def.feedback.style.use(tw(ITEM_BASE_TOKENS));
 
     def.rule({
-      when: (w: any) =>
+      when: (w) =>
         w.any(w.state(hovered).eq(true), w.state(focused).eq(true), w.state(focusVisible).eq(true)),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
 
     def.rule({
-      when: (w: any) => w.state(focusVisible).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('ring-2 ring-ring/40 ring-inset')),
+      when: (w) => w.state(focusVisible).eq(true),
+      intent: (i) => i.feedback.style.use(tw('ring-2 ring-ring/40 ring-inset')),
     });
 
     def.rule({
-      when: (w: any) => w.state(pressed).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted/80 text-foreground')),
+      when: (w) => w.state(pressed).eq(true),
+      intent: (i) => i.feedback.style.use(tw('bg-muted/80 text-foreground')),
     });
 
     def.rule({
-      when: (w: any) => w.state(disabled).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
+      when: (w) => w.state(disabled).eq(true),
+      intent: (i) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
     });
   },
 });

--- a/packages/prototypes/shadcn/src/dropdown/trigger.ts
+++ b/packages/prototypes/shadcn/src/dropdown/trigger.ts
@@ -99,23 +99,23 @@ const dropdownTrigger = definePrototype<ShadcnDropdownTriggerProps, ShadcnDropdo
     def.feedback.style.use(tw(TRIGGER_BASE_TOKENS));
 
     def.rule({
-      when: (w: any) => w.state(hovered).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.state(hovered).eq(true),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
 
     def.rule({
-      when: (w: any) => w.state(focusVisible).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('ring-3 ring-ring/50 ring-offset-2')),
+      when: (w) => w.state(focusVisible).eq(true),
+      intent: (i) => i.feedback.style.use(tw('ring-3 ring-ring/50 ring-offset-2')),
     });
 
     def.rule({
-      when: (w: any) => w.state(pressed).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('translate-y-px bg-muted text-foreground')),
+      when: (w) => w.state(pressed).eq(true),
+      intent: (i) => i.feedback.style.use(tw('translate-y-px bg-muted text-foreground')),
     });
 
     def.rule({
-      when: (w: any) => w.state(disabled).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
+      when: (w) => w.state(disabled).eq(true),
+      intent: (i) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
     });
 
     return (renderer) => {

--- a/packages/prototypes/shadcn/src/hover-card/trigger.ts
+++ b/packages/prototypes/shadcn/src/hover-card/trigger.ts
@@ -34,23 +34,23 @@ const hoverCardTrigger = definePrototype<
     def.feedback.style.use(tw(TRIGGER_BASE_TOKENS));
 
     def.rule({
-      when: (w: any) => w.state(hovered).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.state(hovered).eq(true),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
 
     def.rule({
-      when: (w: any) => w.state(focusVisible).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('ring-3 ring-ring/50 ring-offset-2')),
+      when: (w) => w.state(focusVisible).eq(true),
+      intent: (i) => i.feedback.style.use(tw('ring-3 ring-ring/50 ring-offset-2')),
     });
 
     def.rule({
-      when: (w: any) => w.state(pressed).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('translate-y-px')),
+      when: (w) => w.state(pressed).eq(true),
+      intent: (i) => i.feedback.style.use(tw('translate-y-px')),
     });
 
     def.rule({
-      when: (w: any) => w.state(disabled).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
+      when: (w) => w.state(disabled).eq(true),
+      intent: (i) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
     });
   },
 });

--- a/packages/prototypes/shadcn/src/switch/root.ts
+++ b/packages/prototypes/shadcn/src/switch/root.ts
@@ -37,45 +37,45 @@ const switchRoot = definePrototype<ShadcnSwitchRootProps, ShadcnSwitchRootExpose
     def.feedback.style.use(tw(ROOT_BASE_TOKENS));
 
     def.rule({
-      when: (w: any) => w.state(checked).eq(true),
-      intent: (i: any) =>
+      when: (w) => w.state(checked).eq(true),
+      intent: (i) =>
         i.feedback.style.use(tw('pl-[22px] pr-0.5 bg-primary text-primary-foreground')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.state(checked).eq(false), w.state(hovered).eq(true)),
-      intent: (i: any) => i.feedback.style.use(tw('bg-input')),
+      when: (w) => w.all(w.state(checked).eq(false), w.state(hovered).eq(true)),
+      intent: (i) => i.feedback.style.use(tw('bg-input')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.state(checked).eq(true), w.state(hovered).eq(true)),
-      intent: (i: any) => i.feedback.style.use(tw('bg-primary/90')),
+      when: (w) => w.all(w.state(checked).eq(true), w.state(hovered).eq(true)),
+      intent: (i) => i.feedback.style.use(tw('bg-primary/90')),
     });
 
     def.rule({
-      when: (w: any) => w.state(pressed).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('scale-[0.98]')),
+      when: (w) => w.state(pressed).eq(true),
+      intent: (i) => i.feedback.style.use(tw('scale-[0.98]')),
     });
 
     def.rule({
-      when: (w: any) => w.state(focusVisible).eq(true),
-      intent: (i: any) =>
+      when: (w) => w.state(focusVisible).eq(true),
+      intent: (i) =>
         i.feedback.style.use(tw('ring-3 ring-ring/50 ring-offset-2 ring-offset-background')),
     });
 
     def.rule({
-      when: (w: any) => w.state(disabled).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
+      when: (w) => w.state(disabled).eq(true),
+      intent: (i) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.meta('colorScheme').eq('dark'), w.state(checked).eq(false)),
-      intent: (i: any) => i.feedback.style.use(tw('bg-input/50')),
+      when: (w) => w.all(w.meta('colorScheme').eq('dark'), w.state(checked).eq(false)),
+      intent: (i) => i.feedback.style.use(tw('bg-input/50')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.meta('colorScheme').eq('dark'), w.state(checked).eq(true)),
-      intent: (i: any) => i.feedback.style.use(tw('bg-primary')),
+      when: (w) => w.all(w.meta('colorScheme').eq('dark'), w.state(checked).eq(true)),
+      intent: (i) => i.feedback.style.use(tw('bg-primary')),
     });
   },
 });

--- a/packages/prototypes/shadcn/src/tabs/content.ts
+++ b/packages/prototypes/shadcn/src/tabs/content.ts
@@ -13,8 +13,8 @@ const tabsContent = definePrototype<ShadcnTabsContentProps, ShadcnTabsContentExp
       )
     );
     def.rule({
-      when: (w: any) => w.state(current).eq(false),
-      intent: (i: any) => i.feedback.style.use(tw('hidden')),
+      when: (w) => w.state(current).eq(false),
+      intent: (i) => i.feedback.style.use(tw('hidden')),
     });
   },
 });

--- a/packages/prototypes/shadcn/src/tabs/trigger.ts
+++ b/packages/prototypes/shadcn/src/tabs/trigger.ts
@@ -33,8 +33,8 @@ const tabsTrigger = definePrototype<ShadcnTabsTriggerProps, ShadcnTabsTriggerExp
     def.feedback.style.use(tw(BASE_TOKENS));
 
     def.rule({
-      when: (w: any) => w.state(focusVisible).eq(true),
-      intent: (i: any) =>
+      when: (w) => w.state(focusVisible).eq(true),
+      intent: (i) =>
         i.feedback.style.use(
           tw(
             'bg-background text-foreground shadow-xs ring-3 ring-ring/50 ring-offset-2 ring-offset-background'
@@ -43,24 +43,24 @@ const tabsTrigger = definePrototype<ShadcnTabsTriggerProps, ShadcnTabsTriggerExp
     });
 
     def.rule({
-      when: (w: any) => w.state(selected).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('bg-background text-foreground shadow-xs')),
+      when: (w) => w.state(selected).eq(true),
+      intent: (i) => i.feedback.style.use(tw('bg-background text-foreground shadow-xs')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.state(selected).eq(false)),
-      intent: (i: any) => i.feedback.style.use(tw('bg-background/70 text-foreground shadow-xs')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.state(selected).eq(false)),
+      intent: (i) => i.feedback.style.use(tw('bg-background/70 text-foreground shadow-xs')),
     });
 
     def.rule({
-      when: (w: any) => w.state(pressed).eq(true),
-      intent: (i: any) =>
+      when: (w) => w.state(pressed).eq(true),
+      intent: (i) =>
         i.feedback.style.use(tw('scale-[0.99] bg-background text-foreground shadow-xs')),
     });
 
     def.rule({
-      when: (w: any) => w.state(disabled).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
+      when: (w) => w.state(disabled).eq(true),
+      intent: (i) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
     });
   },
 });

--- a/packages/prototypes/shadcn/src/toggle/index.ts
+++ b/packages/prototypes/shadcn/src/toggle/index.ts
@@ -57,37 +57,37 @@ const toggle = definePrototype<ShadcnToggleProps, ShadcnToggleExposes>({
     (Object.keys(VARIANT_TOKENS) as Array<NonNullable<ShadcnToggleProps['variant']>>).forEach(
       (variant) => {
         def.rule({
-          when: (w: any) => w.prop('variant').eq(variant),
-          intent: (i: any) => i.feedback.style.use(tw(VARIANT_TOKENS[variant])),
+          when: (w) => w.prop('variant').eq(variant),
+          intent: (i) => i.feedback.style.use(tw(VARIANT_TOKENS[variant])),
         });
       }
     );
 
     (Object.keys(SIZE_TOKENS) as Array<NonNullable<ShadcnToggleProps['size']>>).forEach((size) => {
       def.rule({
-        when: (w: any) => w.prop('size').eq(size),
-        intent: (i: any) => i.feedback.style.use(tw(SIZE_TOKENS[size])),
+        when: (w) => w.prop('size').eq(size),
+        intent: (i) => i.feedback.style.use(tw(SIZE_TOKENS[size])),
       });
     });
 
     def.rule({
-      when: (w: any) => w.state(checked).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted')),
+      when: (w) => w.state(checked).eq(true),
+      intent: (i) => i.feedback.style.use(tw('bg-muted')),
     });
 
     def.rule({
-      when: (w: any) => w.all(w.state(hovered).eq(true), w.state(checked).eq(false)),
-      intent: (i: any) => i.feedback.style.use(tw('bg-muted text-foreground')),
+      when: (w) => w.all(w.state(hovered).eq(true), w.state(checked).eq(false)),
+      intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
 
     def.rule({
-      when: (w: any) => w.state(focusVisible).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('border-ring ring-3 ring-ring/50')),
+      when: (w) => w.state(focusVisible).eq(true),
+      intent: (i) => i.feedback.style.use(tw('border-ring ring-3 ring-ring/50')),
     });
 
     def.rule({
-      when: (w: any) => w.state(disabled).eq(true),
-      intent: (i: any) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
+      when: (w) => w.state(disabled).eq(true),
+      intent: (i) => i.feedback.style.use(tw('pointer-events-none opacity-50')),
     });
   },
 });

--- a/packages/runtime/src/kernel/handles/def.ts
+++ b/packages/runtime/src/kernel/handles/def.ts
@@ -192,9 +192,9 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
       return fn;
     })(),
 
-    rule: (spec: RuleSpec<any>) => {
+    rule: (spec: RuleSpec<P>) => {
       ensureSetup('def.rule');
-      const handle = rules.rule(spec as any);
+      const handle = rules.rule(spec);
       recordCaptured(def, 'context', { op: 'rule', handle, off: () => handle.dispose() });
       return handle;
     },

--- a/packages/runtime/test/contract/as-hook.v0.contract.test.ts
+++ b/packages/runtime/test/contract/as-hook.v0.contract.test.ts
@@ -226,8 +226,8 @@ describe('runtime contract: asHook (v0)', () => {
         artifacts = res.artifacts;
 
         def.rule({
-          when: (w: any) => w.state(openHandle).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.state(openHandle).eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
 
         def.lifecycle.onCreated(() => {
@@ -362,8 +362,8 @@ describe('runtime contract: asHook (v0)', () => {
       name: 'asRule',
       setup(def) {
         def.rule({
-          when: (w: any) => w.t(),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.t(),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
       },
     });

--- a/packages/runtime/test/contract/feedback.style.runtime-patch.v0.contract.test.ts
+++ b/packages/runtime/test/contract/feedback.style.runtime-patch.v0.contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { EffectsPort, Prototype, StyleHandle } from '@proto.ui/core';
+import type { DefHandle, EffectsPort, Prototype, StyleHandle } from '@proto.ui/core';
 import { tw } from '@proto.ui/core';
 import { EFFECTS_CAP } from '@proto.ui/module-feedback';
 import { executeWithHost, type RuntimeHost } from '../../src';
@@ -9,7 +9,7 @@ describe('runtime: feedback.style runtime patch v0', () => {
     const styles: StyleHandle[] = [];
     const proto: Prototype = {
       name: 'feedback-style-runtime-patch-surface',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         def.feedback.style.use(tw('opacity-50 bg-blue-500'));
         def.lifecycle.onMounted((run: any) => {
           expect(typeof run.feedback.style.patch).toBe('function');
@@ -36,7 +36,7 @@ describe('runtime: feedback.style runtime patch v0', () => {
 
     const proto: Prototype = {
       name: 'feedback-style-runtime-patch-no-render',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         def.feedback.style.use(tw('opacity-50 bg-blue-500 text-white'));
         def.lifecycle.onMounted((run: any) => {
           run.feedback.style.patch(tw('opacity-100'));
@@ -68,11 +68,11 @@ describe('runtime: feedback.style runtime patch v0', () => {
 
     const proto: Prototype<{ active?: boolean }> = {
       name: 'feedback-style-runtime-patch-after-rule',
-      setup(def: any) {
+      setup(def: DefHandle<{ active?: boolean }>) {
         def.props.define({ active: { type: 'boolean', default: true } } as any);
         def.rule({
-          when: (w: any) => w.prop('active').eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50 bg-blue-500')),
+          when: (w) => w.prop('active').eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50 bg-blue-500')),
         });
         def.lifecycle.onMounted((run: any) => {
           run.feedback.style.patch(tw('opacity-100'));

--- a/packages/runtime/test/contract/rule.meta.v0.contract.test.ts
+++ b/packages/runtime/test/contract/rule.meta.v0.contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Prototype } from '@proto.ui/core';
+import type { DefHandle, Prototype } from '@proto.ui/core';
 import { tw } from '@proto.ui/core';
 import type { RuntimeHost } from '../../src';
 import { executeWithHost } from '../../src';
@@ -9,10 +9,10 @@ describe('runtime contract: rule meta (v0)', () => {
   it('evaluates when.meta using host-provided meta getter', () => {
     const proto: Prototype = {
       name: 'rule-meta-dark-contract',
-      setup(def: any) {
+      setup(def: DefHandle<any>) {
         def.rule({
-          when: (w: any) => w.meta('colorScheme').eq('dark'),
-          intent: (i: any) => i.feedback.style.use(tw('bg-zinc-950')),
+          when: (w) => w.meta('colorScheme').eq('dark'),
+          intent: (i) => i.feedback.style.use(tw('bg-zinc-950')),
         });
         return (r: any) => [r.el('div', {}, ['ok'])];
       },

--- a/packages/runtime/test/contract/rule.props-style.smoke.v0.contract.test.ts
+++ b/packages/runtime/test/contract/rule.props-style.smoke.v0.contract.test.ts
@@ -14,8 +14,8 @@ describe('rule contract smoke: props -> style (v0)', () => {
       setup(def) {
         def.props.define({ active: { type: 'boolean', default: false } } as any);
         def.rule({
-          when: (w: any) => w.prop('active').eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('text-red-500')),
+          when: (w) => w.prop('active').eq(true),
+          intent: (i) => i.feedback.style.use(tw('text-red-500')),
         });
         return (r) => [r.el('div', 'ok')];
       },
@@ -62,8 +62,8 @@ describe('rule contract smoke: props -> style (v0)', () => {
       setup(def) {
         def.props.define({ active: { type: 'boolean', default: true } } as any);
         handle = def.rule({
-          when: (w: any) => w.prop('active').eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.prop('active').eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
         return (r) => [r.el('div', 'ok')];
       },

--- a/packages/runtime/test/contract/state.semantic.v0.contract.test.ts
+++ b/packages/runtime/test/contract/state.semantic.v0.contract.test.ts
@@ -70,8 +70,8 @@ describe('runtime contract: state semantic accessors (v0)', () => {
         b = def.state.fromInteraction('disabled');
 
         def.rule({
-          when: (w: any) => w.state(a).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('opacity-50')),
+          when: (w) => w.state(a).eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
         });
 
         def.lifecycle.onCreated(() => {
@@ -101,8 +101,8 @@ describe('runtime contract: state semantic accessors (v0)', () => {
         b = def.state.fromAccessibility('expanded');
 
         def.rule({
-          when: (w: any) => w.state(a).eq(true),
-          intent: (i: any) => i.feedback.style.use(tw('bg-muted')),
+          when: (w) => w.state(a).eq(true),
+          intent: (i) => i.feedback.style.use(tw('bg-muted')),
         });
 
         def.lifecycle.onCreated(() => {

--- a/spec/tests/T-RULE-0001.yaml
+++ b/spec/tests/T-RULE-0001.yaml
@@ -18,6 +18,14 @@ cases:
       - C-RULE-0004-D
       - C-RULE-INTENT-0001-A
     expectation: analyzable-rule-spec-recorded
+  - id: T-RULE-0001-CASE-AUTHORING-TYPES
+    title: def.rule exposes typed WhenBuilder and IntentBuilder to prototype authors
+    covers:
+      - C-RULE-0004-C
+      - C-RULE-0004-D
+      - C-RULE-WHEN-0001-C
+      - C-RULE-INTENT-FEEDBACK-STYLE-0001-B
+    expectation: typed-rule-authoring-surface
   - id: T-RULE-0001-CASE-SERIALIZABLE-IR
     title: RuleIR contains serializable identities instead of functions, host objects, closures, or live handles
     covers:
@@ -52,6 +60,13 @@ implementations:
     consumesCases:
       - T-RULE-0001-CASE-SPEC-RECORDING
       - T-RULE-0001-CASE-SERIALIZABLE-IR
+  - id: rule-authoring-type-contract
+    kind: workspace-check
+    status: passing
+    path: internal/contracts/types/rule.contract.v0.type-test.ts
+    required: true
+    consumesCases:
+      - T-RULE-0001-CASE-AUTHORING-TYPES
 verifies:
   contracts:
     - id: C-RULE-0003
@@ -66,6 +81,12 @@ verifies:
         - C-RULE-0004-B
         - C-RULE-0004-C
         - C-RULE-0004-D
+    - id: C-RULE-WHEN-0001
+      anchors:
+        - C-RULE-WHEN-0001-C
+    - id: C-RULE-INTENT-FEEDBACK-STYLE-0001
+      anchors:
+        - C-RULE-INTENT-FEEDBACK-STYLE-0001-B
     - id: C-CORE-SYNTAX-0007
       anchors:
         - C-CORE-SYNTAX-0007-A
@@ -86,6 +107,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added rule declaration and serializable IR boundary test mapping.
+  - version: 0.1.0
+    change: updated
+    summary: Added the rule authoring type contract for typed WhenBuilder and IntentBuilder inference.
 tags:
   - rule
   - ir


### PR DESCRIPTION
## Summary

- Move the author-facing RuleSpec, WhenBuilder, IntentBuilder, and related rule authoring types into `@proto.ui/core` so `DefHandle.rule` is typed as `RuleSpec<Props>` instead of `any`.
- Reuse those shared types from `@proto.ui/module-rule` and remove now-unnecessary casts at the rule facade/def boundary.
- Remove `(w: any)` / `(i: any)` annotations from current prototype and contract-test rule call sites so rule usage relies on contextual builder inference.
- Add a type contract covering rule authoring inference for prop keys, comparable prop/state values, feedback style handles, and state intent values, and link it from `T-RULE-0001`.

## Why

Rule usage was painful because `def.rule` erased the RuleSpec shape at the core `DefHandle` boundary. That forced prototype authors to annotate `w` and `i` as `any`, losing API hints and allowing invalid prop keys, invalid equality literals, raw feedback style strings, and wrong state intent values to slip past TypeScript.

## Validation

- `corepack pnpm@10.32.1 -s test:types`
- `corepack pnpm@10.32.1 -s check:types:workspace`
- targeted rule/runtime/adapter/context tests
- `corepack pnpm@10.32.1 exec vitest run packages/spec/fixtures/test`
- `corepack pnpm@10.32.1 -s test`

Note: `gh auth status` on this machine still reports an invalid local GitHub CLI token, so PR creation used the GitHub connector after pushing with git.