### PR TITLE
[codex] Stabilize dialog focus handling

### DIFF
--- a/internal/contracts/focus/base-text/focus-domain.v0.md
+++ b/internal/contracts/focus/base-text/focus-domain.v0.md
@@ -49,11 +49,14 @@ Focus facts are **system-owned**:
 
 - Component Authors may observe them
 - Component Authors must not write them directly as author-owned state
+- The focus system must keep long-lived `focused` and `focusVisible` facts internally consistent.
+- When a new focusable target becomes the owner through a focus request or host focus report, stale `focused`, `focusVisible`, and `active` facts on other focusable targets must be cleared.
 
 Focus commands are **requests**, not direct state mutation:
 
 - issuing a focus command does not itself prove focus has changed
 - actual facts must come from host/runtime resolution
+- fact uniqueness must not depend solely on the host always delivering a matching blur event.
 
 ---
 
@@ -106,7 +109,7 @@ In particular, v0 does not require:
 - identical focus granularity across adapters
 - a single implementation strategy such as DOM roving tabindex
 
-Adapters must preserve **internal consistency** for the focus semantics they implement.
+Adapters must preserve **internal consistency** for the focus semantics they implement. Within one Proto UI focus domain, a missed host blur must not leave multiple focusable targets claiming long-lived `focused` or `focusVisible` ownership.
 
 ---
 

--- a/internal/contracts/focus/base-text/focus-scope.v0.md
+++ b/internal/contracts/focus/base-text/focus-scope.v0.md
@@ -139,15 +139,19 @@ Activation is an explicit runtime action:
 - activating a scope marks that scope as the active coordination boundary;
 - activation records the previously focused logical target when that target is outside the activating scope;
 - activation requests focus for the first eligible logical focusable child when one exists, except when `entry: manual` leaves entry focus to the caller;
+- activation forwards the focus request reason to entry focus so keyboard-triggered entry keeps keyboard modality;
 - if no eligible child exists, `emptyPolicy: container` may activate the scope boundary without forging node focus.
 
 Deactivation is also explicit:
 
 - deactivation clears the scope active fact;
 - deactivation restores focus to the previously captured focus target when that target still exists;
+- deactivation forwards the focus request reason to restored focus so keyboard-triggered close keeps keyboard modality;
 - restore is a controlled focus transfer and may bypass the active-scope gate that ordinary outside focus requests must obey.
 
 While a scope is active, ordinary focus requests from outside that scope should be ignored with a diagnostic warning. Focus requests from the active scope or its logical descendants remain allowed.
+
+When trap/loop is enabled on the top active scope, Tab navigation should be interpreted as structured next/previous focus requests within that scope and should prevent host default traversal from escaping the scope. If the scope temporarily has no focused child because of pointer interaction on blank space or host variance, the next Tab navigation should recover from the last remembered scoped target or from the first/last eligible child.
 
 ---
 

--- a/packages/adapters/base/src/events/web-event-router.ts
+++ b/packages/adapters/base/src/events/web-event-router.ts
@@ -381,6 +381,10 @@ function createProtoEventPayload(type: string, native: any) {
     nativeEvent: native,
     target: native?.target,
     key: typeof native?.key === 'string' ? native.key : undefined,
+    shiftKey: typeof native?.shiftKey === 'boolean' ? native.shiftKey : undefined,
+    altKey: typeof native?.altKey === 'boolean' ? native.altKey : undefined,
+    ctrlKey: typeof native?.ctrlKey === 'boolean' ? native.ctrlKey : undefined,
+    metaKey: typeof native?.metaKey === 'boolean' ? native.metaKey : undefined,
     preventDefault:
       typeof native?.preventDefault === 'function' ? () => native.preventDefault() : undefined,
     stopPropagation:

--- a/packages/adapters/react/test/dialog.test.ts
+++ b/packages/adapters/react/test/dialog.test.ts
@@ -11,6 +11,8 @@ describe('adapter-react: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -43,6 +45,8 @@ describe('adapter-react: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -73,6 +77,8 @@ describe('adapter-react: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: false,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -108,6 +114,8 @@ describe('adapter-react: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -141,6 +149,8 @@ describe('adapter-react: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -170,6 +180,8 @@ describe('adapter-react: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,

--- a/packages/adapters/react/test/focus.test.ts
+++ b/packages/adapters/react/test/focus.test.ts
@@ -47,4 +47,34 @@ describe('adapter-react: focus wiring', () => {
 
     mounted.unmount();
   });
+
+  it('clears previous focus facts when another focusable receives host focus', () => {
+    const createProto = (name: string) =>
+      definePrototype({
+        name,
+        setup() {
+          asButton();
+          return (r) => [r.el('button', name)];
+        },
+      });
+
+    const first = createMountedReactAdapter(createProto('react-focus-unique-first'));
+    const second = createMountedReactAdapter(createProto('react-focus-unique-second'));
+
+    try {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      first.root?.dispatchEvent(new FocusEvent('focus'));
+      expect(first.ref.current.getExposes().focused.get()).toBe(true);
+      expect(first.ref.current.getExposes().focusVisible.get()).toBe(true);
+
+      second.root?.dispatchEvent(new FocusEvent('focus'));
+      expect(second.ref.current.getExposes().focused.get()).toBe(true);
+      expect(second.ref.current.getExposes().focusVisible.get()).toBe(true);
+      expect(first.ref.current.getExposes().focused.get()).toBe(false);
+      expect(first.ref.current.getExposes().focusVisible.get()).toBe(false);
+    } finally {
+      second.unmount();
+      first.unmount();
+    }
+  });
 });

--- a/packages/adapters/vue/test/dialog.test.ts
+++ b/packages/adapters/vue/test/dialog.test.ts
@@ -11,6 +11,8 @@ describe('adapter-vue: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -45,6 +47,8 @@ describe('adapter-vue: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -76,6 +80,8 @@ describe('adapter-vue: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: false,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -113,6 +119,8 @@ describe('adapter-vue: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -149,6 +157,8 @@ describe('adapter-vue: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,
@@ -180,6 +190,8 @@ describe('adapter-vue: dialog integration', () => {
       setup(def) {
         def.context.provide(DIALOG_CONTEXT, {
           open: true,
+          openFocusReason: null,
+          returnFocusReason: null,
           controlled: false,
           disabled: false,
           alert: false,

--- a/packages/adapters/vue/test/focus.test.ts
+++ b/packages/adapters/vue/test/focus.test.ts
@@ -49,4 +49,35 @@ describe('adapter-vue: focus wiring', () => {
 
     mounted.unmount();
   });
+
+  it('clears previous focus facts when another focusable receives host focus', async () => {
+    const createProto = (name: string) =>
+      definePrototype({
+        name,
+        setup() {
+          asButton();
+          return (r) => [r.el('button', name)];
+        },
+      });
+
+    const first = createMountedVueAdapter(createProto('vue-focus-unique-first'));
+    const second = createMountedVueAdapter(createProto('vue-focus-unique-second'));
+    await flushVue();
+
+    try {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      first.root?.dispatchEvent(new FocusEvent('focus'));
+      expect(first.vm.getExposes().focused.get()).toBe(true);
+      expect(first.vm.getExposes().focusVisible.get()).toBe(true);
+
+      second.root?.dispatchEvent(new FocusEvent('focus'));
+      expect(second.vm.getExposes().focused.get()).toBe(true);
+      expect(second.vm.getExposes().focusVisible.get()).toBe(true);
+      expect(first.vm.getExposes().focused.get()).toBe(false);
+      expect(first.vm.getExposes().focusVisible.get()).toBe(false);
+    } finally {
+      second.unmount();
+      first.unmount();
+    }
+  });
 });

--- a/packages/adapters/web-component/test/dialog-overlay.test.ts
+++ b/packages/adapters/web-component/test/dialog-overlay.test.ts
@@ -8,6 +8,7 @@ import {
   dialogTitle,
   dialogDescription,
   dialogClose,
+  button,
 } from '@proto.ui/prototypes-base';
 
 function registerDialogWcs() {
@@ -19,6 +20,7 @@ function registerDialogWcs() {
     dialogTitle,
     dialogDescription,
     dialogClose,
+    button,
   ];
 
   for (const proto of prototypes) {
@@ -62,6 +64,7 @@ describe('adapter-web-component: dialog overlay', () => {
     await Promise.resolve();
 
     expect(document.body.style.overflow).toBe('hidden');
+    expect(document.activeElement).toBe(close);
 
     trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await Promise.resolve();
@@ -136,6 +139,219 @@ describe('adapter-web-component: dialog overlay', () => {
     await Promise.resolve();
 
     expect(styleContains(content, 'hidden')).toBe(true);
+
+    root.remove();
+    document.body.style.overflow = '';
+  });
+
+  it('moves focus through demo-like wrapped dialog content and restores trigger on close', async () => {
+    registerDialogWcs();
+
+    const root = document.createElement('wc-base-dialog-root') as any;
+    const trigger = document.createElement('wc-base-dialog-trigger') as any;
+    const mask = document.createElement('wc-base-dialog-mask') as any;
+    const content = document.createElement('wc-base-dialog-content') as any;
+    const title = document.createElement('wc-base-dialog-title') as any;
+    const description = document.createElement('wc-base-dialog-description') as any;
+    const actions = document.createElement('div');
+    const cancel = document.createElement('wc-base-dialog-close') as any;
+    const confirm = document.createElement('wc-base-dialog-close') as any;
+
+    actions.appendChild(cancel);
+    actions.appendChild(confirm);
+    root.appendChild(trigger);
+    root.appendChild(mask);
+    root.appendChild(content);
+    content.appendChild(title);
+    content.appendChild(description);
+    content.appendChild(actions);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    trigger.focus();
+    trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(styleContains(content, 'hidden')).toBe(false);
+    expect(document.activeElement).toBe(cancel);
+
+    cancel.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(styleContains(content, 'hidden')).toBe(true);
+    expect(document.activeElement).toBe(trigger);
+
+    root.remove();
+    document.body.style.overflow = '';
+  });
+
+  it('routes keyboard activation from a nested trigger to the outer dialog trigger', async () => {
+    registerDialogWcs();
+
+    const root = document.createElement('wc-base-dialog-root') as any;
+    const trigger = document.createElement('wc-base-dialog-trigger') as any;
+    const innerButton = document.createElement('wc-base-button') as any;
+    const content = document.createElement('wc-base-dialog-content') as any;
+    const close = document.createElement('wc-base-dialog-close') as any;
+
+    innerButton.textContent = 'Open Dialog';
+    close.textContent = 'Cancel';
+    trigger.appendChild(innerButton);
+    content.appendChild(close);
+    root.appendChild(trigger);
+    root.appendChild(content);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    innerButton.focus();
+    innerButton.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(styleContains(content, 'hidden')).toBe(false);
+    expect(document.activeElement).toBe(close);
+    expect(close.getExposes().focusVisible.get()).toBe(true);
+
+    close.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    root.remove();
+    document.body.style.overflow = '';
+  });
+
+  it('restores focus-visible to the trigger after keyboard close', async () => {
+    registerDialogWcs();
+
+    const root = document.createElement('wc-base-dialog-root') as any;
+    const trigger = document.createElement('wc-base-dialog-trigger') as any;
+    const content = document.createElement('wc-base-dialog-content') as any;
+    const close = document.createElement('wc-base-dialog-close') as any;
+
+    trigger.textContent = 'Open Dialog';
+    close.textContent = 'Cancel';
+    content.appendChild(close);
+    root.appendChild(trigger);
+    root.appendChild(content);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    trigger.focus();
+    trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(close);
+    expect(close.getExposes().focusVisible.get()).toBe(true);
+
+    close.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(styleContains(content, 'hidden')).toBe(true);
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.getExposes().focusVisible.get()).toBe(true);
+
+    root.remove();
+    document.body.style.overflow = '';
+  });
+
+  it('traps tab navigation inside active dialog content', async () => {
+    registerDialogWcs();
+
+    const root = document.createElement('wc-base-dialog-root') as any;
+    const trigger = document.createElement('wc-base-dialog-trigger') as any;
+    const content = document.createElement('wc-base-dialog-content') as any;
+    const cancel = document.createElement('wc-base-dialog-close') as any;
+    const confirm = document.createElement('wc-base-dialog-close') as any;
+
+    cancel.textContent = 'Cancel';
+    confirm.textContent = 'Confirm';
+    content.appendChild(cancel);
+    content.appendChild(confirm);
+    root.appendChild(trigger);
+    root.appendChild(content);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(cancel);
+
+    cancel.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(confirm);
+
+    confirm.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(cancel);
+
+    cancel.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(confirm);
+
+    confirm.blur();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    content.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(cancel);
+
+    cancel.blur();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    content.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(confirm);
+
+    confirm.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 
     root.remove();
     document.body.style.overflow = '';

--- a/packages/adapters/web-component/test/previewer.demo-renderer.test.ts
+++ b/packages/adapters/web-component/test/previewer.demo-renderer.test.ts
@@ -2,9 +2,17 @@ import { describe, expect, it } from 'vitest';
 import { loadPrototypes } from '../../../../apps/www/src/components/PrototypePreviewer/prototype-modules';
 import { renderDemo } from '../../../../apps/www/src/components/PrototypePreviewer/demo-renderer';
 import demo from '../../../../apps/www/src/content/docs/demo_components/tabs/demo-shadcn-tabs.demo';
+import baseDialogDemo from '../../../../apps/www/src/content/docs/zh-cn/demo-base-dialog.demo';
+import shadcnDialogDemo from '../../../../apps/www/src/content/docs/zh-cn/demo-shadcn-dialog.demo';
 
 function styleContains(el: Element | null, token: string): boolean {
   return (el?.getAttribute('data-pui-style') ?? '').split(/\s+/).includes(token);
+}
+
+async function settle() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe('PrototypePreviewer demo-renderer / wc', () => {
@@ -43,6 +51,96 @@ describe('PrototypePreviewer demo-renderer / wc', () => {
     expect(styleContains(list, 'inline-flex')).toBe(true);
     expect(styleContains(trigger, 'rounded-lg')).toBe(true);
     expect(styleContains(content, 'min-h-28')).toBe(true);
+
+    await session.destroy();
+    host.remove();
+  });
+
+  it('moves focus into the base dialog demo when opened', async () => {
+    await loadPrototypes([
+      'base-dialog-root',
+      'base-dialog-trigger',
+      'base-dialog-mask',
+      'base-dialog-content',
+      'base-dialog-title',
+      'base-dialog-description',
+      'base-dialog-close',
+    ]);
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const session = await renderDemo({
+      runtime: 'wc',
+      demo: baseDialogDemo as any,
+      host,
+    });
+
+    await settle();
+
+    const trigger = host.querySelector('wc-base-dialog-trigger') as HTMLElement | null;
+    const content = host.querySelector('wc-base-dialog-content') as HTMLElement | null;
+    const close = host.querySelector('wc-base-dialog-close') as HTMLElement | null;
+
+    expect(trigger).not.toBeNull();
+    expect(content).not.toBeNull();
+    expect(close).not.toBeNull();
+    expect(styleContains(content, 'hidden')).toBe(true);
+
+    trigger?.focus();
+    trigger?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await settle();
+
+    expect(styleContains(content, 'hidden')).toBe(false);
+    expect(document.activeElement).toBe(close);
+
+    close?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
+
+    await session.destroy();
+    host.remove();
+  });
+
+  it('moves focus into the shadcn dialog demo when opened', async () => {
+    await loadPrototypes([
+      'shadcn-dialog-root',
+      'shadcn-dialog-trigger',
+      'shadcn-dialog-mask',
+      'shadcn-dialog-content',
+      'shadcn-dialog-title',
+      'shadcn-dialog-description',
+      'shadcn-dialog-close',
+    ]);
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const session = await renderDemo({
+      runtime: 'wc',
+      demo: shadcnDialogDemo as any,
+      host,
+    });
+
+    await settle();
+
+    const trigger = host.querySelector('wc-shadcn-dialog-trigger') as HTMLElement | null;
+    const content = host.querySelector('wc-shadcn-dialog-content') as HTMLElement | null;
+    const close = host.querySelector('wc-shadcn-dialog-close') as HTMLElement | null;
+
+    expect(trigger).not.toBeNull();
+    expect(content).not.toBeNull();
+    expect(close).not.toBeNull();
+    expect(styleContains(content, 'hidden')).toBe(true);
+
+    trigger?.focus();
+    trigger?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await settle();
+
+    expect(styleContains(content, 'hidden')).toBe(false);
+    expect(document.activeElement).toBe(close);
+
+    close?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await settle();
 
     await session.destroy();
     host.remove();

--- a/packages/core/src/focus.ts
+++ b/packages/core/src/focus.ts
@@ -146,8 +146,8 @@ export interface FocusScopeHandle<P extends PropsBaseType = PropsBaseType> {
   focusPrev(): void;
   focusSelected(): void;
   restoreFocus(): void;
-  activate(): void;
-  deactivate(): void;
+  activate(options?: FocusRequestOptions): void;
+  deactivate(options?: FocusRequestOptions): void;
   isActive(): boolean;
 
   configure(patch: FocusScopeConfigPatch): void;

--- a/packages/modules/focus/package.json
+++ b/packages/modules/focus/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "@proto.ui/core": "workspace:*",
     "@proto.ui/module-base": "workspace:*",
+    "@proto.ui/module-event": "workspace:*",
+    "@proto.ui/module-state": "workspace:*",
     "@proto.ui/types": "workspace:*"
   },
   "exports": {

--- a/packages/modules/focus/src/center.ts
+++ b/packages/modules/focus/src/center.ts
@@ -25,6 +25,7 @@ export type FocusCenterEntry = {
   getFacts(): FocusFacts;
   getRootTarget(): HTMLElement | null;
   requestFocus(options?: FocusRequestOptions, behavior?: FocusRequestBehavior): void;
+  clearFocus(reason: unknown): void;
   setScopeActive(active: boolean): void;
   pushWarning(message: string): void;
 };
@@ -37,6 +38,7 @@ type ActiveScopeRecord = {
 export class FocusCenter {
   private readonly entries = new Map<FocusInstanceToken, FocusCenterEntry>();
   private readonly activeScopes: ActiveScopeRecord[] = [];
+  private readonly lastFocusedByScope = new Map<FocusInstanceToken, FocusInstanceToken>();
   private currentFocused: FocusInstanceToken | null = null;
 
   upsert(entry: FocusCenterEntry): void {
@@ -46,6 +48,10 @@ export class FocusCenter {
   remove(instance: FocusInstanceToken): void {
     this.entries.delete(instance);
     if (this.currentFocused === instance) this.currentFocused = null;
+    this.lastFocusedByScope.delete(instance);
+    for (const [scope, focused] of this.lastFocusedByScope) {
+      if (focused === instance) this.lastFocusedByScope.delete(scope);
+    }
     for (let i = this.activeScopes.length - 1; i >= 0; i--) {
       if (this.activeScopes[i]?.scope === instance || this.activeScopes[i]?.previous === instance) {
         this.activeScopes.splice(i, 1);
@@ -114,10 +120,20 @@ export class FocusCenter {
   private getFocusedEntry(): FocusCenterEntry | null {
     if (this.currentFocused) {
       const entry = this.entries.get(this.currentFocused);
-      if (entry) return entry;
+      if (entry?.getFacts().focused) return entry;
       this.currentFocused = null;
     }
     return Array.from(this.entries.values()).find((entry) => entry.getFacts().focused) ?? null;
+  }
+
+  private clearOtherFocusedEntries(next: FocusCenterEntry, reason: unknown): void {
+    for (const entry of this.entries.values()) {
+      if (entry.instance === next.instance) continue;
+      if (!entry.isFocusable()) continue;
+      const facts = entry.getFacts();
+      if (!facts.focused && !facts.focusVisible && !facts.active) continue;
+      entry.clearFocus(reason);
+    }
   }
 
   private getScopeMembers(scope: FocusCenterEntry): FocusCenterEntry[] {
@@ -152,14 +168,28 @@ export class FocusCenter {
       );
       return false;
     }
+    this.clearOtherFocusedEntries(entry, options?.reason ?? 'focus.request');
     entry.requestFocus(options, behavior);
     if (behavior?.syncFacts !== false) {
       this.currentFocused = entry.instance;
     }
+    this.noteFocused(entry);
     return true;
   }
 
-  activateScope(scope: FocusCenterEntry): boolean {
+  noteFocused(entry: FocusCenterEntry): void {
+    this.clearOtherFocusedEntries(entry, 'focus.host:focus');
+    this.currentFocused = entry.instance;
+    for (const record of this.activeScopes) {
+      const scope = this.entries.get(record.scope);
+      if (!scope?.isScopeProvider()) continue;
+      if (this.isDescendantOf(entry, scope)) {
+        this.lastFocusedByScope.set(scope.instance, entry.instance);
+      }
+    }
+  }
+
+  activateScope(scope: FocusCenterEntry, options?: FocusRequestOptions): boolean {
     if (!scope.isScopeProvider()) return false;
 
     const existingIndex = this.activeScopes.findIndex((record) => record.scope === scope.instance);
@@ -178,7 +208,7 @@ export class FocusCenter {
       ? (this.getRovingMembers(scope)[0] ?? null)
       : (this.getScopeMembers(scope)[0] ?? null);
     if (target) {
-      this.requestFocus(target, { reason: 'programmatic' }, { syncFacts: true });
+      this.requestFocus(target, options ?? { reason: 'programmatic' }, { syncFacts: true });
       return true;
     }
 
@@ -188,7 +218,7 @@ export class FocusCenter {
     return false;
   }
 
-  deactivateScope(scope: FocusCenterEntry): boolean {
+  deactivateScope(scope: FocusCenterEntry, options?: FocusRequestOptions): boolean {
     let index = -1;
     for (let i = this.activeScopes.length - 1; i >= 0; i--) {
       if (this.activeScopes[i]?.scope === scope.instance) {
@@ -206,20 +236,49 @@ export class FocusCenter {
 
     const previousEntry = previous ? (this.entries.get(previous) ?? null) : null;
     if (previousEntry) {
-      this.requestFocus(
-        previousEntry,
-        { reason: 'programmatic' },
-        {
-          bypassGate: true,
-          syncFacts: true,
-        }
-      );
+      this.requestFocus(previousEntry, options ?? { reason: 'programmatic' }, {
+        bypassGate: true,
+        syncFacts: true,
+      });
     }
     return true;
   }
 
   isScopeActive(scope: FocusCenterEntry): boolean {
     return this.activeScopes.some((record) => record.scope === scope.instance);
+  }
+
+  isTopActiveScope(scope: FocusCenterEntry): boolean {
+    return this.getTopActiveScope()?.instance === scope.instance;
+  }
+
+  focusInScope(scope: FocusCenterEntry, op: 'next' | 'prev'): boolean {
+    if (!scope.isScopeProvider() || !this.isTopActiveScope(scope)) return false;
+
+    const members = this.getScopeMembers(scope);
+    if (members.length === 0) return false;
+
+    const focused = this.getFocusedEntry();
+    const remembered = this.lastFocusedByScope.get(scope.instance) ?? null;
+    const currentIndex = focused
+      ? members.findIndex((entry) => entry.instance === focused.instance)
+      : remembered
+        ? members.findIndex((entry) => entry.instance === remembered)
+        : -1;
+    const delta = op === 'next' ? 1 : -1;
+    let nextIndex =
+      currentIndex >= 0 ? currentIndex + delta : op === 'next' ? 0 : members.length - 1;
+
+    if (scope.getScopeConfig().loop) {
+      nextIndex = (nextIndex + members.length) % members.length;
+    } else {
+      nextIndex = Math.max(0, Math.min(members.length - 1, nextIndex));
+    }
+
+    const target = members[nextIndex] ?? null;
+    if (!target) return false;
+    this.requestFocus(target, { reason: 'keyboard' }, { syncFacts: false });
+    return true;
   }
 
   getRovingMembers(provider: FocusCenterEntry): FocusCenterEntry[] {

--- a/packages/modules/focus/src/create.ts
+++ b/packages/modules/focus/src/create.ts
@@ -92,6 +92,7 @@ class FocusModuleImpl extends ModuleBase {
   private didAutoFocus = false;
   private keyboardModality = false;
   private hostEventsWired = false;
+  private scopeEventsWired = false;
 
   private readonly focusedOwned: OwnedStateHandle<boolean>;
   private readonly focusVisibleOwned: OwnedStateHandle<boolean>;
@@ -152,8 +153,8 @@ class FocusModuleImpl extends ModuleBase {
       focusPrev: () => this.focusPrev(),
       focusSelected: () => this.focusSelected(),
       restoreFocus: () => this.restoreFocus(),
-      activate: () => this.activateScope(),
-      deactivate: () => this.deactivateScope(),
+      activate: (options?: FocusRequestOptions) => this.activateScope(options),
+      deactivate: (options?: FocusRequestOptions) => this.deactivateScope(options),
       isActive: () => this.isScopeActive(),
       configure: (patch: FocusScopeConfigPatch) => this.configureScope(patch),
       getRoving: () => this.getRoving(),
@@ -246,6 +247,9 @@ class FocusModuleImpl extends ModuleBase {
           this.requestFocusDirect(options);
         });
       },
+      clearFocus: (reason: unknown) => {
+        this.runInCallbackScope(() => this.clearFocus(reason));
+      },
       setScopeActive: (active: boolean) => this.setScopeActive(active),
       pushWarning: (message: string) => this.warnings.push(message),
     };
@@ -290,6 +294,7 @@ class FocusModuleImpl extends ModuleBase {
 
   private declareScope(): void {
     this.scopeDeclared = true;
+    this.wireScopeKeyEvents();
     this.syncCenter();
   }
 
@@ -323,11 +328,35 @@ class FocusModuleImpl extends ModuleBase {
       );
       this.setFocusState(this.activeOwned, true, 'reason: focus.host:focus => active');
       this.setFocusState(this.hasFocusedOwned, true, 'reason: focus.host:focus => hasFocused');
+      const entry = this.createCenterEntry();
+      if (entry) FOCUS_CENTER.noteFocused(entry);
     });
     this.eventPort.on('host:blur', () => {
       this.setFocusState(this.focusedOwned, false, 'reason: focus.host:blur => focused');
       this.setFocusState(this.focusVisibleOwned, false, 'reason: focus.host:blur => focusVisible');
       this.setFocusState(this.activeOwned, false, 'reason: focus.host:blur => active');
+    });
+  }
+
+  private wireScopeKeyEvents(): void {
+    if (this.scopeEventsWired) return;
+    this.scopeEventsWired = true;
+
+    this.eventPort.onGlobal('key.down', (ev) => {
+      if (!this.scopeDeclared) return;
+      if (!this.scopeConfig.trap) return;
+      if (this.scopeConfig.navigation !== 'tab' && this.scopeConfig.navigation !== 'tab+arrow') {
+        return;
+      }
+
+      const detail = ev?.detail;
+      if (detail?.key !== 'Tab') return;
+
+      const entry = this.createCenterEntry();
+      if (!entry || !FOCUS_CENTER.isTopActiveScope(entry)) return;
+
+      detail?.preventDefault?.();
+      FOCUS_CENTER.focusInScope(entry, detail?.shiftKey ? 'prev' : 'next');
     });
   }
 
@@ -554,6 +583,12 @@ class FocusModuleImpl extends ModuleBase {
     this.setFocusState(this.hasFocusedOwned, true, options?.reason ?? 'programmatic');
   }
 
+  private clearFocus(reason: unknown): void {
+    this.setFocusState(this.focusedOwned, false, reason);
+    this.setFocusState(this.focusVisibleOwned, false, reason);
+    this.setFocusState(this.activeOwned, false, reason);
+  }
+
   requestFocus(options?: FocusRequestOptions): void {
     if (!this.focusableDeclared || this.focusableConfig.disabled) return;
     const entry = this.createCenterEntry();
@@ -649,20 +684,20 @@ class FocusModuleImpl extends ModuleBase {
     this.requestFocus({ reason: 'programmatic' });
   }
 
-  activateScope(): void {
+  activateScope(options?: FocusRequestOptions): void {
     this.declareScope();
     const entry = this.createCenterEntry();
     if (!entry) return;
-    FOCUS_CENTER.activateScope(entry);
+    FOCUS_CENTER.activateScope(entry, options);
   }
 
-  deactivateScope(): void {
+  deactivateScope(options?: FocusRequestOptions): void {
     const entry = this.createCenterEntry();
     if (!entry) {
       this.setScopeActive(false);
       return;
     }
-    FOCUS_CENTER.deactivateScope(entry);
+    FOCUS_CENTER.deactivateScope(entry, options);
   }
 
   isScopeActive(): boolean {
@@ -777,8 +812,8 @@ export function createFocusModule(ctx: ModuleFactoryArgs): FocusModule {
         focusPrev: () => impl.focusPrev(),
         focusSelected: () => impl.focusSelected(),
         restoreFocus: () => impl.restoreFocus(),
-        activateScope: () => impl.activateScope(),
-        deactivateScope: () => impl.deactivateScope(),
+        activateScope: (options) => impl.activateScope(options),
+        deactivateScope: (options) => impl.deactivateScope(options),
         isScopeActive: () => impl.isScopeActive(),
         getEffectiveRovingKey: () => impl.getEffectiveRovingKey(),
         getEffectiveGroupKey: () => impl.getEffectiveRovingKey(),

--- a/packages/modules/focus/src/types.ts
+++ b/packages/modules/focus/src/types.ts
@@ -36,8 +36,8 @@ export type FocusPort = {
   focusPrev(): void;
   focusSelected(): void;
   restoreFocus(): void;
-  activateScope(): void;
-  deactivateScope(): void;
+  activateScope(options?: FocusRequestOptions): void;
+  deactivateScope(options?: FocusRequestOptions): void;
   isScopeActive(): boolean;
   getEffectiveRovingKey(): FocusRovingKey | undefined;
   getEffectiveGroupKey(): FocusRovingKey | undefined;

--- a/packages/prototypes/base/src/dialog/close.ts
+++ b/packages/prototypes/base/src/dialog/close.ts
@@ -1,6 +1,6 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { asButton } from '../button';
-import { DIALOG_CONTEXT, DIALOG_FAMILY } from './shared';
+import { DIALOG_CONTEXT, DIALOG_FAMILY, type DialogOpenFocusReason } from './shared';
 import type { DialogCloseAsHookContract, DialogCloseExposes, DialogCloseProps } from './types';
 
 function setupDialogClose(def: DefHandle<DialogCloseProps, DialogCloseExposes>): void {
@@ -16,14 +16,17 @@ function setupDialogClose(def: DefHandle<DialogCloseProps, DialogCloseExposes>):
 
   def.context.subscribe(DIALOG_CONTEXT);
 
-  def.event.on('press.commit', (run) => {
+  def.event.on('press.commit', (run, ev) => {
     const ownDisabled = !!run.props.get().disabled;
     const ctx = run.context.read(DIALOG_CONTEXT);
     if (ownDisabled || ctx.disabled) return;
     if (ctx.controlled) return;
+    const returnFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
     run.context.update(DIALOG_CONTEXT, (prev) => ({
       ...prev,
       open: false,
+      openFocusReason: null,
+      returnFocusReason,
     }));
   });
 }

--- a/packages/prototypes/base/src/dialog/content.ts
+++ b/packages/prototypes/base/src/dialog/content.ts
@@ -1,7 +1,7 @@
 import { defineAsHook, definePrototype, tw, type DefHandle } from '@proto.ui/core';
 import { asBoundary, asFocusScope, asOverlay } from '@proto.ui/hooks';
 import { asTransition } from '../tools';
-import { DIALOG_CONTEXT, DIALOG_FAMILY } from './shared';
+import { DIALOG_CONTEXT, DIALOG_FAMILY, type DialogOpenFocusReason } from './shared';
 import type {
   DialogContentAsHookContract,
   DialogContentExposes,
@@ -34,7 +34,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   const boundary = asBoundary();
 
   const focusScope = asFocusScope<DialogContentProps>();
-  focusScope.configure({ trap: true });
+  focusScope.configure({ trap: true, loop: true });
 
   const transition = asTransition();
   const controls = transition.controls;
@@ -44,14 +44,18 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
 
   let mountedRun: any = null;
 
-  const updateOpen = (nextOpen: boolean, reason?: string) => {
+  const updateOpen = (
+    nextOpen: boolean,
+    reason?: string,
+    options?: { focusReason?: DialogOpenFocusReason | null }
+  ) => {
     const prevOpen = open.get();
     open.set(nextOpen, reason ?? 'reason: dialog content sync => open');
     if (nextOpen) {
       overlay.openOverlay(reason ?? 'dialog.open');
-      if (!prevOpen) focusScope.activate();
+      if (!prevOpen) focusScope.activate({ reason: options?.focusReason ?? 'programmatic' });
     } else {
-      if (prevOpen) focusScope.deactivate();
+      if (prevOpen) focusScope.deactivate({ reason: options?.focusReason ?? 'programmatic' });
       overlay.close(reason ?? 'dialog.close');
     }
   };
@@ -63,14 +67,18 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
 
   def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
     syncAlert(run);
-    updateOpen(next.open, 'reason: dialog context sync => content');
+    updateOpen(next.open, 'reason: dialog context sync => content', {
+      focusReason: next.open ? next.openFocusReason : next.returnFocusReason,
+    });
   });
 
   def.lifecycle.onMounted((run) => {
     mountedRun = run;
     syncAlert(run);
     const ctx = run.context.read(DIALOG_CONTEXT);
-    updateOpen(ctx.open, 'reason: lifecycle.onMounted => dialog content open sync');
+    updateOpen(ctx.open, 'reason: lifecycle.onMounted => dialog content open sync', {
+      focusReason: ctx.open ? ctx.openFocusReason : ctx.returnFocusReason,
+    });
     if (ctx.open) {
       controls.enter();
     } else {
@@ -92,11 +100,17 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
       if (!run) return;
       const ctx = run.context.read(DIALOG_CONTEXT);
       if (ctx.controlled) return;
-      run.context.update(DIALOG_CONTEXT, (prev: any) => ({ ...prev, open: false }));
+      run.context.update(DIALOG_CONTEXT, (prev: any) => ({
+        ...prev,
+        open: false,
+        openFocusReason: null,
+        returnFocusReason: null,
+      }));
     }
   });
 
   def.event.onGlobal('host:pointerdown', (run, ev) => {
+    const returnFocusReason: DialogOpenFocusReason = 'pointer';
     const ctx = run.context.read(DIALOG_CONTEXT);
     if (!ctx.open) return;
     if (alertProp.get()) return;
@@ -109,27 +123,38 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     if (classification !== 'outside') return;
 
     if (ctx.controlled) {
-      focusScope.deactivate();
+      focusScope.deactivate({ reason: returnFocusReason });
       overlay.close('outside.press');
       controls.leave();
       return;
     }
-    run.context.update(DIALOG_CONTEXT, (prev) => ({ ...prev, open: false }));
+    run.context.update(DIALOG_CONTEXT, (prev) => ({
+      ...prev,
+      open: false,
+      openFocusReason: null,
+      returnFocusReason,
+    }));
   });
 
   def.event.onGlobal('key.down', (run, ev) => {
+    const returnFocusReason: DialogOpenFocusReason = 'keyboard';
     const ctx = run.context.read(DIALOG_CONTEXT);
     if (!ctx.open) return;
     const key = ev?.detail?.key;
     if (key !== 'Escape') return;
 
     if (ctx.controlled) {
-      focusScope.deactivate();
+      focusScope.deactivate({ reason: returnFocusReason });
       overlay.close('escape');
       controls.leave();
       return;
     }
-    run.context.update(DIALOG_CONTEXT, (prev) => ({ ...prev, open: false }));
+    run.context.update(DIALOG_CONTEXT, (prev) => ({
+      ...prev,
+      open: false,
+      openFocusReason: null,
+      returnFocusReason,
+    }));
   });
 
   def.rule({

--- a/packages/prototypes/base/src/dialog/root.ts
+++ b/packages/prototypes/base/src/dialog/root.ts
@@ -6,6 +6,8 @@ import type { DialogRootAsHookContract, DialogRootExposes, DialogRootProps } fro
 function sameContext(a: DialogContextValue, b: DialogContextValue): boolean {
   return (
     a.open === b.open &&
+    a.openFocusReason === b.openFocusReason &&
+    a.returnFocusReason === b.returnFocusReason &&
     a.controlled === b.controlled &&
     a.disabled === b.disabled &&
     a.alert === b.alert
@@ -29,6 +31,8 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
 
   def.context.provide(DIALOG_CONTEXT, {
     open: false,
+    openFocusReason: null,
+    returnFocusReason: null,
     controlled: false,
     disabled: false,
     alert: false,
@@ -41,6 +45,8 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
 
   const initialContext: DialogContextValue = {
     open: false,
+    openFocusReason: null,
+    returnFocusReason: null,
     controlled: false,
     disabled: false,
     alert: false,

--- a/packages/prototypes/base/src/dialog/shared.ts
+++ b/packages/prototypes/base/src/dialog/shared.ts
@@ -1,7 +1,11 @@
 import { createAnatomyFamily, createContextKey } from '@proto.ui/core';
 
+export type DialogOpenFocusReason = 'programmatic' | 'keyboard' | 'pointer';
+
 export type DialogContextValue = {
   open: boolean;
+  openFocusReason: DialogOpenFocusReason | null;
+  returnFocusReason: DialogOpenFocusReason | null;
   controlled: boolean;
   disabled: boolean;
   alert: boolean;

--- a/packages/prototypes/base/src/dialog/trigger.ts
+++ b/packages/prototypes/base/src/dialog/trigger.ts
@@ -1,6 +1,6 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { asButton } from '../button';
-import { DIALOG_CONTEXT, DIALOG_FAMILY } from './shared';
+import { DIALOG_CONTEXT, DIALOG_FAMILY, type DialogOpenFocusReason } from './shared';
 import type {
   DialogTriggerAsHookContract,
   DialogTriggerExposes,
@@ -20,14 +20,17 @@ function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExpo
 
   def.context.subscribe(DIALOG_CONTEXT);
 
-  def.event.on('press.commit', (run) => {
+  def.event.on('press.commit', (run, ev) => {
     const ownDisabled = !!run.props.get().disabled;
     const ctx = run.context.read(DIALOG_CONTEXT);
     if (ownDisabled || ctx.disabled) return;
     if (ctx.controlled) return;
+    const openFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
     run.context.update(DIALOG_CONTEXT, (prev) => ({
       ...prev,
       open: !prev.open,
+      openFocusReason: prev.open ? null : openFocusReason,
+      returnFocusReason: prev.open ? openFocusReason : null,
     }));
   });
 }

--- a/packages/prototypes/shadcn/test/dialog.test.ts
+++ b/packages/prototypes/shadcn/test/dialog.test.ts
@@ -54,6 +54,7 @@ describe('prototypes/shadcn: dialog', () => {
     expect(styleContains(content, 'shadow-lg')).toBe(true);
     expect(styleContains(title, 'text-lg')).toBe(true);
     expect(styleContains(description, 'text-muted-foreground')).toBe(true);
+    expect(document.activeElement).toBe(close);
 
     close.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await Promise.resolve();

--- a/packages/runtime/test/contract/dropdown-menu.v0.contract.test.ts
+++ b/packages/runtime/test/contract/dropdown-menu.v0.contract.test.ts
@@ -11,7 +11,11 @@ import {
   ANATOMY_ROOT_TARGET_CAP,
 } from '@proto.ui/module-anatomy';
 import { CONTEXT_INSTANCE_TOKEN_CAP, CONTEXT_PARENT_CAP } from '@proto.ui/module-context';
-import { FOCUS_INSTANCE_TOKEN_CAP, FOCUS_PARENT_CAP } from '@proto.ui/module-focus';
+import {
+  FOCUS_INSTANCE_TOKEN_CAP,
+  FOCUS_PARENT_CAP,
+  FOCUS_RUN_IN_CALLBACK_CAP,
+} from '@proto.ui/module-focus';
 import {
   AS_TRIGGER_GET_PROTO_CAP,
   AS_TRIGGER_INSTANCE_CAP,
@@ -81,6 +85,7 @@ function createDropdownRuntimeTree(options?: {
     const scheduled: Array<() => void> = [];
     let raw = { ...(args.raw ?? {}) };
     let exposes: Record<string, any> | null = null;
+    let runInCallbackScope: ((fn: () => void) => void) | null = null;
 
     const host: RuntimeHost<any> = {
       prototypeName: args.prototypeName,
@@ -112,6 +117,16 @@ function createDropdownRuntimeTree(options?: {
         wiring.attach('focus', [
           [FOCUS_INSTANCE_TOKEN_CAP, args.target],
           [FOCUS_PARENT_CAP, (instance: unknown) => parents.get(instance) ?? null],
+          [
+            FOCUS_RUN_IN_CALLBACK_CAP,
+            (fn: () => void) => {
+              if (runInCallbackScope) {
+                runInCallbackScope(fn);
+                return;
+              }
+              fn();
+            },
+          ],
         ]);
         wiring.attach('as-trigger', [
           [AS_TRIGGER_INSTANCE_CAP, args.target],
@@ -126,6 +141,9 @@ function createDropdownRuntimeTree(options?: {
       scheduled,
       target: args.target,
       getExposes: () => exposes,
+      setRunInCallbackScope(next: (fn: () => void) => void) {
+        runInCallbackScope = next;
+      },
       applyRawProps(next: Record<string, unknown>) {
         raw = { ...next };
       },
@@ -158,6 +176,10 @@ function createDropdownRuntimeTree(options?: {
     itemA: executeWithHost(dropdownItem as any, itemA.host as any),
     itemB: executeWithHost(dropdownItem as any, itemB.host as any),
   };
+  root.setRunInCallbackScope(execs.root.invokeInCallbackScope);
+  content.setRunInCallbackScope(execs.content.invokeInCallbackScope);
+  itemA.setRunInCallbackScope(execs.itemA.invokeInCallbackScope);
+  itemB.setRunInCallbackScope(execs.itemB.invokeInCallbackScope);
 
   const syncAll = () => {
     execs.root.controller.update();

--- a/packages/runtime/test/contract/focus-roving.v0.contract.test.ts
+++ b/packages/runtime/test/contract/focus-roving.v0.contract.test.ts
@@ -14,6 +14,8 @@ import { EVENT_GLOBAL_TARGET_CAP, EVENT_ROOT_TARGET_CAP } from '@proto.ui/module
 import type { PropsBaseType } from '@proto.ui/types';
 
 const createHost = <P extends PropsBaseType>(name: string) => {
+  const rootTarget = new EventTarget();
+  const globalTarget = new EventTarget();
   const host: RuntimeHost<P> = {
     prototypeName: name,
     getRawProps: () => ({}) as any,
@@ -22,6 +24,12 @@ const createHost = <P extends PropsBaseType>(name: string) => {
     },
     schedule(task) {
       task();
+    },
+    onRuntimeReady(wiring) {
+      wiring.attach('event', [
+        [EVENT_ROOT_TARGET_CAP, () => rootTarget],
+        [EVENT_GLOBAL_TARGET_CAP, () => globalTarget],
+      ]);
     },
   };
 

--- a/packages/runtime/test/contract/focus.v0.contract.test.ts
+++ b/packages/runtime/test/contract/focus.v0.contract.test.ts
@@ -322,6 +322,58 @@ describe('runtime contract: focus (v0)', () => {
     expect(result.controller.getRuleStyleTokens()).toContain('ring-2');
   });
 
+  it('FOCUS-0470: host focus clears stale focus facts from the previous owner', () => {
+    let first!: FocusableHandle<PropsBaseType>;
+    let second!: FocusableHandle<PropsBaseType>;
+
+    const First = definePrototype({
+      name: 'x-focus-0470-first',
+      setup() {
+        first = asFocusable<PropsBaseType>();
+        return (r) => r.el('button', 'first');
+      },
+    });
+    const Second = definePrototype({
+      name: 'x-focus-0470-second',
+      setup() {
+        second = asFocusable<PropsBaseType>();
+        return (r) => r.el('button', 'second');
+      },
+    });
+
+    const order = new Map<string, number>([
+      ['first', 0],
+      ['second', 1],
+    ]);
+    const globalTarget = new FocusTarget('global', new Map());
+    const targets = {
+      first: new FocusTarget('first', order),
+      second: new FocusTarget('second', order),
+    };
+    const parents = new Map<unknown, unknown | null>([
+      [targets.first, null],
+      [targets.second, null],
+    ]);
+    const focused: string[] = [];
+    const hostOptions = { globalTarget, parents, focused };
+
+    executeWithHost(First as any, createTreeHost(First.name, targets.first, hostOptions) as any);
+    executeWithHost(Second as any, createTreeHost(Second.name, targets.second, hostOptions) as any);
+
+    globalTarget.dispatchEvent(new Event('key.down'));
+    targets.first.dispatchEvent(new Event('host:focus'));
+
+    expect(first.focused.get()).toBe(true);
+    expect(first.focusVisible.get()).toBe(true);
+
+    targets.second.dispatchEvent(new Event('host:focus'));
+
+    expect(second.focused.get()).toBe(true);
+    expect(second.focusVisible.get()).toBe(true);
+    expect(first.focused.get()).toBe(false);
+    expect(first.focusVisible.get()).toBe(false);
+  });
+
   it('FOCUS-0500: disabled focusable rejects focus requests', () => {
     let focusable!: FocusableHandle<PropsBaseType>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,6 +530,12 @@ importers:
       '@proto.ui/module-base':
         specifier: workspace:*
         version: link:../base
+      '@proto.ui/module-event':
+        specifier: workspace:*
+        version: link:../event
+      '@proto.ui/module-state':
+        specifier: workspace:*
+        version: link:../state
       '@proto.ui/types':
         specifier: workspace:*
         version: link:../../types

--- a/spec/contracts/C-AS-FOCUS-SCOPE-0002.yaml
+++ b/spec/contracts/C-AS-FOCUS-SCOPE-0002.yaml
@@ -38,6 +38,18 @@ criteria:
     text:
       zh-CN: active scope 自身及其 logical descendants 的 focus request 必须继续允许。
       en: Focus requests from the active scope itself and its logical descendants must remain allowed.
+  - id: C-AS-FOCUS-SCOPE-0002-G
+    text:
+      zh-CN: '`activate(options)` 与 `deactivate(options)` 必须把 focus request reason 传递给 scope entry focus 与 previous owner restore；键盘触发的 open/close 不得在 scope 边界处丢失 keyboard modality。'
+      en: '`activate(options)` and `deactivate(options)` must forward focus request reason to scope entry focus and previous-owner restore; keyboard-triggered open/close must not lose keyboard modality at the scope boundary.'
+  - id: C-AS-FOCUS-SCOPE-0002-H
+    text:
+      zh-CN: active top scope 启用 trap/loop 时，Tab 导航必须由 scope 统一解释为 scope 内 next/prev focus request，并阻止宿主默认遍历逃离 active scope。
+      en: When the active top scope enables trap/loop, Tab navigation must be interpreted by the scope as in-scope next/previous focus requests and must prevent host default traversal from escaping the active scope.
+  - id: C-AS-FOCUS-SCOPE-0002-I
+    text:
+      zh-CN: active scope 内部因指针点击空白区域或宿主差异暂时没有 focused child 时，后续 Tab 导航必须能从 scope 记忆的最近 scoped focus 或首尾 eligible child 恢复，不能让焦点遍历逃离 scope。
+      en: If an active scope temporarily has no focused child due to pointer interaction on blank space or host variance, subsequent Tab navigation must recover from the scope's remembered scoped focus or the first/last eligible child and must not let traversal escape the scope.
 sources:
   - path: internal/contracts/focus/base-text/focus-scope.v0.md
     sections:
@@ -54,12 +66,17 @@ sources:
     sections:
       - FocusModuleImpl.activateScope
       - FocusModuleImpl.deactivateScope
+      - FocusModuleImpl.wireScopeKeyEvents
   - path: packages/runtime/test/contract/focus.v0.contract.test.ts
     sections:
       - FOCUS-0800
       - FOCUS-0810
       - FOCUS-0820
       - FOCUS-0830
+  - path: packages/adapters/web-component/test/dialog-overlay.test.ts
+    sections:
+      - restores focus-visible to the trigger after keyboard close
+      - traps tab navigation inside active dialog content
 dependsOn:
   contracts:
     - C-FOCUS-0001
@@ -73,6 +90,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured explicit focus scope activation, outside request gating, and previous owner restore.
+  - version: 0.1.1
+    change: refined
+    summary: Added request reason propagation and active scope Tab trap recovery requirements from dialog focus stabilization.
 tags:
   - focus
   - focus-scope

--- a/spec/contracts/C-FOCUS-0001.yaml
+++ b/spec/contracts/C-FOCUS-0001.yaml
@@ -30,6 +30,14 @@ criteria:
     text:
       zh-CN: Focus requests 是对宿主/runtime 的请求，不得被解释为原型作者直接写入 focus facts。
       en: Focus requests are requests to the host/runtime and must not be treated as prototype-author writes to focus facts.
+  - id: C-FOCUS-0001-E
+    text:
+      zh-CN: 同一 focus domain 内，长期 `focused` 与 `focusVisible` 事实必须保持唯一主 owner；当新的 focusable 通过 focus request 或 host focus 上报成为 owner 时，runtime 必须清理其他 focusable 上残留的 `focused`、`focusVisible` 与 `active` 事实。
+      en: Within one focus domain, long-lived `focused` and `focusVisible` facts must keep a single primary owner; when a new focusable becomes the owner through a focus request or host focus report, runtime must clear stale `focused`, `focusVisible`, and `active` facts on other focusables.
+  - id: C-FOCUS-0001-F
+    text:
+      zh-CN: 焦点事实唯一性不得完全依赖宿主一定会投递 blur；adapter、commit gate 或宿主差异导致 blur 缺失时，focus center 仍必须维持内部事实一致性。
+      en: Focus fact uniqueness must not rely entirely on the host always delivering blur; if adapter, commit gate, or host variance causes blur to be missed, the focus center must still preserve internal fact consistency.
 sources:
   - path: internal/contracts/focus/base-text/focus-domain.v0.md
   - path: internal/contracts/focus/base-text/focus-model.v0.md
@@ -37,6 +45,14 @@ sources:
   - path: packages/modules/focus/src/create.ts
     sections:
       - FocusModuleImpl
+  - path: packages/modules/focus/src/center.ts
+    sections:
+      - FocusCenter
+      - FocusCenter.requestFocus
+      - FocusCenter.noteFocused
+  - path: packages/runtime/test/contract/focus.v0.contract.test.ts
+    sections:
+      - FOCUS-0470
 dependsOn:
   contracts:
     - C-AS-HOOK-PRIVILEGED-0001
@@ -48,6 +64,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured the baseline focus domain model after the logical-tree focus discussion.
+  - version: 0.1.1
+    change: refined
+    summary: Added focus fact uniqueness and stale fact cleanup requirements learned from cross-adapter dialog focus behavior.
 tags:
   - focus
   - domain

--- a/spec/tests/T-FOCUS-0001.yaml
+++ b/spec/tests/T-FOCUS-0001.yaml
@@ -28,6 +28,12 @@ cases:
       - C-FOCUS-0001-C
       - C-AS-FOCUSABLE-0001-C
     expectation: focus-facts-observed-state-handles
+  - id: T-FOCUS-0001-CASE-UNIQUE-OWNER
+    title: A new host focus owner clears stale focus facts from the previous owner
+    covers:
+      - C-FOCUS-0001-E
+      - C-FOCUS-0001-F
+    expectation: focus-center-clears-stale-owner-without-blur
   - id: T-FOCUS-0001-CASE-DISABLED
     title: Disabled focusable rejects focus requests
     covers:
@@ -50,14 +56,31 @@ implementations:
       - T-FOCUS-0001-CASE-SCOPE-ONCE
       - T-FOCUS-0001-CASE-SETUP-ONLY
       - T-FOCUS-0001-CASE-FACT-HANDLES
+      - T-FOCUS-0001-CASE-UNIQUE-OWNER
       - T-FOCUS-0001-CASE-DISABLED
       - T-FOCUS-0001-CASE-SCOPE-CONTAINER
+  - id: adapter-react-focus-unique-owner
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/focus.test.ts
+    required: false
+    consumesCases:
+      - T-FOCUS-0001-CASE-UNIQUE-OWNER
+  - id: adapter-vue-focus-unique-owner
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/focus.test.ts
+    required: false
+    consumesCases:
+      - T-FOCUS-0001-CASE-UNIQUE-OWNER
 verifies:
   contracts:
     - id: C-FOCUS-0001
       anchors:
         - C-FOCUS-0001-C
         - C-FOCUS-0001-D
+        - C-FOCUS-0001-E
+        - C-FOCUS-0001-F
     - id: C-AS-FOCUSABLE-0001
       anchors:
         - C-AS-FOCUSABLE-0001-A
@@ -75,6 +98,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Mapped existing focus runtime contract tests to focus target and scope contracts.
+  - version: 0.1.1
+    change: refined
+    summary: Added unique focus owner coverage and cross-adapter focus fact cleanup implementations.
 tags:
   - focus
   - as-focusable


### PR DESCRIPTION
## Summary

- Stabilize dialog focus scope activation/deactivation so keyboard modality is preserved across entry and restore.
- Make the focus center clear stale focused/focusVisible/active facts when a new focus owner is reported.
- Add WC dialog regression coverage plus React/Vue focus uniqueness coverage.
- Reflect the focus fact uniqueness and focus scope trap/reason rules back into focus contract entities and runtime contract tests.

## Validation

- `corepack pnpm@10.32.1 -s check:types:workspace`
- `corepack pnpm@10.32.1 exec vitest run packages/runtime/test/contract/focus.v0.contract.test.ts packages/adapters/react/test/focus.test.ts packages/adapters/vue/test/focus.test.ts packages/adapters/web-component/test/dialog-overlay.test.ts packages/adapters/web-component/test/previewer.demo-renderer.test.ts packages/prototypes/shadcn/test/dialog.test.ts packages/adapters/web-component/test/focus.test.ts packages/adapters/react/test/dialog.test.ts packages/adapters/vue/test/dialog.test.ts --reporter verbose`