### PR TITLE
[codex] Align base button prototype contract

### DIFF
--- a/apps/workspace/src/main.tsx
+++ b/apps/workspace/src/main.tsx
@@ -95,6 +95,7 @@ const UI_TEXT = {
     language: 'Language',
     entityTypes: {
       contract: 'Contracts',
+      prototype: 'Prototypes',
       module: 'Modules',
       decision: 'Decisions',
       'host-cap': 'Host Capabilities',
@@ -182,6 +183,7 @@ const UI_TEXT = {
     language: '语言',
     entityTypes: {
       contract: '契约',
+      prototype: '原型',
       module: '模块',
       decision: '决策',
       'host-cap': 'Host 能力',
@@ -1381,6 +1383,7 @@ function getGraphNodeRadius(id: string, selectedId: string | null): number {
 function getEntityTypePrefix(type: SpecEntity['type']): string {
   const prefixes: Record<SpecEntity['type'], string> = {
     contract: 'C',
+    prototype: 'P',
     module: 'M',
     decision: 'D',
     'host-cap': 'HC',
@@ -1401,12 +1404,13 @@ function getOrderedEntityTypes(groups: Record<string, SpecEntity[]>): Array<Spec
 function getEntityTypeOrder(type: SpecEntity['type']): number {
   const order: Record<SpecEntity['type'], number> = {
     contract: 0,
-    test: 1,
-    module: 2,
-    knowledge: 3,
-    decision: 4,
-    'host-cap': 5,
-    version: 6,
+    prototype: 1,
+    test: 2,
+    module: 3,
+    knowledge: 4,
+    decision: 5,
+    'host-cap': 6,
+    version: 7,
   };
 
   return order[type] ?? 99;

--- a/internal/contracts/types/props.specmap.v0.type-test.ts
+++ b/internal/contracts/types/props.specmap.v0.type-test.ts
@@ -1,4 +1,10 @@
+import type { PropsSnapshot } from '@proto.ui/core';
 import type { PropsSpecMap } from '@proto.ui/types';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Expect<T extends true> = T;
 
 type P = { disabled: boolean | null; count: number };
 
@@ -35,6 +41,17 @@ type P2 = { disabled: boolean; count: number };
   disabled: { type: 'boolean', empty: 'accept' },
   count: { type: 'number' },
 }) satisfies PropsSpecMap<P2>;
+
+type ResolvedOptional = PropsSnapshot<{ disabled?: boolean; label?: string | null }>;
+type ResolvedAny = PropsSnapshot<any>;
+
+type _ResolvedOptionalHasDeclaredKeys = Expect<
+  Equal<ResolvedOptional, Readonly<{ disabled: boolean; label: string | null }>>
+>;
+type _ResolvedOptionalExcludesUndefined = Expect<
+  Equal<Extract<ResolvedOptional['disabled'], undefined>, never>
+>;
+type _ResolvedAnyStaysKeyWide = Expect<IsAny<ResolvedAny['anyKey']>>;
 
 // ❌ kind mismatch
 

--- a/internal/records/2026-06-30-a11y-module-planning-for-button.zh-CN.md
+++ b/internal/records/2026-06-30-a11y-module-planning-for-button.zh-CN.md
@@ -1,0 +1,54 @@
+# 2026-06-30 A11y Module Planning for Button Cataloging
+
+> Internal record. Not normative. 本文记录 `P-BASE-BUTTON` 编目前暴露出的 accessibility module 计划，不直接替代正式 `C-*` / `D-*` 实体。
+
+## 背景
+
+Button 的原型契约需要较早处理 accessibility：
+
+- Button 需要可映射到 button role 的语义。
+- Button 需要 accessible name。
+- Button 可能需要 description、disabled reason、tooltip 等辅助表达。
+- 这些能力不适合全部塞进 Button props，也不适合长期依赖 adapter 自行猜测。
+
+因此，accessibility 很可能需要成为一个顶层原型作者 API，与 `def.rule` 类似，通过 `def.a11y` 访问。
+
+## 暂定方向
+
+1. Accessibility 应作为顶层 module / channel 进入系统编目，工作名为 `a11y`。
+2. 原型作者侧入口暂定为 `def.a11y`。
+3. `def.a11y` 应服务跨原型的 accessibility 需求，而不是 Button 私有 API。
+4. Button 第一版 P 实体只要求可访问语义与 accessible name，不提前固化 `def.a11y` 的最终 API 形状。
+5. Button 的 `label` 是否成为 props，需要等 `def.a11y` 的形状讨论后再决定。
+
+## 可能能力
+
+候选能力包括：
+
+- role / semantic role mapping
+- accessible name
+- accessible description
+- disabled reason
+- required / invalid / described-by 类语义
+- 与 host ARIA、native accessibility API、adapter output 的映射边界
+
+## 与 Button 的关系
+
+Button 契约可以先写：
+
+- Button 必须具备可映射到 button role 的可访问语义。
+- Button 必须支持 accessible name。
+- Button 的 accessible name 可来自内容、显式 label 或 accessibility API。
+
+但 Button 契约暂不决定：
+
+- 是否存在 `label?: string` props。
+- `def.a11y` 的 API 命名、生命周期与类型。
+- ARIA description、disabled reason、tooltip 是否作为 Button core props。
+
+## 后续工作
+
+1. 起草 a11y module 的 scope record。
+2. 比较 WAI-ARIA、HTML accessibility mapping 与 Open UI 对常见控件语义的描述。
+3. 决定 `def.a11y` 是否作为顶层 DefHandle API 进入 v0。
+4. 回到 `P-BASE-BUTTON`，补充或调整 accessible name / description / disabled reason 准则。

--- a/internal/records/2026-07-01-as-hook-result-ergonomics-fracture.zh-CN.md
+++ b/internal/records/2026-07-01-as-hook-result-ergonomics-fracture.zh-CN.md
@@ -1,0 +1,66 @@
+# asHook result ergonomics fracture
+
+Date: 2026-07-01
+
+## Context
+
+Base Button 契约跟进到 `shadcn-button` 时暴露出一个 asHook 易用性问题：`shadcn-button` 理应直接消费 `asButton().stateHandles.focusVisible`，但实际失败点不是 Button 语义，而是 asHook result projection 的命名与消费方式不够直观。
+
+具体表现是：
+
+- `asButton` 通过 `def.expose.state('focusVisible', focusable.focusVisible)` 暴露 Button protocol 的公开 state name。
+- focus module 内部 state semantic 是 `@focus/focusVisible`。
+- asHook runtime 早期按 state 内部 semantic 收集 named state handles，导致调用者拿不到预期的 `stateHandles.focusVisible`。
+- 消费侧如果不知道 expose key、internal semantic、`stateHandles`、`getState(...)` 与 rule state dependency 的关系，很容易写出看似合理但无法被规则驱动的代码。
+
+本轮已经修复明确 bug：`def.expose.state(key, handle)` 进入 asHook result projection 时，应以 expose key 作为公开 projected state name。
+
+## Fracture Status
+
+- id: `F-AS-HOOK-RESULT-ERGONOMICS`
+- status: `open`
+- affectedNextStage: `as-hook`
+- action: `carry-to-next-asHook-pass`
+- blocksButtonPilot: `false`
+- blocksAsHookGovernance: `true`
+
+当前断口不阻塞 Base Button pilot，因为 `stateHandles` 的 expose-key projection 已经有 runtime 合约测试覆盖。但它暴露出 asHook result API 仍然不够好用，后续 asHook 契约压实时应继续处理。
+
+## Current Facts
+
+- `C-AS-HOOK-0006` 已经记录 `AsHookResult` 可以暴露 handles、artifacts、render fragment 与 disposers。
+- `C-AS-HOOK-0007` 已经记录 asHook state handles 必须投影为 borrowed views。
+- `T-AS-HOOK-0002` 已经覆盖 borrowed state projection，并新增了 expose key 命名的 runtime contract case。
+- `asButton().stateHandles` 对 Button 这类 protocol asHook 是有价值的消费面，因为外层视觉原型需要复用 Button 的 interaction facts。
+- 当前 `stateHandles` 是可选字段；调用者仍需要防御式判断，或者通过更强类型/辅助 API 确认某个 asHook 必定提供某些 handles。
+- 当前 `stateHandles`、`getState(...)`、`artifacts.stateHandles` 存在多个等价入口，缺少面向原型作者的推荐消费路径。
+
+## Open Questions
+
+1. `AsHookResult` 对于已声明 contract 的 asHook，是否应在类型上把必需 `stateHandles` 从 optional 收紧为 required？
+2. `getState(key)` 与 `stateHandles[key]` 是否需要同时保留；若保留，哪个应作为推荐 authoring 入口？
+3. asHook 是否需要一个内部 helper/assertion，例如 `expectStateHandles(asButton(), ['focusVisible'])`，用于把缺失 projection 转化为更早、更清楚的诊断？
+4. `def.expose.state(key, handle)` 的 expose key 是否应明确成为 asHook projected state name 的首选公开名称，并写入 `C-AS-HOOK-0007` 或 `C-AS-HOOK-0006`？
+5. 对于 focus 这类内部 semantic 带命名空间的 privileged state，是否需要 tooling 在 asHook result 中展示“公开 name / internal semantic”的映射，避免调试时混淆？
+
+## Next Checkpoints
+
+1. 在下一轮 asHook 契约整理中，决定 `AsHookResult` 的推荐 authoring surface。
+2. 评估是否把 expose-key projection 从 runtime test 反哺进 `C-AS-HOOK-0007` criteria。
+3. 评估类型层是否能让已声明 state contract 的 `stateHandles` 变成 required，至少对普通 authored asHook 生效。
+4. 检查 `shadcn-dialog-trigger`、`shadcn-dialog-close` 等其它消费 `asButton` 或 button-like asHook 的视觉原型，是否也应改为直接消费 projected handles。
+
+## Related Artifacts
+
+- `C-AS-HOOK-0006`
+- `C-AS-HOOK-0007`
+- `T-AS-HOOK-0002`
+- `P-BASE-BUTTON`
+- `packages/runtime/src/kernel/as-hook.ts`
+- `packages/runtime/src/kernel/handles/def.ts`
+- `packages/runtime/test/contract/as-hook.v0.contract.test.ts`
+- `packages/prototypes/shadcn/src/button/index.ts`
+
+## Notes
+
+这条 record 不是规范源。它记录的是从 Base Button pilot 中暴露出的 API ergonomics 断口：runtime bug 已修复，但 asHook result 的推荐形状、类型收紧、诊断与 tooling 展示仍未完成。

--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -153,7 +153,7 @@ export interface RunHandle<Props extends PropsBaseType> {
   };
 
   props: {
-    get(): Readonly<Props>;
+    get(): PropsSnapshot<Props>;
     getRaw(): Readonly<Props & PropsBaseType>;
     isProvided(key: keyof Props): boolean;
   };
@@ -302,15 +302,21 @@ export interface ReservedFactories {
   slot(): TemplateNode;
 }
 
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
 /**
  * Resolved props snapshot type:
- * - Shape is P
- * - Values are whatever component author declared in P (including nulls if they want them)
- *
- * Note: runtime canonicalization (undefined -> null) is a policy detail; TS can only reflect it
- * if author chose to include null in P[K]. That’s intentional to avoid lying types.
+ * - Declared keys are present on the resolved snapshot.
+ * - Undefined is not a resolved value. Empty/fallback resolution may still produce null
+ *   only when the declared value domain allows it.
+ * - `any` stays wide so generic prototype registries can remain intentionally erased.
  */
-export type PropsSnapshot<P extends PropsBaseType> = Readonly<P>;
+export type PropsSnapshot<P extends PropsBaseType> =
+  IsAny<P> extends true
+    ? Readonly<P>
+    : Readonly<{
+        [K in keyof P]-?: Exclude<P[K], undefined>;
+      }>;
 
 /** Defaults should be aligned to Props shape. */
 export type PropsDefaults<P extends PropsBaseType> = Partial<P>;

--- a/packages/modules/props/src/kernel/kernel.ts
+++ b/packages/modules/props/src/kernel/kernel.ts
@@ -52,7 +52,7 @@ export class PropsKernel<P extends PropsBaseType> {
   private prevValid: Partial<Record<keyof P, any>> = {};
 
   private raw: Readonly<P & PropsBaseType> = Object.freeze({} as Readonly<P & PropsBaseType>);
-  private resolved: PropsSnapshot<P> = Object.freeze({} as PropsSnapshot<P>);
+  private resolved: PropsSnapshot<P> = Object.freeze({} as PropsSnapshot<P>) as PropsSnapshot<P>;
 
   private diags: PropsKernelDiag[] = [];
   private hydrated = false;
@@ -454,7 +454,7 @@ export class PropsKernel<P extends PropsBaseType> {
     this.defaultStack = [];
     this.prevValid = {};
     this.raw = Object.freeze({} as Readonly<P & PropsBaseType>);
-    this.resolved = Object.freeze({} as PropsSnapshot<P>);
+    this.resolved = Object.freeze({} as PropsSnapshot<P>) as PropsSnapshot<P>;
   }
 
   private normalizeRawInput(input: Record<string, any>): Record<string, any> {

--- a/packages/prototypes/base/src/button/button.ts
+++ b/packages/prototypes/base/src/button/button.ts
@@ -6,8 +6,10 @@ import type { ButtonAsHookContract, ButtonExposes, ButtonProps, ButtonStateHandl
 export type { ButtonProps, ButtonExposes, ButtonStateHandles, ButtonAsHookContract } from './types';
 
 function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
+  // P-BASE-BUTTON-TRIGGER-SEMANTICS, P-BASE-BUTTON-NESTED-TRIGGER-ROUTE
   asTrigger();
 
+  // P-BASE-BUTTON-PROP-DISABLED
   def.props.define({
     disabled: { type: 'boolean', empty: 'fallback' },
   });
@@ -15,50 +17,51 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
     disabled: false,
   });
 
+  // P-BASE-BUTTON-DISABLED-EXPOSE
   const disabled = def.state.fromInteraction('disabled');
   def.expose.state('disabled', disabled);
-  const focusable = asFocusable<ButtonProps>();
-  focusable.configure({ disabled: false });
+
+  // P-BASE-BUTTON-POINTER-HOVER
   const hovered = def.state.fromInteraction('hovered');
-  const focused = focusable.focused;
-  const focusVisible = focusable.focusVisible;
-  const legacyFocused = def.state.fromInteraction('focused');
-  const legacyFocusVisible = def.state.fromInteraction('focusVisible');
-  const pressed = def.state.fromInteraction('pressed');
-
-  const syncDisabled = (nextDisabled: boolean) => {
-    disabled.set(nextDisabled, 'reason: sync disabled');
-    focusable.setDisabled(nextDisabled);
-  };
-
-  def.lifecycle.onCreated((run) => {
-    syncDisabled(!!run.props.get().disabled);
-  });
-
-  def.props.watch(['disabled'], (_run, next) => {
-    syncDisabled(!!next.disabled);
-  });
-
   def.expose.state('hovered', hovered);
 
-  focusable.focused.watch((_run, event) => {
-    if (event.type !== 'next') return;
-    legacyFocused.set(event.next, 'reason: asButton focus projection => focused');
-  });
-  focusable.focusVisible.watch((_run, event) => {
-    if (event.type !== 'next') return;
-    legacyFocusVisible.set(event.next, 'reason: asButton focus projection => focusVisible');
-  });
+  // P-BASE-BUTTON-FOCUSABLE, P-BASE-BUTTON-DISABLED-REJECT-FOCUS
+  const focusable = asFocusable<ButtonProps>();
+  focusable.configure({ disabled: false });
+
+  const focused = focusable.focused;
+  const focusVisible = focusable.focusVisible;
+
+  // P-BASE-BUTTON-FOCUSABLE
   def.expose.state('focused', focused);
   def.expose.state('focusVisible', focusVisible);
+
+  // P-BASE-BUTTON-REQUEST-FOCUS, P-BASE-BUTTON-DISABLED-REJECT-FOCUS
   def.expose.method('focusSelf', (options) => {
     if (disabled.get()) return;
     focusable.focusSelf(options);
   });
 
+  // P-BASE-BUTTON-PRESS-LIFECYCLE
+  const pressed = def.state.fromInteraction('pressed');
   def.expose.state('pressed', pressed);
 
+  // P-BASE-BUTTON-PROP-DISABLED-CONTROLLED, P-BASE-BUTTON-DISABLED-CLEAR-TRANSIENT
+  const syncDisabled = (nextDisabled: boolean) => {
+    disabled.set(nextDisabled, 'reason: sync disabled');
+    focusable.setDisabled(nextDisabled);
+  };
+  def.lifecycle.onCreated((run) => {
+    syncDisabled(run.props.get().disabled);
+  });
+  def.props.watch(['disabled'], (_run, next) => {
+    syncDisabled(next.disabled);
+  });
+
+  // P-BASE-BUTTON-CLICK-SIGNAL, P-BASE-BUTTON-CLICK-PROTOCOL-NAME
   def.expose.event('click', { payload: 'void' });
+
+  // P-BASE-BUTTON-KEYBOARD-ACTIVATION, P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT
   def.event.onGlobal('key.down', (_run, ev) => {
     const detail = ev?.detail;
     if (disabled.get()) return;
@@ -67,12 +70,32 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
     detail?.preventDefault?.();
   });
 
+  // P-BASE-BUTTON-ROLE-COMMAND, P-BASE-BUTTON-DISABLED-SUPPRESS-ACTIVATION
   def.event.on('press.commit', (run) => {
     if (disabled.get()) return;
     run.expose.emit('click');
   });
+
+  /*
+   * TODO(P-BASE-BUTTON-ACCESSIBLE-ROLE): practice through the future a11y prototype syntax.
+   * TODO(P-BASE-BUTTON-ACCESSIBLE-NAME): practice through the future a11y prototype syntax.
+   * TODO(P-BASE-BUTTON-CONTENT-LABEL-SOURCE): practice through the future a11y prototype syntax.
+   * TODO(P-BASE-BUTTON-PROP-LABEL-DEFERRED): keep accessible naming out of core props once a11y syntax exists.
+   * TODO(P-BASE-BUTTON-A11Y-ENHANCEMENT): practice optional a11y enhancements through the future a11y syntax.
+   */
 }
 
+/*
+ * P-BASE-BUTTON criteria outside Button-internal prototype syntax:
+ * - P-BASE-BUTTON-NO-VISUAL-VARIANT-CORE: absence of visual props is the implementation.
+ * - P-BASE-BUTTON-PROP-VISUAL-DEFERRED: owned by feedback/style or visual variants.
+ * - P-BASE-BUTTON-ICON-CONTENT: content/styling convention, not a Button structure API.
+ * - P-BASE-BUTTON-PROP-FORM-DEFERRED: awaits Form prototype cataloging.
+ * - P-BASE-BUTTON-FORM-EXTENSION: awaits Form prototype cataloging.
+ * - P-BASE-BUTTON-PROP-COMMAND-DEFERRED: awaits command/overlay capability cataloging.
+ */
+
+// P-BASE-BUTTON-AUTHORING-ENTRIES
 export const asButton = defineAsHook<ButtonProps, ButtonExposes, ButtonAsHookContract>({
   name: 'as-button',
   setup: setupButton,

--- a/packages/prototypes/base/src/button/types.ts
+++ b/packages/prototypes/base/src/button/types.ts
@@ -1,16 +1,24 @@
 import { ExposeEvent, ExposeMethod, ExposeState, FocusRequestOptions, State } from '@proto.ui/core';
 
 export interface ButtonProps {
+  // P-BASE-BUTTON-PROP-DISABLED
   disabled?: boolean;
+  // P-BASE-BUTTON-PROP-NO-EVENT-CALLBACK: click is exposed as a signal, not accepted as props.
 }
 
 export type ButtonExposes = {
+  // P-BASE-BUTTON-DISABLED-EXPOSE
   disabled: ExposeState<boolean>;
+  // P-BASE-BUTTON-POINTER-HOVER
   hovered: ExposeState<boolean>;
+  // P-BASE-BUTTON-FOCUSABLE
   focused: ExposeState<boolean>;
   focusVisible: ExposeState<boolean>;
+  // P-BASE-BUTTON-PRESS-LIFECYCLE
   pressed: ExposeState<boolean>;
+  // P-BASE-BUTTON-REQUEST-FOCUS
   focusSelf: ExposeMethod<(options?: FocusRequestOptions) => void>;
+  // P-BASE-BUTTON-CLICK-SIGNAL, P-BASE-BUTTON-CLICK-PROTOCOL-NAME
   click: ExposeEvent<void>;
 };
 

--- a/packages/prototypes/base/test/as-button.test.ts
+++ b/packages/prototypes/base/test/as-button.test.ts
@@ -15,7 +15,7 @@ import {
   AS_TRIGGER_PARENT_CAP,
 } from '@proto.ui/module-as-trigger';
 import { EXPOSE_STATE_SET_EXPOSES_CAP } from '@proto.ui/module-expose-state';
-import { asButton } from '../src/button';
+import button, { asButton } from '../src/button';
 
 function createHost(initialRaw: Record<string, unknown> = {}) {
   let raw = { ...initialRaw };
@@ -63,6 +63,9 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
 
 describe('prototypes/base: asButton', () => {
   it('tracks hovered/focused/pressed and gates click emission when disabled', () => {
+    // T-BASE-BUTTON-0001-CASE-DISABLED-CONTROLLED
+    // T-BASE-BUTTON-0001-CASE-INTERACTION-STATES
+    // T-BASE-BUTTON-0001-CASE-CLICK-SIGNAL
     const P: Prototype<{ disabled?: boolean }> = definePrototype({
       name: 'x-base-as-button',
       setup() {
@@ -119,6 +122,7 @@ describe('prototypes/base: asButton', () => {
   });
 
   it('prevents Space default action when focused', () => {
+    // T-BASE-BUTTON-0001-CASE-KEYBOARD-SPACE
     const P: Prototype<{ disabled?: boolean }> = definePrototype({
       name: 'x-base-as-button-space-boundary',
       setup() {
@@ -149,5 +153,33 @@ describe('prototypes/base: asButton', () => {
     );
 
     expect(prevented).toBe(true);
+  });
+
+  it('keeps base-button and asButton aligned as Button authoring entries', () => {
+    // T-BASE-BUTTON-0001-CASE-AUTHORING-ENTRIES
+    const asHookCtx = createHost({ disabled: false });
+    const Direct = button as Prototype<{ disabled?: boolean }>;
+    const directCtx = createHost({ disabled: false });
+    const P: Prototype<{ disabled?: boolean }> = definePrototype({
+      name: 'x-base-as-button-authoring-entry',
+      setup() {
+        asButton();
+        return (r) => r.el('button', 'ok');
+      },
+    });
+
+    executeWithHost(P as any, asHookCtx.host as any);
+    executeWithHost(Direct as any, directCtx.host as any);
+
+    const asHookExposes = asHookCtx.getExposes() as any;
+    const directExposes = directCtx.getExposes() as any;
+
+    expect(Object.keys(directExposes).sort()).toEqual(Object.keys(asHookExposes).sort());
+
+    asHookCtx.rootTarget.dispatchEvent(new CustomEvent('press.commit'));
+    directCtx.rootTarget.dispatchEvent(new CustomEvent('press.commit'));
+
+    expect(asHookCtx.emitted).toEqual(['click']);
+    expect(directCtx.emitted).toEqual(['click']);
   });
 });

--- a/packages/prototypes/shadcn/src/button/index.ts
+++ b/packages/prototypes/shadcn/src/button/index.ts
@@ -67,12 +67,11 @@ const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
       disabled: false,
     });
 
-    asButton();
-    const disabled = def.state.fromInteraction('disabled');
-    const hovered = def.state.fromInteraction('hovered');
-    const focused = def.state.fromInteraction('focused');
-    const focusVisible = def.state.fromInteraction('focusVisible');
-    const pressed = def.state.fromInteraction('pressed');
+    const buttonState = asButton().stateHandles;
+    if (!buttonState) {
+      throw new Error('[shadcn-button] asButton must project Button state handles.');
+    }
+    const { disabled, hovered, focusVisible, pressed } = buttonState;
     const expanded = def.state.fromAccessibility('expanded');
     const invalid = def.state.fromAccessibility('invalid');
 

--- a/packages/runtime/src/kernel/as-hook.ts
+++ b/packages/runtime/src/kernel/as-hook.ts
@@ -52,17 +52,34 @@ function isStateHandleLike(x: any): x is StateHandleLike {
 function collectNamedStateHandles(entries: unknown[]): Record<string, StateHandleLike> | undefined {
   const named = new Map<string, StateHandleLike>();
   const seenIds = new Set<unknown>();
+  const namesById = new Map<unknown, string[]>();
 
   for (const entry of entries) {
-    if (!isStateHandleLike(entry)) continue;
+    const exposeKey =
+      (entry as any)?.op === 'expose.state' && typeof (entry as any)?.key === 'string'
+        ? ((entry as any).key as string)
+        : undefined;
+    const handle = exposeKey ? (entry as any).handle : entry;
+    if (!isStateHandleLike(handle)) continue;
 
-    const semantic = entry.__stateSemantic;
+    const semantic = exposeKey ?? handle.__stateSemantic;
     if (typeof semantic !== 'string' || !semantic) continue;
 
-    const id = entry.__stateId ?? semantic;
+    const id = handle.__stateId ?? semantic;
+    if (exposeKey) {
+      for (const previousName of namesById.get(id) ?? []) {
+        named.delete(previousName);
+      }
+      namesById.set(id, [semantic]);
+      seenIds.add(id);
+      named.set(semantic, handle);
+      continue;
+    }
+
     if (seenIds.has(id)) continue;
     seenIds.add(id);
-    named.set(semantic, entry);
+    namesById.set(id, [semantic]);
+    named.set(semantic, handle);
   }
 
   if (named.size === 0) return undefined;

--- a/packages/runtime/src/kernel/handles/def.ts
+++ b/packages/runtime/src/kernel/handles/def.ts
@@ -174,7 +174,7 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
       fn.state = (key: string, handle: any) => {
         ensureSetup('def.expose.state');
         expose.expose(key, handle);
-        recordCaptured(def, 'state', handle);
+        recordCaptured(def, 'state', { op: 'expose.state', key, handle });
       };
 
       fn.value = (key: string, value: any) => {

--- a/packages/runtime/test/contract/as-hook.v0.contract.test.ts
+++ b/packages/runtime/test/contract/as-hook.v0.contract.test.ts
@@ -247,6 +247,51 @@ describe('runtime contract: asHook (v0)', () => {
     expect(controller.getRuleStyleTokens()).toContain('opacity-50');
   });
 
+  it('AS-HOOK-0455: expose.state key names the projected state handle', () => {
+    let named: any;
+    let publicHandle: any;
+
+    const asState = defineAsHook<
+      PropsBaseType,
+      { open: State<boolean> },
+      { state: { open: State<boolean> } }
+    >({
+      name: 'asExposeNamedState',
+      setup(def) {
+        const internalOpen = def.state.bool('@internal/open', false);
+        def.expose.state('open', internalOpen);
+      },
+    });
+
+    const P: Prototype = definePrototype({
+      name: 'x-as-hook-0455',
+      setup(def) {
+        const res = asState();
+        named = res.stateHandles;
+        publicHandle = res.getState?.('open');
+
+        def.rule({
+          when: (w) => w.state(publicHandle).eq(true),
+          intent: (i) => i.feedback.style.use(tw('opacity-50')),
+        });
+
+        def.lifecycle.onCreated(() => {
+          publicHandle?.set(true);
+        });
+
+        return (r) => r.el('div', 'ok');
+      },
+    });
+
+    const { host } = createHost(P.name);
+    const { controller } = executeWithHost(P as any, host as any);
+
+    expect(typeof named?.open?.watch).toBe('function');
+    expect(named?.open).toBe(publicHandle);
+    expect(named?.['@internal/open']).toBeUndefined();
+    expect(controller.getRuleStyleTokens()).toContain('opacity-50');
+  });
+
   it('AS-HOOK-0460: event disposers are exposed but remain setup-only', () => {
     let calls = 0;
     let res: any;

--- a/packages/spec/engine/src/node.ts
+++ b/packages/spec/engine/src/node.ts
@@ -144,6 +144,7 @@ function validateEntityTimelines(loaded: LoadedSpecEntity[], issues: SpecValidat
 
 const RELATION_TARGET_TYPES = {
   contracts: 'contract',
+  prototypes: 'prototype',
   modules: 'module',
   decisions: 'decision',
   hostCaps: 'host-cap',

--- a/packages/spec/schema/src/index.ts
+++ b/packages/spec/schema/src/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const SPEC_ENTITY_TYPES = [
   'contract',
+  'prototype',
   'module',
   'decision',
   'host-cap',
@@ -12,6 +13,7 @@ export const SPEC_ENTITY_TYPES = [
 
 export const SPEC_ENTITY_PREFIXES = {
   contract: 'C',
+  prototype: 'P',
   module: 'M',
   decision: 'D',
   'host-cap': 'HC',
@@ -78,10 +80,11 @@ export type SpecIdParts = {
   id: string;
   prefix: string;
   domain: string;
-  number: number;
+  number?: number;
 };
 
-const specIdPattern = /^(C|M|D|HC|T|V|K)-([A-Z0-9]+(?:-[A-Z0-9]+)*)-(\d{4})$/;
+const specIdPattern =
+  /^(?:(P)-([A-Z0-9]+(?:-[A-Z0-9]+)*)|((?:C|M|D|HC|T|V|K)-([A-Z0-9]+(?:-[A-Z0-9]+)*)-(\d{4})))$/;
 const semverPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
 
 export const specVersionSchema = z.string().regex(semverPattern, 'Expected a semver version.');
@@ -111,6 +114,7 @@ export const specRelationTargetSchema = z
 export const specRelationsSchema = z
   .object({
     contracts: z.array(specRelationTargetSchema).optional(),
+    prototypes: z.array(specRelationTargetSchema).optional(),
     modules: z.array(specRelationTargetSchema).optional(),
     decisions: z.array(specRelationTargetSchema).optional(),
     hostCaps: z.array(specRelationTargetSchema).optional(),
@@ -340,9 +344,9 @@ export function parseSpecId(id: string): SpecIdParts {
 
   return {
     id,
-    prefix: match[1],
-    domain: match[2],
-    number: Number(match[3]),
+    prefix: match[1] ?? match[3].split('-', 1)[0],
+    domain: match[2] ?? match[4],
+    number: match[5] ? Number(match[5]) : undefined,
   };
 }
 

--- a/spec/decisions/D-BASE-PROTOTYPE-INDEPENDENCE-0001.yaml
+++ b/spec/decisions/D-BASE-PROTOTYPE-INDEPENDENCE-0001.yaml
@@ -1,0 +1,59 @@
+id: D-BASE-PROTOTYPE-INDEPENDENCE-0001
+type: decision
+title: Base prototypes stay independently consumable
+status: draft
+since: 0.1.0
+summary: Base prototype protocols should stay independently consumable; shared hooks with protocol names must serve their owning prototype protocol rather than becoming cross-prototype substrate.
+statement:
+  zh-CN: >-
+    Base prototype library 中的基础原型应尽量保持可独立引入、独立编目与独立演进。带有具体协议名的 authored asHook，例如 `asButton`，应视为其所属 prototype protocol 的 authoring entry，而不是供 checkbox、toggle、switch 等其他基础原型复用的通用行为 substrate。其他基础原型可以依赖相同的核心契约、特权 asHook 或 module 能力，但不应通过消费另一个基础原型的协议钩子来获得自身语义。
+
+
+  en: >-
+    Base prototype-library protocols should remain independently consumable, cataloged, and evolvable where possible. Authored asHooks with concrete protocol names, such as `asButton`, should be treated as authoring entries of their owning prototype protocol rather than generic behavior substrates for other base prototypes such as checkbox, toggle, or switch. Other base prototypes may depend on the same core contracts, privileged asHooks, or module capabilities, but should not obtain their own semantics by consuming another base prototype's protocol hook.
+
+
+criteria:
+  - id: D-BASE-PROTOTYPE-INDEPENDENCE-0001-A
+    text:
+      zh-CN: '一个基础原型不应为了获得自身核心语义而依赖另一个基础原型的 protocol-specific authored asHook。'
+      en: 'A base prototype should not depend on another base prototype protocol-specific authored asHook to obtain its own core semantics.'
+  - id: D-BASE-PROTOTYPE-INDEPENDENCE-0001-B
+    text:
+      zh-CN: '`asButton` 应属于 Button protocol 的 authoring entry；checkbox、toggle、switch 等协议不应把 `asButton` 当作通用交互 substrate。'
+      en: '`asButton` should belong to the Button protocol authoring entries; protocols such as checkbox, toggle, and switch should not treat `asButton` as a generic interaction substrate.'
+  - id: D-BASE-PROTOTYPE-INDEPENDENCE-0001-C
+    text:
+      zh-CN: 基础原型之间可以共享核心契约、特权 asHook、module port 或 adapter capability，但共享点应落在核心层或特权能力层，而不是落在另一个基础原型协议上。
+      en: Base prototypes may share core contracts, privileged asHooks, module ports, or adapter capabilities, but the sharing point should live in the core or privileged capability layer rather than in another base prototype protocol.
+  - id: D-BASE-PROTOTYPE-INDEPENDENCE-0001-D
+    text:
+      zh-CN: 可选能力与特定场景能力可以由 owning prototype 自行支持；是否抽成跨原型能力必须经过独立契约讨论。
+      en: Optional and scenario-specific capabilities may be supported by the owning prototype itself; extracting them into cross-prototype capabilities requires separate contract discussion.
+sources:
+  - path: packages/prototypes/base/src/button/button.ts
+    sections:
+      - asButton
+      - base-button
+  - path: packages/cli/src/registry/components.ts
+    sections:
+      - base-button
+  - path: internal/records/2026-06-26-core-compaction-pass-0.1.zh-CN.md
+    sections:
+      - Prototype Cataloging Pilot
+relates:
+  decisions:
+    - D-PROTOTYPE-ENTITY-NAMING-0001
+    - D-AS-HOOK-CALLER-NAME-0001
+  knowledge:
+    - K-COMPONENT-INTERACTION-0001
+    - K-PROTOTYPE-COMPOSITION-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Recorded base prototype independence and narrowed protocol-specific authored asHooks to their owning prototype protocols.
+tags:
+  - prototype
+  - base
+  - as-hook
+  - catalog

--- a/spec/decisions/D-PROTOTYPE-ENTITY-NAMING-0001.yaml
+++ b/spec/decisions/D-PROTOTYPE-ENTITY-NAMING-0001.yaml
@@ -1,0 +1,54 @@
+id: D-PROTOTYPE-ENTITY-NAMING-0001
+type: decision
+title: Prototype contract entities use singleton P-prefixed protocol identities
+status: draft
+since: 0.1.0
+summary: Prototype-level contract catalog entries use the singleton `P-{PROTOCOL}` entity family and describe one stable prototype protocol, not one implementation file or one authoring form.
+statement:
+  zh-CN: >-
+    第一轮原型编目中，prototype-level contract entity 使用 `P-{PROTOCOL}` 标识，例如 `P-BASE-BUTTON`。一个 `P-*` 实体描述一个稳定 prototype protocol，并且同一原型协议默认只有一个 P 实体，不使用 `0001` 序号拆分。direct prototype form、authored asHook form 或其他官方 authoring entry 可以作为该实体的多个 authoring entries 记录。`P-*` 实体可以依赖 `C-*` 核心契约与特权 asHook 契约，但不把这些依赖重新定义为自身拥有的核心语义。
+
+
+  en: >-
+    In the first prototype cataloging pass, prototype-level contract entities use the `P-{PROTOCOL}` identifier family, such as `P-BASE-BUTTON`. A `P-*` entity describes one stable prototype protocol, and each prototype protocol has one P entity by default rather than `0001`-sequenced splits. Direct prototype forms, authored asHook forms, or other official authoring entries for the same protocol may be recorded as multiple authoring entries of that entity. A `P-*` entity may depend on `C-*` core contracts and privileged asHook contracts, but must not redefine those dependencies as core semantics owned by the prototype itself.
+
+
+criteria:
+  - id: D-PROTOTYPE-ENTITY-NAMING-0001-A
+    text:
+      zh-CN: 'Prototype contract entities 必须使用 `P-*` 前缀，而不是复用 `C-*` 核心契约前缀。'
+      en: 'Prototype contract entities must use the `P-*` prefix instead of reusing the `C-*` core-contract prefix.'
+  - id: D-PROTOTYPE-ENTITY-NAMING-0001-B
+    text:
+      zh-CN: '一个 `P-*` 实体描述一个 prototype protocol；它不得仅表示某个源码文件、包导出名或宿主 adapter 产物。'
+      en: 'A `P-*` entity describes one prototype protocol; it must not merely represent one source file, package export name, or host-adapter artifact.'
+  - id: D-PROTOTYPE-ENTITY-NAMING-0001-C
+    text:
+      zh-CN: '同一 prototype protocol 默认只允许一个 P 实体，并应使用 `P-{PROTOCOL}` 形态，例如 `P-BASE-BUTTON`；不得使用 `P-BASE-BUTTON-0001` 作为首选形态。'
+      en: 'One prototype protocol should have one P entity by default and should use the `P-{PROTOCOL}` shape, such as `P-BASE-BUTTON`; `P-BASE-BUTTON-0001` must not be the preferred shape.'
+  - id: D-PROTOTYPE-ENTITY-NAMING-0001-D
+    text:
+      zh-CN: '当 direct prototype 与 authored asHook 共享同一协议面时，必须在同一个 `P-*` 实体中记录为不同 authoring entries。'
+      en: 'When a direct prototype and an authored asHook share the same protocol surface, they must be recorded as distinct authoring entries in the same `P-*` entity.'
+  - id: D-PROTOTYPE-ENTITY-NAMING-0001-E
+    text:
+      zh-CN: '`P-*` 实体对核心能力的使用应通过 `dependsOn.contracts` 指向已有 `C-*` 契约，而不是在原型实体中重新定义核心能力。'
+      en: 'A `P-*` entity should point to existing `C-*` contracts through `dependsOn.contracts` for core capabilities instead of redefining those capabilities inside the prototype entity.'
+sources:
+  - path: internal/records/2026-06-26-core-compaction-fracture-inventory.zh-CN.md
+    sections:
+      - F-012
+  - path: internal/contracts/prototype-base/button.v0.md
+  - path: packages/prototypes/base/src/button/button.ts
+relates:
+  knowledge:
+    - K-COMPONENT-INTERACTION-0001
+    - K-PROTOTYPE-COMPOSITION-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Closed the minimum naming decision needed to start prototype-level P entity cataloging.
+tags:
+  - prototype
+  - catalog
+  - naming

--- a/spec/prototypes/P-BASE-BUTTON.yaml
+++ b/spec/prototypes/P-BASE-BUTTON.yaml
@@ -22,6 +22,14 @@ criteria:
     text:
       zh-CN: '`base-button` direct prototype 与 `asButton` authored asHook 是同一 Button protocol 的两个 authoring entries。'
       en: 'The `base-button` direct prototype and the `asButton` authored asHook are two authoring entries of the same Button protocol.'
+  - id: P-BASE-BUTTON-TRIGGER-SEMANTICS
+    text:
+      zh-CN: Button 必须通过官方 trigger 能力处理 activation route。
+      en: Button must process its activation route through the official trigger capability.
+  - id: P-BASE-BUTTON-NESTED-TRIGGER-ROUTE
+    text:
+      zh-CN: 连续嵌套的 Button/trigger 场景必须遵循官方 trigger route 合并规则。
+      en: Continuously nested Button/trigger scenarios must follow the official trigger route merging rules.
   - id: P-BASE-BUTTON-PROP-DISABLED
     text:
       zh-CN: 'Button 必须接受 `disabled?: boolean` props input，默认值为 `false`。'
@@ -30,34 +38,6 @@ criteria:
     text:
       zh-CN: 当 App Maker 更新 `disabled` props input 时，Button 必须同步自身 disabled state 与相关交互能力。
       en: When the App Maker updates the `disabled` props input, Button must synchronize its disabled state and related interaction capabilities.
-  - id: P-BASE-BUTTON-PROP-NO-EVENT-CALLBACK
-    text:
-      zh-CN: Button props 不包含 `onClick` 之类事件回调；Button activation 通过 expose event 发出 `click` signal。
-      en: Button props do not include event callbacks such as `onClick`; Button activation emits the `click` signal through expose event.
-  - id: P-BASE-BUTTON-PROP-LABEL-DEFERRED
-    text:
-      zh-CN: Button 的 accessible name 是核心可访问能力，但第一版 core props 不强制把它定义为 `label` prop。
-      en: Button accessible name is a core accessibility capability, but the first core props surface does not force it to be a `label` prop.
-  - id: P-BASE-BUTTON-PROP-FORM-DEFERRED
-    text:
-      zh-CN: '`type`、`name`、`value`、`form` 与 `form*` 类能力属于 Form 联动场景，不进入 Base Button 第一层 core props。'
-      en: '`type`, `name`, `value`, `form`, and `form*` capabilities belong to Form integration and do not enter the first Base Button core props surface.'
-  - id: P-BASE-BUTTON-PROP-COMMAND-DEFERRED
-    text:
-      zh-CN: '`command`、`commandfor`、popover/dialog command 等宿主 command 能力不进入 Base Button 第一层 core props。'
-      en: '`command`, `commandfor`, popover/dialog command, and similar host command capabilities do not enter the first Base Button core props surface.'
-  - id: P-BASE-BUTTON-PROP-VISUAL-DEFERRED
-    text:
-      zh-CN: '`size`、`variant`、`tone`、`shape` 等视觉配置不进入 Base Button core props。'
-      en: Visual configuration such as `size`, `variant`, `tone`, and `shape` does not enter Base Button core props.
-  - id: P-BASE-BUTTON-ACCESSIBLE-ROLE
-    text:
-      zh-CN: Button 必须具备可映射到 button role 的可访问语义。
-      en: Button must carry accessibility semantics that can be mapped to a button role.
-  - id: P-BASE-BUTTON-ACCESSIBLE-NAME
-    text:
-      zh-CN: Button 必须支持 accessible name。
-      en: Button must support an accessible name.
   - id: P-BASE-BUTTON-DISABLED-EXPOSE
     text:
       zh-CN: Button 必须 expose `disabled` state。
@@ -74,18 +54,6 @@ criteria:
     text:
       zh-CN: Button 必须响应指向性设备的 hover 进入与离开，并 expose `hovered` state。
       en: Button must respond to pointer hover enter and leave, and must expose `hovered` state.
-  - id: P-BASE-BUTTON-PRESS-LIFECYCLE
-    text:
-      zh-CN: Button 必须维护 press lifecycle，并 expose `pressed` state。`pressed` 表示被按压住时的状态。
-      en: Button must maintain the press lifecycle and expose `pressed` state. `pressed` means the button is being held down.
-  - id: P-BASE-BUTTON-KEYBOARD-ACTIVATION
-    text:
-      zh-CN: Button 必须支持键盘 activation。Space 与 Enter 应触发 Button activation。
-      en: Button must support keyboard activation. Space and Enter should trigger Button activation.
-  - id: P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT
-    text:
-      zh-CN: 当已聚焦 Button 通过 Space 触发 activation 时，Button 应请求阻止宿主默认副作用。
-      en: When a focused Button is activated through Space, Button should request prevention of host default side effects.
   - id: P-BASE-BUTTON-FOCUSABLE
     text:
       zh-CN: Button 必须是 focus target，并 expose `focused` 与 `focusVisible` state。
@@ -98,6 +66,10 @@ criteria:
     text:
       zh-CN: 当 `disabled` 为 true 时，Button 必须拒绝主动焦点请求。
       en: When `disabled` is true, Button must reject active focus requests.
+  - id: P-BASE-BUTTON-PRESS-LIFECYCLE
+    text:
+      zh-CN: Button 必须维护 press lifecycle，并 expose `pressed` state。`pressed` 表示被按压住时的状态。
+      en: Button must maintain the press lifecycle and expose `pressed` state. `pressed` means the button is being held down.
   - id: P-BASE-BUTTON-CLICK-SIGNAL
     text:
       zh-CN: Button 成功 activation 后必须发出名为 `click` 的 outward signal。
@@ -106,34 +78,62 @@ criteria:
     text:
       zh-CN: '`click` 是 Button protocol 约定的 outward signal 名称。'
       en: '`click` is the outward signal name defined by the Button protocol.'
-  - id: P-BASE-BUTTON-TRIGGER-SEMANTICS
+  - id: P-BASE-BUTTON-PROP-NO-EVENT-CALLBACK
     text:
-      zh-CN: Button 必须通过官方 trigger 能力处理 activation route。
-      en: Button must process its activation route through the official trigger capability.
-  - id: P-BASE-BUTTON-NESTED-TRIGGER-ROUTE
+      zh-CN: Button props 不包含 `onClick` 之类事件回调；Button activation 通过 expose event 发出 `click` signal。
+      en: Button props do not include event callbacks such as `onClick`; Button activation emits the `click` signal through expose event.
+  - id: P-BASE-BUTTON-KEYBOARD-ACTIVATION
     text:
-      zh-CN: 连续嵌套的 Button/trigger 场景必须遵循官方 trigger route 合并规则。
-      en: Continuously nested Button/trigger scenarios must follow the official trigger route merging rules.
-  - id: P-BASE-BUTTON-NO-VISUAL-VARIANT-CORE
+      zh-CN: Button 必须支持键盘 activation。Space 与 Enter 应触发 Button activation。
+      en: Button must support keyboard activation. Space and Enter should trigger Button activation.
+  - id: P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT
     text:
-      zh-CN: Button 核心契约不定义 size、variant、tone、shape 等视觉参数。
-      en: Button core contract does not define visual parameters such as size, variant, tone, or shape.
+      zh-CN: 当已聚焦 Button 通过 Space 触发 activation 时，Button 应请求阻止宿主默认副作用。
+      en: When a focused Button is activated through Space, Button should request prevention of host default side effects.
+  - id: P-BASE-BUTTON-ACCESSIBLE-ROLE
+    text:
+      zh-CN: Button 必须具备可映射到 button role 的可访问语义。
+      en: Button must carry accessibility semantics that can be mapped to a button role.
+  - id: P-BASE-BUTTON-ACCESSIBLE-NAME
+    text:
+      zh-CN: Button 必须支持 accessible name。
+      en: Button must support an accessible name.
   - id: P-BASE-BUTTON-CONTENT-LABEL-SOURCE
     text:
       zh-CN: Button 可以从内容、显式 label 或 accessibility API 获得 label。
       en: Button may obtain its label from content, an explicit label, or an accessibility API.
-  - id: P-BASE-BUTTON-ICON-CONTENT
+  - id: P-BASE-BUTTON-PROP-LABEL-DEFERRED
     text:
-      zh-CN: Icon 可以作为 Button 内容参与渲染与样式上下文，但不是 Button protocol 的独立结构部分。
-      en: An icon may participate in rendering and style context as Button content, but is not an independent structural part of the Button protocol.
-  - id: P-BASE-BUTTON-FORM-EXTENSION
-    text:
-      zh-CN: Form submit、reset 与 form association 属于 Button 的后续扩展场景。
-      en: Form submit, reset, and form association belong to later Button extension scenarios.
+      zh-CN: Button 的 accessible name 是核心可访问能力，但第一版 core props 不强制把它定义为 `label` prop。
+      en: Button accessible name is a core accessibility capability, but the first core props surface does not force it to be a `label` prop.
   - id: P-BASE-BUTTON-A11Y-ENHANCEMENT
     text:
       zh-CN: ARIA description、disabled reason、tooltip 等辅助表达属于可选 accessibility enhancement。
       en: Auxiliary expressions such as ARIA description, disabled reason, and tooltip belong to optional accessibility enhancement.
+  - id: P-BASE-BUTTON-NO-VISUAL-VARIANT-CORE
+    text:
+      zh-CN: Button 核心契约不定义 size、variant、tone、shape 等视觉参数。
+      en: Button core contract does not define visual parameters such as size, variant, tone, or shape.
+  - id: P-BASE-BUTTON-PROP-VISUAL-DEFERRED
+    text:
+      zh-CN: '`size`、`variant`、`tone`、`shape` 等视觉配置不进入 Base Button core props。'
+      en: Visual configuration such as `size`, `variant`, `tone`, and `shape` does not enter Base Button core props.
+  - id: P-BASE-BUTTON-ICON-CONTENT
+    text:
+      zh-CN: Icon 可以作为 Button 内容参与渲染与样式上下文，但不是 Button protocol 的独立结构部分。
+      en: An icon may participate in rendering and style context as Button content, but is not an independent structural part of the Button protocol.
+  - id: P-BASE-BUTTON-PROP-FORM-DEFERRED
+    text:
+      zh-CN: '`type`、`name`、`value`、`form` 与 `form*` 类能力属于 Form 联动场景，不进入 Base Button 第一层 core props。'
+      en: '`type`, `name`, `value`, `form`, and `form*` capabilities belong to Form integration and do not enter the first Base Button core props surface.'
+  - id: P-BASE-BUTTON-FORM-EXTENSION
+    text:
+      zh-CN: Form submit、reset 与 form association 属于 Button 的后续扩展场景。
+      en: Form submit, reset, and form association belong to later Button extension scenarios.
+  - id: P-BASE-BUTTON-PROP-COMMAND-DEFERRED
+    text:
+      zh-CN: '`command`、`commandfor`、popover/dialog command 等宿主 command 能力不进入 Base Button 第一层 core props。'
+      en: '`command`, `commandfor`, popover/dialog command, and similar host command capabilities do not enter the first Base Button core props surface.'
 openQuestions:
   - id: P-BASE-BUTTON-Q-A11Y-API
     question:
@@ -209,6 +209,9 @@ relates:
   knowledge:
     - K-COMPONENT-INTERACTION-0001
     - K-DESIGN-TRADEOFF-0001
+verifies:
+  tests:
+    - T-BASE-BUTTON-0001
 revisions:
   - version: 0.1.0
     change: introduced

--- a/spec/prototypes/P-BASE-BUTTON.yaml
+++ b/spec/prototypes/P-BASE-BUTTON.yaml
@@ -1,0 +1,223 @@
+id: P-BASE-BUTTON
+type: prototype
+title: Base Button is a focusable command control
+status: draft
+since: 0.1.0
+summary: Base Button is the base prototype protocol for a focusable command control that can be disabled, reacts to pointer and keyboard activation, exposes interaction facts, and emits a `click` outward signal when activation succeeds.
+statement:
+  zh-CN: >-
+    Base Button 是一个可聚焦、可禁用、可由多种输入方式激活的 command control。它表达一次离散 action，并在成功激活时向 App Maker 发出名为 `click` 的 outward signal。`base-button` direct prototype 与 `asButton` authored asHook 是同一 Button protocol 的两个 authoring entries。
+
+
+  en: >-
+    Base Button is a focusable, disable-able command control that can be activated through multiple input modes. It expresses one discrete action and emits an outward signal named `click` to the App Maker when activation succeeds. The `base-button` direct prototype and the `asButton` authored asHook are two authoring entries of the same Button protocol.
+
+
+criteria:
+  - id: P-BASE-BUTTON-ROLE-COMMAND
+    text:
+      zh-CN: Button 表示一个触发离散 action 的 command control。
+      en: Button represents a command control that triggers a discrete action.
+  - id: P-BASE-BUTTON-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-button` direct prototype 与 `asButton` authored asHook 是同一 Button protocol 的两个 authoring entries。'
+      en: 'The `base-button` direct prototype and the `asButton` authored asHook are two authoring entries of the same Button protocol.'
+  - id: P-BASE-BUTTON-PROP-DISABLED
+    text:
+      zh-CN: 'Button 必须接受 `disabled?: boolean` props input，默认值为 `false`。'
+      en: 'Button must accept a `disabled?: boolean` props input whose default is `false`.'
+  - id: P-BASE-BUTTON-PROP-DISABLED-CONTROLLED
+    text:
+      zh-CN: 当 App Maker 更新 `disabled` props input 时，Button 必须同步自身 disabled state 与相关交互能力。
+      en: When the App Maker updates the `disabled` props input, Button must synchronize its disabled state and related interaction capabilities.
+  - id: P-BASE-BUTTON-PROP-NO-EVENT-CALLBACK
+    text:
+      zh-CN: Button props 不包含 `onClick` 之类事件回调；Button activation 通过 expose event 发出 `click` signal。
+      en: Button props do not include event callbacks such as `onClick`; Button activation emits the `click` signal through expose event.
+  - id: P-BASE-BUTTON-PROP-LABEL-DEFERRED
+    text:
+      zh-CN: Button 的 accessible name 是核心可访问能力，但第一版 core props 不强制把它定义为 `label` prop。
+      en: Button accessible name is a core accessibility capability, but the first core props surface does not force it to be a `label` prop.
+  - id: P-BASE-BUTTON-PROP-FORM-DEFERRED
+    text:
+      zh-CN: '`type`、`name`、`value`、`form` 与 `form*` 类能力属于 Form 联动场景，不进入 Base Button 第一层 core props。'
+      en: '`type`, `name`, `value`, `form`, and `form*` capabilities belong to Form integration and do not enter the first Base Button core props surface.'
+  - id: P-BASE-BUTTON-PROP-COMMAND-DEFERRED
+    text:
+      zh-CN: '`command`、`commandfor`、popover/dialog command 等宿主 command 能力不进入 Base Button 第一层 core props。'
+      en: '`command`, `commandfor`, popover/dialog command, and similar host command capabilities do not enter the first Base Button core props surface.'
+  - id: P-BASE-BUTTON-PROP-VISUAL-DEFERRED
+    text:
+      zh-CN: '`size`、`variant`、`tone`、`shape` 等视觉配置不进入 Base Button core props。'
+      en: Visual configuration such as `size`, `variant`, `tone`, and `shape` does not enter Base Button core props.
+  - id: P-BASE-BUTTON-ACCESSIBLE-ROLE
+    text:
+      zh-CN: Button 必须具备可映射到 button role 的可访问语义。
+      en: Button must carry accessibility semantics that can be mapped to a button role.
+  - id: P-BASE-BUTTON-ACCESSIBLE-NAME
+    text:
+      zh-CN: Button 必须支持 accessible name。
+      en: Button must support an accessible name.
+  - id: P-BASE-BUTTON-DISABLED-EXPOSE
+    text:
+      zh-CN: Button 必须 expose `disabled` state。
+      en: Button must expose `disabled` state.
+  - id: P-BASE-BUTTON-DISABLED-SUPPRESS-ACTIVATION
+    text:
+      zh-CN: 当 `disabled` 为 true 时，Button 不得完成 activation，也不得发出 `click` signal。
+      en: When `disabled` is true, Button must not complete activation and must not emit the `click` signal.
+  - id: P-BASE-BUTTON-DISABLED-CLEAR-TRANSIENT
+    text:
+      zh-CN: 当 `disabled` 变为 true 时，Button 必须清理自身 transient interaction state。
+      en: When `disabled` becomes true, Button must clear its own transient interaction state.
+  - id: P-BASE-BUTTON-POINTER-HOVER
+    text:
+      zh-CN: Button 必须响应指向性设备的 hover 进入与离开，并 expose `hovered` state。
+      en: Button must respond to pointer hover enter and leave, and must expose `hovered` state.
+  - id: P-BASE-BUTTON-PRESS-LIFECYCLE
+    text:
+      zh-CN: Button 必须维护 press lifecycle，并 expose `pressed` state。`pressed` 表示被按压住时的状态。
+      en: Button must maintain the press lifecycle and expose `pressed` state. `pressed` means the button is being held down.
+  - id: P-BASE-BUTTON-KEYBOARD-ACTIVATION
+    text:
+      zh-CN: Button 必须支持键盘 activation。Space 与 Enter 应触发 Button activation。
+      en: Button must support keyboard activation. Space and Enter should trigger Button activation.
+  - id: P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT
+    text:
+      zh-CN: 当已聚焦 Button 通过 Space 触发 activation 时，Button 应请求阻止宿主默认副作用。
+      en: When a focused Button is activated through Space, Button should request prevention of host default side effects.
+  - id: P-BASE-BUTTON-FOCUSABLE
+    text:
+      zh-CN: Button 必须是 focus target，并 expose `focused` 与 `focusVisible` state。
+      en: Button must be a focus target and must expose `focused` and `focusVisible` state.
+  - id: P-BASE-BUTTON-REQUEST-FOCUS
+    text:
+      zh-CN: Button 必须提供主动请求焦点的能力。
+      en: Button must provide a capability for actively requesting focus.
+  - id: P-BASE-BUTTON-DISABLED-REJECT-FOCUS
+    text:
+      zh-CN: 当 `disabled` 为 true 时，Button 必须拒绝主动焦点请求。
+      en: When `disabled` is true, Button must reject active focus requests.
+  - id: P-BASE-BUTTON-CLICK-SIGNAL
+    text:
+      zh-CN: Button 成功 activation 后必须发出名为 `click` 的 outward signal。
+      en: After successful activation, Button must emit an outward signal named `click`.
+  - id: P-BASE-BUTTON-CLICK-PROTOCOL-NAME
+    text:
+      zh-CN: '`click` 是 Button protocol 约定的 outward signal 名称。'
+      en: '`click` is the outward signal name defined by the Button protocol.'
+  - id: P-BASE-BUTTON-TRIGGER-SEMANTICS
+    text:
+      zh-CN: Button 必须通过官方 trigger 能力处理 activation route。
+      en: Button must process its activation route through the official trigger capability.
+  - id: P-BASE-BUTTON-NESTED-TRIGGER-ROUTE
+    text:
+      zh-CN: 连续嵌套的 Button/trigger 场景必须遵循官方 trigger route 合并规则。
+      en: Continuously nested Button/trigger scenarios must follow the official trigger route merging rules.
+  - id: P-BASE-BUTTON-NO-VISUAL-VARIANT-CORE
+    text:
+      zh-CN: Button 核心契约不定义 size、variant、tone、shape 等视觉参数。
+      en: Button core contract does not define visual parameters such as size, variant, tone, or shape.
+  - id: P-BASE-BUTTON-CONTENT-LABEL-SOURCE
+    text:
+      zh-CN: Button 可以从内容、显式 label 或 accessibility API 获得 label。
+      en: Button may obtain its label from content, an explicit label, or an accessibility API.
+  - id: P-BASE-BUTTON-ICON-CONTENT
+    text:
+      zh-CN: Icon 可以作为 Button 内容参与渲染与样式上下文，但不是 Button protocol 的独立结构部分。
+      en: An icon may participate in rendering and style context as Button content, but is not an independent structural part of the Button protocol.
+  - id: P-BASE-BUTTON-FORM-EXTENSION
+    text:
+      zh-CN: Form submit、reset 与 form association 属于 Button 的后续扩展场景。
+      en: Form submit, reset, and form association belong to later Button extension scenarios.
+  - id: P-BASE-BUTTON-A11Y-ENHANCEMENT
+    text:
+      zh-CN: ARIA description、disabled reason、tooltip 等辅助表达属于可选 accessibility enhancement。
+      en: Auxiliary expressions such as ARIA description, disabled reason, and tooltip belong to optional accessibility enhancement.
+openQuestions:
+  - id: P-BASE-BUTTON-Q-A11Y-API
+    question:
+      zh-CN: Button 的 accessible name、description、disabled reason 与 role mapping 应由 `def.a11y` 顶层 API、Button props、adapter inference 还是组合方式提供？
+      en: Should Button accessible name, description, disabled reason, and role mapping be provided by a top-level `def.a11y` API, Button props, adapter inference, or a combination?
+    context:
+      zh-CN: 当前 Button 契约先要求可访问语义与 accessible name，但不提前固化 `label` prop 或 `def.a11y` API 形状。
+      en: The current Button contract requires accessibility semantics and accessible name without prematurely fixing a `label` prop or `def.a11y` API shape.
+    blocks:
+      - a11y module catalog
+      - def.a11y API design
+  - id: P-BASE-BUTTON-Q-FORM-INTEGRATION
+    question:
+      zh-CN: Form 原型编目后，Button 的 `type`、`name`、`value`、`form*` 能力应以 Button 扩展、Form 协议能力，还是宿主 adapter 能力表达？
+      en: After Form prototype cataloging, should Button `type`, `name`, `value`, and `form*` capabilities be expressed as Button extensions, Form protocol capabilities, or host-adapter capabilities?
+    context:
+      zh-CN: Base Button 第一层契约不吸收 Form 联动，但保留后续扩展入口。
+      en: The first Base Button contract layer does not absorb Form integration, but keeps an extension path open.
+    blocks:
+      - form prototype catalog
+      - button form extension design
+  - id: P-BASE-BUTTON-Q-COMMAND-INTEGRATION
+    question:
+      zh-CN: 宿主 command、popover 与 dialog command 能力应归属于 Button 扩展、trigger 扩展，还是独立 command/overlay 协议？
+      en: Should host command, popover, and dialog command capabilities belong to Button extensions, trigger extensions, or independent command/overlay protocols?
+    context:
+      zh-CN: Base Button 只承诺离散 command control，不把宿主 command 属性直接纳入 core props。
+      en: Base Button only commits to a discrete command control and does not directly include host command attributes in core props.
+    blocks:
+      - command capability catalog
+      - overlay prototype catalog
+sources:
+  - path: internal/contracts/prototype-base/button.v0.md
+  - path: packages/prototypes/base/src/button/button.ts
+    sections:
+      - setupButton
+      - asButton
+      - base-button
+  - path: packages/prototypes/base/src/button/types.ts
+  - path: packages/prototypes/base/test/as-button.test.ts
+    sections:
+      - tracks hovered/focused/pressed and gates click emission when disabled
+      - prevents Space default action when focused
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/button/
+    label: WAI-ARIA APG Button Pattern
+  - path: https://www.w3.org/TR/wai-aria-1.2/#button
+    label: WAI-ARIA button role
+  - path: https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element
+    label: HTML Standard button element
+  - path: https://open-ui.org/components/button/
+    label: Open UI Button
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0003
+    - C-PROPS-0001
+    - C-PROPS-0003
+    - C-AS-HOOK-0001
+    - C-AS-TRIGGER-0001
+    - C-AS-FOCUSABLE-0001
+    - C-STATE-INTERACTION-0001
+    - C-STATE-INTERACTION-0002
+    - C-STATE-INTERACTION-0003
+    - C-EVENT-TYPE-0001
+    - C-EVENT-TYPE-0002
+    - C-EXPOSE-STATE-0001
+    - C-EXPOSE-EVENT-0001
+relates:
+  decisions:
+    - D-PROTOTYPE-ENTITY-NAMING-0001
+    - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+    - D-AS-HOOK-CALLER-NAME-0001
+    - D-FOCUS-STATE-INTERACTION-BOUNDARY-0001
+  knowledge:
+    - K-COMPONENT-INTERACTION-0001
+    - K-DESIGN-TRADEOFF-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced the first Base Button prototype contract entity with props, accessibility, interaction, focus, signal, and extension boundaries.
+tags:
+  - prototype
+  - base
+  - button
+  - as-button
+  - trigger
+  - focus
+  - accessibility

--- a/spec/tests/T-BASE-BUTTON-0001.yaml
+++ b/spec/tests/T-BASE-BUTTON-0001.yaml
@@ -1,0 +1,91 @@
+id: T-BASE-BUTTON-0001
+type: test
+title: Base Button protocol contract tests
+status: draft
+since: 0.1.0
+summary: Contract test coverage for the Base Button prototype protocol and its asButton authoring entry.
+cases:
+  - id: T-BASE-BUTTON-0001-CASE-DISABLED-CONTROLLED
+    title: disabled props synchronize disabled exposure and interaction capabilities
+    covers:
+      - P-BASE-BUTTON-PROP-DISABLED
+      - P-BASE-BUTTON-PROP-DISABLED-CONTROLLED
+      - P-BASE-BUTTON-DISABLED-EXPOSE
+      - P-BASE-BUTTON-DISABLED-CLEAR-TRANSIENT
+      - P-BASE-BUTTON-DISABLED-REJECT-FOCUS
+    expectation: disabled-props-synchronize-button-state-and-capabilities
+  - id: T-BASE-BUTTON-0001-CASE-INTERACTION-STATES
+    title: pointer, focus, and press interactions are exposed as button state
+    covers:
+      - P-BASE-BUTTON-POINTER-HOVER
+      - P-BASE-BUTTON-PRESS-LIFECYCLE
+      - P-BASE-BUTTON-FOCUSABLE
+    expectation: button-interaction-facts-are-exposed
+  - id: T-BASE-BUTTON-0001-CASE-CLICK-SIGNAL
+    title: confirmed activation emits the click outward signal while enabled
+    covers:
+      - P-BASE-BUTTON-ROLE-COMMAND
+      - P-BASE-BUTTON-DISABLED-SUPPRESS-ACTIVATION
+      - P-BASE-BUTTON-CLICK-SIGNAL
+      - P-BASE-BUTTON-CLICK-PROTOCOL-NAME
+      - P-BASE-BUTTON-TRIGGER-SEMANTICS
+    expectation: press-commit-emits-click-only-while-enabled
+  - id: T-BASE-BUTTON-0001-CASE-KEYBOARD-SPACE
+    title: focused Space activation requests prevention of host default side effects
+    covers:
+      - P-BASE-BUTTON-KEYBOARD-ACTIVATION
+      - P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT
+    expectation: focused-space-prevents-host-default
+  - id: T-BASE-BUTTON-0001-CASE-AUTHORING-ENTRIES
+    title: base-button and asButton remain authoring entries of one Button protocol
+    covers:
+      - P-BASE-BUTTON-AUTHORING-ENTRIES
+      - P-BASE-BUTTON-PROP-NO-EVENT-CALLBACK
+      - P-BASE-BUTTON-REQUEST-FOCUS
+    expectation: base-button-and-as-button-share-protocol-surface
+  - id: T-BASE-BUTTON-0001-CASE-DEFERRED-SURFACES
+    title: deferred accessibility, form, command, visual, and content surfaces remain catalog-visible
+    covers:
+      - P-BASE-BUTTON-PROP-LABEL-DEFERRED
+      - P-BASE-BUTTON-PROP-FORM-DEFERRED
+      - P-BASE-BUTTON-PROP-COMMAND-DEFERRED
+      - P-BASE-BUTTON-PROP-VISUAL-DEFERRED
+      - P-BASE-BUTTON-ACCESSIBLE-ROLE
+      - P-BASE-BUTTON-ACCESSIBLE-NAME
+      - P-BASE-BUTTON-NO-VISUAL-VARIANT-CORE
+      - P-BASE-BUTTON-CONTENT-LABEL-SOURCE
+      - P-BASE-BUTTON-ICON-CONTENT
+      - P-BASE-BUTTON-FORM-EXTENSION
+      - P-BASE-BUTTON-A11Y-ENHANCEMENT
+    expectation: deferred-button-surfaces-remain-explicit
+implementations:
+  - id: prototypes-base-as-button-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/as-button.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-BUTTON-0001-CASE-DISABLED-CONTROLLED
+      - T-BASE-BUTTON-0001-CASE-INTERACTION-STATES
+      - T-BASE-BUTTON-0001-CASE-CLICK-SIGNAL
+      - T-BASE-BUTTON-0001-CASE-KEYBOARD-SPACE
+    exercises:
+      - P-BASE-BUTTON
+    notes:
+      - Covers current executable Button behavior through the asButton authoring entry.
+      - Does not yet cover a11y, form, command, or visual deferred surfaces.
+sources:
+  - path: packages/prototypes/base/test/as-button.test.ts
+  - path: packages/prototypes/base/src/button/button.ts
+exercises:
+  prototypes:
+    - P-BASE-BUTTON
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced Base Button protocol test entity aligned to P-BASE-BUTTON criteria.
+tags:
+  - prototype
+  - base
+  - button
+  - test


### PR DESCRIPTION
## Summary

- Add prototype entity support and introduce the singleton `P-BASE-BUTTON` contract entity.
- Align Base Button implementation comments, exposed state/event/method surfaces, and contract tests with the Button P criteria.
- Tighten resolved props snapshot typing so declared props do not force defensive `undefined` checks in prototype code.

## Validation

- `corepack pnpm@10.32.1 --filter apps-workspace generate:spec`
- `corepack pnpm@10.32.1 -s check:types:workspace`
- `corepack pnpm@10.32.1 exec tsc -p internal/contracts/types/tsconfig.json`
- `corepack pnpm@10.32.1 exec vitest run packages/prototypes/base/test/as-button.test.ts packages/runtime/test/contract/props-integration.v0.contract.test.ts packages/runtime/test/contract/run-props-wiring.v0.contract.test.ts packages/modules/props/test/contract/resolve-fallback.v0.contract.test.ts packages/spec/fixtures/test --reporter verbose`
- `git diff --check`

Note: local HTTPS/gh auth is currently invalid, so the branch was pushed through the available SSH Git credential and the PR was opened through the GitHub connector.