### PR TITLE
[codex] Tighten privileged asHook definitions

### DIFF
--- a/apps/www/src/content/docs/en/specifications/as-hook.mdx
+++ b/apps/www/src/content/docs/en/specifications/as-hook.mdx
@@ -203,7 +203,8 @@ export const button = definePrototype({
   name: 'button',
   setup(def) {
     asTrigger();
-    asFocusable({ disabled: false });
+    const focusable = asFocusable();
+    focusable.configure({ disabled: false });
     const pressed = def.state.fromInteraction('pressed');
 
     return () => ({
@@ -237,6 +238,8 @@ asHook setup
 
 The asHook runtime only captures, attaches, and exposes results. Each module still owns its own dedupe, merge, conflict, diagnostic, and execution-order semantics. asHook does not create independent props/state/event/feedback/context/expose/rule runtime domains for itself.
 
+An asHook may depend on any sub-API on the `def` handle. Using `def.props`, `def.state`, `def.event`, `def.feedback`, `def.expose`, `def.context`, `def.rule`, `def.lifecycle`, or another setup API is normal asHook design, not over-coupling. The same phase rules apply as in prototypes: `def` declarations happen during setup, and callback APIs declared by the asHook may later receive `run` in the same way prototype-authored callbacks do.
+
 Current capture buckets are implementation details, not public semantics. Contracts describe which setup effects are captured, which artifacts/disposers/handles are exposed, and how those effects attach to the caller.
 
 ## AsHookResult
@@ -256,9 +259,11 @@ Contributions that cannot or need not be removed may expose only handles or arti
 
 ## State Projection
 
-State created or introduced inside an asHook should be projected to the caller as a borrowed view, not an owned view.
+Controllable state created or introduced inside an asHook should be projected to the caller as a borrowed view, not an owned view.
 
 The caller may read it, set defaults, set runtime values, and register watchers; however, the state source remains reusable logic introduced by the asHook rather than state directly declared and fully owned by the caller.
+
+System-maintained facts introduced by privileged asHooks may instead be exposed as observed state-backed handles. They should still carry standard state metadata so rule, expose, and diagnostics can consume them as state-shaped values.
 
 Interaction state follows the same boundary. If an asHook declares interaction state internally, that state must belong to the caller interaction subject rather than becoming asHook-private state.
 
@@ -282,6 +287,8 @@ Trace is not writable prototype-author state and is not a runtime behavior chann
 A privileged asHook is an official asHook form that exposes powerful, host-sensitive, or otherwise non-author-facing module-port capabilities to prototype authors through a restricted API.
 
 Typical areas include focus, overlay, hit participation, interaction boundary, and APIs such as `asTrigger` that need to move event targets or coordinate multiple modules.
+
+Privileged asHooks still share the normal asHook `def` syntax rights. They should express props, state, event, feedback, expose, context, rule, lifecycle, and other prototype-syntax behavior through `def` where possible. Non-public module ports, facades, or host capabilities should be reserved for the parts that ordinary prototype syntax cannot express.
 
 Each privileged asHook is its own API and must define:
 

--- a/apps/www/src/content/docs/zh-cn/specifications/as-hook.mdx
+++ b/apps/www/src/content/docs/zh-cn/specifications/as-hook.mdx
@@ -203,7 +203,8 @@ export const button = definePrototype({
   name: 'button',
   setup(def) {
     asTrigger();
-    asFocusable({ disabled: false });
+    const focusable = asFocusable();
+    focusable.configure({ disabled: false });
     const pressed = def.state.fromInteraction('pressed');
 
     return () => ({
@@ -237,6 +238,8 @@ asHook setup
 
 asHook runtime 只负责捕获、归属与暴露结果。每个模块内部的去重、合并、冲突、诊断和执行顺序仍由对应模块契约负责。asHook 不为自身创建独立的 props/state/event/feedback/context/expose/rule 运行域。
 
+asHook 可以依赖 `def` 句柄上的任意子 API。使用 `def.props`、`def.state`、`def.event`、`def.feedback`、`def.expose`、`def.context`、`def.rule`、`def.lifecycle` 或其他 setup API，是正常的 asHook 设计，不构成过度耦合。它与 prototype 遵守同一套 phase 规则：`def` 声明发生在 setup 期间；asHook 声明的 callback API 之后也可以像 prototype 自己声明的 callback 一样获得 `run`。
+
 当前实现中的 capture bucket 是实现细节，不是公开语义。契约只描述捕获了哪些 setup effects、暴露哪些 artifacts/disposers/handles，以及这些效果如何归属调用者。
 
 ## AsHookResult
@@ -256,9 +259,11 @@ disposer 的边界很重要：它用于让调用者在 setup 期间撤销 asHook
 
 ## State Projection
 
-asHook 内部创建或引入的 state 暴露给调用者时，应投影为 borrowed view，而不是 owned view。
+asHook 内部创建或引入的可控 state 暴露给调用者时，应投影为 borrowed view，而不是 owned view。
 
 这表示调用者可以读取、设置默认值、在 runtime 设置值，并注册 watcher；但这个 state 的来源仍然是 asHook 引入的可复用逻辑，不是调用者直接声明并完全拥有的 state。
+
+特权 asHook 引入的系统维护事实，也可以暴露为 observed 且 state-backed 的 handle。它们仍应携带标准 state metadata，使 rule、expose 与 diagnostics 能把它们当作 state-shaped value 消费。
 
 interaction state 也遵守这条边界。若 asHook 内部声明 interaction state，它必须归属调用者所在交互主体，而不是成为 asHook 私有 state。
 
@@ -282,6 +287,8 @@ trace 不是原型作者可写状态，也不是 runtime 行为通路。诊断�
 特权 asHook 是官方提供的 asHook 形态，用于把过于强力、过于依赖宿主，或不适合直接暴露给原型作者的 module port 能力，以受限 API 交给原型作者使用。
 
 典型方向包括 focus、overlay、hit participation、interaction boundary，以及 `asTrigger` 这类需要移动 event target 或协调多个模块的能力。
+
+特权 asHook 仍然共享普通 asHook 的 `def` 语法权利。props、state、event、feedback、expose、context、rule、lifecycle 等可以由原型语法表达的部分，应优先通过 `def` 表达。非公开 module port、facade 或 host capability 应保留给普通原型语法无法表达的部分。
 
 每个特权 asHook 都是独特 API，必须定义自己的：
 

--- a/internal/contracts/focus/as-focusable.v0.md
+++ b/internal/contracts/focus/as-focusable.v0.md
@@ -1,6 +1,6 @@
 # as-focusable.v0.md
 
-> This contract specifies Proto UI v0 `asFocusable(...)`.
+> This contract specifies Proto UI v0 `asFocusable()`.
 
 - Base text: `base-text/as-focusable.v0.md`
-- Key conclusion: `asFocusable(...)` is a privileged, configurable, singleton-install hook for focus nodes.
+- Key conclusion: `asFocusable()` is a privileged, no-arg, singleton-install hook for focus nodes; setup-time configuration goes through the returned handle.

--- a/internal/contracts/focus/base-text/as-focusable.v0.md
+++ b/internal/contracts/focus/base-text/as-focusable.v0.md
@@ -2,13 +2,13 @@
 
 > Status: Draft - v0
 >
-> This document defines the v0 contract for `asFocusable(...)`.
+> This document defines the v0 contract for `asFocusable()`.
 
 ---
 
 ## 0. Positioning
 
-`asFocusable(...)` declares that the current prototype instance participates as a **focus node**.
+`asFocusable()` declares that the current prototype instance participates as a **focus node**.
 
 It is responsible for:
 
@@ -27,25 +27,26 @@ It is **not** responsible for:
 
 ## 1. Invocation Model
 
-`asFocusable(...)` is a privileged, configurable, singleton-install asHook.
+`asFocusable()` is a privileged, no-arg, singleton-install asHook.
 
 - the first call installs the focusable capability
 - later calls must reuse the same underlying handle
-- repeated calls may contribute setup-time configuration patches
+- setup-time configuration must go through the returned handle
 - repeated calls must not reinstall the focusable capability
 
 ---
 
-## 2. Initial Parameters
+## 2. Setup-Time Configuration
 
-Initial parameters should be optional by default.
+`asFocusable()` accepts no initialization parameter.
 
 v0 intent:
 
-- `asFocusable()` with no arguments should be valid
-- fields that can be configured later in setup should not be init-required
+- `asFocusable()` with no arguments declares default focusable participation
+- fields that need refinement must be configured through `handle.configure(...)`
+- privileged asHook caller shape must not reintroduce parameter patches
 
-Possible late-configurable fields include:
+Setup-configurable fields include:
 
 - `scopeKey`
 - `autoFocus`
@@ -53,7 +54,7 @@ Possible late-configurable fields include:
 - `navParticipation`
 - `meta`
 
-Any field that must be init-required in the future must be explicitly justified by structure or safety constraints.
+Any field that must become init-required in the future must be represented by a distinct privileged asHook contract, not by adding parameters back to `asFocusable()`.
 
 ---
 
@@ -74,11 +75,11 @@ If no `scopeKey` is provided:
 
 ## 4. Return Handle
 
-`asFocusable(...)` should return a `FocusableHandle`-like object.
+`asFocusable()` should return a `FocusableHandle`-like object.
 
 Its v0 surface should minimally allow:
 
-- reading focus facts
+- reading state-backed focus facts
 - issuing focus requests
 - setup-only configuration refinement
 
@@ -100,35 +101,39 @@ type FocusableHandle = {
 
 `configure(...)` must be setup-only.
 
+The focus fact handles returned by `asFocusable()` must be standard state-shaped handles backed by the State module metadata. They are observed, not author-owned: callers may read and watch them, and rule/expose systems may consume them as state handles, but prototype authors must not receive direct write authority for these facts.
+
 ---
 
 ## 5. Repeated Configuration
 
-When `asFocusable(...)` is called multiple times in setup:
+When `asFocusable()` is called multiple times in setup:
 
 - installation must remain singleton-like
-- setup-time configuration may be merged deterministically
+- setup-time configuration through the returned handle may be merged deterministically
 - later compatible fields may override earlier compatible fields
 - unsafe conflicts must throw, or at minimum emit a clear warning
 
-v0 should prefer explicit configuration merge over repeated side-effectful installation.
+v0 should prefer explicit returned-handle configuration over repeated side-effectful installation.
 
 ---
 
 ## 6. Projection Boundary
 
-`asFocusable(...)` may project to:
+`asFocusable()` may expose or project to:
 
-- interaction-derived state such as `focused`
+- focus-owned state such as `focused` and `focusVisible`
 - outward expose methods such as `focus()`
 
 But the hook itself is the primary authoring boundary for focus-node semantics.
+
+Compatibility projections to legacy interaction state slots may exist during migration, but `state-interaction` is not the owner of focus facts.
 
 ---
 
 ## 7. Non-Goals
 
-v0 does not require `asFocusable(...)` to expose:
+v0 does not require `asFocusable()` to expose:
 
 - arbitrary member lookup
 - next/prev navigation

--- a/internal/contracts/state/interaction/base-text/interaction-signals.v0.md
+++ b/internal/contracts/state/interaction/base-text/interaction-signals.v0.md
@@ -53,11 +53,11 @@ interaction signal **不是**：
 
 v0 必须至少提供以下 interaction signals：
 
-### 2.1 `focused: boolean`
+### 2.1 `hovered: boolean`
 
 #### 语义
 
-表示组件当前是否处于“获得焦点”的状态。
+表示组件当前是否处于 hover 交互中。
 
 #### 默认值
 
@@ -65,17 +65,18 @@ v0 必须至少提供以下 interaction signals：
 
 #### 进入条件（示意）
 
-- 宿主交互表明组件获得焦点
+- 宿主交互表明指针 hover 到组件上
 
 #### 退出条件（示意）
 
-- 宿主交互表明组件失去焦点
+- 指针离开组件
+- 指针交互被取消
 
 #### 一致性要求（v0）
 
-- 在组件 unmount / dispose 后，`focused` **不得**保持为 `true`
+- 在组件 unmount / dispose 后，`hovered` **不得**保持为 `true`
 
-> 注：v0 不规定“focus”是 root-focus 还是 focus-within，只要求语义内部一致，由 adapter 决定具体策略。
+> 注：`focused` 与 `focusVisible` 这类 focus-owned facts 归属 focus 特权 asHook 领域，不再由 state-interaction 拥有。
 
 ---
 

--- a/internal/contracts/state/interaction/interaction-signals.v0.md
+++ b/internal/contracts/state/interaction/interaction-signals.v0.md
@@ -53,11 +53,11 @@ Each interaction signal has the following properties:
 
 v0 MUST provide at least the following interaction signals:
 
-### 2.1 `focused: boolean`
+### 2.1 `hovered: boolean`
 
 #### Semantics
 
-Indicates whether the component is currently in a “focused” state.
+Indicates whether the component is currently in a hover interaction.
 
 #### Default
 
@@ -65,17 +65,18 @@ Indicates whether the component is currently in a “focused” state.
 
 #### Enter conditions (illustrative)
 
-- Host interaction indicates that the component gains focus
+- Host interaction indicates pointer hover over the component
 
 #### Exit conditions (illustrative)
 
-- Host interaction indicates that the component loses focus
+- Pointer leaves the component
+- Pointer interaction is cancelled
 
 #### Consistency requirement (v0)
 
-- After unmount / dispose, `focused` MUST NOT remain `true`
+- After unmount / dispose, `hovered` MUST NOT remain `true`
 
-> Note: v0 does not mandate whether focus semantics are root-focus or focus-within. Adapters are free to choose a consistent policy.
+> Note: focus-owned facts such as `focused` and `focusVisible` are governed by the focus privileged asHook domain, not by state-interaction.
 
 ---
 

--- a/internal/records/2026-06-26-core-compaction-fracture-inventory.zh-CN.md
+++ b/internal/records/2026-06-26-core-compaction-fracture-inventory.zh-CN.md
@@ -611,7 +611,7 @@ Decision 潜力：
 
 当前事实：
 
-- `asButton` 调用 `asFocusable({ disabled: false })`。
+- 当时 `asButton` 使用带 patch 参数的 `asFocusable` 调用；2026-06-27 已迁移为 `asFocusable()` 加返回 handle 配置。
 - button 的 exposed states 包含 `focused` 与 `focusVisible`。
 - `focusSelf` expose method 依赖 focus handle。
 - focus tests 已覆盖 disabled focusable rejects focus requests。

--- a/internal/records/2026-06-27-as-hook-privileged-no-arg-migration-fracture.zh-CN.md
+++ b/internal/records/2026-06-27-as-hook-privileged-no-arg-migration-fracture.zh-CN.md
@@ -24,7 +24,8 @@ Date: 2026-06-27
 - `asTrigger()` 已经是无参数 privileged asHook。
 - `defineAsHook(...)` authored caller 已经是无参数 caller。
 - 基于 prototype spec 声明的 authored asHook 通常天然无参数。
-- `asFocusable(patch)`、`asOverlay(patch)`、`asFocusScope(patch)`、`asFocusGroup(patch)`、`asBoundary(patch)`、`asHitParticipation(...)`、`asTransition(options)` 仍带参数化或 configurable 行为。
+- `asFocusable()` 已迁移为无参数 caller；setup-time 配置通过返回的 `FocusableHandle.configure(...)` 完成。
+- `asOverlay(patch)`、`asFocusScope(patch)`、`asFocusGroup(patch)`、`asBoundary(patch)`、`asHitParticipation(...)`、`asTransition(options)` 仍带参数化或 configurable 行为。
 - `useCollection(options)` / `useCollectionItem(options)` 当前通过 `defineHook` 实现，但它们仍消费 anatomy ports，不能简单归入普通作者函数。
 
 ## Progress
@@ -33,6 +34,8 @@ Date: 2026-06-27
 - Done: ordinary authored asHook repeat semantics are first-call-wins with result reuse.
 - Done: use-style helpers have been renamed away from `asXxx` to reduce caller-shape ambiguity.
 - Recorded: privileged no-arg migration direction now has spec entity `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001`.
+- Done: `asFocusable` caller shape migrated to no-arg; focusable configuration now goes through the returned handle.
+- Done: focus-owned `focused` / `focusVisible` facts moved out of state-interaction runtime wiring ownership, returned as state-backed observed handles, and recorded by `D-FOCUS-STATE-INTERACTION-BOUNDARY-0001`.
 - Open: parameterized privileged hooks still need API-by-API migration plans.
 - Open: `useCollection` / `useCollectionItem` need a final classification.
 - Open: returned configuration APIs need concrete contracts and tests before replacing existing patch/options parameters.

--- a/packages/hooks/src/as-boundary.ts
+++ b/packages/hooks/src/as-boundary.ts
@@ -1,17 +1,26 @@
 import type { BoundaryConfigPatch, BoundaryHandle } from '@proto.ui/core';
-import { getActiveAsHookContext } from '@proto.ui/core/internal';
+import type { PropsBaseType } from '@proto.ui/types';
+import { definePrivilegedAsHook } from './privileged';
 
-export function asBoundary(patch?: BoundaryConfigPatch): BoundaryHandle<any> {
-  const { rt, facades } = getActiveAsHookContext('asBoundary');
-  rt.ensureSetup('asHook(asBoundary)');
-  rt.register('asBoundary', { privileged: true, mode: 'configurable' });
+type BoundaryFacade = {
+  getBoundary<P extends PropsBaseType = PropsBaseType>(): BoundaryHandle<P>;
+};
 
-  const facade = facades.boundary as { getBoundary: () => BoundaryHandle<any> } | undefined;
-  if (!facade || typeof facade.getBoundary !== 'function') {
-    throw new Error('[AsHook] boundary facade unavailable for asBoundary.');
-  }
+const getBoundary = definePrivilegedAsHook<PropsBaseType, BoundaryHandle<PropsBaseType>>({
+  name: 'asBoundary',
+  setup: ({ facades }) => {
+    const facade = facades.boundary as BoundaryFacade | undefined;
+    if (!facade || typeof facade.getBoundary !== 'function') {
+      throw new Error('[AsHook] boundary facade unavailable for asBoundary.');
+    }
+    return facade.getBoundary();
+  },
+});
 
-  const handle = facade.getBoundary();
+export function asBoundary<P extends PropsBaseType = PropsBaseType>(
+  patch?: BoundaryConfigPatch
+): BoundaryHandle<P> {
+  const handle = getBoundary() as BoundaryHandle<P>;
   if (patch) handle.configure(patch);
   return handle;
 }

--- a/packages/hooks/src/as-focus-group.ts
+++ b/packages/hooks/src/as-focus-group.ts
@@ -1,17 +1,26 @@
 import type { FocusGroupConfigPatch, FocusGroupHandle } from '@proto.ui/core';
-import { getActiveAsHookContext } from '@proto.ui/core/internal';
+import type { PropsBaseType } from '@proto.ui/types';
+import { definePrivilegedAsHook } from './privileged';
 
-export function asFocusGroup(patch?: FocusGroupConfigPatch): FocusGroupHandle<any> {
-  const { rt, facades } = getActiveAsHookContext('asFocusGroup');
-  rt.ensureSetup(`asHook(asFocusGroup)`);
-  rt.register('asFocusGroup', { privileged: true, mode: 'configurable' });
+type FocusGroupFacade = {
+  getGroup<P extends PropsBaseType = PropsBaseType>(): FocusGroupHandle<P>;
+};
 
-  const facade = facades.focus as { getGroup: () => FocusGroupHandle<any> } | undefined;
-  if (!facade || typeof facade.getGroup !== 'function') {
-    throw new Error(`[AsHook] focus facade unavailable for asFocusGroup.`);
-  }
+const getFocusGroup = definePrivilegedAsHook<PropsBaseType, FocusGroupHandle<PropsBaseType>>({
+  name: 'asFocusGroup',
+  setup: ({ facades }) => {
+    const facade = facades.focus as FocusGroupFacade | undefined;
+    if (!facade || typeof facade.getGroup !== 'function') {
+      throw new Error(`[AsHook] focus facade unavailable for asFocusGroup.`);
+    }
+    return facade.getGroup();
+  },
+});
 
-  const handle = facade.getGroup();
+export function asFocusGroup<P extends PropsBaseType = PropsBaseType>(
+  patch?: FocusGroupConfigPatch
+): FocusGroupHandle<P> {
+  const handle = getFocusGroup() as FocusGroupHandle<P>;
   if (patch) handle.configure(patch);
   return handle;
 }

--- a/packages/hooks/src/as-focus-scope.ts
+++ b/packages/hooks/src/as-focus-scope.ts
@@ -1,17 +1,26 @@
 import type { FocusScopeConfigPatch, FocusScopeHandle } from '@proto.ui/core';
-import { getActiveAsHookContext } from '@proto.ui/core/internal';
+import type { PropsBaseType } from '@proto.ui/types';
+import { definePrivilegedAsHook } from './privileged';
 
-export function asFocusScope(patch?: FocusScopeConfigPatch): FocusScopeHandle<any> {
-  const { rt, facades } = getActiveAsHookContext('asFocusScope');
-  rt.ensureSetup(`asHook(asFocusScope)`);
-  rt.register('asFocusScope', { privileged: true, mode: 'configurable' });
+type FocusScopeFacade = {
+  getScope<P extends PropsBaseType = PropsBaseType>(): FocusScopeHandle<P>;
+};
 
-  const facade = facades.focus as { getScope: () => FocusScopeHandle<any> } | undefined;
-  if (!facade || typeof facade.getScope !== 'function') {
-    throw new Error(`[AsHook] focus facade unavailable for asFocusScope.`);
-  }
+const getFocusScope = definePrivilegedAsHook<PropsBaseType, FocusScopeHandle<PropsBaseType>>({
+  name: 'asFocusScope',
+  setup: ({ facades }) => {
+    const facade = facades.focus as FocusScopeFacade | undefined;
+    if (!facade || typeof facade.getScope !== 'function') {
+      throw new Error(`[AsHook] focus facade unavailable for asFocusScope.`);
+    }
+    return facade.getScope();
+  },
+});
 
-  const handle = facade.getScope();
+export function asFocusScope<P extends PropsBaseType = PropsBaseType>(
+  patch?: FocusScopeConfigPatch
+): FocusScopeHandle<P> {
+  const handle = getFocusScope() as FocusScopeHandle<P>;
   if (patch) handle.configure(patch);
   return handle;
 }

--- a/packages/hooks/src/as-focusable.ts
+++ b/packages/hooks/src/as-focusable.ts
@@ -1,7 +1,7 @@
-import type { FocusableConfigPatch, FocusableHandle } from '@proto.ui/core';
+import type { FocusableHandle } from '@proto.ui/core';
 import { getActiveAsHookContext } from '@proto.ui/core/internal';
 
-export function asFocusable(patch?: FocusableConfigPatch): FocusableHandle<any> {
+export function asFocusable(): FocusableHandle<any> {
   const { rt, facades } = getActiveAsHookContext('asFocusable');
   rt.ensureSetup(`asHook(asFocusable)`);
   rt.register('asFocusable', { privileged: true, mode: 'configurable' });
@@ -12,6 +12,5 @@ export function asFocusable(patch?: FocusableConfigPatch): FocusableHandle<any> 
   }
 
   const handle = facade.getFocusable();
-  if (patch) handle.configure(patch);
   return handle;
 }

--- a/packages/hooks/src/as-focusable.ts
+++ b/packages/hooks/src/as-focusable.ts
@@ -1,16 +1,22 @@
 import type { FocusableHandle } from '@proto.ui/core';
-import { getActiveAsHookContext } from '@proto.ui/core/internal';
+import type { PropsBaseType } from '@proto.ui/types';
+import { definePrivilegedAsHook } from './privileged';
 
-export function asFocusable(): FocusableHandle<any> {
-  const { rt, facades } = getActiveAsHookContext('asFocusable');
-  rt.ensureSetup(`asHook(asFocusable)`);
-  rt.register('asFocusable', { privileged: true, mode: 'configurable' });
+type FocusableFacade = {
+  getFocusable<P extends PropsBaseType = PropsBaseType>(): FocusableHandle<P>;
+};
 
-  const facade = facades.focus as { getFocusable: () => FocusableHandle<any> } | undefined;
-  if (!facade || typeof facade.getFocusable !== 'function') {
-    throw new Error(`[AsHook] focus facade unavailable for asFocusable.`);
-  }
+const getFocusable = definePrivilegedAsHook<PropsBaseType, FocusableHandle<PropsBaseType>>({
+  name: 'asFocusable',
+  setup: ({ facades }) => {
+    const facade = facades.focus as FocusableFacade | undefined;
+    if (!facade || typeof facade.getFocusable !== 'function') {
+      throw new Error(`[AsHook] focus facade unavailable for asFocusable.`);
+    }
+    return facade.getFocusable();
+  },
+});
 
-  const handle = facade.getFocusable();
-  return handle;
+export function asFocusable<P extends PropsBaseType = PropsBaseType>(): FocusableHandle<P> {
+  return getFocusable() as FocusableHandle<P>;
 }

--- a/packages/hooks/src/as-hit-participation.ts
+++ b/packages/hooks/src/as-hit-participation.ts
@@ -1,21 +1,29 @@
 import type { HitParticipationConfigPatch, HitParticipationHandle } from '@proto.ui/core';
-import { getActiveAsHookContext } from '@proto.ui/core/internal';
+import type { PropsBaseType } from '@proto.ui/types';
+import { definePrivilegedAsHook } from './privileged';
 
-export function asHitParticipation(
+type HitParticipationFacade = {
+  getHitParticipation<P extends PropsBaseType = PropsBaseType>(): HitParticipationHandle<P>;
+};
+
+const getHitParticipation = definePrivilegedAsHook<
+  PropsBaseType,
+  HitParticipationHandle<PropsBaseType>
+>({
+  name: 'asHitParticipation',
+  setup: ({ facades }) => {
+    const facade = facades['hit-participation'] as HitParticipationFacade | undefined;
+    if (!facade || typeof facade.getHitParticipation !== 'function') {
+      throw new Error('[AsHook] hit-participation facade unavailable for asHitParticipation.');
+    }
+    return facade.getHitParticipation();
+  },
+});
+
+export function asHitParticipation<P extends PropsBaseType = PropsBaseType>(
   patch?: HitParticipationConfigPatch
-): HitParticipationHandle<any> {
-  const { rt, facades } = getActiveAsHookContext('asHitParticipation');
-  rt.ensureSetup('asHook(asHitParticipation)');
-  rt.register('asHitParticipation', { privileged: true, mode: 'configurable' });
-
-  const facade = facades['hit-participation'] as
-    | { getHitParticipation: () => HitParticipationHandle<any> }
-    | undefined;
-  if (!facade || typeof facade.getHitParticipation !== 'function') {
-    throw new Error('[AsHook] hit-participation facade unavailable for asHitParticipation.');
-  }
-
-  const handle = facade.getHitParticipation();
+): HitParticipationHandle<P> {
+  const handle = getHitParticipation() as HitParticipationHandle<P>;
   if (patch) handle.configure(patch);
   return handle;
 }

--- a/packages/hooks/src/as-overlay.ts
+++ b/packages/hooks/src/as-overlay.ts
@@ -1,17 +1,26 @@
 import type { OverlayConfigPatch, OverlayHandle } from '@proto.ui/core';
-import { getActiveAsHookContext } from '@proto.ui/core/internal';
+import type { PropsBaseType } from '@proto.ui/types';
+import { definePrivilegedAsHook } from './privileged';
 
-export function asOverlay(patch?: OverlayConfigPatch): OverlayHandle<any> {
-  const { rt, facades } = getActiveAsHookContext('asOverlay');
-  rt.ensureSetup(`asHook(asOverlay)`);
-  rt.register('asOverlay', { privileged: true, mode: 'configurable' });
+type OverlayFacade = {
+  getOverlay<P extends PropsBaseType = PropsBaseType>(): OverlayHandle<P>;
+};
 
-  const facade = facades.overlay as { getOverlay: () => OverlayHandle<any> } | undefined;
-  if (!facade || typeof facade.getOverlay !== 'function') {
-    throw new Error(`[AsHook] overlay facade unavailable for asOverlay.`);
-  }
+const getOverlay = definePrivilegedAsHook<PropsBaseType, OverlayHandle<PropsBaseType>>({
+  name: 'asOverlay',
+  setup: ({ facades }) => {
+    const facade = facades.overlay as OverlayFacade | undefined;
+    if (!facade || typeof facade.getOverlay !== 'function') {
+      throw new Error(`[AsHook] overlay facade unavailable for asOverlay.`);
+    }
+    return facade.getOverlay();
+  },
+});
 
-  const handle = facade.getOverlay();
+export function asOverlay<P extends PropsBaseType = PropsBaseType>(
+  patch?: OverlayConfigPatch
+): OverlayHandle<P> {
+  const handle = getOverlay() as OverlayHandle<P>;
   if (patch) handle.configure(patch);
   return handle;
 }

--- a/packages/hooks/src/as-trigger.ts
+++ b/packages/hooks/src/as-trigger.ts
@@ -1,15 +1,17 @@
-import { getActiveAsHookContext } from '@proto.ui/core/internal';
+import type { PropsBaseType } from '@proto.ui/types';
+import { definePrivilegedAsHook } from './privileged';
 
-export function asTrigger(): void {
-  const { rt, facades } = getActiveAsHookContext('asTrigger');
-  rt.ensureSetup(`asHook(asTrigger)`);
-  const reg = rt.register('asTrigger', { privileged: true, mode: 'once' });
-  if (reg.action !== 'setup') return;
+type AsTriggerFacade = {
+  apply(): void;
+};
 
-  const facade = facades['as-trigger'] as { apply: () => void } | undefined;
-  if (!facade || typeof facade.apply !== 'function') {
-    throw new Error(`[AsHook] asTrigger facade unavailable.`);
-  }
-
-  facade.apply();
-}
+export const asTrigger = definePrivilegedAsHook<PropsBaseType, void>({
+  name: 'asTrigger',
+  setup: ({ facades }) => {
+    const facade = facades['as-trigger'] as AsTriggerFacade | undefined;
+    if (!facade || typeof facade.apply !== 'function') {
+      throw new Error(`[AsHook] asTrigger facade unavailable.`);
+    }
+    facade.apply();
+  },
+});

--- a/packages/hooks/src/privileged.ts
+++ b/packages/hooks/src/privileged.ts
@@ -1,0 +1,50 @@
+import type { AsHookMode, AsHookRuntime, DefHandle } from '@proto.ui/core';
+import { getActiveAsHookContext } from '@proto.ui/core/internal';
+import type { PropsBaseType } from '@proto.ui/types';
+
+type PrivilegedAsHookRegistration = ReturnType<AsHookRuntime['register']>;
+
+export type PrivilegedAsHookContext<P extends PropsBaseType = PropsBaseType> = Readonly<{
+  def: DefHandle<P, Record<string, unknown>>;
+  rt: AsHookRuntime;
+  facades: Record<string, unknown>;
+  ports: Record<string, unknown>;
+  registration: PrivilegedAsHookRegistration;
+}>;
+
+export type PrivilegedAsHookDefinition<P extends PropsBaseType, Result> = Readonly<{
+  name: string;
+  mode?: AsHookMode;
+  setup: (ctx: PrivilegedAsHookContext<P>) => Result;
+  reuse?: (ctx: PrivilegedAsHookContext<P>) => Result;
+}>;
+
+export function definePrivilegedAsHook<P extends PropsBaseType, Result>(
+  definition: PrivilegedAsHookDefinition<P, Result>
+): () => Result {
+  return () => {
+    const active = getActiveAsHookContext(definition.name);
+    active.rt.ensureSetup(`asHook(${definition.name})`);
+
+    const registration = active.rt.register(definition.name, {
+      privileged: true,
+      mode: definition.mode ?? 'once',
+    });
+    const ctx: PrivilegedAsHookContext<P> = {
+      def: active.def as DefHandle<P, Record<string, unknown>>,
+      rt: active.rt,
+      facades: active.facades,
+      ports: active.ports,
+      registration,
+    };
+
+    if (registration.action === 'skip') {
+      if (definition.reuse) return definition.reuse(ctx);
+      return registration.state.result as Result;
+    }
+
+    const result = definition.setup(ctx);
+    registration.state.result = result as any;
+    return result;
+  };
+}

--- a/packages/modules/expose-state-web/src/utils.ts
+++ b/packages/modules/expose-state-web/src/utils.ts
@@ -7,8 +7,10 @@ function mapOfficialSemanticName(semantic: string): string | null {
     case '@interaction/pressed':
       return 'pressed';
     case '@interaction/focused':
+    case '@focus/focused':
       return 'focused';
     case '@interaction/focusVisible':
+    case '@focus/focusVisible':
       return 'focus-visible';
     case '@accessibility/expanded':
       return 'expanded';
@@ -63,6 +65,8 @@ export function createExposeStateWebNativeVariantPolicy({ semantic }: { semantic
     case '@interaction/disabled':
     case '@interaction/focused':
     case '@interaction/focusVisible':
+    case '@focus/focused':
+    case '@focus/focusVisible':
       return false;
     default:
       return true;

--- a/packages/modules/focus/src/create.ts
+++ b/packages/modules/focus/src/create.ts
@@ -10,6 +10,7 @@ import {
   FocusScopeConfigPatch,
   FocusScopeHandle,
   FocusScopeKey,
+  type OwnedStateHandle,
   type FocusableConfig,
   FocusableConfigPatch,
   FocusableHandle,
@@ -19,7 +20,8 @@ import { createModule, defineModule, ModuleBase } from '@proto.ui/module-base';
 import type { ModuleFactoryArgs } from '@proto.ui/module-base';
 import type { PropsBaseType } from '@proto.ui/types';
 import type { FocusFacade, FocusModule, FocusPort } from './types';
-import type { StateEvent } from '@proto.ui/types';
+import type { EventPort } from '@proto.ui/module-event';
+import type { StateFacade, StatePort } from '@proto.ui/module-state';
 import {
   FOCUS_BLUR_CAP,
   FOCUS_INSTANCE_TOKEN_CAP,
@@ -55,34 +57,6 @@ const DEFAULT_GROUP_CONFIG: FocusGroupConfig = Object.freeze({
   selectOnFocus: false,
 });
 
-function createObservedBoolHandle(initialValue = false) {
-  let value = initialValue;
-  const watchers = new Set<(run: any, e: StateEvent<boolean>) => void>();
-
-  const handle: ObservedStateHandle<boolean, any> = {
-    get: () => value,
-    watch: (cb) => {
-      watchers.add(cb as any);
-      return () => {
-        watchers.delete(cb as any);
-      };
-    },
-  };
-
-  return {
-    handle: Object.freeze(handle),
-    set(next: boolean, reason?: unknown) {
-      if (Object.is(next, value)) return;
-      const prev = value;
-      value = next;
-      const event: StateEvent<boolean> = { type: 'next', next, prev, reason };
-      for (const watcher of watchers) {
-        watcher(undefined as any, event);
-      }
-    },
-  };
-}
-
 function mergeMeta(
   prev: Readonly<Record<string, unknown>> | undefined,
   next: Readonly<Record<string, unknown>> | undefined
@@ -113,16 +87,82 @@ class FocusModuleImpl extends ModuleBase {
   private readonly prototypeName: string;
   private readonly warnings: string[] = [];
   private didAutoFocus = false;
+  private keyboardModality = false;
+  private hostEventsWired = false;
 
-  private readonly focusedState = createObservedBoolHandle(false);
-  private readonly focusVisibleState = createObservedBoolHandle(false);
-  private readonly focusableState = createObservedBoolHandle(false);
-  private readonly activeState = createObservedBoolHandle(false);
-  private readonly hasFocusedState = createObservedBoolHandle(false);
+  private readonly focusedOwned: OwnedStateHandle<boolean>;
+  private readonly focusVisibleOwned: OwnedStateHandle<boolean>;
+  private readonly focusableOwned: OwnedStateHandle<boolean>;
+  private readonly activeOwned: OwnedStateHandle<boolean>;
+  private readonly hasFocusedOwned: OwnedStateHandle<boolean>;
 
-  constructor(caps: ModuleFactoryArgs['caps'], prototypeName: string) {
+  private readonly focusedState: ObservedStateHandle<boolean, any>;
+  private readonly focusVisibleState: ObservedStateHandle<boolean, any>;
+  private readonly focusableState: ObservedStateHandle<boolean, any>;
+  private readonly activeState: ObservedStateHandle<boolean, any>;
+  private readonly hasFocusedState: ObservedStateHandle<boolean, any>;
+
+  private readonly focusableHandle: FocusableHandle<any>;
+  private readonly scopeHandle: FocusScopeHandle<any>;
+  private readonly groupHandle: FocusGroupHandle<any>;
+
+  constructor(
+    caps: ModuleFactoryArgs['caps'],
+    prototypeName: string,
+    private readonly eventPort: EventPort,
+    private readonly statePort: StatePort,
+    stateFacade: StateFacade
+  ) {
     super(caps);
     this.prototypeName = prototypeName;
+
+    this.focusedOwned = stateFacade.bool('@focus/focused', false);
+    this.focusVisibleOwned = stateFacade.bool('@focus/focusVisible', false);
+    this.focusableOwned = stateFacade.bool('@focus/focusable', false);
+    this.activeOwned = stateFacade.bool('@focus/active', false);
+    this.hasFocusedOwned = stateFacade.bool('@focus/hasFocused', false);
+
+    this.focusedState = statePort.createObservedHandle(this.focusedOwned) as any;
+    this.focusVisibleState = statePort.createObservedHandle(this.focusVisibleOwned) as any;
+    this.focusableState = statePort.createObservedHandle(this.focusableOwned) as any;
+    this.activeState = statePort.createObservedHandle(this.activeOwned) as any;
+    this.hasFocusedState = statePort.createObservedHandle(this.hasFocusedOwned) as any;
+
+    this.focusableHandle = {
+      focused: this.focusedState,
+      focusVisible: this.focusVisibleState,
+      focusable: this.focusableState,
+      focus: (options?: FocusRequestOptions) => this.requestFocus(options),
+      focusSelf: (options?: FocusRequestOptions) => this.requestNativeFocus(options),
+      blur: () => this.blur(),
+      isFocused: () => this.focusedState.get(),
+      setDisabled: (disabled: boolean) => this.setDisabled(disabled),
+      configure: (patch: FocusableConfigPatch) => this.configureFocusable(patch),
+    };
+
+    this.scopeHandle = {
+      active: this.activeState,
+      hasFocused: this.hasFocusedState,
+      focusFirst: () => this.focusFirst(),
+      focusLast: () => this.focusLast(),
+      focusNext: () => this.focusNext(),
+      focusPrev: () => this.focusPrev(),
+      focusSelected: () => this.focusSelected(),
+      restoreFocus: () => this.restoreFocus(),
+      configure: (patch: FocusScopeConfigPatch) => this.configureScope(patch),
+      getGroup: () => this.groupHandle,
+    };
+
+    this.groupHandle = {
+      active: this.activeState,
+      hasFocused: this.hasFocusedState,
+      focusFirst: () => this.focusFirst(),
+      focusLast: () => this.focusLast(),
+      focusNext: () => this.focusNext(),
+      focusPrev: () => this.focusPrev(),
+      focusSelected: () => this.focusSelected(),
+      configure: (patch: FocusGroupConfigPatch) => this.configureGroup(patch),
+    };
   }
 
   private ensureSetup(op: string) {
@@ -139,6 +179,24 @@ class FocusModuleImpl extends ModuleBase {
     if (!this.caps.has(FOCUS_ROOT_TARGET_CAP)) return null;
     const getter = this.caps.get(FOCUS_ROOT_TARGET_CAP);
     return getter?.() ?? null;
+  }
+
+  private getCallbackCtx(): unknown {
+    return this.sys?.getCallbackCtx?.() ?? undefined;
+  }
+
+  private setFocusState(
+    handle: OwnedStateHandle<boolean>,
+    next: boolean,
+    reason?: unknown,
+    options?: { defaultOnly?: boolean }
+  ): void {
+    if (Object.is(handle.get(), next)) return;
+    if (options?.defaultOnly) {
+      this.statePort.setDefault(handle, next);
+      return;
+    }
+    this.statePort.set(handle, next, reason, this.getCallbackCtx());
   }
 
   private getSelfToken() {
@@ -184,43 +242,53 @@ class FocusModuleImpl extends ModuleBase {
     }
   }
 
-  private readonly focusableHandle: FocusableHandle<any> = {
-    focused: this.focusedState.handle,
-    focusVisible: this.focusVisibleState.handle,
-    focusable: this.focusableState.handle,
-    focus: (options?: FocusRequestOptions) => this.requestFocus(options),
-    focusSelf: (options?: FocusRequestOptions) => this.requestNativeFocus(options),
-    blur: () => this.blur(),
-    isFocused: () => this.focusedState.handle.get(),
-    setDisabled: (disabled: boolean) => this.setDisabled(disabled),
-    configure: (patch: FocusableConfigPatch) => this.configureFocusable(patch),
-  };
+  private declareFocusable(): void {
+    if (!this.focusableDeclared) {
+      this.focusableDeclared = true;
+      this.setFocusState(this.focusableOwned, !this.focusableConfig.disabled, 'focus declared', {
+        defaultOnly: true,
+      });
+    }
+    this.wireHostFocusEvents();
+    this.syncHostFocusable();
+    this.syncCenter();
+  }
 
-  private readonly scopeHandle: FocusScopeHandle<any> = {
-    active: this.activeState.handle,
-    hasFocused: this.hasFocusedState.handle,
-    focusFirst: () => this.focusFirst(),
-    focusLast: () => this.focusLast(),
-    focusNext: () => this.focusNext(),
-    focusPrev: () => this.focusPrev(),
-    focusSelected: () => this.focusSelected(),
-    restoreFocus: () => this.restoreFocus(),
-    configure: (patch: FocusScopeConfigPatch) => this.configureScope(patch),
-    getGroup: () => this.groupHandle,
-  };
+  private wireHostFocusEvents(): void {
+    if (this.hostEventsWired) return;
+    this.hostEventsWired = true;
 
-  private readonly groupHandle: FocusGroupHandle<any> = {
-    active: this.activeState.handle,
-    hasFocused: this.hasFocusedState.handle,
-    focusFirst: () => this.focusFirst(),
-    focusLast: () => this.focusLast(),
-    focusNext: () => this.focusNext(),
-    focusPrev: () => this.focusPrev(),
-    focusSelected: () => this.focusSelected(),
-    configure: (patch: FocusGroupConfigPatch) => this.configureGroup(patch),
-  };
+    this.eventPort.onGlobal('key.down', () => {
+      this.keyboardModality = true;
+    });
+    this.eventPort.on('pointer.down', () => {
+      this.keyboardModality = false;
+      this.setFocusState(
+        this.focusVisibleOwned,
+        false,
+        'reason: focus.pointer.down => focusVisible'
+      );
+    });
+    this.eventPort.on('host:focus', () => {
+      if (!this.focusableDeclared || this.focusableConfig.disabled) return;
+      this.setFocusState(this.focusedOwned, true, 'reason: focus.host:focus => focused');
+      this.setFocusState(
+        this.focusVisibleOwned,
+        this.keyboardModality,
+        'reason: focus.host:focus => focusVisible'
+      );
+      this.setFocusState(this.activeOwned, true, 'reason: focus.host:focus => active');
+      this.setFocusState(this.hasFocusedOwned, true, 'reason: focus.host:focus => hasFocused');
+    });
+    this.eventPort.on('host:blur', () => {
+      this.setFocusState(this.focusedOwned, false, 'reason: focus.host:blur => focused');
+      this.setFocusState(this.focusVisibleOwned, false, 'reason: focus.host:blur => focusVisible');
+      this.setFocusState(this.activeOwned, false, 'reason: focus.host:blur => active');
+    });
+  }
 
   getFocusable<P extends PropsBaseType = PropsBaseType>(): FocusableHandle<P> {
+    this.declareFocusable();
     return this.focusableHandle as FocusableHandle<P>;
   }
 
@@ -234,7 +302,7 @@ class FocusModuleImpl extends ModuleBase {
 
   configureFocusable(patch: FocusableConfigPatch): void {
     this.ensureSetup('focus.configureFocusable');
-    this.focusableDeclared = true;
+    this.declareFocusable();
     if (typeof patch.autoFocus !== 'undefined') {
       pushOverrideWarning(
         this.warnings,
@@ -426,10 +494,10 @@ class FocusModuleImpl extends ModuleBase {
     if (target && this.caps.has(FOCUS_REQUEST_FOCUS_CAP)) {
       this.caps.get(FOCUS_REQUEST_FOCUS_CAP)(target, options);
     }
-    this.focusedState.set(true, options?.reason ?? 'programmatic');
-    this.focusVisibleState.set(options?.reason === 'keyboard', options?.reason);
-    this.activeState.set(true, options?.reason ?? 'programmatic');
-    this.hasFocusedState.set(true, options?.reason ?? 'programmatic');
+    this.setFocusState(this.focusedOwned, true, options?.reason ?? 'programmatic');
+    this.setFocusState(this.focusVisibleOwned, options?.reason === 'keyboard', options?.reason);
+    this.setFocusState(this.activeOwned, true, options?.reason ?? 'programmatic');
+    this.setFocusState(this.hasFocusedOwned, true, options?.reason ?? 'programmatic');
   }
 
   private requestNativeFocus(options?: FocusRequestOptions): void {
@@ -445,9 +513,9 @@ class FocusModuleImpl extends ModuleBase {
     if (target && this.caps.has(FOCUS_BLUR_CAP)) {
       this.caps.get(FOCUS_BLUR_CAP)(target);
     }
-    this.focusedState.set(false, 'blur');
-    this.focusVisibleState.set(false, 'blur');
-    this.activeState.set(false, 'blur');
+    this.setFocusState(this.focusedOwned, false, 'blur');
+    this.setFocusState(this.focusVisibleOwned, false, 'blur');
+    this.setFocusState(this.activeOwned, false, 'blur');
   }
 
   focusFirst(): void {
@@ -467,10 +535,10 @@ class FocusModuleImpl extends ModuleBase {
     }
     if (this.focusableConfig.disabled) return;
     if (this.scopeConfig.emptyPolicy === 'container') {
-      this.activeState.set(true, 'focusFirst:container');
-      this.hasFocusedState.set(false, 'focusFirst:container');
-      this.focusedState.set(false, 'focusFirst:container');
-      this.focusVisibleState.set(false, 'focusFirst:container');
+      this.setFocusState(this.activeOwned, true, 'focusFirst:container');
+      this.setFocusState(this.hasFocusedOwned, false, 'focusFirst:container');
+      this.setFocusState(this.focusedOwned, false, 'focusFirst:container');
+      this.setFocusState(this.focusVisibleOwned, false, 'focusFirst:container');
       return;
     }
     this.requestFocus({ reason: 'programmatic' });
@@ -557,7 +625,9 @@ class FocusModuleImpl extends ModuleBase {
       ...this.focusableConfig,
       disabled,
     });
-    this.focusableState.set(this.focusableDeclared && !disabled, reason);
+    this.setFocusState(this.focusableOwned, this.focusableDeclared && !disabled, reason, {
+      defaultOnly: this.sys?.execPhase?.() === 'setup',
+    });
     if (disabled) {
       this.blur();
     }
@@ -601,11 +671,11 @@ class FocusModuleImpl extends ModuleBase {
 
   getFacts(): FocusFacts {
     return Object.freeze({
-      focused: this.focusedState.handle.get(),
-      focusVisible: this.focusVisibleState.handle.get(),
-      focusable: this.focusableState.handle.get(),
-      active: this.activeState.handle.get(),
-      hasFocused: this.hasFocusedState.handle.get(),
+      focused: this.focusedState.get(),
+      focusVisible: this.focusVisibleState.get(),
+      focusable: this.focusableState.get(),
+      active: this.activeState.get(),
+      hasFocused: this.hasFocusedState.get(),
     });
   }
 
@@ -631,8 +701,11 @@ export function createFocusModule(ctx: ModuleFactoryArgs): FocusModule {
     init,
     caps,
     deps,
-    build: () => {
-      const impl = new FocusModuleImpl(caps, init.prototypeName);
+    build: ({ deps }) => {
+      const eventPort = deps.requirePort<EventPort>('event');
+      const statePort = deps.requirePort<StatePort>('state');
+      const stateFacade = deps.requireFacade<StateFacade>('state');
+      const impl = new FocusModuleImpl(caps, init.prototypeName, eventPort, statePort, stateFacade);
       const port: FocusPort = {
         configureFocusable: (patch) => impl.configureFocusable(patch),
         configureGroup: (patch) => impl.configureGroup(patch),
@@ -673,6 +746,6 @@ export function createFocusModule(ctx: ModuleFactoryArgs): FocusModule {
 
 export const FocusModuleDef = defineModule({
   name: 'focus',
-  deps: [],
+  deps: ['event', 'state'],
   create: createFocusModule,
 });

--- a/packages/modules/state-interaction/src/create.ts
+++ b/packages/modules/state-interaction/src/create.ts
@@ -7,7 +7,6 @@ import type { StateInteractionFacade, StateInteractionModule } from './types';
 
 class StateInteractionModuleImpl {
   private readonly handles = new Map<InteractionStateName, any>();
-  private keyboardModality = false;
 
   constructor(
     private readonly stateFacade: StateFacade,
@@ -74,32 +73,8 @@ class StateInteractionModuleImpl {
         return;
       }
 
-      case 'focused': {
-        this.eventPort.on('host:focus', () => {
-          if (this.isDisabled()) return;
-          state.set(true, 'reason: state-interaction.host:focus => focused');
-        });
-        this.eventPort.on('host:blur', () => {
-          state.set(false, 'reason: state-interaction.host:blur => focused');
-        });
-        return;
-      }
-
+      case 'focused':
       case 'focusVisible': {
-        this.eventPort.onGlobal('key.down', () => {
-          this.keyboardModality = true;
-        });
-        this.eventPort.on('pointer.down', () => {
-          this.keyboardModality = false;
-          state.set(false, 'reason: state-interaction.pointer.down => focusVisible');
-        });
-        this.eventPort.on('host:focus', () => {
-          if (this.isDisabled()) return;
-          state.set(this.keyboardModality, 'reason: state-interaction.host:focus => focusVisible');
-        });
-        this.eventPort.on('host:blur', () => {
-          state.set(false, 'reason: state-interaction.host:blur => focusVisible');
-        });
         return;
       }
 
@@ -117,7 +92,7 @@ class StateInteractionModuleImpl {
   }
 
   private clearTransientInteractionStates(reason: string) {
-    for (const name of ['hovered', 'pressed', 'focused', 'focusVisible'] as const) {
+    for (const name of ['hovered', 'pressed'] as const) {
       this.handles.get(name)?.set?.(false, reason);
     }
   }

--- a/packages/modules/state/src/impl.ts
+++ b/packages/modules/state/src/impl.ts
@@ -193,19 +193,38 @@ export class StateModuleImpl {
       this.emitDisconnect(handle);
     },
 
+    set: (handle, value, reason, ctx) => {
+      this.ensureAlive(`state.port.set`);
+      return this.withCtx(ctx ?? this.getCallbackCtx(), () =>
+        this.kernel.setInternal(handle, value, reason as any)
+      );
+    },
+
+    setDefault: (handle, value) => {
+      this.ensureAlive(`state.port.setDefault`);
+      return this.kernel.setDefaultInternal(handle, value);
+    },
+
     createObservedHandle: (handle) => {
       this.ensureAlive(`state.port.createObservedHandle`);
-      return {
+      const observed = {
         get: () => {
           this.ensureAlive(`state.port.createObservedHandle.get`);
           return handle.get();
         },
-        watch: (cb) => {
+        watch: (cb: InternalStateWatchCallback<any>) => {
           this.ensureAlive(`state.port.createObservedHandle.watch`);
           this.sys.ensureSetup(`state.port.createObservedHandle.watch`);
           return this.addWatcher(handle, cb);
         },
       };
+
+      (observed as any).__stateId = (handle as any).__stateId;
+      (observed as any).__stateSemantic = (handle as any).__stateSemantic;
+      (observed as any).__stateKind = (handle as any).__stateKind;
+      (observed as any).__stateSpec = (handle as any).__stateSpec;
+
+      return observed;
     },
 
     createBorrowedHandle: (handle) => {

--- a/packages/modules/state/src/kernel.ts
+++ b/packages/modules/state/src/kernel.ts
@@ -76,6 +76,18 @@ export class StateKernel {
     return this.getRecord<any>(id).spec.kind as StateKind;
   }
 
+  /** Internal module mutation path. Module ports enforce access boundaries. */
+  setInternal<V>(handle: OwnedStateHandle<V>, next: V, reason?: StateSetReason): void {
+    const id = this.getIdFromHandle(handle);
+    this.setById<V>(id, next, reason);
+  }
+
+  /** Internal setup/default mutation path. Does not emit. */
+  setDefaultInternal<V>(handle: OwnedStateHandle<V>, next: V): void {
+    const id = this.getIdFromHandle(handle);
+    this.setDefaultById<V>(id, next);
+  }
+
   // ---- byId helpers ----
 
   private getById<V>(id: StateId): V {

--- a/packages/modules/state/src/types.ts
+++ b/packages/modules/state/src/types.ts
@@ -25,6 +25,19 @@ export type StatePort = {
   disconnect(handle: OwnedStateHandle<any>): void;
 
   /**
+   * Internal module-owned mutation path.
+   *
+   * This bypasses author-facing phase guards and is intended for runtime modules
+   * that maintain official state facts.
+   */
+  set<V>(handle: OwnedStateHandle<V>, value: V, reason?: unknown, ctx?: unknown): void;
+
+  /**
+   * Internal module-owned default mutation path. Does not emit.
+   */
+  setDefault<V>(handle: OwnedStateHandle<V>, value: V): void;
+
+  /**
    * Create an internal "observed" view for a slot.
    * This is NOT the component-author facing ObservedStateHandle type (that one is typed with RunHandle<P>),
    * but it's sufficient for internal modules that only need get+watch with opaque ctx.

--- a/packages/modules/state/test/port.v0.test.ts
+++ b/packages/modules/state/test/port.v0.test.ts
@@ -158,6 +158,9 @@ describe('module-state port (v0)', () => {
     const observed = port.createObservedHandle(owned);
 
     expect(observed.get()).toBe(false);
+    expect((observed as any).__stateId).toBe((owned as any).__stateId);
+    expect((observed as any).__stateSemantic).toBe('open');
+    expect((observed as any).__stateSpec).toEqual((owned as any).__stateSpec);
 
     const calls: Array<{ ctx: unknown; e: any }> = [];
     const off = observed.watch((ctx, e) => calls.push({ ctx, e }));

--- a/packages/prototypes/base/src/button/button.ts
+++ b/packages/prototypes/base/src/button/button.ts
@@ -17,7 +17,7 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
 
   const disabled = def.state.fromInteraction('disabled');
   def.expose.state('disabled', disabled);
-  const focusable = asFocusable();
+  const focusable = asFocusable<ButtonProps>();
   focusable.configure({ disabled: false });
   const hovered = def.state.fromInteraction('hovered');
   const focused = focusable.focused;

--- a/packages/prototypes/base/src/button/button.ts
+++ b/packages/prototypes/base/src/button/button.ts
@@ -17,10 +17,13 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
 
   const disabled = def.state.fromInteraction('disabled');
   def.expose.state('disabled', disabled);
-  const focusable = asFocusable({ disabled: false });
+  const focusable = asFocusable();
+  focusable.configure({ disabled: false });
   const hovered = def.state.fromInteraction('hovered');
-  const focused = def.state.fromInteraction('focused');
-  const focusVisible = def.state.fromInteraction('focusVisible');
+  const focused = focusable.focused;
+  const focusVisible = focusable.focusVisible;
+  const legacyFocused = def.state.fromInteraction('focused');
+  const legacyFocusVisible = def.state.fromInteraction('focusVisible');
   const pressed = def.state.fromInteraction('pressed');
 
   const syncDisabled = (nextDisabled: boolean) => {
@@ -38,24 +41,13 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
 
   def.expose.state('hovered', hovered);
 
-  focused.watch((_run, event) => {
-    if (event.type === 'disconnect') {
-      focusable.blur();
-      return;
-    }
-    if (event.next) {
-      focusable.focus({ reason: focusVisible.get() ? 'keyboard' : 'programmatic' });
-      return;
-    }
-    focusable.blur();
+  focusable.focused.watch((_run, event) => {
+    if (event.type !== 'next') return;
+    legacyFocused.set(event.next, 'reason: asButton focus projection => focused');
   });
-  focusVisible.watch((_run, event) => {
-    if (event.type === 'disconnect') {
-      focusable.blur();
-      return;
-    }
-    if (!focused.get()) return;
-    focusable.focus({ reason: event.next ? 'keyboard' : 'programmatic' });
+  focusable.focusVisible.watch((_run, event) => {
+    if (event.type !== 'next') return;
+    legacyFocusVisible.set(event.next, 'reason: asButton focus projection => focusVisible');
   });
   def.expose.state('focused', focused);
   def.expose.state('focusVisible', focusVisible);

--- a/packages/prototypes/base/src/checkbox/root.ts
+++ b/packages/prototypes/base/src/checkbox/root.ts
@@ -45,7 +45,7 @@ function setupCheckboxRoot(def: DefHandle<CheckboxRootProps, CheckboxRootExposes
   });
 
   asButton();
-  asFocusable();
+  asFocusable<CheckboxRootProps>();
 
   const checked = def.state.fromAccessibility('checked');
   const disabled = def.state.fromInteraction('disabled');

--- a/packages/prototypes/base/src/dropdown/item.ts
+++ b/packages/prototypes/base/src/dropdown/item.ts
@@ -8,9 +8,10 @@ const DROPDOWN_ROVING_HANDLED = '__dropdownRovingHandled';
 
 function setupDropdownItem(def: DefHandle<DropdownItemProps, DropdownItemExposes>): void {
   asButton();
-  const focusable = asFocusable({ groupKey: DROPDOWN_FOCUS_GROUP });
+  const focusable = asFocusable();
+  focusable.configure({ groupKey: DROPDOWN_FOCUS_GROUP });
   const hovered = def.state.fromInteraction('hovered');
-  const focused = def.state.fromInteraction('focused');
+  const focused = focusable.focused;
   const active = def.state.bool('active', false);
   useCollectionItem({
     family: DROPDOWN_FAMILY,

--- a/packages/prototypes/base/src/dropdown/item.ts
+++ b/packages/prototypes/base/src/dropdown/item.ts
@@ -8,7 +8,7 @@ const DROPDOWN_ROVING_HANDLED = '__dropdownRovingHandled';
 
 function setupDropdownItem(def: DefHandle<DropdownItemProps, DropdownItemExposes>): void {
   asButton();
-  const focusable = asFocusable();
+  const focusable = asFocusable<DropdownItemProps>();
   focusable.configure({ groupKey: DROPDOWN_FOCUS_GROUP });
   const hovered = def.state.fromInteraction('hovered');
   const focused = focusable.focused;

--- a/packages/prototypes/base/src/dropdown/trigger.ts
+++ b/packages/prototypes/base/src/dropdown/trigger.ts
@@ -15,7 +15,7 @@ const DROPDOWN_OPEN_HANDLED = '__dropdownOpenHandled';
 function setupDropdownTrigger(def: DefHandle<DropdownTriggerProps, DropdownTriggerExposes>): void {
   def.anatomy.claim(DROPDOWN_FAMILY, { role: 'trigger' });
   asButton();
-  const focusable = asFocusable();
+  const focusable = asFocusable<DropdownTriggerProps>();
   const focused = focusable.focused;
 
   def.props.define({

--- a/packages/prototypes/base/src/dropdown/trigger.ts
+++ b/packages/prototypes/base/src/dropdown/trigger.ts
@@ -1,4 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
+import { asFocusable } from '@proto.ui/hooks';
 import { asButton } from '../button';
 import { DROPDOWN_CONTEXT, DROPDOWN_FAMILY } from './shared';
 import type {
@@ -14,7 +15,8 @@ const DROPDOWN_OPEN_HANDLED = '__dropdownOpenHandled';
 function setupDropdownTrigger(def: DefHandle<DropdownTriggerProps, DropdownTriggerExposes>): void {
   def.anatomy.claim(DROPDOWN_FAMILY, { role: 'trigger' });
   asButton();
-  const focused = def.state.fromInteraction('focused');
+  const focusable = asFocusable();
+  const focused = focusable.focused;
 
   def.props.define({
     disabled: { type: 'boolean', empty: 'fallback' },

--- a/packages/prototypes/base/src/hover-card/trigger.ts
+++ b/packages/prototypes/base/src/hover-card/trigger.ts
@@ -23,7 +23,7 @@ function setupHoverCardTrigger(
 
   def.context.subscribe(HOVER_CARD_CONTEXT);
   const hovered = def.state.fromInteraction('hovered');
-  const focusable = asFocusable();
+  const focusable = asFocusable<HoverCardTriggerProps>();
   const focused = focusable.focused;
 
   const updateFlags = (

--- a/packages/prototypes/base/src/hover-card/trigger.ts
+++ b/packages/prototypes/base/src/hover-card/trigger.ts
@@ -1,4 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
+import { asFocusable } from '@proto.ui/hooks';
 import { asButton } from '../button';
 import { HOVER_CARD_CONTEXT, HOVER_CARD_FAMILY } from './shared';
 import type {
@@ -22,7 +23,8 @@ function setupHoverCardTrigger(
 
   def.context.subscribe(HOVER_CARD_CONTEXT);
   const hovered = def.state.fromInteraction('hovered');
-  const focused = def.state.fromInteraction('focused');
+  const focusable = asFocusable();
+  const focused = focusable.focused;
 
   const updateFlags = (
     run: any,

--- a/packages/prototypes/base/src/select/item.ts
+++ b/packages/prototypes/base/src/select/item.ts
@@ -17,7 +17,7 @@ function syncBoolState(
 
 function setupSelectItem(def: DefHandle<SelectItemProps, SelectItemExposes>): void {
   asButton();
-  const focusable = asFocusable();
+  const focusable = asFocusable<SelectItemProps>();
   focusable.configure({ groupKey: SELECT_FOCUS_GROUP });
   const hovered = def.state.fromInteraction('hovered');
   const focused = focusable.focused;

--- a/packages/prototypes/base/src/select/item.ts
+++ b/packages/prototypes/base/src/select/item.ts
@@ -17,9 +17,10 @@ function syncBoolState(
 
 function setupSelectItem(def: DefHandle<SelectItemProps, SelectItemExposes>): void {
   asButton();
-  const focusable = asFocusable({ groupKey: SELECT_FOCUS_GROUP });
+  const focusable = asFocusable();
+  focusable.configure({ groupKey: SELECT_FOCUS_GROUP });
   const hovered = def.state.fromInteraction('hovered');
-  const focused = def.state.fromInteraction('focused');
+  const focused = focusable.focused;
   const active = def.state.bool('active', false);
   const selected = def.state.fromAccessibility('selected');
 

--- a/packages/prototypes/base/src/select/trigger.ts
+++ b/packages/prototypes/base/src/select/trigger.ts
@@ -14,7 +14,7 @@ const SELECT_ROVING_HANDLED = '__selectRovingHandled';
 function setupSelectTrigger(def: DefHandle<SelectTriggerProps, SelectTriggerExposes>): void {
   def.anatomy.claim(SELECT_FAMILY, { role: 'trigger' });
   asButton();
-  const focusable = asFocusable();
+  const focusable = asFocusable<SelectTriggerProps>();
   const focused = focusable.focused;
 
   def.props.define({

--- a/packages/prototypes/base/src/select/trigger.ts
+++ b/packages/prototypes/base/src/select/trigger.ts
@@ -1,4 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
+import { asFocusable } from '@proto.ui/hooks';
 import { asButton } from '../button';
 import { SELECT_CONTEXT, SELECT_FAMILY } from './shared';
 import type {
@@ -13,7 +14,8 @@ const SELECT_ROVING_HANDLED = '__selectRovingHandled';
 function setupSelectTrigger(def: DefHandle<SelectTriggerProps, SelectTriggerExposes>): void {
   def.anatomy.claim(SELECT_FAMILY, { role: 'trigger' });
   asButton();
-  const focused = def.state.fromInteraction('focused');
+  const focusable = asFocusable();
+  const focused = focusable.focused;
 
   def.props.define({
     disabled: { type: 'boolean', empty: 'fallback' },

--- a/packages/prototypes/base/src/tabs/trigger.ts
+++ b/packages/prototypes/base/src/tabs/trigger.ts
@@ -14,7 +14,7 @@ function syncSelectedFromContext(
 
 function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>): void {
   asButton();
-  const focusable = asFocusable();
+  const focusable = asFocusable<TabsTriggerProps>();
   focusable.configure({ groupKey: TABS_FOCUS_GROUP });
   const focused = focusable.focused;
   const selected = def.state.fromAccessibility('selected');

--- a/packages/prototypes/base/src/tabs/trigger.ts
+++ b/packages/prototypes/base/src/tabs/trigger.ts
@@ -14,8 +14,9 @@ function syncSelectedFromContext(
 
 function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>): void {
   asButton();
-  const focusable = asFocusable({ groupKey: TABS_FOCUS_GROUP });
-  const focused = def.state.fromInteraction('focused');
+  const focusable = asFocusable();
+  focusable.configure({ groupKey: TABS_FOCUS_GROUP });
+  const focused = focusable.focused;
   const selected = def.state.fromAccessibility('selected');
   useCollectionItem({
     family: TABS_FAMILY,

--- a/packages/runtime/test/contract/boundary.v0.contract.test.ts
+++ b/packages/runtime/test/contract/boundary.v0.contract.test.ts
@@ -31,17 +31,17 @@ const createHost = <P extends PropsBaseType>(
 
 describe('runtime contract: interaction boundary (v0)', () => {
   it('BOUNDARY-0100: repeated asBoundary(...) calls on one instance reuse one underlying boundary and merge setup-time configuration deterministically', () => {
-    let a!: BoundaryHandle<any>;
-    let b!: BoundaryHandle<any>;
+    let a!: BoundaryHandle<PropsBaseType>;
+    let b!: BoundaryHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-boundary-0100',
       setup() {
-        a = asBoundary({
+        a = asBoundary<PropsBaseType>({
           debugLabel: 'alpha',
           meta: { origin: 'first' },
         });
-        b = asBoundary({
+        b = asBoundary<PropsBaseType>({
           debugLabel: 'beta',
           meta: { step: 2 },
         });
@@ -65,7 +65,7 @@ describe('runtime contract: interaction boundary (v0)', () => {
       expect.arrayContaining([expect.stringContaining('debugLabel overridden')])
     );
     expect((P as any).__asHooks).toEqual([
-      { name: 'asBoundary', order: 0, privileged: true, mode: 'configurable' },
+      { name: 'asBoundary', order: 0, privileged: true, mode: 'once' },
     ]);
   });
 
@@ -339,15 +339,15 @@ describe('runtime contract: interaction boundary (v0)', () => {
 
   it('BOUNDARY-0800: stacked consumers can distinguish the top-most boundary so one outside interaction does not close multiple layers', async () => {
     const outsider = document.createElement('button');
-    let firstBoundary!: BoundaryHandle<any>;
-    let secondBoundary!: BoundaryHandle<any>;
+    let firstBoundary!: BoundaryHandle<PropsBaseType>;
+    let secondBoundary!: BoundaryHandle<PropsBaseType>;
     let firstOutsideCalls = 0;
     let secondOutsideCalls = 0;
 
     const First = definePrototype({
       name: 'x-boundary-0800-first',
       setup() {
-        firstBoundary = asBoundary();
+        firstBoundary = asBoundary<PropsBaseType>();
         firstBoundary.subscribeOutside(() => {
           firstOutsideCalls += 1;
         });
@@ -358,7 +358,7 @@ describe('runtime contract: interaction boundary (v0)', () => {
     const Second = definePrototype({
       name: 'x-boundary-0800-second',
       setup() {
-        secondBoundary = asBoundary();
+        secondBoundary = asBoundary<PropsBaseType>();
         secondBoundary.subscribeOutside(() => {
           secondOutsideCalls += 1;
         });

--- a/packages/runtime/test/contract/focus-group.v0.contract.test.ts
+++ b/packages/runtime/test/contract/focus-group.v0.contract.test.ts
@@ -25,14 +25,18 @@ describe('runtime contract: focus-group (v0)', () => {
   it('FOCUS-GROUP-0100: repeated asFocusGroup calls reuse one handle and keep last patch', () => {
     const first = createFocusGroupKey({ debugLabel: 'group-1' });
     const second = createFocusGroupKey({ debugLabel: 'group-2' });
-    let a!: FocusGroupHandle<any>;
-    let b!: FocusGroupHandle<any>;
+    let a!: FocusGroupHandle<PropsBaseType>;
+    let b!: FocusGroupHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-focus-group-0100',
       setup() {
-        a = asFocusGroup({ key: first, navigation: 'arrow' });
-        b = asFocusGroup({ key: second, orientation: 'horizontal', selectOnFocus: true });
+        a = asFocusGroup<PropsBaseType>({ key: first, navigation: 'arrow' });
+        b = asFocusGroup<PropsBaseType>({
+          key: second,
+          orientation: 'horizontal',
+          selectOnFocus: true,
+        });
         return (r) => r.el('div', 'ok');
       },
     });
@@ -54,12 +58,12 @@ describe('runtime contract: focus-group (v0)', () => {
   });
 
   it('FOCUS-GROUP-0200: asFocusScope exposes its internal group handle', () => {
-    let group!: FocusGroupHandle<any>;
+    let group!: FocusGroupHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-focus-group-0200',
       setup() {
-        const scope = asFocusScope({
+        const scope = asFocusScope<PropsBaseType>({
           entry: 'selected',
           group: { navigation: 'arrow', orientation: 'horizontal' },
         });

--- a/packages/runtime/test/contract/focus.v0.contract.test.ts
+++ b/packages/runtime/test/contract/focus.v0.contract.test.ts
@@ -2,16 +2,51 @@ import { describe, expect, it } from 'vitest';
 import {
   createFocusScopeKey,
   definePrototype,
+  tw,
   type FocusScopeHandle,
   type FocusableHandle,
 } from '@proto.ui/core';
 import { asFocusable, asFocusScope } from '@proto.ui/hooks';
 import type { RuntimeHost } from '../../src';
 import { executeWithHost } from '../../src';
+import { EVENT_GLOBAL_TARGET_CAP, EVENT_ROOT_TARGET_CAP } from '@proto.ui/module-event';
 import type { FocusPort } from '@proto.ui/module-focus';
 import type { PropsBaseType } from '@proto.ui/types';
 
-const createHost = <P extends PropsBaseType>(name: string) => {
+function createMockTarget() {
+  type Rec = { type: string; fn: (ev: any) => void; options?: unknown };
+  const listeners: Rec[] = [];
+
+  return {
+    addEventListener(type: string, fn: (ev: any) => void, options?: unknown) {
+      listeners.push({ type, fn, options });
+    },
+    removeEventListener(type: string, fn: (ev: any) => void, options?: unknown) {
+      for (let i = listeners.length - 1; i >= 0; i--) {
+        const rec = listeners[i]!;
+        if (rec.type !== type || rec.fn !== fn || rec.options !== options) continue;
+        listeners.splice(i, 1);
+        return;
+      }
+    },
+    dispatchEvent() {
+      return true;
+    },
+    fire(type: string, ev: any = { type }) {
+      for (const rec of listeners.filter((item) => item.type === type).slice()) {
+        rec.fn(ev);
+      }
+    },
+  } as EventTarget & { fire(type: string, ev?: any): void };
+}
+
+const createHost = <P extends PropsBaseType>(
+  name: string,
+  targets?: { root?: EventTarget | null; global?: EventTarget | null }
+) => {
+  const rootTarget = targets?.root === undefined ? createMockTarget() : targets.root;
+  const globalTarget = targets?.global === undefined ? createMockTarget() : targets.global;
+
   const host: RuntimeHost<P> = {
     prototypeName: name,
     getRawProps: () => ({}) as any,
@@ -20,6 +55,12 @@ const createHost = <P extends PropsBaseType>(name: string) => {
     },
     schedule(task) {
       task();
+    },
+    onRuntimeReady(wiring) {
+      wiring.attach('event', [
+        [EVENT_ROOT_TARGET_CAP, () => rootTarget ?? null],
+        [EVENT_GLOBAL_TARGET_CAP, () => globalTarget ?? null],
+      ]);
     },
   };
 
@@ -36,8 +77,10 @@ describe('runtime contract: focus (v0)', () => {
     const P = definePrototype({
       name: 'x-focus-0100',
       setup() {
-        a = asFocusable({ scopeKey: first });
-        b = asFocusable({ scopeKey: second });
+        a = asFocusable();
+        a.configure({ scopeKey: first });
+        b = asFocusable();
+        b.configure({ scopeKey: second });
         return (r) => r.el('div', 'ok');
       },
     });
@@ -134,7 +177,8 @@ describe('runtime contract: focus (v0)', () => {
     const P = definePrototype({
       name: 'x-focus-0400',
       setup(def) {
-        focusable = asFocusable({ disabled: false });
+        focusable = asFocusable();
+        focusable.configure({ disabled: false });
         def.lifecycle.onCreated(() => {
           focusable.focus({ reason: 'keyboard' });
         });
@@ -155,13 +199,76 @@ describe('runtime contract: focus (v0)', () => {
     });
   });
 
+  it('FOCUS-0450: host focus events update focus-owned observed facts', () => {
+    let focusable!: FocusableHandle<any>;
+    const root = createMockTarget();
+    const global = createMockTarget();
+
+    const P = definePrototype({
+      name: 'x-focus-0450',
+      setup() {
+        focusable = asFocusable();
+        return (r) => r.el('div', 'ok');
+      },
+    });
+
+    const { host } = createHost(P.name, { root, global });
+    const result = executeWithHost(P as any, host as any);
+    const port = result.caps.getPort<FocusPort>('focus');
+
+    expect(focusable.focused.get()).toBe(false);
+    expect((focusable.focused as any).__stateId).toBeTruthy();
+    expect((focusable.focused as any).__stateSemantic).toBe('@focus/focused');
+    expect((focusable.focusVisible as any).__stateSemantic).toBe('@focus/focusVisible');
+    global.fire('key.down', { type: 'key.down' });
+    root.fire('host:focus', { type: 'host:focus' });
+    expect(focusable.focused.get()).toBe(true);
+    expect(focusable.focusVisible.get()).toBe(true);
+    expect(port?.getFacts().active).toBe(true);
+
+    root.fire('pointer.down', { type: 'pointer.down' });
+    expect(focusable.focusVisible.get()).toBe(false);
+
+    root.fire('host:blur', { type: 'host:blur' });
+    expect(focusable.focused.get()).toBe(false);
+    expect(port?.getFacts().active).toBe(false);
+  });
+
+  it('FOCUS-0460: focus fact handles are rule-consumable state handles', () => {
+    let focusable!: FocusableHandle<any>;
+    const root = createMockTarget();
+    const global = createMockTarget();
+
+    const P = definePrototype({
+      name: 'x-focus-0460',
+      setup(def) {
+        focusable = asFocusable();
+        def.rule({
+          when: (w) => w.state(focusable.focusVisible).eq(true),
+          intent: (i) => i.feedback.style.use(tw('ring-2')),
+        });
+        return (r) => r.el('div', 'ok');
+      },
+    });
+
+    const { host } = createHost(P.name, { root, global });
+    const result = executeWithHost(P as any, host as any);
+
+    expect(result.controller.getRuleStyleTokens()).not.toContain('ring-2');
+
+    global.fire('key.down', { type: 'key.down' });
+    root.fire('host:focus', { type: 'host:focus' });
+    expect(result.controller.getRuleStyleTokens()).toContain('ring-2');
+  });
+
   it('FOCUS-0500: disabled focusable rejects focus requests', () => {
     let focusable!: FocusableHandle<any>;
 
     const P = definePrototype({
       name: 'x-focus-0500',
       setup(def) {
-        focusable = asFocusable({ disabled: true });
+        focusable = asFocusable();
+        focusable.configure({ disabled: true });
         def.lifecycle.onCreated(() => {
           focusable.focus({ reason: 'keyboard' });
         });
@@ -186,7 +293,8 @@ describe('runtime contract: focus (v0)', () => {
     const P = definePrototype({
       name: 'x-focus-0600',
       setup() {
-        asFocusable({ autoFocus: true });
+        const focusable = asFocusable();
+        focusable.configure({ autoFocus: true });
         return (r) => r.el('div', 'ok');
       },
     });

--- a/packages/runtime/test/contract/focus.v0.contract.test.ts
+++ b/packages/runtime/test/contract/focus.v0.contract.test.ts
@@ -71,15 +71,15 @@ describe('runtime contract: focus (v0)', () => {
   it('FOCUS-0100: repeated asFocusable calls reuse one handle and last compatible scopeKey wins', () => {
     const first = createFocusScopeKey({ debugLabel: 'first' });
     const second = createFocusScopeKey({ debugLabel: 'second' });
-    let a!: FocusableHandle<any>;
-    let b!: FocusableHandle<any>;
+    let a!: FocusableHandle<PropsBaseType>;
+    let b!: FocusableHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-focus-0100',
       setup() {
-        a = asFocusable();
+        a = asFocusable<PropsBaseType>();
         a.configure({ scopeKey: first });
-        b = asFocusable();
+        b = asFocusable<PropsBaseType>();
         b.configure({ scopeKey: second });
         return (r) => r.el('div', 'ok');
       },
@@ -99,20 +99,20 @@ describe('runtime contract: focus (v0)', () => {
     });
     expect(port?.getWarnings()).toEqual([expect.stringContaining('focusable.scopeKey overridden')]);
     expect((P as any).__asHooks).toEqual([
-      { name: 'asFocusable', order: 0, privileged: true, mode: 'configurable' },
+      { name: 'asFocusable', order: 0, privileged: true, mode: 'once' },
     ]);
   });
 
   it('FOCUS-0200: repeated asFocusScope calls reuse one handle and key patch is retained', () => {
     const scopeKey = createFocusScopeKey({ debugLabel: 'scope-2' });
-    let scopeA!: FocusScopeHandle<any>;
-    let scopeB!: FocusScopeHandle<any>;
+    let scopeA!: FocusScopeHandle<PropsBaseType>;
+    let scopeB!: FocusScopeHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-focus-0200',
       setup() {
-        scopeA = asFocusScope({ navigation: 'tab' });
-        scopeB = asFocusScope({ key: scopeKey, navigation: 'arrow', loop: true });
+        scopeA = asFocusScope<PropsBaseType>({ navigation: 'tab' });
+        scopeB = asFocusScope<PropsBaseType>({ key: scopeKey, navigation: 'arrow', loop: true });
         return (r) => r.el('div', 'ok');
       },
     });
@@ -140,19 +140,19 @@ describe('runtime contract: focus (v0)', () => {
       ])
     );
     expect((P as any).__asHooks).toEqual([
-      { name: 'asFocusScope', order: 0, privileged: true, mode: 'configurable' },
+      { name: 'asFocusScope', order: 0, privileged: true, mode: 'once' },
     ]);
   });
 
   it('FOCUS-0300: configure is setup-only on focus handles', () => {
     const key = createFocusScopeKey({ debugLabel: 'late' });
-    let focusable!: FocusableHandle<any>;
+    let focusable!: FocusableHandle<PropsBaseType>;
     let thrown: unknown;
 
     const P = definePrototype({
       name: 'x-focus-0300',
       setup(def) {
-        focusable = asFocusable();
+        focusable = asFocusable<PropsBaseType>();
         def.lifecycle.onCreated(() => {
           try {
             focusable.configure({ scopeKey: key });
@@ -172,12 +172,12 @@ describe('runtime contract: focus (v0)', () => {
   });
 
   it('FOCUS-0400: focus commands update minimal facts snapshot', () => {
-    let focusable!: FocusableHandle<any>;
+    let focusable!: FocusableHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-focus-0400',
       setup(def) {
-        focusable = asFocusable();
+        focusable = asFocusable<PropsBaseType>();
         focusable.configure({ disabled: false });
         def.lifecycle.onCreated(() => {
           focusable.focus({ reason: 'keyboard' });
@@ -200,14 +200,14 @@ describe('runtime contract: focus (v0)', () => {
   });
 
   it('FOCUS-0450: host focus events update focus-owned observed facts', () => {
-    let focusable!: FocusableHandle<any>;
+    let focusable!: FocusableHandle<PropsBaseType>;
     const root = createMockTarget();
     const global = createMockTarget();
 
     const P = definePrototype({
       name: 'x-focus-0450',
       setup() {
-        focusable = asFocusable();
+        focusable = asFocusable<PropsBaseType>();
         return (r) => r.el('div', 'ok');
       },
     });
@@ -235,14 +235,14 @@ describe('runtime contract: focus (v0)', () => {
   });
 
   it('FOCUS-0460: focus fact handles are rule-consumable state handles', () => {
-    let focusable!: FocusableHandle<any>;
+    let focusable!: FocusableHandle<PropsBaseType>;
     const root = createMockTarget();
     const global = createMockTarget();
 
     const P = definePrototype({
       name: 'x-focus-0460',
       setup(def) {
-        focusable = asFocusable();
+        focusable = asFocusable<PropsBaseType>();
         def.rule({
           when: (w) => w.state(focusable.focusVisible).eq(true),
           intent: (i) => i.feedback.style.use(tw('ring-2')),
@@ -262,12 +262,12 @@ describe('runtime contract: focus (v0)', () => {
   });
 
   it('FOCUS-0500: disabled focusable rejects focus requests', () => {
-    let focusable!: FocusableHandle<any>;
+    let focusable!: FocusableHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-focus-0500',
       setup(def) {
-        focusable = asFocusable();
+        focusable = asFocusable<PropsBaseType>();
         focusable.configure({ disabled: true });
         def.lifecycle.onCreated(() => {
           focusable.focus({ reason: 'keyboard' });
@@ -293,7 +293,7 @@ describe('runtime contract: focus (v0)', () => {
     const P = definePrototype({
       name: 'x-focus-0600',
       setup() {
-        const focusable = asFocusable();
+        const focusable = asFocusable<PropsBaseType>();
         focusable.configure({ autoFocus: true });
         return (r) => r.el('div', 'ok');
       },
@@ -313,12 +313,12 @@ describe('runtime contract: focus (v0)', () => {
   });
 
   it('FOCUS-0700: scope emptyPolicy=container activates scope without node focus', () => {
-    let scope!: FocusScopeHandle<any>;
+    let scope!: FocusScopeHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-focus-0700',
       setup(def) {
-        scope = asFocusScope({ emptyPolicy: 'container' });
+        scope = asFocusScope<PropsBaseType>({ emptyPolicy: 'container' });
         def.lifecycle.onCreated(() => {
           scope.focusFirst();
         });

--- a/packages/runtime/test/contract/hit-participation.v0.contract.test.ts
+++ b/packages/runtime/test/contract/hit-participation.v0.contract.test.ts
@@ -35,18 +35,18 @@ const createHost = <P extends PropsBaseType>(name: string) => {
 
 describe('runtime contract: hit participation (v0)', () => {
   it('HIT-0100: repeated asHitParticipation(...) calls on one instance reuse one underlying capability and merge setup-time configuration deterministically', () => {
-    let a!: HitParticipationHandle<any>;
-    let b!: HitParticipationHandle<any>;
+    let a!: HitParticipationHandle<PropsBaseType>;
+    let b!: HitParticipationHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-hit-0100',
       setup() {
-        a = asHitParticipation({
+        a = asHitParticipation<PropsBaseType>({
           mode: 'disabled',
           debugLabel: 'alpha',
           meta: { origin: 'first' },
         });
-        b = asHitParticipation({
+        b = asHitParticipation<PropsBaseType>({
           mode: 'passthrough',
           debugLabel: 'beta',
           meta: { step: 2 },
@@ -75,7 +75,7 @@ describe('runtime contract: hit participation (v0)', () => {
       ])
     );
     expect((P as any).__asHooks).toEqual([
-      { name: 'asHitParticipation', order: 0, privileged: true, mode: 'configurable' },
+      { name: 'asHitParticipation', order: 0, privileged: true, mode: 'once' },
     ]);
   });
 

--- a/packages/runtime/test/contract/overlay.v0.contract.test.ts
+++ b/packages/runtime/test/contract/overlay.v0.contract.test.ts
@@ -32,14 +32,14 @@ const createHost = <P extends PropsBaseType>(
 
 describe('runtime contract: overlay (v0)', () => {
   it('OVERLAY-0100: repeated asOverlay calls reuse one handle and merge configuration', () => {
-    let a!: OverlayHandle<any>;
-    let b!: OverlayHandle<any>;
+    let a!: OverlayHandle<PropsBaseType>;
+    let b!: OverlayHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-overlay-0100',
       setup() {
-        a = asOverlay({ placement: 'bottom', defaultOpen: true });
-        b = asOverlay({ placement: 'top', closeOnOutsidePress: false });
+        a = asOverlay<PropsBaseType>({ placement: 'bottom', defaultOpen: true });
+        b = asOverlay<PropsBaseType>({ placement: 'top', closeOnOutsidePress: false });
         return (r) => r.el('div', 'ok');
       },
     });
@@ -61,18 +61,18 @@ describe('runtime contract: overlay (v0)', () => {
       expect.arrayContaining([expect.stringContaining('placement overridden')])
     );
     expect((P as any).__asHooks).toEqual([
-      { name: 'asOverlay', order: 0, privileged: true, mode: 'configurable' },
+      { name: 'asOverlay', order: 0, privileged: true, mode: 'once' },
     ]);
   });
 
   it('OVERLAY-0200: configure is setup-only on overlay handles', () => {
-    let overlay!: OverlayHandle<any>;
+    let overlay!: OverlayHandle<PropsBaseType>;
     let thrown: unknown;
 
     const P = definePrototype({
       name: 'x-overlay-0200',
       setup(def) {
-        overlay = asOverlay();
+        overlay = asOverlay<PropsBaseType>();
         def.lifecycle.onCreated(() => {
           try {
             overlay.configure({ placement: 'right' });
@@ -92,12 +92,12 @@ describe('runtime contract: overlay (v0)', () => {
   });
 
   it('OVERLAY-0300: imperative open close toggle updates state and last reason', () => {
-    let overlay!: OverlayHandle<any>;
+    let overlay!: OverlayHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-overlay-0300',
       setup(def) {
-        overlay = asOverlay();
+        overlay = asOverlay<PropsBaseType>();
         def.lifecycle.onCreated(() => {
           overlay.openOverlay('trigger.press');
           overlay.toggle('item.commit');
@@ -116,7 +116,7 @@ describe('runtime contract: overlay (v0)', () => {
   });
 
   it('OVERLAY-0400: registration methods retain trigger anchor and content references', () => {
-    let overlay!: OverlayHandle<any>;
+    let overlay!: OverlayHandle<PropsBaseType>;
     const trigger = { id: 'trigger' };
     const anchor = { id: 'anchor' };
     const content = { id: 'content' };
@@ -124,7 +124,7 @@ describe('runtime contract: overlay (v0)', () => {
     const P = definePrototype({
       name: 'x-overlay-0400',
       setup() {
-        overlay = asOverlay();
+        overlay = asOverlay<PropsBaseType>();
         overlay.registerTrigger(trigger);
         overlay.registerAnchor(anchor);
         overlay.registerContent(content);
@@ -144,13 +144,13 @@ describe('runtime contract: overlay (v0)', () => {
   });
 
   it('OVERLAY-0500: boundary outside notifications close an open overlay when closeOnOutsidePress is enabled', () => {
-    let overlay!: OverlayHandle<any>;
+    let overlay!: OverlayHandle<PropsBaseType>;
     const outsider = document.createElement('button');
 
     const P = definePrototype({
       name: 'x-overlay-0500',
       setup(def) {
-        overlay = asOverlay({ closeOnOutsidePress: true, defaultOpen: true });
+        overlay = asOverlay<PropsBaseType>({ closeOnOutsidePress: true, defaultOpen: true });
         def.lifecycle.onMounted(() => {
           overlay.registerTrigger(document.createElement('button'));
         });

--- a/packages/runtime/test/contract/state.semantic.v0.contract.test.ts
+++ b/packages/runtime/test/contract/state.semantic.v0.contract.test.ts
@@ -185,36 +185,28 @@ describe('runtime contract: state semantic accessors (v0)', () => {
     expect(seenInAuthorCallback).toBe(true);
   });
 
-  it('runtime-managed interaction state respects disabled as an interaction gate', () => {
+  it('runtime-managed interaction state respects disabled as a hover/press interaction gate', () => {
     let disabled: any;
     let hovered: any;
-    let focused: any;
-    let focusVisible: any;
     let pressed: any;
     const root = createMockTarget();
-    const global = createMockTarget();
 
     const P: Prototype = {
       name: 'state-interaction-disabled-gate',
       setup(def) {
         disabled = def.state.fromInteraction('disabled');
         hovered = def.state.fromInteraction('hovered');
-        focused = def.state.fromInteraction('focused');
-        focusVisible = def.state.fromInteraction('focusVisible');
         pressed = def.state.fromInteraction('pressed');
         return (r) => [r.el('div', 'ok')];
       },
     };
 
-    const result = executeWithHost(P as any, createHost(P.name, { root, global }) as any);
+    const result = executeWithHost(P as any, createHost(P.name, { root }) as any);
 
     root.fire('pointer.enter', { type: 'pointer.enter' });
-    global.fire('key.down', { type: 'key.down' });
-    root.fire('host:focus', { type: 'host:focus' });
     root.fire('pointer.down', { type: 'pointer.down' });
 
     expect(hovered.get()).toBe(true);
-    expect(focused.get()).toBe(true);
     expect(pressed.get()).toBe(true);
 
     result.invokeInCallbackScope(() => {
@@ -222,21 +214,16 @@ describe('runtime contract: state semantic accessors (v0)', () => {
     });
 
     expect(hovered.get()).toBe(false);
-    expect(focused.get()).toBe(false);
-    expect(focusVisible.get()).toBe(false);
     expect(pressed.get()).toBe(false);
 
     root.fire('pointer.enter', { type: 'pointer.enter' });
-    root.fire('host:focus', { type: 'host:focus' });
     root.fire('pointer.down', { type: 'pointer.down' });
 
     expect(hovered.get()).toBe(false);
-    expect(focused.get()).toBe(false);
-    expect(focusVisible.get()).toBe(false);
     expect(pressed.get()).toBe(false);
   });
 
-  it('runtime-managed focusVisible is cleared by pointer modality', () => {
+  it('legacy focusVisible interaction slot is shared but not runtime-managed by state-interaction', () => {
     let focusVisible: any;
     const root = createMockTarget();
     const global = createMockTarget();
@@ -253,7 +240,7 @@ describe('runtime contract: state semantic accessors (v0)', () => {
 
     global.fire('key.down', { type: 'key.down' });
     root.fire('host:focus', { type: 'host:focus' });
-    expect(focusVisible.get()).toBe(true);
+    expect(focusVisible.get()).toBe(false);
 
     root.fire('pointer.down', { type: 'pointer.down' });
     expect(focusVisible.get()).toBe(false);

--- a/spec/contracts/C-AS-HOOK-0005.yaml
+++ b/spec/contracts/C-AS-HOOK-0005.yaml
@@ -3,14 +3,14 @@ type: contract
 title: asHook effects attach to the caller and module conflicts stay module-owned
 status: draft
 since: 0.1.0
-summary: Effects declared by an asHook through setup APIs must attach to the caller prototype, while duplicate detection and conflict handling remain owned by each module.
+summary: Effects declared by an asHook through setup APIs must attach to the caller prototype; asHooks may depend on any def sub-API, while duplicate detection and conflict handling remain owned by each module.
 statement:
   zh-CN: >-
-    asHook setup 期间通过 `def` 引入的 props、state、event、feedback、expose、context、rule、lifecycle 或其他 setup effects，都必须附着到调用者 prototype，而不是成为 asHook 私有的独立主体效果。asHook runtime 只负责让这些 effects 归属到调用者并形成可诊断的结果；每个模块内部的去重、合并、冲突、诊断和执行顺序仍由对应模块契约负责。
+    asHook setup 与 prototype setup 共享同一套 `def` 语法权利。asHook 可以对 `def` 句柄上的 props、state、event、feedback、expose、context、rule、lifecycle 或其他子 API 产生依赖，这不构成过度耦合；这些 setup effects 都必须附着到调用者 prototype，而不是成为 asHook 私有的独立主体效果。asHook runtime 只负责让这些 effects 归属到调用者并形成可诊断的结果；每个模块内部的去重、合并、冲突、诊断和执行顺序仍由对应模块契约负责。
 
 
   en: >-
-    Props, state, event, feedback, expose, context, rule, lifecycle, or other setup effects introduced through `def` during asHook setup must attach to the caller prototype instead of becoming private effects of an independent asHook subject. The asHook runtime only ensures these effects belong to the caller and can be diagnosed; each module still owns its own dedupe, merge, conflict, diagnostic, and execution-order semantics.
+    asHook setup and prototype setup share the same `def` syntax rights. An asHook may depend on props, state, event, feedback, expose, context, rule, lifecycle, or any other sub-API on the `def` handle; this is not over-coupling. Setup effects introduced through those APIs must attach to the caller prototype instead of becoming private effects of an independent asHook subject. The asHook runtime only ensures these effects belong to the caller and can be diagnosed; each module still owns its own dedupe, merge, conflict, diagnostic, and execution-order semantics.
 
 
 criteria:
@@ -18,6 +18,10 @@ criteria:
     text:
       zh-CN: asHook 通过 `def` 引入的 setup effects 必须归属调用者 prototype。
       en: Setup effects introduced by asHook through `def` must belong to the caller prototype.
+  - id: C-AS-HOOK-0005-A2
+    text:
+      zh-CN: asHook 可以使用 `def` 句柄上的任意子 API；对这些子 API 的依赖不应被视为过度耦合。
+      en: An asHook may use any sub-API on the `def` handle; depending on those sub-APIs must not be treated as over-coupling.
   - id: C-AS-HOOK-0005-B
     text:
       zh-CN: asHook 不得为自身创建独立的 props/state/event/feedback/context/expose/rule 运行域。
@@ -52,6 +56,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured caller-owned effects and module-owned conflict handling for asHook.
+  - version: 0.1.1
+    change: clarified
+    summary: Clarified that asHooks share prototype def syntax rights and may depend on any def sub-API.
 tags:
   - as-hook
   - effects

--- a/spec/contracts/C-AS-HOOK-PRIVILEGED-0001.yaml
+++ b/spec/contracts/C-AS-HOOK-PRIVILEGED-0001.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: Privileged asHooks may use non-author-facing module ports or host-sensitive capabilities, and each privileged asHook must define its own caller shape, returned handle/API, repeat, configuration, and safety rules.
 statement:
   zh-CN: >-
-    特权 asHook 是官方提供的 asHook 形态，用于把过于强力、过于依赖宿主，或不适合直接暴露给原型作者的 module port 能力，以受限 API 交给原型作者使用。特权 asHook 可以使用普通 authored asHook 无权访问的 facade、port 或宿主协同能力；因此每个特权 asHook 都必须作为独特 API 定义自己的 caller shape、返回 handle/API、重复调用策略、配置合并、冲突诊断与安全边界。特权 asHook 必须在 trace 中标记 privileged。既有参数化特权 asHook 属于迁移断口；长期方向由 `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001` 收口为尽可能无参数 caller 和返回配置 API。
+    特权 asHook 是官方提供的 asHook 形态，用于把过于强力、过于依赖宿主，或不适合直接暴露给原型作者的 module port 能力，以受限 API 交给原型作者使用。特权 asHook 与普通 asHook 一样可以使用完整 `def` 语法，并且应优先用 `def` 语法表达可由原型语法表达的部分；只有普通 asHook 无权访问或原型语法表达力不足的部分，才应使用非公开 facade、port 或宿主协同能力。因此每个特权 asHook 都必须作为独特 API 定义自己的 caller shape、返回 handle/API、重复调用策略、配置合并、冲突诊断与安全边界。特权 asHook 必须在 trace 中标记 privileged。既有参数化特权 asHook 属于迁移断口；长期方向由 `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001` 收口为尽可能无参数 caller 和返回配置 API。
 
 
   en: >-
-    A privileged asHook is an official asHook form that exposes powerful, host-sensitive, or otherwise non-author-facing module-port capabilities to prototype authors through a restricted API. Privileged asHooks may use facades, ports, or host coordination capabilities unavailable to ordinary authored asHooks; therefore each privileged asHook must define its own caller shape, returned handles/APIs, repeat policy, configuration merge, conflict diagnostics, and safety boundaries as a distinct API. Privileged asHooks must mark themselves as privileged in trace metadata. Existing parameterized privileged asHooks are a migration fracture; `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001` narrows the long-term direction toward no-arg callers where possible and returned configuration APIs.
+    A privileged asHook is an official asHook form that exposes powerful, host-sensitive, or otherwise non-author-facing module-port capabilities to prototype authors through a restricted API. Like ordinary asHooks, privileged asHooks may use the full `def` syntax, and should prefer `def` syntax for behavior that prototype syntax can express; non-public facades, ports, or host coordination capabilities should be used only for capabilities unavailable to ordinary asHooks or not expressible through prototype syntax. Therefore each privileged asHook must define its own caller shape, returned handles/APIs, repeat policy, configuration merge, conflict diagnostics, and safety boundaries as a distinct API. Privileged asHooks must mark themselves as privileged in trace metadata. Existing parameterized privileged asHooks are a migration fracture; `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001` narrows the long-term direction toward no-arg callers where possible and returned configuration APIs.
 
 
 criteria:
@@ -18,6 +18,10 @@ criteria:
     text:
       zh-CN: 特权 asHook 可以使用普通原型作者 API 不开放的 module port、facade 或宿主协同能力。
       en: Privileged asHooks may use module ports, facades, or host coordination capabilities not exposed through ordinary prototype-author APIs.
+  - id: C-AS-HOOK-PRIVILEGED-0001-A2
+    text:
+      zh-CN: 特权 asHook 应优先使用 `def` 句柄语法表达 props、state、event、feedback、expose、context、rule、lifecycle 等可由原型语法表达的部分。
+      en: Privileged asHooks should prefer `def` handle syntax for props, state, event, feedback, expose, context, rule, lifecycle, and other behavior expressible through prototype syntax.
   - id: C-AS-HOOK-PRIVILEGED-0001-B
     text:
       zh-CN: 每个特权 asHook 必须定义自身的 caller shape、返回 handle/API、重复调用策略、配置合并和冲突诊断规则。
@@ -63,6 +67,9 @@ revisions:
   - version: 0.1.0
     change: updated
     summary: Rephrased privileged asHook API obligations around caller shape and returned handles/APIs, and linked the no-arg migration fracture.
+  - version: 0.1.1
+    change: clarified
+    summary: Clarified that privileged asHooks still share asHook def syntax rights and should use non-public ports only for capabilities outside prototype syntax.
 tags:
   - as-hook
   - privileged

--- a/spec/contracts/C-AS-HOOK-PRIVILEGED-0001.yaml
+++ b/spec/contracts/C-AS-HOOK-PRIVILEGED-0001.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: Privileged asHooks may use non-author-facing module ports or host-sensitive capabilities, and each privileged asHook must define its own caller shape, returned handle/API, repeat, configuration, and safety rules.
 statement:
   zh-CN: >-
-    特权 asHook 是官方提供的 asHook 形态，用于把过于强力、过于依赖宿主，或不适合直接暴露给原型作者的 module port 能力，以受限 API 交给原型作者使用。特权 asHook 与普通 asHook 一样可以使用完整 `def` 语法，并且应优先用 `def` 语法表达可由原型语法表达的部分；只有普通 asHook 无权访问或原型语法表达力不足的部分，才应使用非公开 facade、port 或宿主协同能力。因此每个特权 asHook 都必须作为独特 API 定义自己的 caller shape、返回 handle/API、重复调用策略、配置合并、冲突诊断与安全边界。特权 asHook 必须在 trace 中标记 privileged。既有参数化特权 asHook 属于迁移断口；长期方向由 `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001` 收口为尽可能无参数 caller 和返回配置 API。
+    特权 asHook 是官方提供的 asHook 形态，用于把过于强力、过于依赖宿主，或不适合直接暴露给原型作者的 module port 能力，以受限 API 交给原型作者使用。特权 asHook 与普通 asHook 一样可以使用完整 `def` 语法，并且应优先用 `def` 语法表达可由原型语法表达的部分；只有普通 asHook 无权访问或原型语法表达力不足的部分，才应使用非公开 facade、port 或宿主协同能力。官方特权 asHook 实现应通过内部 define helper 显式获得 `def`、facade 与 port 上下文；该 helper 不属于原型作者 API。因此每个特权 asHook 都必须作为独特 API 定义自己的 caller shape、返回 handle/API、重复调用策略、配置合并、冲突诊断与安全边界。特权 asHook 必须在 trace 中标记 privileged。既有参数化特权 asHook 属于迁移断口；长期方向由 `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001` 收口为尽可能无参数 caller 和返回配置 API。
 
 
   en: >-
-    A privileged asHook is an official asHook form that exposes powerful, host-sensitive, or otherwise non-author-facing module-port capabilities to prototype authors through a restricted API. Like ordinary asHooks, privileged asHooks may use the full `def` syntax, and should prefer `def` syntax for behavior that prototype syntax can express; non-public facades, ports, or host coordination capabilities should be used only for capabilities unavailable to ordinary asHooks or not expressible through prototype syntax. Therefore each privileged asHook must define its own caller shape, returned handles/APIs, repeat policy, configuration merge, conflict diagnostics, and safety boundaries as a distinct API. Privileged asHooks must mark themselves as privileged in trace metadata. Existing parameterized privileged asHooks are a migration fracture; `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001` narrows the long-term direction toward no-arg callers where possible and returned configuration APIs.
+    A privileged asHook is an official asHook form that exposes powerful, host-sensitive, or otherwise non-author-facing module-port capabilities to prototype authors through a restricted API. Like ordinary asHooks, privileged asHooks may use the full `def` syntax, and should prefer `def` syntax for behavior that prototype syntax can express; non-public facades, ports, or host coordination capabilities should be used only for capabilities unavailable to ordinary asHooks or not expressible through prototype syntax. Official privileged asHook implementations should obtain `def`, facade, and port context through an internal define helper; that helper is not a prototype-author API. Therefore each privileged asHook must define its own caller shape, returned handles/APIs, repeat policy, configuration merge, conflict diagnostics, and safety boundaries as a distinct API. Privileged asHooks must mark themselves as privileged in trace metadata. Existing parameterized privileged asHooks are a migration fracture; `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001` narrows the long-term direction toward no-arg callers where possible and returned configuration APIs.
 
 
 criteria:
@@ -22,6 +22,10 @@ criteria:
     text:
       zh-CN: 特权 asHook 应优先使用 `def` 句柄语法表达 props、state、event、feedback、expose、context、rule、lifecycle 等可由原型语法表达的部分。
       en: Privileged asHooks should prefer `def` handle syntax for props, state, event, feedback, expose, context, rule, lifecycle, and other behavior expressible through prototype syntax.
+  - id: C-AS-HOOK-PRIVILEGED-0001-A3
+    text:
+      zh-CN: 官方特权 asHook 实现应通过内部 define helper 显式接收 `def`、facade 与 port 上下文；该 helper 不得作为原型作者 API 暴露。
+      en: Official privileged asHook implementations should receive `def`, facade, and port context through an internal define helper; that helper must not be exposed as a prototype-author API.
   - id: C-AS-HOOK-PRIVILEGED-0001-B
     text:
       zh-CN: 每个特权 asHook 必须定义自身的 caller shape、返回 handle/API、重复调用策略、配置合并和冲突诊断规则。
@@ -53,6 +57,9 @@ sources:
   - path: packages/hooks/src/as-trigger.ts
     sections:
       - asTrigger
+  - path: packages/hooks/src/privileged.ts
+    sections:
+      - definePrivilegedAsHook
 dependsOn:
   contracts:
     - C-AS-HOOK-0001
@@ -60,6 +67,7 @@ dependsOn:
 relates:
   decisions:
     - D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001
+    - D-AS-HOOK-PRIVILEGED-DEFINE-0001
 revisions:
   - version: 0.1.0
     change: introduced
@@ -70,6 +78,9 @@ revisions:
   - version: 0.1.1
     change: clarified
     summary: Clarified that privileged asHooks still share asHook def syntax rights and should use non-public ports only for capabilities outside prototype syntax.
+  - version: 0.1.2
+    change: updated
+    summary: Added the internal privileged asHook define helper as the governed implementation entry for official privileged hooks.
 tags:
   - as-hook
   - privileged

--- a/spec/contracts/C-STATE-INTERACTION-0002.yaml
+++ b/spec/contracts/C-STATE-INTERACTION-0002.yaml
@@ -36,12 +36,12 @@ criteria:
       en: Declaring and maintaining interaction state must not implicitly trigger render or commit; UI updates must still occur through explicit update, rule, or another path defined by a separate contract.
   - id: C-STATE-INTERACTION-0002-F
     text:
-      zh-CN: 同一交互主体的 `disabled` interaction state 为 true 时，runtime-managed wiring 不得把 hovered、pressed、focused 或 focusVisible 激活为 true，并必须清理已经激活的这些瞬时 interaction state。
-      en: When the same interaction subject's `disabled` interaction state is true, runtime-managed wiring must not activate hovered, pressed, focused, or focusVisible to true and must clear any already-active transient interaction states among them.
+      zh-CN: 同一交互主体的 `disabled` interaction state 为 true 时，state-interaction runtime-managed wiring 不得把 hovered 或 pressed 激活为 true，并必须清理已经激活的 hovered/pressed 瞬时 interaction state。
+      en: When the same interaction subject's `disabled` interaction state is true, state-interaction runtime-managed wiring must not activate hovered or pressed to true and must clear any already-active hovered/pressed transient interaction state.
   - id: C-STATE-INTERACTION-0002-G
     text:
-      zh-CN: '`focusVisible` 必须反映 keyboard modality；进入 pointer modality 时，已激活的 focusVisible 必须被清理。'
-      en: '`focusVisible` must reflect keyboard modality; when pointer modality is entered, an active focusVisible state must be cleared.'
+      zh-CN: '`focused` 与 `focusVisible` 不属于 state-interaction 的 runtime-managed wiring 所有权；需要焦点事实的原型必须通过 focus 特权 asHook 或其后续投影契约取得。'
+      en: '`focused` and `focusVisible` are not owned by state-interaction runtime-managed wiring; prototypes that need focus facts must obtain them through the focus privileged asHook or a later focus projection contract.'
 openQuestions:
   - id: C-STATE-INTERACTION-0002-Q-MODULE-HOST-CAP-CATALOG
     question:
@@ -89,6 +89,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured interaction state as runtime-managed event-backed state semantics.
+  - version: 0.1.1
+    change: narrowed
+    summary: Removed focus-owned focused/focusVisible semantics from state-interaction wiring ownership.
 tags:
   - state
   - interaction

--- a/spec/decisions/D-AS-HOOK-PRIVILEGED-DEFINE-0001.yaml
+++ b/spec/decisions/D-AS-HOOK-PRIVILEGED-DEFINE-0001.yaml
@@ -1,0 +1,44 @@
+id: D-AS-HOOK-PRIVILEGED-DEFINE-0001
+type: decision
+title: Privileged asHooks use an internal define helper
+status: draft
+since: 0.1.0
+summary: Official privileged asHooks should be implemented through an internal helper that provides def syntax plus restricted facade and module-port context without exposing that capability to prototype authors.
+statement:
+  zh-CN: >-
+    特权 asHook 需要同时保持 asHook/原型语法的一致性，并访问普通原型作者 API 不开放的 facade 或 module port 能力。因此 `@proto.ui/hooks` 内部应提供定义特权 asHook 的 helper，让实现显式获得 `def`、facades、ports 与 asHook registration 上下文。该 helper 只服务官方包内部实现，不作为原型作者 API 暴露。特权 asHook 除了必须使用非公开能力的部分，仍应优先通过 `def` 语法表达 props、state、event、feedback、expose、context、rule、lifecycle 等效果；这可以避免把所有逻辑下沉到 module 中，导致 module 凭空依赖多个基础 module 并削弱模块原子性。
+
+  en: >-
+    A privileged asHook must preserve asHook/prototype syntax consistency while accessing facades or module ports that ordinary prototype-author APIs do not expose. Therefore `@proto.ui/hooks` should provide an internal helper for defining privileged asHooks, giving implementations explicit access to `def`, facades, ports, and asHook registration context. This helper only serves official package internals and is not exposed as a prototype-author API. Except for logic that truly needs non-public capabilities, privileged asHooks should still express props, state, event, feedback, expose, context, rule, lifecycle, and similar effects through `def` syntax; this avoids pushing all behavior into modules and making modules depend on unrelated base modules, which would weaken module atomicity.
+
+consequences:
+  - zh-CN: asTrigger、asFocusable 等官方特权 asHook 可以用统一入口登记 privileged trace 与重复策略。
+    en: Official privileged asHooks such as asTrigger and asFocusable can register privileged trace metadata and repeat policy through one entry point.
+  - zh-CN: 特权 asHook 的非公开能力访问点集中在 hooks 包内部，而不是扩散到原型作者语法面。
+    en: Non-public capability access for privileged asHooks stays concentrated inside the hooks package instead of spreading into prototype-author syntax.
+  - zh-CN: 可由 `def` 表达的逻辑仍留在 asHook 实现中，避免 module 为了支撑单个 hook 而依赖不相关基础 module。
+    en: Logic expressible through `def` remains in the asHook implementation, preventing modules from depending on unrelated base modules just to support one hook.
+relates:
+  contracts:
+    - C-AS-HOOK-PRIVILEGED-0001
+  decisions:
+    - D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001
+sources:
+  - path: packages/hooks/src/privileged.ts
+    sections:
+      - definePrivilegedAsHook
+  - path: packages/hooks/src/as-trigger.ts
+    sections:
+      - asTrigger
+  - path: packages/hooks/src/as-focusable.ts
+    sections:
+      - asFocusable
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Recorded the internal privileged asHook define helper as a governance boundary.
+tags:
+  - as-hook
+  - privileged
+  - module-port
+  - architecture

--- a/spec/decisions/D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001.yaml
+++ b/spec/decisions/D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: Privileged asHooks that still accept patch/options parameters are an open migration fracture; the intended direction is no-arg callers with setup-time configuration exposed through returned handles or explicit configuration APIs.
 statement:
   zh-CN: >-
-    v0 的 asHook 语义收口不只影响普通 `defineAsHook(...)` 产物，也暴露了既有特权 asHook 的迁移断口。现存 `asFocusable(patch)`、`asOverlay(patch)`、`asFocusScope(patch)`、`asFocusGroup(patch)`、`asBoundary(patch)`、`asHitParticipation(...)`、`asTransition(options)` 等 API 仍带有参数化或 configurable 重复调用语义；这些能力暂按各自既有实现维持，但不应继续作为长期 asHook caller 形态扩散。后续迁移方向是：特权 asHook caller 本身也应尽可能无参数；需要配置时，通过第一次调用返回的 handle/API 提供 setup 期配置入口，并由对应特权 asHook 契约定义合并、冲突诊断和返回值复用规则。
+    v0 的 asHook 语义收口不只影响普通 `defineAsHook(...)` 产物，也暴露了既有特权 asHook 的迁移断口。`asFocusable(patch)` 已按本决策迁移为 `asFocusable()` 加返回 handle 配置；现存 `asOverlay(patch)`、`asFocusScope(patch)`、`asFocusGroup(patch)`、`asBoundary(patch)`、`asHitParticipation(...)`、`asTransition(options)` 等 API 仍带有参数化或 configurable 重复调用语义。这些能力暂按各自既有实现维持，但不应继续作为长期 asHook caller 形态扩散。后续迁移方向是：特权 asHook caller 本身也应尽可能无参数；需要配置时，通过第一次调用返回的 handle/API 提供 setup 期配置入口，并由对应特权 asHook 契约定义合并、冲突诊断和返回值复用规则。
 
 
   en: >-
-    The v0 asHook semantic narrowing affects more than ordinary `defineAsHook(...)` products: it exposes an open migration fracture in existing privileged asHooks. Current APIs such as `asFocusable(patch)`, `asOverlay(patch)`, `asFocusScope(patch)`, `asFocusGroup(patch)`, `asBoundary(patch)`, `asHitParticipation(...)`, and `asTransition(options)` still carry parameterized or configurable repeat-call semantics. These capabilities remain governed by their existing implementations for now, but should not continue to spread as the long-term asHook caller shape. The migration direction is that privileged asHook callers should also be no-arg where possible; configuration should be exposed through setup-time handles/APIs returned by the first call, with merge, conflict diagnostics, and return-value reuse defined by each privileged asHook contract.
+    The v0 asHook semantic narrowing affects more than ordinary `defineAsHook(...)` products: it exposes an open migration fracture in existing privileged asHooks. `asFocusable(patch)` has now migrated under this decision to `asFocusable()` plus returned-handle configuration; current APIs such as `asOverlay(patch)`, `asFocusScope(patch)`, `asFocusGroup(patch)`, `asBoundary(patch)`, `asHitParticipation(...)`, and `asTransition(options)` still carry parameterized or configurable repeat-call semantics. These capabilities remain governed by their existing implementations for now, but should not continue to spread as the long-term asHook caller shape. The migration direction is that privileged asHook callers should also be no-arg where possible; configuration should be exposed through setup-time handles/APIs returned by the first call, with merge, conflict diagnostics, and return-value reuse defined by each privileged asHook contract.
 
 
 openQuestions:
@@ -85,6 +85,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Recorded the privileged asHook no-arg migration as an open fracture after narrowing ordinary authored asHook semantics.
+  - version: 0.1.1
+    change: partially-implemented
+    summary: Migrated asFocusable to a no-arg caller with setup-time configuration through the returned FocusableHandle.
 tags:
   - as-hook
   - privileged

--- a/spec/decisions/D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001.yaml
+++ b/spec/decisions/D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001.yaml
@@ -88,6 +88,9 @@ revisions:
   - version: 0.1.1
     change: partially-implemented
     summary: Migrated asFocusable to a no-arg caller with setup-time configuration through the returned FocusableHandle.
+  - version: 0.1.2
+    change: clarified
+    summary: Clarified implementation direction by moving asFocusable and simple handle-backed privileged hooks to once registration with repeated configuration through returned handles.
 tags:
   - as-hook
   - privileged

--- a/spec/decisions/D-FOCUS-STATE-INTERACTION-BOUNDARY-0001.yaml
+++ b/spec/decisions/D-FOCUS-STATE-INTERACTION-BOUNDARY-0001.yaml
@@ -1,0 +1,46 @@
+id: D-FOCUS-STATE-INTERACTION-BOUNDARY-0001
+type: decision
+title: Focus facts are owned by the focus privileged domain
+status: draft
+since: 0.1.0
+summary: Focus-related facts such as focused and focusVisible are state-backed facts owned by focus privileged asHooks instead of state-interaction; state-interaction keeps hover, press, and disabled interaction wiring.
+statement:
+  zh-CN: >-
+    `focused` 与 `focusVisible` 表达的是焦点系统事实，而不是通用 interaction state 可以独立决定的事实。v0 收口方向是：focus 事实由 `asFocusable()` 及后续 focus 特权 asHook/投影契约维护，并作为 state-backed observed handle 返回，以便 rule、expose 与 diagnostics 按 state-shaped value 消费；`state-interaction` 不再订阅 host focus/blur 或 keyboard modality 来拥有这些状态。`state-interaction` 继续负责 hovered、pressed 与 disabled gate 这类通用交互 wiring。旧有 `fromInteraction('focused' | 'focusVisible')` 类型面暂作为兼容断口保留，后续需要通过 focus projection 契约替代。
+
+
+  en: >-
+    `focused` and `focusVisible` are focus-system facts rather than facts that generic interaction state can decide independently. The v0 direction is that focus facts are maintained by `asFocusable()` and later focus privileged asHook/projection contracts, and returned as state-backed observed handles so rule, expose, and diagnostics can consume them as state-shaped values; `state-interaction` no longer subscribes to host focus/blur or keyboard modality to own these states. `state-interaction` continues to own generic interaction wiring such as hovered, pressed, and disabled gating. The legacy `fromInteraction('focused' | 'focusVisible')` type surface remains as a compatibility fracture for now and should be replaced by a focus projection contract later.
+
+relates:
+  contracts:
+    - C-STATE-INTERACTION-0002
+  decisions:
+    - D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001
+sources:
+  - path: packages/modules/focus/src/create.ts
+    sections:
+      - FocusModuleImpl
+  - path: packages/modules/state-interaction/src/create.ts
+    sections:
+      - StateInteractionModuleImpl
+  - path: internal/contracts/focus/base-text/as-focusable.v0.md
+  - path: internal/contracts/state/interaction/interaction-signals.v0.md
+openQuestions:
+  - id: D-FOCUS-STATE-INTERACTION-BOUNDARY-0001-Q1
+    question:
+      zh-CN: focus-owned facts 应通过 `def.state.fromFocus(...)`、`asFocusable().focused` 直接消费，还是通过 asHook state projection 暴露给组合原型？
+      en: Should focus-owned facts be consumed through `def.state.fromFocus(...)`, directly through `asFocusable().focused`, or through asHook state projection for composed prototypes?
+    blocks:
+      - focus-projection-contract
+      - state-interaction-compat-removal
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Recorded the focus/state-interaction ownership boundary after migrating asFocusable to a no-arg caller and state-backed focus fact handles.
+tags:
+  - focus
+  - state
+  - interaction
+  - as-hook
+  - fracture


### PR DESCRIPTION
## Summary

- migrate focus facts out of generic interaction state and expose focus facts through `asFocusable` state handles
- add an internal `definePrivilegedAsHook` helper for official privileged asHook implementations
- move simple handle-backed privileged hooks toward `once` registration with repeated setup-time configuration through returned handles
- tighten `asFocusable` and related privileged hook handle generics at base prototype and contract test call sites

## Validation

- `pnpm -s check:types:workspace`
- `pnpm exec vitest run packages/runtime/test/contract/focus.v0.contract.test.ts packages/runtime/test/contract/focus-group.v0.contract.test.ts packages/runtime/test/contract/as-trigger.v0.contract.test.ts packages/runtime/test/contract/boundary.v0.contract.test.ts packages/runtime/test/contract/overlay.v0.contract.test.ts packages/runtime/test/contract/hit-participation.v0.contract.test.ts`
- `git diff --check`