### PR TITLE
[codex] add a11y semantic module

### DIFF
--- a/apps/workspace/src/main.tsx
+++ b/apps/workspace/src/main.tsx
@@ -9,7 +9,12 @@ import {
   type SpecSnapshotDiff,
 } from '@proto.ui/spec-engine';
 import { buildSpecGraph, type SpecGraph } from '@proto.ui/spec-graph';
-import { SPEC_RELATION_KINDS, type SpecEntity } from '@proto.ui/spec-schema';
+import {
+  SPEC_RELATION_KINDS,
+  type SpecEntity,
+  type SpecRelations,
+  type SpecRelationTarget,
+} from '@proto.ui/spec-schema';
 
 import './styles.css';
 
@@ -79,6 +84,15 @@ const UI_TEXT = {
       exercises: 'Exercises',
       requires: 'Requires',
       owns: 'Owns',
+    },
+    relationTargetKinds: {
+      contracts: 'Contracts',
+      prototypes: 'Prototypes',
+      modules: 'Modules',
+      decisions: 'Decisions',
+      hostCaps: 'Host Capabilities',
+      tests: 'Tests',
+      knowledge: 'Knowledge',
     },
     semanticDiff: 'Semantic Diff',
     added: 'Added',
@@ -167,6 +181,15 @@ const UI_TEXT = {
       exercises: '演练',
       requires: '要求',
       owns: '拥有',
+    },
+    relationTargetKinds: {
+      contracts: '契约',
+      prototypes: '原型',
+      modules: '模块',
+      decisions: '决策',
+      hostCaps: 'Host 能力',
+      tests: '测试',
+      knowledge: '知识',
     },
     semanticDiff: '语义差异',
     added: '新增',
@@ -500,7 +523,12 @@ function WorkspaceView(props: {
         </header>
 
         <section className="main-grid">
-          <EntityInspector entity={props.selectedEntity} locale={props.locale} t={props.t} />
+          <EntityInspector
+            entity={props.selectedEntity}
+            locale={props.locale}
+            t={props.t}
+            onSelectEntity={props.onSelectEntity}
+          />
           <DiffPanel diff={props.diff} t={props.t} />
           <GraphPanel
             entities={props.snapshot.entities}
@@ -532,7 +560,12 @@ function SummaryMetric(props: { label: string; value: number; tone?: 'ok' | 'war
   );
 }
 
-function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: UiText }) {
+function EntityInspector(props: {
+  entity: SpecEntity | null;
+  locale: Locale;
+  t: UiText;
+  onSelectEntity(id: string): void;
+}) {
   if (!props.entity) {
     return <section className="panel">{props.t.noEntity}</section>;
   }
@@ -576,7 +609,11 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
           <h3>{props.t.criteria}</h3>
           <div className="criteria-list">
             {entity.criteria.map((criterion) => (
-              <article className="criterion-row" key={criterion.id}>
+              <article
+                className="criterion-row"
+                data-criterion-id={criterion.id}
+                key={criterion.id}
+              >
                 <strong>{criterion.id}</strong>
                 <p>{renderLocalizedText(criterion.text, props.locale)}</p>
                 {criterion.rationale ? (
@@ -585,6 +622,13 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
                     {renderLocalizedText(criterion.rationale, props.locale)}
                   </p>
                 ) : null}
+                <RelationList
+                  compact
+                  relations={criterion.dependsOn}
+                  title={props.t.relationKinds.dependsOn}
+                  t={props.t}
+                  onSelectEntity={props.onSelectEntity}
+                />
               </article>
             ))}
           </div>
@@ -713,6 +757,8 @@ function EntityInspector(props: { entity: SpecEntity | null; locale: Locale; t: 
             key={relationKind}
             title={props.t.relationKinds[relationKind]}
             relations={entity[relationKind]}
+            t={props.t}
+            onSelectEntity={props.onSelectEntity}
           />
         ))}
       </section>
@@ -781,30 +827,72 @@ function getCaseImplementations(entity: SpecEntity): Map<string, SpecEntity['imp
   return caseImplementations;
 }
 
-function RelationList(props: { title: string; relations: SpecEntity['relates'] }) {
+function RelationList(props: {
+  title: string;
+  relations: SpecRelations;
+  t: UiText;
+  compact?: boolean;
+  onSelectEntity?(id: string): void;
+}) {
   if (!props.relations) return null;
 
   const entries = Object.entries(props.relations).flatMap(([kind, targets]) =>
-    (targets ?? []).map((target) => ({ kind, target }))
+    (targets ?? []).map((target) => ({ kind: kind as keyof NonNullable<SpecRelations>, target }))
   );
 
   if (entries.length === 0) return null;
 
   return (
-    <div className="relations">
+    <div className={props.compact ? 'relations compact-relations' : 'relations'}>
       <h3>{props.title}</h3>
       <div className="relation-list">
         {entries.map(({ kind, target }) => (
-          <span className="relation-chip" key={`${kind}:${target.id}`}>
-            <strong>{target.id}</strong>
-            {target.anchors?.length ? <small>{target.anchors.join(', ')}</small> : null}
-            {target.role ? <small>role={target.role}</small> : null}
-            {target.coverageImpact ? <small>coverageImpact={target.coverageImpact}</small> : null}
-            {target.note ? <small>{target.note}</small> : null}
-          </span>
+          <RelationChip
+            key={`${kind}:${target.id}`}
+            kind={kind}
+            target={target}
+            t={props.t}
+            onSelectEntity={props.onSelectEntity}
+          />
         ))}
       </div>
     </div>
+  );
+}
+
+function RelationChip(props: {
+  kind: keyof NonNullable<SpecRelations>;
+  target: SpecRelationTarget;
+  t: UiText;
+  onSelectEntity?(id: string): void;
+}) {
+  const content = (
+    <>
+      <strong>{props.target.id}</strong>
+      <small>{props.t.relationTargetKinds[props.kind]}</small>
+      {props.target.anchors?.length ? <small>{props.target.anchors.join(', ')}</small> : null}
+      {props.target.role ? <small>role={props.target.role}</small> : null}
+      {props.target.coverageImpact ? (
+        <small>coverageImpact={props.target.coverageImpact}</small>
+      ) : null}
+      {props.target.note ? <small>{props.target.note}</small> : null}
+    </>
+  );
+
+  if (!props.onSelectEntity) {
+    return <span className="relation-chip">{content}</span>;
+  }
+
+  return (
+    <button
+      className="relation-chip relation-button"
+      data-relation-kind={props.kind}
+      data-relation-target={props.target.id}
+      type="button"
+      onClick={() => props.onSelectEntity?.(props.target.id)}
+    >
+      {content}
+    </button>
   );
 }
 

--- a/apps/workspace/src/styles.css
+++ b/apps/workspace/src/styles.css
@@ -415,12 +415,22 @@ h1 {
   margin-top: 12px;
 }
 
+.compact-relations {
+  margin-top: 10px;
+}
+
 .relations h3,
 .detail-section h3,
 .diff-column h3 {
   margin: 0 0 8px;
   color: #44524b;
   font-size: 14px;
+}
+
+.compact-relations h3 {
+  margin-bottom: 6px;
+  color: #607068;
+  font-size: 12px;
 }
 
 .detail-section > p {
@@ -727,6 +737,10 @@ h1 {
   gap: 8px;
 }
 
+.compact-relations .relation-list {
+  gap: 6px;
+}
+
 .relation-chip,
 .diff-item {
   display: grid;
@@ -737,6 +751,29 @@ h1 {
   padding: 6px 9px;
   font-size: 13px;
   font-weight: 700;
+}
+
+.relation-chip {
+  border: 1px solid transparent;
+  text-align: left;
+}
+
+.relation-button {
+  cursor: pointer;
+  font: inherit;
+}
+
+.relation-button:hover,
+.relation-button:focus-visible {
+  border-color: #9fbaae;
+  background: #e2eee8;
+  outline: none;
+}
+
+.compact-relations .relation-chip {
+  display: inline-grid;
+  padding: 5px 7px;
+  font-size: 12px;
 }
 
 .relation-chip small {

--- a/internal/records/2026-06-26-core-compaction-fracture-inventory.zh-CN.md
+++ b/internal/records/2026-06-26-core-compaction-fracture-inventory.zh-CN.md
@@ -23,7 +23,13 @@ type FractureStatus = 'open' | 'resolved' | 'obsolete' | 'merged' | 'deferred';
 ```
 
 ```ts
-type FractureAction = 'close' | 'merge' | 'defer' | 'decide-now' | 'carry-to-prototype-stage';
+type FractureAction =
+  | 'close'
+  | 'merge'
+  | 'defer'
+  | 'decide-now'
+  | 'carry-to-prototype-stage'
+  | 'carry-to-next-asHook-pass';
 ```
 
 ---
@@ -57,33 +63,35 @@ type FractureAction = 'close' | 'merge' | 'defer' | 'decide-now' | 'carry-to-pro
 | F-009 | `module` 实体 schema 未定 | deferred | no | none | defer |
 | F-010 | `host-cap` 实体 schema 未定 | deferred | no | adapter | defer |
 | F-011 | `adapter profile` 实体预留策略未定 | deferred | no | adapter | defer |
-| F-012 | `prototype` 实体命名、编号与继承关系未定 | open | yes | base-prototype | decide-now |
+| F-012 | `prototype` 实体命名、编号与继承关系未定 | resolved | no | none | close |
 | F-013 | focus/overlay/hit/boundary 与 asHook scope 总问题过宽 | merged | no | none | merge |
-| F-014 | focus 是核心能力、privileged asHook 还是 adapter expectation | open | yes | base-prototype | decide-now |
+| F-014 | focus 是核心能力、privileged asHook 还是 adapter expectation | resolved | no | none | close |
 | F-015 | overlay/hit/boundary 与 privileged asHook 的关系图未定 | deferred | no | none | defer |
 | F-016 | 旧契约文档归档目录与迁移策略未定 | deferred | no | none | defer |
 | F-017 | asHook name / trace identity 规则与实现不一致 | resolved | no | as-hook | carry-to-prototype-stage |
-| F-018 | parameterized/configurable asHook 已实现但文档仍标 proposed | open | no | as-hook | carry-to-prototype-stage |
+| F-018 | parameterized/configurable asHook 已实现但文档仍标 proposed | open | no | as-hook | carry-to-next-asHook-pass |
 | F-019 | `asTrigger` 缺少独立契约归属与实体边界 | resolved | no | as-hook | carry-to-prototype-stage |
-| F-020 | `disabled` 行为的所有权边界未压实 | open | yes | base-prototype | decide-now |
-| F-021 | interaction signal 集合与 `fromInteraction` 投影未完全同步 | open | yes | base-prototype | decide-now |
-| F-022 | expose event `click` 与 native/proto event 的边界需明确 | open | yes | base-prototype | decide-now |
+| F-020 | `disabled` 行为的所有权边界未压实 | resolved | no | none | close |
+| F-021 | interaction signal 集合与 `fromInteraction` 投影未完全同步 | deferred | no | base-prototype | defer |
+| F-022 | expose event `click` 与 native/proto event 的边界需明确 | resolved | no | none | close |
 
-Pilot 阻塞项：
+Pilot 阻塞项（2026-07-02 更新后）：
 
 ```text
-F-012 prototype 实体命名、编号与继承关系
-F-014 focus scope 边界
-F-020 disabled 所有权边界
-F-021 interaction signal / fromInteraction 同步
-F-022 expose event click 边界
+当前没有仍阻塞 BaseButton/asButton 与 asTrigger 常见使用路径的已知断口。
+F-018、F-021 仍保留后续治理问题，但不再阻塞本轮 pilot。
 ```
 
-本轮已处理或进入落地的项：
+本轮已处理或进入落地的项（2026-07-02 更新）：
 
 ```text
+F-012 已由 D-PROTOTYPE-ENTITY-NAMING-0001 与 P-BASE-BUTTON 试点落地覆盖。
+F-014 已由 focus domain / asFocusable / asFocusScope / asFocusRoving 契约与实现修复覆盖；roving 细节进入后续列表类原型阶段。
 F-017 已由 D-AS-HOOK-CALLER-NAME-0001 覆盖，剩余工作是文档/tooling 落地。
-F-019 已起草 asTrigger 最小核心契约实体，剩余工作是 review 与后续映射收口。
+F-019 已由 C-AS-TRIGGER-0001 与 T-AS-TRIGGER-0001 覆盖。
+F-020 已在 P-BASE-BUTTON / asButton 实现中收口为 Button 自治协调 disabled prop、state、focus eligibility 与 activation gate。
+F-021 中 focus facts 越权归属问题已由 D-FOCUS-STATE-INTERACTION-BOUNDARY-0001 解决；通用 interaction signal 集合同步延期。
+F-022 已在 P-BASE-BUTTON 中明确：Button 的 `click` 是 protocol outward signal，不等同 native click 或 `press.commit`。
 ```
 
 ---
@@ -529,15 +537,16 @@ Decision 潜力：
 当前事实：
 
 - `internal/contracts/prototype-base/button.v0.md` 已经把 `base-button` 与 `asButton` 视为同一协议面。
-- 但 prototype 实体的命名、编号、继承/复用关系尚未正式定案。
-- 第一轮 pilot 必须创建或更新 prototype-level 实体，否则无法稳定映射规则、测试和依赖。
+- `spec/decisions/D-PROTOTYPE-ENTITY-NAMING-0001.yaml` 已记录 prototype 实体命名规则。
+- `spec/prototypes/P-BASE-BUTTON.yaml` 已作为首个 prototype 实体落地，并采用单一 `P-BASE-BUTTON` 实体承载 `base-button` direct prototype 与 `asButton` authoring entry。
+- `spec/tests/T-BASE-BUTTON-0001.yaml` 已建立 Button prototype 测试实体映射。
 
 判断：
 
-- status: `open`
-- blocksPrototypeCataloging: `true`
-- affectedNextStage: `base-prototype`
-- action: `decide-now`
+- status: `resolved`
+- blocksPrototypeCataloging: `false`
+- affectedNextStage: `none`
+- action: `close`
 
 Issue 潜力：
 
@@ -549,15 +558,12 @@ Decision 潜力：
 
 分析：
 
-这是阻塞项。无需一次性解决所有 inheritance 语义，但必须先定一个 pilot 用法。例如：
-
-- `prototype-base.button.v0` 作为协议实体。
-- `base-button` 与 `asButton` 作为同一协议的两个 authoring entry。
-- higher-level prototypes 对 button 的复用先用 `depends-on` 或 `implements`，暂不引入复杂继承模型。
+该断口已经解除。当前试点选择不引入复杂继承模型，而是让一个官方基础原型对应一个稳定 `P-*` 实体；direct prototype 与 asHook authoring entry 作为同一 protocol 的不同入口记录在 prototype 实体 criteria 中。higher-level prototypes 对基础原型的复用仍应通过后续关系图治理继续压实，但不再阻塞 Button/asTrigger pilot。
 
 下一步：
 
-- 在正式编目 `BaseButton/asButton` 前，先写一条最小 naming decision。
+- 在 Core Compaction closure 中标记 F-012 closed。
+- 后续批量原型编目继续沿用 `P-*` 单实体模型，除非出现需要单独决策的继承/扩展场景。
 
 ---
 
@@ -612,18 +618,21 @@ Decision 潜力：
 当前事实：
 
 - 当时 `asButton` 使用带 patch 参数的 `asFocusable` 调用；2026-06-27 已迁移为 `asFocusable()` 加返回 handle 配置。
+- focus 已被编目为宿主协同的逻辑交互目标管理域，见 `C-FOCUS-0001` 与 `C-FOCUS-0002`。
+- `asFocusable()` 已被编目为特权 no-arg once asHook，见 `C-AS-FOCUSABLE-0001`。
+- `asFocusScope()` 与 `asFocusRoving()` 已完成契约与测试实体编目，见 `C-AS-FOCUS-SCOPE-*`、`C-AS-FOCUS-ROVING-0001`、`T-FOCUS-*`。
+- `D-FOCUS-STATE-INTERACTION-BOUNDARY-0001` 已记录 focus facts 不再由 generic state-interaction 直接拥有。
 - button 的 exposed states 包含 `focused` 与 `focusVisible`。
 - `focusSelf` expose method 依赖 focus handle。
 - focus tests 已覆盖 disabled focusable rejects focus requests。
-- `as-focusable.v0.md` 将 `asFocusable(...)` 定位为 privileged、configurable、singleton-install asHook。
-- adapter 层也有 asButton focus tests。
+- dialog / adapter 手动验证中暴露的 focus scope activation、restore 与 focus-visible 问题已经通过 focus center 与 adapter wiring 修复，并由 runtime/adapter 测试覆盖。
 
 判断：
 
-- status: `open`
-- blocksPrototypeCataloging: `true`
-- affectedNextStage: `base-prototype`
-- action: `decide-now`
+- status: `resolved`
+- blocksPrototypeCataloging: `false`
+- affectedNextStage: `none`
+- action: `close`
 
 Issue 潜力：
 
@@ -635,18 +644,18 @@ Decision 潜力：
 
 分析：
 
-这不是“focus 行为不存在”的问题，而是归属边界问题。对 `BaseButton/asButton` 来说，至少要定：
+这不是“focus 行为不存在”的问题，而是归属边界问题。当前归属已足够支持 Button/asTrigger pilot：
 
-- `focused/focusVisible` 是 button 暴露的状态，但其事实来源是 focus/interaction 系统。
+- `focused/focusVisible` 是 Button 暴露的状态，但其事实来源是 focus domain / `asFocusable()`。
 - `focusSelf` 是 button 暴露的方法，但实际执行由 `asFocusable`/focus port 负责。
 - `disabled` 同步到 focusable config 后，focus 请求必须被拒绝。
 
-不需要在 pilot 中解决 focus scope、roving focus、trap/restore 等问题。
+focus scope、roving focus、trap/restore 等能力已经完成最小契约与实现修复，足以支撑 dialog 与 Button 当前路径。已发现的 roving 细节问题不阻塞 Button/asTrigger pilot，应等列表、菜单、tabs 等集合类原型编目时再提升。
 
 下一步：
 
-- 为 BaseButton 依赖清单增加 `depends-on focus.as-focusable`。
-- 明确 BaseButton 只承诺消费 focus node 能力，不定义 focus domain 全部语义。
+- 在 Core Compaction closure 中标记 F-014 closed for pilot。
+- 把 roving 细节问题留给集合类原型编目阶段，而不是继续阻塞 Button/asTrigger。
 
 ---
 
@@ -799,14 +808,17 @@ Decision 潜力：
 - asHook contract 将 parameterized caller shape、mode model、setup/configure split 标为 proposed direction。
 - core/runtime 已支持 `options`、`mode: configurable`、`configure(...)`。
 - runtime tests 覆盖 `AS-HOOK-0700`、`AS-HOOK-0800`、`AS-HOOK-0900`、`AS-HOOK-1000`。
-- `asFocusable(...)` contract 也依赖 privileged configurable singleton-install 模型。
+- 普通 authored asHook 已收口为 no-arg once caller。
+- `asFocusable()`、`asFocusScope()` 与 `asFocusRoving()` 已迁移为 no-arg caller，并通过返回 handle 进行 setup-time 配置。
+- `D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001` 与 `C-AS-HOOK-PRIVILEGED-0001` 已记录特权 asHook 迁移方向。
+- `asOverlay(patch)`、`asBoundary(patch)`、`asHitParticipation(...)`、`asTransition(options)` 与 collection/use-style hooks 仍需要逐个归类与迁移计划。
 
 判断：
 
 - status: `open`
 - blocksPrototypeCataloging: `false`
 - affectedNextStage: `as-hook`
-- action: `carry-to-prototype-stage`
+- action: `carry-to-next-asHook-pass`
 
 Issue 潜力：
 
@@ -818,12 +830,12 @@ Decision 潜力：
 
 分析：
 
-它不直接阻塞 `asButton` 与 `asTrigger`，因为 `asButton` 是 `mode: once`，`asTrigger` 也是 privileged once。它间接影响 `asFocusable`，因为 focus 已经是 configurable privileged asHook。
+它不直接阻塞 `asButton` 与 `asTrigger`，因为 `asButton` 是 ordinary once authored asHook，`asTrigger` 是 privileged once asHook。它过去间接影响 `asFocusable`，但 focus 相关 hooks 已经完成 no-arg + returned handle 的迁移。剩余问题属于下一轮 asHook governance，而不是当前 prototype pilot blocker。
 
 下一步：
 
-- Pilot 中只引用已被测试覆盖的最小行为。
-- 不在本轮强行完整提升 configurable authored asHook 模型。
+- Pilot 中只引用已被测试覆盖的 no-arg once 与 privileged asHook 行为。
+- 下一轮 asHook pass 中继续处理剩余 parameterized privileged hooks 与 collection/use-style hook 的最终归类。
 
 ---
 
@@ -892,16 +904,19 @@ Decision 潜力：
 - `button` contract 要求 `disabled=true` suppress `click` 并清除 transient interaction states。
 - `asButton` 定义 `disabled` prop，创建 `def.state.fromInteraction('disabled')`，并 expose `disabled` state。
 - `syncDisabled` 会设置 disabled state，并调用 `focusable.setDisabled(nextDisabled)`。
-- state-interaction module 中 `disabled` 会清理 hovered、pressed、focused、focusVisible。
+- state-interaction module 中 `disabled` 会清理 `hovered` 与 `pressed` 等 interaction-owned transient state；focus facts 已移出 state-interaction ownership。
 - Web event router 有 `isEnabled` gate，disabled 时不 emit `press.commit` 或 global key events。
 - focus tests 证明 disabled focusable rejects focus requests。
+- `P-BASE-BUTTON` 已明确 Button 拥有 `disabled` props input、disabled exposed state、activation suppression 与 transient state cleanup 的协调责任。
+- `asButton` 实现已将 disabled 同步到 state、focus eligibility 与 activation handler。
+- `T-BASE-BUTTON-0001` 已覆盖 disabled props 同步、interaction cleanup、focus rejection 与 disabled activation suppression。
 
 判断：
 
-- status: `open`
-- blocksPrototypeCataloging: `true`
-- affectedNextStage: `base-prototype`
-- action: `decide-now`
+- status: `resolved`
+- blocksPrototypeCataloging: `false`
+- affectedNextStage: `none`
+- action: `close`
 
 Issue 潜力：
 
@@ -913,20 +928,20 @@ Decision 潜力：
 
 分析：
 
-`disabled` 不是单一行为。它至少跨越五层：
+`disabled` 不是单一行为。当前 Button pilot 已将其拆分为多层协作：
 
 1. props default 与 prop watch：`asButton` 拥有。
 2. exposed disabled state：`asButton` 承诺。
 3. focus disabled config：focus/asFocusable 拥有。
-4. transient interaction state reset：state-interaction 拥有。
+4. transient interaction state reset：Button 触发 disabled 同步，state-interaction 与 focus 分别清理自己拥有的事实。
 5. press/click/event suppression：event router gate 与 button `press.commit` handler 共同承担。
 
-如果不压实边界，后续 higher-level prototype 会不知道该依赖 `asButton`、`asTrigger`、focus、event gate，还是自己重复实现 disabled。
+这已足够支撑常见 Button 使用方式。不同组件对 disabled 的细分语义仍可能不同，但该问题属于后续对应原型的自治设计，不再阻塞 BaseButton/asButton。
 
 下一步：
 
-- 在 BaseButton 依赖清单中拆出 disabled 子关系。
-- 最小决策建议：BaseButton 拥有 disabled prop/expose/coordination；focus 与 event/state-interaction 拥有各自响应 disabled 的机制。
+- 在 Core Compaction closure 中标记 F-020 closed。
+- 后续原型若拥有不同 disabled 语义，应在各自 P 实体中记录，而不是让 state-interaction 独断所有 disabled 行为。
 
 ---
 
@@ -942,18 +957,20 @@ Decision 潜力：
 
 当前事实：
 
-- public core type `InteractionStateName` 包含 `disabled | hovered | pressed | focused | focusVisible`。
-- `BaseButton/asButton` 使用全部五个中的多个。
+- public core type `InteractionStateName` 包含 `disabled | hovered | pressed` 等 interaction-owned facts；focus facts 已改由 focus domain 直接提供。
+- `BaseButton/asButton` 使用 `disabled`、`hovered`、`pressed`，并通过 `asFocusable()` 消费 `focused` 与 `focusVisible`。
 - `interaction-signals.v0.md` 只明确列出 `focused` 与 `pressed`，措辞是 v0 MUST provide at least。
 - interaction-state-projection 文档只存在于 `base-text` 目录，没有同步到根级英文 contract 文件。
 - state core 文档明确 interaction-derived / fromInteraction 不在 state core 中定义。
+- `D-FOCUS-STATE-INTERACTION-BOUNDARY-0001` 已解决 focus facts 是否属于 state-interaction 的阻塞问题。
+- `P-BASE-BUTTON` 与 `T-BASE-BUTTON-0001` 已覆盖 Button 当前使用的 interaction facts。
 
 判断：
 
-- status: `open`
-- blocksPrototypeCataloging: `true`
+- status: `deferred`
+- blocksPrototypeCataloging: `false`
 - affectedNextStage: `base-prototype`
-- action: `decide-now`
+- action: `defer`
 
 Issue 潜力：
 
@@ -965,12 +982,12 @@ Decision 潜力：
 
 分析：
 
-这是 `BaseButton/asButton` 的直接阻塞项。实现和测试已经依赖这些 names，但核心 contract 尚未完整列出并同步 projection 文档。如果不处理，button 规则会引用一组核心契约未正式承认的 interaction-derived handles。
+这不再是 `BaseButton/asButton` 的直接阻塞项。阻塞点主要来自 focus facts 是否被 generic interaction signals 越权拥有；该问题已经通过 focus domain 编目和实现迁移解决。剩余问题是通用 interaction signal 集合与旧文档同步：哪些事实是所有交互原型可共享的 generic facts，哪些事实应由具体原型、focus、a11y 或其它 domain 自治。
 
 下一步：
 
-- 最小决策：为 button pilot 明确 v0 button-relevant interaction projection set。
-- 可以先不全量重写 interaction contract，但依赖清单必须标出该断口。
+- 将 Button pilot 需要的 interaction facts 映射保留在 `P-BASE-BUTTON` / `T-BASE-BUTTON-0001`。
+- 后续单独整理 state-interaction contract，避免把 focus、a11y 或组件自治语义重新吸回 generic interaction signals。
 
 ---
 
@@ -992,13 +1009,16 @@ Decision 潜力：
 - event type contract 把 `press.commit` 定义为 protocol core activation intent。
 - expose event contract 说 outward events live in a dedicated namespace and must be fired via event module emit capability。
 - Web event router 明确由 `event.emit()` 分发的 CustomEvent 不触发 `press.commit`，避免 `asButton` 合成 `click` 导致重复 toggle。
+- `P-BASE-BUTTON` 已记录 `click` 是 Button protocol 约定的 outward signal 名称。
+- Button 实现通过 `press.commit` 输入语义派生 `run.expose.emit('click')` 输出语义。
+- `T-BASE-BUTTON-0001` 已覆盖 enabled activation emits `click`，disabled activation suppresses `click`。
 
 判断：
 
-- status: `open`
-- blocksPrototypeCataloging: `true`
-- affectedNextStage: `base-prototype`
-- action: `decide-now`
+- status: `resolved`
+- blocksPrototypeCataloging: `false`
+- affectedNextStage: `none`
+- action: `close`
 
 Issue 潜力：
 
@@ -1010,22 +1030,20 @@ Decision 潜力：
 
 分析：
 
-这是 `BaseButton/asButton` 编目必须压实的边界。button 的 outward `click` 不是 native DOM click，也不是 Proto core event `press.commit`。它是 component → app maker 的 exposed event，由 button protocol 从 activation intent 派生。
+这是 `BaseButton/asButton` 编目必须压实的边界。当前已经明确：button 的 outward `click` 不是 native DOM click，也不是 Proto core event `press.commit`。它是 component → app maker 的 exposed event，由 Button protocol 从 activation intent 派生。
 
 如果不明确，后续测试映射会把 native click、host:click、press.commit、expose click 混在一起。
 
 下一步：
 
-- 在 BaseButton contract 中明确：
-  - `press.commit` 是输入事件语义。
-  - exposed `click` 是输出事件语义。
-  - 输出 click 不应重新进入 press.commit 映射。
+- 在 Core Compaction closure 中标记 F-022 closed。
+- 后续 adapter profile 可继续讨论 outward `click` 在不同宿主中投影得多贴近原生事件，但这不改变 Button protocol 的输入/输出边界。
 
 ---
 
-## 6）第一批建议处理顺序
+## 6）第一批建议处理顺序（2026-07-02 状态更新）
 
-建议先处理这些 `decide-now` 项：
+第一批 `decide-now` 项目前已经处理到不再阻塞 Button/asTrigger pilot：
 
 1. F-012：prototype 实体命名、编号与直接/组合 entry 的绑定方式。
 2. F-017：asHook name / trace identity 命名域。
@@ -1040,6 +1058,13 @@ Decision 潜力：
 - 先定实体命名和 asHook identity，否则后续关系图会污染。
 - 再定 `asTrigger`，因为 `BaseButton` 依赖 official privileged trigger path。
 - 再定 interaction/focus/disabled/click，因为它们构成 `BaseButton` 的行为规则主体。
+
+当前结果：
+
+- F-012、F-014、F-017、F-019、F-020、F-022 可以在 closure report 中标记为 closed / resolved for pilot。
+- F-018 保持 open，但已从 Button/asTrigger pilot blocker 变为下一轮 asHook governance 任务。
+- F-021 降级为 deferred：Button 所需的 interaction facts 已有实体与测试映射，通用 interaction signal 集合同步留给后续 state-interaction pass。
+- a11y 并非本 inventory 的原始 F 项，但它在 Button 编目中暴露为新的基础能力缺口；当前已由 `D-A11Y-SEMANTIC-DOMAIN-0001`、`C-A11Y-0001`、`HC-A11Y-0001`、`M-A11Y-0001` 与 `T-A11Y-0001` 完成最小闭环。Button 的 optional a11y enhancement / relation / name source priority 继续 deferred。
 
 ---
 
@@ -1057,31 +1082,36 @@ Decision 潜力：
 
 ---
 
-## 8）下一步
+## 8）下一步（2026-07-02 状态更新）
 
-下一步建议产出两类文件：
+下一步不再是继续逐个处理上述 blocker，而是产出 Core Compaction Pass 0.1 closure：
 
-1. `Prototype Cataloging Dependencies` 初稿：
+1. `Core Compaction Pass 0.1 Closure` record：
+   - 已关闭断口。
+   - 部分解决 / carry-to-next-pass 断口。
+   - deferred 扩展能力断口。
+   - Button/asTrigger pilot readiness。
+
+2. `Prototype Cataloging Dependencies` 清单：
    - `BaseButton / asButton`
    - `asTrigger`
+   - 标明 props、state-interaction、focus、asTrigger、event/expose-event、a11y 等依赖的稳定度。
 
-2. 最小决策记录：
-   - prototype entity naming
-   - asHook identity naming
-   - `asTrigger` contract home
-   - interaction projection set
-   - disabled ownership
-   - exposed click boundary
-
-完成这些后，才能进入规则 verification 与测试映射压实。
+3. Rule verification 与 test mapping 的收尾：
+   - `T-AS-TRIGGER-0001`
+   - `T-BASE-BUTTON-0001`
+   - `T-FOCUS-*`
+   - `T-A11Y-0001`
+   - asHook result ergonomics 断口对应的 `T-AS-HOOK-*` 增量。
 
 ---
 
-## 9）后续讨论待办
+## 9）后续讨论待办（2026-07-02 状态更新）
 
-以下问题保留为后续设计讨论，不纳入 `asTrigger` 最小核心契约：
+以下问题保留为后续设计讨论，不纳入当前 Button/asTrigger pilot blocker：
 
-- F-014：focus 在 BaseButton 中的依赖边界。重点讨论 focus 状态是否应由 focus privileged asHook 投影，而不是由 generic interaction signals 直接拥有。
-- F-020：disabled 所有权边界。重点讨论 `disabled` 是否适合作为 generic interaction signal；不同交互组件对 disabled 的语义可能不同，props 上的 `disabled` 只表示 prototype 接收该输入，如何协调输入与内部交互状态应由具体 prototype 或特权 asHook 负责。
-- F-021：interaction signal 集合与 `fromInteraction` 投影。重点拆分 pointer/press facts 与 focus facts，不让 interaction signals 越权定义尚未编目的 focus 系统。
-- F-022：exposed `click` 边界。初步方向是 Button 的 `click` 是 button protocol 的 outward custom event/signal，不是 native click，也不是 `press.commit` 的别名；adapter 可以决定它在宿主中映射得多贴近原生事件。
+- F-018：剩余 parameterized privileged hooks 的 no-arg / returned-handle migration。
+- F-021：通用 interaction signal 集合与 `fromInteraction` 文档同步；重点避免 focus、a11y 或具体原型自治事实被 generic interaction signals 重新吞并。
+- asHook result ergonomics：`stateHandles` / `getState(...)` / expose-key projection 的推荐 authoring surface 与类型收紧。
+- a11y enhancement：relation、description composition、disabled reason、explicit label/name source priority、host projection 降级策略。
+- focus roving 细节：等列表、菜单、tabs 等集合类原型编目时跟进。

--- a/internal/records/2026-07-03-next-prototype-catalog-switch-first.zh-CN.md
+++ b/internal/records/2026-07-03-next-prototype-catalog-switch-first.zh-CN.md
@@ -1,0 +1,162 @@
+# 2026-07-03 下一轮原型编目方向：Switch First
+
+> Internal record. Not normative. 本文记录 Core Compaction / Prototype Cataloging Pilot 在 Button/asTrigger/a11y 之后的下一步方向选择。本文不直接新增 `P-*` 实体，也不替代后续人工讨论、契约审查与测试编目。
+
+---
+
+## 1）背景
+
+本轮契约压实最初目标是清理阻塞 `BaseButton / asButton` 与 `asTrigger` 的核心断口。经过 Button、focus、a11y、asTrigger 与 workspace 可视化相关工作后，当前事实是：
+
+- `P-BASE-BUTTON` 已作为首个 prototype entity 落地。
+- `asTrigger` 已有独立核心契约与测试实体。
+- focus domain、asFocusable、asFocusScope、asFocusRoving 的最小模型已经足以支撑 Button/Dialog 当前路径。
+- a11y module 已经提供可投射语义对象的最小能力，并被 Button 消费。
+- `P-*` criteria 现在可以记录准则级 `dependsOn`，workspace GUI 也可以展示这些依赖。
+
+同时，直接横向压实所有剩余断口的策略已经被证明不够经济：缺少原型实验牵引时，很多契约边界很难形成可审查的人工决策。
+
+因此，下一阶段应继续选择一个合适的原型作为编目牵引点，遇到断口再逐个压实。
+
+---
+
+## 2）候选方向
+
+本轮主要比较两个方向：
+
+- 小步推进：`Switch`
+- 大步推进：`Tabs`
+
+相关的已实现原型事实：
+
+- `packages/prototypes/base/src/switch/*` 已存在。
+- `packages/prototypes/base/src/tabs/*` 已存在。
+- `packages/prototypes/base/test/switch.test.ts` 与 `packages/prototypes/base/test/tabs.test.ts` 均已有测试基础。
+
+相关的已知契约事实：
+
+- 已有 Button、asTrigger、focus、a11y、state interaction、event/expose 等基础契约可供复用。
+- 已知 roving focus 细节问题被有意推迟到列表、菜单、tabs 等集合类原型阶段。
+- collection/use-style hooks 的最终归类仍是后续治理问题。
+
+---
+
+## 3）问题陈述
+
+下一轮原型编目需要满足两个目标：
+
+1. 继续通过真实原型压实核心契约，而不是脱离实现横向讨论所有断口。
+2. 控制单轮 blast radius，避免一次性引入过多未压实的复合组件结构、导航和集合能力。
+
+如果直接选择 `Tabs`，它会同时牵引：
+
+- composite widget 结构。
+- tablist/tab/tabpanel 的 anatomy 与 a11y 映射。
+- roving focus ownership 与 keyboard navigation policy。
+- collection/useCollection/useCollectionItem 的最终归类。
+- controlled/uncontrolled active value 与 content visibility。
+
+这些问题都重要，但它们会让下一轮编目从“单一交互主体”直接跳到“复合交互系统”，验证和审查成本较高。
+
+---
+
+## 4）当前决策
+
+下一轮 prototype cataloging 推荐选择：
+
+```text
+P-BASE-SWITCH first, P-BASE-TABS deferred.
+```
+
+`Switch` 作为 Button 之后的下一步牵引原型，用来压实：
+
+- 单一交互主体上的持久二值状态。
+- `checked/on` 与 Button transient `pressed` 的边界。
+- `disabled` 在不同交互组件中的自治语义。
+- `asButton` 不应被 switch 复用的基础原型独立性决策。
+- `role=switch`、accessible name、checked state projection 与 a11y module 的关系。
+- Switch props 最小面，尤其是 `checked` / `defaultChecked` / `disabled` 是否进入第一层 core props。
+- Switch activation 后应 emit 何种 outward signal，以及该 signal 是否携带 next checked value。
+
+`Tabs` 暂不作为下一轮首选，但保留为 Switch 后的复合组件牵引点。
+
+---
+
+## 5）理由
+
+选择 `Switch` 的主要理由：
+
+1. 它比 Button 多出一个真实的新语义面：持久二值状态。
+2. 它仍是单一交互主体，不会立刻扩大到集合、roving、tabpanel 与复合结构。
+3. 它可以复用并检验 Button 阶段形成的契约方法：P 实体准则、准则级依赖、原型代码注释、T 实体与测试用例映射。
+4. 它会自然检验 `D-BASE-PROTOTYPE-INDEPENDENCE-0001`：Switch 不应通过消费 `asButton` 获得自己的协议语义。
+5. 它会逼迫我们更精确地区分 transient press lifecycle 与 persistent binary value。
+
+选择暂缓 `Tabs` 的主要理由：
+
+1. `Tabs` 的价值很高，但它一次性牵引的未压实面过多。
+2. focus roving 细节问题确实适合在 `Tabs` 阶段处理，但最好先通过 `Switch` 完成第二个小型 P 实体闭环。
+3. collection/use-style hooks 的最终归类还没有完成，直接做 `Tabs` 容易把 prototype cataloging 与 collection governance 绑死。
+
+---
+
+## 6）暂缓或备选方向
+
+### Toggle
+
+`Toggle` 可以作为 `Switch` 后的对照项。它与 Button 的关系更近，会逼迫我们判断：
+
+- Toggle protocol 是否拥有持久 `pressed`。
+- Button 的 `pressed` 是否只能表示 transient press lifecycle。
+- Toggle 与 Switch 在外部状态命名、a11y role 和 event signal 上如何区分。
+
+暂不作为下一轮首选，是因为它和 Button 太近，可能不足以检验不同类型组件的 disabled、a11y 与 persistent value 语义。
+
+### Checkbox
+
+`Checkbox` 也适合作为二值/多值状态原型，但它更早牵引：
+
+- `indeterminate`。
+- form association。
+- checkbox group 语义。
+
+这些问题有价值，但比 `Switch` 更容易拉入 form 与 group 断口。
+
+### Tabs
+
+`Tabs` 保留为后续大步推进对象。它适合在 `Switch` 后用于集中处理：
+
+- roving focus 细节。
+- collection/use-style hook 治理。
+- composite widget anatomy。
+- tablist/tab/tabpanel a11y。
+- active value 与 content visibility。
+
+---
+
+## 7）下一步工作
+
+建议下一轮按以下顺序推进：
+
+1. 阅读现有 `base switch` 实现与测试，确认当前行为事实。
+2. 对照 ARIA / Open UI / HTML 相关资料，先在对话中讨论 Switch 是什么。
+3. 起草 `P-BASE-SWITCH` 准则，不直接一次性落实体。
+4. 决定 Switch props 最小面、state/expose/event/a11y/focus/disabled 边界。
+5. 落 `P-BASE-SWITCH` 与对应 `T-BASE-SWITCH-*` 测试实体。
+6. 将可实践准则跟进到 `base switch` 原型代码，并注明 criteria ID。
+7. 迁移或补齐原型测试、runtime/module 测试。
+8. 遇到新的断口时，优先记录并逐个压实，不横向追求一次性清零。
+
+---
+
+## 8）非目标
+
+本记录不决定以下问题：
+
+- `P-BASE-SWITCH` 的最终 criteria 文本。
+- Switch 是否采用 `checked`、`on`、`selected` 或其他 exposed state 名称。
+- Switch outward signal 的最终命名。
+- controlled/uncontrolled props 的完整契约。
+- Tabs / collection / roving focus 的最终模型。
+
+这些问题需要在 Switch 编目前继续讨论，并由后续 P/C/T/D 实体分别承载。

--- a/packages/adapters/react/package.json
+++ b/packages/adapters/react/package.json
@@ -11,6 +11,7 @@
     "@proto.ui/adapter-base": "workspace:*",
     "@proto.ui/module-anatomy": "workspace:*",
     "@proto.ui/module-as-trigger": "workspace:*",
+    "@proto.ui/module-a11y": "workspace:*",
     "@proto.ui/module-boundary": "workspace:*",
     "@proto.ui/module-context": "workspace:*",
     "@proto.ui/module-feedback": "workspace:*",

--- a/packages/adapters/react/src/runtime/modules.ts
+++ b/packages/adapters/react/src/runtime/modules.ts
@@ -13,6 +13,7 @@ import {
   AS_TRIGGER_INSTANCE_CAP,
   AS_TRIGGER_PARENT_CAP,
 } from '@proto.ui/module-as-trigger';
+import { A11Y_PROJECT_CAP, createWebA11yProjector } from '@proto.ui/module-a11y';
 import { createWebBoundaryHostBridge, BOUNDARY_HOST_BRIDGE_CAP } from '@proto.ui/module-boundary';
 import { CONTEXT_INSTANCE_TOKEN_CAP, CONTEXT_PARENT_CAP } from '@proto.ui/module-context';
 import { EFFECTS_CAP } from '@proto.ui/module-feedback';
@@ -80,6 +81,7 @@ export function createReactModules<Props extends PropsBaseType>(args: {
   return createCapsWiring()
     .use('props', [[RAW_PROPS_SOURCE_CAP, rawPropsSource]])
     .use('feedback', [[EFFECTS_CAP, effectsPort]])
+    .use('a11y', [[A11Y_PROJECT_CAP, createWebA11yProjector(el)]])
     .use('event', [
       [EVENT_ROOT_TARGET_CAP, () => router.rootTarget],
       [EVENT_GLOBAL_TARGET_CAP, () => router.globalTarget],

--- a/packages/adapters/vue/package.json
+++ b/packages/adapters/vue/package.json
@@ -11,6 +11,7 @@
     "@proto.ui/adapter-base": "workspace:*",
     "@proto.ui/module-anatomy": "workspace:*",
     "@proto.ui/module-as-trigger": "workspace:*",
+    "@proto.ui/module-a11y": "workspace:*",
     "@proto.ui/module-boundary": "workspace:*",
     "@proto.ui/module-context": "workspace:*",
     "@proto.ui/module-feedback": "workspace:*",

--- a/packages/adapters/vue/src/runtime/modules.ts
+++ b/packages/adapters/vue/src/runtime/modules.ts
@@ -13,6 +13,7 @@ import {
   AS_TRIGGER_INSTANCE_CAP,
   AS_TRIGGER_PARENT_CAP,
 } from '@proto.ui/module-as-trigger';
+import { A11Y_PROJECT_CAP, createWebA11yProjector } from '@proto.ui/module-a11y';
 import { createWebBoundaryHostBridge, BOUNDARY_HOST_BRIDGE_CAP } from '@proto.ui/module-boundary';
 import { CONTEXT_INSTANCE_TOKEN_CAP, CONTEXT_PARENT_CAP } from '@proto.ui/module-context';
 import { EFFECTS_CAP } from '@proto.ui/module-feedback';
@@ -79,6 +80,7 @@ export function createVueModules<Props extends PropsBaseType>(args: {
   return createCapsWiring()
     .use('props', [[RAW_PROPS_SOURCE_CAP, rawPropsSource]])
     .use('feedback', [[EFFECTS_CAP, effectsPort]])
+    .use('a11y', [[A11Y_PROJECT_CAP, createWebA11yProjector(el)]])
     .use('event', [
       [EVENT_ROOT_TARGET_CAP, () => router.rootTarget],
       [EVENT_GLOBAL_TARGET_CAP, () => router.globalTarget],

--- a/packages/adapters/web-component/package.json
+++ b/packages/adapters/web-component/package.json
@@ -11,6 +11,7 @@
     "@proto.ui/adapter-base": "workspace:*",
     "@proto.ui/module-anatomy": "workspace:*",
     "@proto.ui/module-as-trigger": "workspace:*",
+    "@proto.ui/module-a11y": "workspace:*",
     "@proto.ui/module-boundary": "workspace:*",
     "@proto.ui/module-feedback": "workspace:*",
     "@proto.ui/module-props": "workspace:*",

--- a/packages/adapters/web-component/src/runtime/modules.ts
+++ b/packages/adapters/web-component/src/runtime/modules.ts
@@ -13,6 +13,7 @@ import {
   AS_TRIGGER_INSTANCE_CAP,
   AS_TRIGGER_PARENT_CAP,
 } from '@proto.ui/module-as-trigger';
+import { A11Y_PROJECT_CAP, createWebA11yProjector } from '@proto.ui/module-a11y';
 import { createWebBoundaryHostBridge, BOUNDARY_HOST_BRIDGE_CAP } from '@proto.ui/module-boundary';
 import { CONTEXT_INSTANCE_TOKEN_CAP, CONTEXT_PARENT_CAP } from '@proto.ui/module-context';
 import { EFFECTS_CAP } from '@proto.ui/module-feedback';
@@ -87,6 +88,7 @@ export function createWebComponentModules<Props extends PropsBaseType>(args: {
   return createCapsWiring()
     .use('props', [[RAW_PROPS_SOURCE_CAP, rawPropsSource]])
     .use('feedback', [[EFFECTS_CAP, effectsPort]])
+    .use('a11y', [[A11Y_PROJECT_CAP, createWebA11yProjector(el)]])
     .use('event', [
       [EVENT_ROOT_TARGET_CAP, () => router.rootTarget],
       [EVENT_GLOBAL_TARGET_CAP, () => router.globalTarget],

--- a/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { Prototype } from '@proto.ui/core';
+import { definePrototype } from '@proto.ui/core';
+import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
+
+describe('contract: adapter-web-component / a11y projection (v0)', () => {
+  it('A11Y-WC-0100: projects supported semantic object IR to host attributes', () => {
+    // T-A11Y-0001-CASE-WEB-PROJECTION
+    const P: Prototype<{ disabled?: boolean }> = definePrototype({
+      name: 'x-a11y-wc-projection',
+      setup(def) {
+        def.props.define({
+          disabled: { type: 'boolean', empty: 'fallback' },
+        });
+        def.props.setDefaults({ disabled: false });
+
+        const disabled = def.state.bool('button.disabled', false);
+        def.a11y.role('button');
+        def.a11y.name('Save');
+        def.a11y.description('Stores changes');
+        def.a11y.state('disabled', disabled);
+        def.a11y.action('activate', { event: 'click' });
+        def.a11y.tree({ mergeChildren: true });
+        def.props.watch(['disabled'], (_run, next) => {
+          disabled.set(next.disabled);
+        });
+
+        return (r) => r.el('button', 'Save');
+      },
+    });
+
+    if (!customElements.get(P.name)) {
+      customElements.define(
+        P.name,
+        AdaptToWebComponent(P, { register: false, registerAs: P.name })
+      );
+    }
+
+    const el = document.createElement(P.name) as HTMLElement;
+    document.body.appendChild(el);
+
+    expect(el.getAttribute('role')).toBe('button');
+    expect(el.getAttribute('aria-label')).toBe('Save');
+    expect(el.getAttribute('aria-description')).toBe('Stores changes');
+    expect(el.getAttribute('aria-disabled')).toBe('false');
+    expect(el.getAttribute('data-pui-a11y-actions')).toBe('activate');
+    expect(el.getAttribute('data-pui-a11y-merge-children')).toBe('true');
+
+    setElementProps(el, { disabled: true });
+
+    expect(el.getAttribute('aria-disabled')).toBe('true');
+  });
+});

--- a/packages/core/src/a11y.ts
+++ b/packages/core/src/a11y.ts
@@ -1,0 +1,41 @@
+import type { State } from './state';
+
+export type A11yRole = string;
+
+export type A11yTextAlternative = { kind: 'content' } | { kind: 'text'; value: string };
+
+export type A11yStateKey = string;
+export type A11yActionKey = string;
+
+export type A11yStateBinding<V = unknown> = {
+  key: A11yStateKey;
+  state: State<V>;
+};
+
+export type A11yActionSpec = {
+  event?: string;
+};
+
+export type A11yTreeBehavior = {
+  hidden?: boolean;
+  mergeChildren?: boolean;
+};
+
+export type A11ySemanticObjectSnapshot = {
+  role?: A11yRole;
+  name?: A11yTextAlternative;
+  description?: A11yTextAlternative;
+  states: Record<A11yStateKey, unknown>;
+  actions: Record<A11yActionKey, A11yActionSpec>;
+  tree?: A11yTreeBehavior;
+};
+
+export type A11yDefAPI = {
+  role(role: A11yRole): void;
+  name(value: string): void;
+  nameFromContent(): void;
+  description(value: string): void;
+  state<V>(key: A11yStateKey, handle: State<V>): void;
+  action(key: A11yActionKey, spec?: A11yActionSpec): void;
+  tree(patch: A11yTreeBehavior): void;
+};

--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -22,6 +22,7 @@ import {
 import type { AnatomyClaimDecl, AnatomyFamily, AnatomyOrderView, AnatomyPartView } from './anatomy';
 import { State, StateDefAPI, type BorrowedStateHandle, type OwnedStateHandle } from './state';
 import type { Unsubscribe } from './state';
+import type { A11yDefAPI } from './a11y';
 
 // 统一错误上下文，方便在 runtime 做 phase guard 时给出可诊断信息
 
@@ -262,6 +263,8 @@ export interface DefHandle<Props extends PropsBaseType, Exposes = Record<string,
   anatomy: {
     claim(family: AnatomyFamily, decl: AnatomyClaimDecl): void;
   };
+
+  a11y: A11yDefAPI;
 }
 
 export type ContextOnChange<P extends PropsBaseType, T extends JsonObject> = (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from './errors';
 
 export * from './state';
 export * from './context';
+export * from './a11y';
 export * from './focus';
 export * from './boundary';
 export * from './hit-participation';

--- a/packages/modules/a11y/README.md
+++ b/packages/modules/a11y/README.md
@@ -1,0 +1,5 @@
+# @proto.ui/module-a11y
+
+Proto UI module that records accessibility semantic object IR for host projection.
+
+This package is intentionally not a Web ARIA wrapper. Adapters decide how to map the semantic object snapshot to their host accessibility surface.

--- a/packages/modules/a11y/package.json
+++ b/packages/modules/a11y/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@proto.ui/module-a11y",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "dependencies": {
+    "@proto.ui/core": "workspace:*",
+    "@proto.ui/module-base": "workspace:*",
+    "@proto.ui/module-state": "workspace:*"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "description": "Proto UI module that records accessibility semantic object IR.",
+  "license": "MIT",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/a11y",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Proto-UI/Proto-UI.git",
+    "directory": "packages/modules/a11y"
+  },
+  "bugs": {
+    "url": "https://github.com/Proto-UI/Proto-UI/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "proto-ui",
+    "proto",
+    "ui",
+    "module",
+    "a11y",
+    "accessibility"
+  ]
+}

--- a/packages/modules/a11y/src/caps.ts
+++ b/packages/modules/a11y/src/caps.ts
@@ -1,0 +1,6 @@
+import { cap } from '@proto.ui/core';
+import type { A11ySemanticObjectSnapshot } from '@proto.ui/core';
+
+export type A11yProjector = (snapshot: A11ySemanticObjectSnapshot) => void;
+
+export const A11Y_PROJECT_CAP = cap<A11yProjector>('@proto.ui/a11y/project');

--- a/packages/modules/a11y/src/create.ts
+++ b/packages/modules/a11y/src/create.ts
@@ -1,0 +1,182 @@
+import { createModule, defineModule, ModuleBase } from '@proto.ui/module-base';
+import type { ModuleFactoryArgs } from '@proto.ui/module-base';
+import type {
+  A11yActionKey,
+  A11yActionSpec,
+  A11yRole,
+  A11ySemanticObjectSnapshot,
+  A11yStateKey,
+  A11yTextAlternative,
+  A11yTreeBehavior,
+  State,
+  Unsubscribe,
+} from '@proto.ui/core';
+import type { StatePort } from '@proto.ui/module-state';
+
+import { A11Y_PROJECT_CAP } from './caps';
+import type { A11yFacade, A11yModule, A11yPort, A11ySemanticObjectIR } from './types';
+
+class A11yModuleImpl extends ModuleBase {
+  private readonly ir: A11ySemanticObjectIR = {
+    states: new Map(),
+    actions: new Map(),
+  };
+  private readonly stateWatchOffs: Unsubscribe[] = [];
+  private stateWatchesInstalled = false;
+
+  constructor(
+    caps: ModuleFactoryArgs['caps'],
+    private readonly statePort: StatePort
+  ) {
+    super(caps);
+  }
+
+  readonly facade: A11yFacade = {
+    role: (role) => {
+      this.ensureSetup('def.a11y.role');
+      this.ir.role = role;
+      this.applyProjection();
+    },
+    name: (value) => {
+      this.ensureSetup('def.a11y.name');
+      this.ir.name = { kind: 'text', value };
+      this.applyProjection();
+    },
+    nameFromContent: () => {
+      this.ensureSetup('def.a11y.nameFromContent');
+      this.ir.name = { kind: 'content' };
+      this.applyProjection();
+    },
+    description: (value) => {
+      this.ensureSetup('def.a11y.description');
+      this.ir.description = { kind: 'text', value };
+      this.applyProjection();
+    },
+    state: <V>(key: A11yStateKey, handle: State<V>) => {
+      this.ensureSetup('def.a11y.state');
+      this.ir.states.set(key, { key, handle: handle as State<unknown> });
+      this.applyProjection();
+    },
+    action: (key: A11yActionKey, spec: A11yActionSpec = {}) => {
+      this.ensureSetup('def.a11y.action');
+      this.ir.actions.set(key, { ...spec });
+      this.applyProjection();
+    },
+    tree: (patch: A11yTreeBehavior) => {
+      this.ensureSetup('def.a11y.tree');
+      this.ir.tree = { ...(this.ir.tree ?? {}), ...patch };
+      this.applyProjection();
+    },
+  };
+
+  readonly port: A11yPort = {
+    getSnapshot: () => this.getSnapshot(),
+    getIR: () => ({
+      role: this.ir.role,
+      name: cloneTextAlternative(this.ir.name),
+      description: cloneTextAlternative(this.ir.description),
+      states: new Map(this.ir.states),
+      actions: new Map(this.ir.actions),
+      tree: this.ir.tree ? { ...this.ir.tree } : undefined,
+    }),
+  };
+
+  override onProtoPhase(phase: 'setup' | 'mounted' | 'updated' | 'unmounted'): void {
+    super.onProtoPhase(phase);
+    if (phase === 'mounted' || phase === 'updated') {
+      this.installStateWatches();
+      this.applyProjection();
+    }
+    if (phase === 'unmounted') {
+      this.dispose();
+    }
+  }
+
+  afterRenderCommit(): void {
+    this.installStateWatches();
+    this.applyProjection();
+  }
+
+  dispose(): void {
+    while (this.stateWatchOffs.length) {
+      this.stateWatchOffs.pop()?.();
+    }
+    this.stateWatchesInstalled = false;
+  }
+
+  private ensureSetup(op: string): void {
+    this.sys.ensureSetup(op);
+  }
+
+  private installStateWatches(): void {
+    if (this.stateWatchesInstalled) return;
+
+    for (const binding of this.ir.states.values()) {
+      const off = this.statePort.watch(binding.handle as any, () => {
+        this.applyProjection();
+      });
+      this.stateWatchOffs.push(off);
+    }
+
+    this.stateWatchesInstalled = true;
+  }
+
+  private getSnapshot(): A11ySemanticObjectSnapshot {
+    const states: Record<string, unknown> = {};
+    for (const [key, binding] of this.ir.states) {
+      states[key] = binding.handle.get();
+    }
+
+    return {
+      role: this.ir.role,
+      name: cloneTextAlternative(this.ir.name),
+      description: cloneTextAlternative(this.ir.description),
+      states,
+      actions: Object.fromEntries(this.ir.actions),
+      tree: this.ir.tree ? { ...this.ir.tree } : undefined,
+    };
+  }
+
+  private applyProjection(): void {
+    if (!this.caps.has(A11Y_PROJECT_CAP)) return;
+    this.caps.get(A11Y_PROJECT_CAP)(this.getSnapshot());
+  }
+}
+
+function cloneTextAlternative(
+  value: A11yTextAlternative | undefined
+): A11yTextAlternative | undefined {
+  if (!value) return undefined;
+  return value.kind === 'text' ? { kind: 'text', value: value.value } : { kind: 'content' };
+}
+
+export function createA11yModule(ctx: ModuleFactoryArgs): A11yModule {
+  const { init, caps, deps } = ctx;
+
+  return createModule<'a11y', 'instance', A11yFacade, A11yPort>({
+    name: 'a11y',
+    scope: 'instance',
+    init,
+    caps,
+    deps,
+    build: ({ caps, deps }) => {
+      const impl = new A11yModuleImpl(caps, deps.requirePort<StatePort>('state'));
+
+      return {
+        facade: impl.facade,
+        port: impl.port,
+        hooks: {
+          onProtoPhase: (p) => impl.onProtoPhase(p),
+          afterRenderCommit: () => impl.afterRenderCommit(),
+          dispose: () => impl.dispose(),
+        },
+      };
+    },
+  }) as A11yModule;
+}
+
+export const A11yModuleDef = defineModule({
+  name: 'a11y',
+  deps: ['state'],
+  create: createA11yModule,
+});

--- a/packages/modules/a11y/src/index.ts
+++ b/packages/modules/a11y/src/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export * from './caps';
+export * from './create';
+export * from './web';

--- a/packages/modules/a11y/src/types.ts
+++ b/packages/modules/a11y/src/types.ts
@@ -1,0 +1,40 @@
+import type {
+  A11yActionKey,
+  A11yActionSpec,
+  A11yDefAPI,
+  A11yRole,
+  A11ySemanticObjectSnapshot,
+  A11yStateKey,
+  A11yTextAlternative,
+  A11yTreeBehavior,
+  ModuleInstance,
+  ModulePort,
+  State,
+} from '@proto.ui/core';
+
+export type A11yFacade = A11yDefAPI;
+
+export type A11yStateBinding = {
+  key: A11yStateKey;
+  handle: State<unknown>;
+};
+
+export type A11ySemanticObjectIR = {
+  role?: A11yRole;
+  name?: A11yTextAlternative;
+  description?: A11yTextAlternative;
+  states: Map<A11yStateKey, A11yStateBinding>;
+  actions: Map<A11yActionKey, A11yActionSpec>;
+  tree?: A11yTreeBehavior;
+};
+
+export type A11yPort = ModulePort & {
+  getSnapshot(): A11ySemanticObjectSnapshot;
+  getIR(): A11ySemanticObjectIR;
+};
+
+export type A11yModule = ModuleInstance<A11yFacade> & {
+  name: 'a11y';
+  scope: 'instance';
+  port: A11yPort;
+};

--- a/packages/modules/a11y/src/web.ts
+++ b/packages/modules/a11y/src/web.ts
@@ -1,0 +1,80 @@
+import type { A11ySemanticObjectSnapshot } from '@proto.ui/core';
+
+import type { A11yProjector } from './caps';
+
+const ARIA_STATE_ATTRS: Record<string, string> = {
+  checked: 'aria-checked',
+  disabled: 'aria-disabled',
+  expanded: 'aria-expanded',
+  invalid: 'aria-invalid',
+  pressed: 'aria-pressed',
+  selected: 'aria-selected',
+};
+
+export function createWebA11yProjector(el: HTMLElement): A11yProjector {
+  return (snapshot) => {
+    applyWebA11ySnapshot(el, snapshot);
+  };
+}
+
+export function applyWebA11ySnapshot(el: HTMLElement, snapshot: A11ySemanticObjectSnapshot): void {
+  if (typeof snapshot.role !== 'undefined') {
+    setOptionalAttr(el, 'role', snapshot.role);
+  }
+
+  if (snapshot.name) {
+    if (snapshot.name.kind === 'text') {
+      el.setAttribute('aria-label', snapshot.name.value);
+    } else {
+      el.removeAttribute('aria-label');
+    }
+  }
+
+  if (snapshot.description) {
+    if (snapshot.description.kind === 'text') {
+      el.setAttribute('aria-description', snapshot.description.value);
+    } else {
+      el.removeAttribute('aria-description');
+    }
+  }
+
+  for (const [key, attr] of Object.entries(ARIA_STATE_ATTRS)) {
+    if (Object.prototype.hasOwnProperty.call(snapshot.states, key)) {
+      setNullableBooleanAttr(el, attr, snapshot.states[key]);
+    }
+  }
+
+  const actionKeys = Object.keys(snapshot.actions).sort();
+  if (actionKeys.length) {
+    setOptionalAttr(el, 'data-pui-a11y-actions', actionKeys.join(' '));
+  }
+
+  if (snapshot.tree) {
+    if (Object.prototype.hasOwnProperty.call(snapshot.tree, 'hidden')) {
+      setNullableBooleanAttr(el, 'aria-hidden', snapshot.tree.hidden);
+    }
+    if (Object.prototype.hasOwnProperty.call(snapshot.tree, 'mergeChildren')) {
+      setNullableBooleanAttr(el, 'data-pui-a11y-merge-children', snapshot.tree.mergeChildren);
+    }
+  }
+}
+
+function setOptionalAttr(el: HTMLElement, attr: string, value: string | undefined): void {
+  if (value === undefined || value === '') {
+    el.removeAttribute(attr);
+    return;
+  }
+  el.setAttribute(attr, value);
+}
+
+function setNullableBooleanAttr(el: HTMLElement, attr: string, value: unknown): void {
+  if (value === undefined || value === null) {
+    el.removeAttribute(attr);
+    return;
+  }
+  if (typeof value === 'boolean') {
+    el.setAttribute(attr, value ? 'true' : 'false');
+    return;
+  }
+  el.setAttribute(attr, String(value));
+}

--- a/packages/prototypes/base/src/button/button.ts
+++ b/packages/prototypes/base/src/button/button.ts
@@ -20,6 +20,7 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
   // P-BASE-BUTTON-DISABLED-EXPOSE
   const disabled = def.state.fromInteraction('disabled');
   def.expose.state('disabled', disabled);
+  def.a11y.state('disabled', disabled);
 
   // P-BASE-BUTTON-POINTER-HOVER
   const hovered = def.state.fromInteraction('hovered');
@@ -60,6 +61,14 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
 
   // P-BASE-BUTTON-CLICK-SIGNAL, P-BASE-BUTTON-CLICK-PROTOCOL-NAME
   def.expose.event('click', { payload: 'void' });
+  // P-BASE-BUTTON-ROLE-COMMAND
+  def.a11y.action('activate', { event: 'click' });
+
+  // P-BASE-BUTTON-ACCESSIBLE-ROLE
+  def.a11y.role('button');
+
+  // P-BASE-BUTTON-ACCESSIBLE-NAME, P-BASE-BUTTON-CONTENT-LABEL-SOURCE
+  def.a11y.nameFromContent();
 
   // P-BASE-BUTTON-KEYBOARD-ACTIVATION, P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT
   def.event.onGlobal('key.down', (_run, ev) => {
@@ -77,9 +86,6 @@ function setupButton(def: DefHandle<ButtonProps, ButtonExposes>): void {
   });
 
   /*
-   * TODO(P-BASE-BUTTON-ACCESSIBLE-ROLE): practice through the future a11y prototype syntax.
-   * TODO(P-BASE-BUTTON-ACCESSIBLE-NAME): practice through the future a11y prototype syntax.
-   * TODO(P-BASE-BUTTON-CONTENT-LABEL-SOURCE): practice through the future a11y prototype syntax.
    * TODO(P-BASE-BUTTON-PROP-LABEL-DEFERRED): keep accessible naming out of core props once a11y syntax exists.
    * TODO(P-BASE-BUTTON-A11Y-ENHANCEMENT): practice optional a11y enhancements through the future a11y syntax.
    */

--- a/packages/prototypes/base/test/as-button.test.ts
+++ b/packages/prototypes/base/test/as-button.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Prototype } from '@proto.ui/core';
+import type { A11ySemanticObjectSnapshot } from '@proto.ui/core';
 import { definePrototype } from '@proto.ui/core';
 import type { RuntimeHost } from '@proto.ui/runtime';
 import { executeWithHost } from '@proto.ui/runtime';
@@ -14,6 +15,7 @@ import {
   AS_TRIGGER_INSTANCE_CAP,
   AS_TRIGGER_PARENT_CAP,
 } from '@proto.ui/module-as-trigger';
+import { A11Y_PROJECT_CAP } from '@proto.ui/module-a11y';
 import { EXPOSE_STATE_SET_EXPOSES_CAP } from '@proto.ui/module-expose-state';
 import button, { asButton } from '../src/button';
 
@@ -22,6 +24,7 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
   const rootTarget = new EventTarget();
   const globalTarget = new EventTarget();
   const emitted: string[] = [];
+  const a11ySnapshots: A11ySemanticObjectSnapshot[] = [];
   let exposes: Record<string, any> | null = null;
 
   const host: RuntimeHost<any> = {
@@ -44,6 +47,14 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
         [AS_TRIGGER_PARENT_CAP, () => null],
         [AS_TRIGGER_GET_PROTO_CAP, () => null],
       ]);
+      wiring.attach('a11y', [
+        [
+          A11Y_PROJECT_CAP,
+          (snapshot: A11ySemanticObjectSnapshot) => {
+            a11ySnapshots.push(snapshot);
+          },
+        ],
+      ]);
       wiring.attach('expose-state', [
         [EXPOSE_STATE_SET_EXPOSES_CAP, (next: Record<string, unknown>) => (exposes = next)],
       ]);
@@ -57,6 +68,9 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
     emitted,
     getExposes() {
       return exposes;
+    },
+    getA11ySnapshot() {
+      return a11ySnapshots.at(-1);
     },
   };
 }
@@ -80,6 +94,12 @@ describe('prototypes/base: asButton', () => {
 
     const exposes = ctx.getExposes() as any;
     expect(exposes).toBeTruthy();
+    expect(ctx.getA11ySnapshot()).toMatchObject({
+      role: 'button',
+      name: { kind: 'content' },
+      states: { disabled: false },
+      actions: { activate: { event: 'click' } },
+    });
 
     ctx.rootTarget.dispatchEvent(new CustomEvent('pointer.enter'));
     expect(exposes.hovered.get()).toBe(true);
@@ -98,6 +118,7 @@ describe('prototypes/base: asButton', () => {
     expect(ctx.emitted).toEqual(['click']);
 
     controller.applyRawProps({ disabled: true } as any);
+    expect(ctx.getA11ySnapshot()?.states.disabled).toBe(true);
     expect(exposes.hovered.get()).toBe(false);
     expect(exposes.focused.get()).toBe(false);
     expect(exposes.focusVisible.get()).toBe(false);

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -20,6 +20,7 @@
     "@proto.ui/module-state": "workspace:*",
     "@proto.ui/module-state-interaction": "workspace:*",
     "@proto.ui/module-state-accessibility": "workspace:*",
+    "@proto.ui/module-a11y": "workspace:*",
     "@proto.ui/module-context": "workspace:*",
     "@proto.ui/module-anatomy": "workspace:*",
     "@proto.ui/module-as-trigger": "workspace:*",

--- a/packages/runtime/src/instance/instance.ts
+++ b/packages/runtime/src/instance/instance.ts
@@ -17,6 +17,7 @@ import { RuleModuleDef } from '@proto.ui/module-rule';
 import { StateModuleDef } from '@proto.ui/module-state';
 import { StateInteractionModuleDef } from '@proto.ui/module-state-interaction';
 import { StateAccessibilityModuleDef } from '@proto.ui/module-state-accessibility';
+import { A11yModuleDef } from '@proto.ui/module-a11y';
 import { ContextModuleDef } from '@proto.ui/module-context';
 import type { ContextPort } from '@proto.ui/module-context';
 import { AsTriggerModuleDef } from '@proto.ui/module-as-trigger';
@@ -78,6 +79,7 @@ export function createRuntimeInstance<P extends PropsBaseType>(
     StateModuleDef,
     StateInteractionModuleDef,
     StateAccessibilityModuleDef,
+    A11yModuleDef,
     ContextModuleDef,
     FocusModuleDef,
     BoundaryModuleDef,

--- a/packages/runtime/src/kernel/handles/def.ts
+++ b/packages/runtime/src/kernel/handles/def.ts
@@ -11,6 +11,7 @@ import type { EventFacade } from '@proto.ui/module-event';
 import type { StateFacade } from '@proto.ui/module-state';
 import type { StateInteractionFacade } from '@proto.ui/module-state-interaction';
 import type { StateAccessibilityFacade } from '@proto.ui/module-state-accessibility';
+import type { A11yFacade } from '@proto.ui/module-a11y';
 import type { ContextFacade } from '@proto.ui/module-context';
 import type { ExposeFacade } from '@proto.ui/module-expose';
 import type { AnatomyFacade } from '@proto.ui/module-anatomy';
@@ -61,6 +62,7 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
   const state = facades['state'] as StateFacade;
   const stateInteraction = facades['state-interaction'] as StateInteractionFacade | undefined;
   const stateAccessibility = facades['state-accessibility'] as StateAccessibilityFacade | undefined;
+  const a11y = facades['a11y'] as A11yFacade | undefined;
   const context = facades['context'] as ContextFacade;
   const expose = facades['expose'] as ExposeFacade;
   const anatomy = facades['anatomy'] as AnatomyFacade | undefined;
@@ -325,6 +327,51 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
         ensureSetup('def.anatomy.claim');
         if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
         anatomy.claim(family, decl);
+      },
+    },
+
+    a11y: {
+      role(role) {
+        ensureSetup('def.a11y.role');
+        if (!a11y) throw new Error(`[A11y] module unavailable.`);
+        a11y.role(role);
+        recordCaptured(def, 'context', { op: 'a11y.role', role });
+      },
+      name(value) {
+        ensureSetup('def.a11y.name');
+        if (!a11y) throw new Error(`[A11y] module unavailable.`);
+        a11y.name(value);
+        recordCaptured(def, 'context', { op: 'a11y.name', value });
+      },
+      nameFromContent() {
+        ensureSetup('def.a11y.nameFromContent');
+        if (!a11y) throw new Error(`[A11y] module unavailable.`);
+        a11y.nameFromContent();
+        recordCaptured(def, 'context', { op: 'a11y.nameFromContent' });
+      },
+      description(value) {
+        ensureSetup('def.a11y.description');
+        if (!a11y) throw new Error(`[A11y] module unavailable.`);
+        a11y.description(value);
+        recordCaptured(def, 'context', { op: 'a11y.description', value });
+      },
+      state(key, handle) {
+        ensureSetup('def.a11y.state');
+        if (!a11y) throw new Error(`[A11y] module unavailable.`);
+        a11y.state(key, handle);
+        recordCaptured(def, 'state', { op: 'a11y.state', key, handle });
+      },
+      action(key, spec) {
+        ensureSetup('def.a11y.action');
+        if (!a11y) throw new Error(`[A11y] module unavailable.`);
+        a11y.action(key, spec);
+        recordCaptured(def, 'event', { op: 'a11y.action', key, spec });
+      },
+      tree(patch) {
+        ensureSetup('def.a11y.tree');
+        if (!a11y) throw new Error(`[A11y] module unavailable.`);
+        a11y.tree(patch);
+        recordCaptured(def, 'context', { op: 'a11y.tree', patch });
       },
     },
   };

--- a/packages/runtime/test/contract/a11y.v0.contract.test.ts
+++ b/packages/runtime/test/contract/a11y.v0.contract.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { A11ySemanticObjectSnapshot, Prototype } from '@proto.ui/core';
+import { definePrototype } from '@proto.ui/core';
+import { A11Y_PROJECT_CAP, type A11yPort } from '@proto.ui/module-a11y';
+import { executeWithHost, type RuntimeHost } from '../../src';
+
+function createHost(initialRaw: Record<string, unknown> = {}) {
+  let raw = { ...initialRaw };
+  const snapshots: A11ySemanticObjectSnapshot[] = [];
+
+  const host: RuntimeHost<any> = {
+    prototypeName: 'x-a11y-contract',
+    getRawProps: () => raw,
+    commit(_children, signal) {
+      signal?.done();
+    },
+    schedule(task) {
+      task();
+    },
+    onRuntimeReady(wiring) {
+      wiring.attach('a11y', [
+        [
+          A11Y_PROJECT_CAP,
+          (snapshot: A11ySemanticObjectSnapshot) => {
+            snapshots.push(snapshot);
+          },
+        ],
+      ]);
+    },
+  };
+
+  return {
+    host,
+    snapshots,
+    applyRaw(nextRaw: Record<string, unknown>) {
+      raw = { ...nextRaw };
+    },
+  };
+}
+
+describe('runtime contract: a11y (v0)', () => {
+  it('A11Y-0100: def.a11y records semantic object IR and projects state snapshots', () => {
+    // T-A11Y-0001-CASE-IR
+    const P: Prototype<{ disabled?: boolean }> = definePrototype({
+      name: 'x-a11y-ir-contract',
+      setup(def) {
+        def.props.define({
+          disabled: { type: 'boolean', empty: 'fallback' },
+        });
+        def.props.setDefaults({ disabled: false });
+
+        const disabled = def.state.bool('button.disabled', false);
+        def.a11y.role('button');
+        def.a11y.name('Save');
+        def.a11y.description('Stores changes');
+        def.a11y.state('disabled', disabled);
+        def.a11y.action('activate', { event: 'click' });
+        def.a11y.tree({ mergeChildren: true });
+
+        def.lifecycle.onCreated((run) => {
+          disabled.set(run.props.get().disabled);
+        });
+        def.props.watch(['disabled'], (_run, next) => {
+          disabled.set(next.disabled);
+        });
+
+        return (r) => r.el('button', 'Save');
+      },
+    });
+
+    const ctx = createHost({ disabled: false });
+    const { caps, controller } = executeWithHost(P as any, ctx.host as any);
+    const port = caps.getPort<A11yPort>('a11y');
+
+    expect(port?.getSnapshot()).toEqual({
+      role: 'button',
+      name: { kind: 'text', value: 'Save' },
+      description: { kind: 'text', value: 'Stores changes' },
+      states: { disabled: false },
+      actions: { activate: { event: 'click' } },
+      tree: { mergeChildren: true },
+    });
+
+    ctx.applyRaw({ disabled: true });
+    controller.applyRawProps({ disabled: true } as any);
+
+    expect(port?.getSnapshot().states.disabled).toBe(true);
+    expect(ctx.snapshots.at(-1)?.states.disabled).toBe(true);
+  });
+});

--- a/packages/spec/engine/src/node.ts
+++ b/packages/spec/engine/src/node.ts
@@ -164,6 +164,10 @@ function validateWorkspaceRelations(
     for (const relationKind of SPEC_RELATION_KINDS) {
       validateRelationGroup(entry, byId, issues, relationKind, entry.entity[relationKind]);
     }
+
+    for (const criterion of entry.entity.criteria) {
+      validateRelationGroup(entry, byId, issues, 'dependsOn', criterion.dependsOn, criterion.id);
+    }
   }
 }
 
@@ -198,7 +202,8 @@ function validateRelationGroup(
   byId: Map<string, LoadedSpecEntity>,
   issues: SpecValidationIssue[],
   groupName: SpecRelationKind,
-  relations: SpecRelations
+  relations: SpecRelations,
+  sourceId = entry.entity.id
 ): void {
   if (!relations) return;
 
@@ -209,7 +214,7 @@ function validateRelationGroup(
       if (target.since && target.until && compareSpecVersions(target.until, target.since) <= 0) {
         issues.push({
           filePath: entry.filePath,
-          message: `${entry.entity.id} ${groupName}.${relationKey} relation to ${target.id} has until <= since.`,
+          message: `${sourceId} ${groupName}.${relationKey} relation to ${target.id} has until <= since.`,
         });
       }
 
@@ -218,7 +223,7 @@ function validateRelationGroup(
       if (!targetEntry) {
         issues.push({
           filePath: entry.filePath,
-          message: `${entry.entity.id} ${groupName}.${relationKey} target does not exist: ${target.id}.`,
+          message: `${sourceId} ${groupName}.${relationKey} target does not exist: ${target.id}.`,
         });
         continue;
       }
@@ -226,7 +231,7 @@ function validateRelationGroup(
       if (targetEntry.entity.type !== expectedType) {
         issues.push({
           filePath: entry.filePath,
-          message: `${entry.entity.id} ${groupName}.${relationKey} target ${target.id} is ${targetEntry.entity.type}, expected ${expectedType}.`,
+          message: `${sourceId} ${groupName}.${relationKey} target ${target.id} is ${targetEntry.entity.type}, expected ${expectedType}.`,
         });
       }
 
@@ -235,14 +240,14 @@ function validateRelationGroup(
       if (compareSpecVersions(relationSince, entry.entity.since) < 0) {
         issues.push({
           filePath: entry.filePath,
-          message: `${entry.entity.id} ${groupName}.${relationKey} relation to ${target.id} starts before the source entity exists.`,
+          message: `${sourceId} ${groupName}.${relationKey} relation to ${target.id} starts before the source entity exists.`,
         });
       }
 
       if (compareSpecVersions(relationSince, targetEntry.entity.since) < 0) {
         issues.push({
           filePath: entry.filePath,
-          message: `${entry.entity.id} ${groupName}.${relationKey} relation to ${target.id} starts before the target entity exists.`,
+          message: `${sourceId} ${groupName}.${relationKey} relation to ${target.id} starts before the target entity exists.`,
         });
       }
 
@@ -252,7 +257,7 @@ function validateRelationGroup(
       ) {
         issues.push({
           filePath: entry.filePath,
-          message: `${entry.entity.id} ${groupName}.${relationKey} relation to ${target.id} extends beyond the target removal version.`,
+          message: `${sourceId} ${groupName}.${relationKey} relation to ${target.id} extends beyond the target removal version.`,
         });
       }
     }

--- a/packages/spec/fixtures/test/workspace-relations.test.ts
+++ b/packages/spec/fixtures/test/workspace-relations.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { loadSpecWorkspaceFromDirectory } from '@proto.ui/spec-engine/node';
+import { describe, expect, it } from 'vitest';
+
+describe('spec workspace relations', () => {
+  it('validates criterion-level dependency target types', async () => {
+    const specDir = await mkdtemp(path.join(os.tmpdir(), 'proto-ui-spec-relations-'));
+
+    try {
+      await writeFile(
+        path.join(specDir, 'D-VALID-0001.yaml'),
+        [
+          'id: D-VALID-0001',
+          'type: decision',
+          'title: Valid decision',
+          'status: active',
+          'since: 0.1.0',
+          'criteria: []',
+          '',
+        ].join('\n')
+      );
+      await writeFile(
+        path.join(specDir, 'P-VALID.yaml'),
+        [
+          'id: P-VALID',
+          'type: prototype',
+          'title: Valid prototype',
+          'status: draft',
+          'since: 0.1.0',
+          'criteria:',
+          '  - id: P-VALID-CRITERION',
+          '    text: Criterion with wrong relation type.',
+          '    dependsOn:',
+          '      contracts:',
+          '        - D-VALID-0001',
+          '',
+        ].join('\n')
+      );
+
+      const workspace = await loadSpecWorkspaceFromDirectory(specDir);
+
+      expect(workspace.issues).toEqual([
+        {
+          filePath: path.join(specDir, 'P-VALID.yaml'),
+          message:
+            'P-VALID-CRITERION dependsOn.contracts target D-VALID-0001 is decision, expected contract.',
+        },
+      ]);
+    } finally {
+      await rm(specDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/spec/schema/src/index.ts
+++ b/packages/spec/schema/src/index.ts
@@ -141,6 +141,7 @@ export const specCriterionSchema = z.object({
   id: z.string().min(1),
   text: specLocalizedTextSchema,
   rationale: specLocalizedTextSchema.optional(),
+  dependsOn: specRelationsSchema,
 });
 
 export const specOpenQuestionSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,9 @@ importers:
       '@proto.ui/hooks':
         specifier: workspace:*
         version: link:../../hooks
+      '@proto.ui/module-a11y':
+        specifier: workspace:*
+        version: link:../../modules/a11y
       '@proto.ui/module-anatomy':
         specifier: workspace:*
         version: link:../../modules/anatomy
@@ -250,6 +253,9 @@ importers:
       '@proto.ui/hooks':
         specifier: workspace:*
         version: link:../../hooks
+      '@proto.ui/module-a11y':
+        specifier: workspace:*
+        version: link:../../modules/a11y
       '@proto.ui/module-anatomy':
         specifier: workspace:*
         version: link:../../modules/anatomy
@@ -313,6 +319,9 @@ importers:
       '@proto.ui/hooks':
         specifier: workspace:*
         version: link:../../hooks
+      '@proto.ui/module-a11y':
+        specifier: workspace:*
+        version: link:../../modules/a11y
       '@proto.ui/module-anatomy':
         specifier: workspace:*
         version: link:../../modules/anatomy
@@ -404,6 +413,18 @@ importers:
       '@proto.ui/types':
         specifier: workspace:*
         version: link:../types
+
+  packages/modules/a11y:
+    dependencies:
+      '@proto.ui/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@proto.ui/module-base':
+        specifier: workspace:*
+        version: link:../base
+      '@proto.ui/module-state':
+        specifier: workspace:*
+        version: link:../state
 
   packages/modules/anatomy:
     dependencies:
@@ -770,6 +791,9 @@ importers:
       '@proto.ui/hooks':
         specifier: workspace:*
         version: link:../hooks
+      '@proto.ui/module-a11y':
+        specifier: workspace:*
+        version: link:../modules/a11y
       '@proto.ui/module-anatomy':
         specifier: workspace:*
         version: link:../modules/anatomy

--- a/spec/contracts/C-A11Y-0001.yaml
+++ b/spec/contracts/C-A11Y-0001.yaml
@@ -1,0 +1,76 @@
+id: C-A11Y-0001
+type: contract
+title: Accessibility exposes projectable semantic objects
+status: draft
+since: 0.1.0
+summary: The a11y domain records projectable semantic object facts such as role, name, description, state, action, relation, and semantic tree behavior.
+statement:
+  zh-CN: >-
+    Accessibility 是一个可由宿主投影的 semantic object domain。原型通过 a11y API 声明当前交互对象的 role、name、description、state、action、relation 与 semantic tree behavior；runtime 将这些声明保存为稳定 IR，adapter 负责把 IR 投影到宿主的无障碍表达。a11y IR 可以引用 state/focus/event/anatomy 等其它域事实，但 a11y 不重新拥有这些域。
+
+
+  en: >-
+    Accessibility is a host-projectable semantic object domain. A prototype declares role, name, description, state, action, relation, and semantic tree behavior for the current interaction object through a11y APIs; the runtime stores these declarations as stable IR, and adapters project the IR to host accessibility output. A11y IR may reference facts from state, focus, event, anatomy, and other domains, but a11y does not re-own those domains.
+
+
+criteria:
+  - id: C-A11Y-0001-A
+    text:
+      zh-CN: a11y domain 必须输出可由 adapter 投影的 semantic object IR。
+      en: The a11y domain must output semantic object IR that adapters can project.
+  - id: C-A11Y-0001-B
+    text:
+      zh-CN: semantic object 至少应能表达 role、name、description、state 与 action。
+      en: A semantic object should at least be able to express role, name, description, state, and action.
+  - id: C-A11Y-0001-C
+    text:
+      zh-CN: role 表达交互对象是什么，不得直接等同于某个宿主 attribute 名称。
+      en: Role describes what the interaction object is and must not be equated directly with a host attribute name.
+  - id: C-A11Y-0001-D
+    text:
+      zh-CN: name 与 description 必须作为 semantic object 的事实记录，而不是 Button 等单个原型的私有 props 规则。
+      en: Name and description must be recorded as semantic object facts rather than private props rules of a single prototype such as Button.
+  - id: C-A11Y-0001-E
+    text:
+      zh-CN: a11y state 可以引用 state handle；其值读取与生命周期仍由 state domain 负责。
+      en: A11y state may reference state handles; value reading and lifecycle remain owned by the state domain.
+  - id: C-A11Y-0001-F
+    text:
+      zh-CN: a11y action 可以引用 expose event 或其它交互通路；action 本身不重新定义 event route。
+      en: A11y action may reference expose events or other interaction routes; the action itself does not redefine the event route.
+  - id: C-A11Y-0001-G
+    text:
+      zh-CN: adapter 可以按宿主能力选择原生 role/name/state/action 投影、降级投影或仅保留诊断 IR。
+      en: Adapters may choose native role/name/state/action projection, degraded projection, or diagnostic-only IR based on host capabilities.
+sources:
+  - path: internal/records/2026-06-30-a11y-module-planning-for-button.zh-CN.md
+  - path: packages/modules/a11y/src/types.ts
+  - path: packages/modules/a11y/src/create.ts
+  - path: packages/modules/a11y/src/web.ts
+  - path: packages/runtime/test/contract/a11y.v0.contract.test.ts
+  - path: https://www.w3.org/TR/accname-1.2/
+    label: W3C Accessible Name and Description Computation
+  - path: https://www.w3.org/TR/wai-aria-1.2/
+    label: WAI-ARIA 1.2
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0003
+    - C-STATE-0008
+    - C-EXPOSE-EVENT-0001
+relates:
+  decisions:
+    - D-A11Y-SEMANTIC-DOMAIN-0001
+  prototypes:
+    - P-BASE-BUTTON
+verifies:
+  tests:
+    - T-A11Y-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced the minimal semantic object contract for the a11y module.
+tags:
+  - a11y
+  - accessibility
+  - semantic-object
+  - host-projection

--- a/spec/decisions/D-A11Y-SEMANTIC-DOMAIN-0001.yaml
+++ b/spec/decisions/D-A11Y-SEMANTIC-DOMAIN-0001.yaml
@@ -1,0 +1,56 @@
+id: D-A11Y-SEMANTIC-DOMAIN-0001
+type: decision
+title: Accessibility is a semantic object domain
+status: draft
+since: 0.1.0
+summary: Proto UI models accessibility as host-projectable semantic objects instead of Web ARIA attributes or platform-specific accessibility API calls.
+statement:
+  zh-CN: >-
+    Proto UI 的 accessibility 应建模为可投影的 semantic object domain。原型作者声明的是交互对象的 role、name、description、state、action、relation 与 semantic tree behavior；adapter 再把这些语义投影到 Web ARIA、native accessibility API、测试语义树或宿主自己的无障碍系统。ARIA、Android semantics、Apple accessibility 与 Windows UIA 都是宿主投影目标，而不是 Proto UI 的核心模型本身。
+
+
+  en: >-
+    Proto UI accessibility should be modeled as a projectable semantic object domain. Component Authors declare role, name, description, state, action, relation, and semantic tree behavior for interaction objects; adapters then project those semantics to Web ARIA, native accessibility APIs, test semantic trees, or the host's accessibility system. ARIA, Android semantics, Apple accessibility, and Windows UIA are host projection targets rather than the Proto UI core model itself.
+
+
+criteria:
+  - id: D-A11Y-SEMANTIC-DOMAIN-0001-A
+    text:
+      zh-CN: a11y module 不得被定义为 Web ARIA attribute wrapper。
+      en: The a11y module must not be defined as a Web ARIA attribute wrapper.
+  - id: D-A11Y-SEMANTIC-DOMAIN-0001-B
+    text:
+      zh-CN: a11y API 应优先表达跨平台 semantic object facts，再由 adapter 决定宿主投影。
+      en: A11y APIs should express cross-platform semantic object facts first, then let adapters decide host projection.
+  - id: D-A11Y-SEMANTIC-DOMAIN-0001-C
+    text:
+      zh-CN: accessibility state lane、focus domain、event/asTrigger 与 anatomy 可以参与 a11y 语义，但不应被 a11y module 吞并。
+      en: Accessibility state lanes, focus domain, event/asTrigger, and anatomy may participate in a11y semantics, but should not be absorbed by the a11y module.
+sources:
+  - path: internal/records/2026-06-30-a11y-module-planning-for-button.zh-CN.md
+  - path: spec/prototypes/P-BASE-BUTTON.yaml
+    sections:
+      - P-BASE-BUTTON-ACCESSIBLE-ROLE
+      - P-BASE-BUTTON-ACCESSIBLE-NAME
+  - path: https://www.w3.org/TR/accname-1.2/
+    label: W3C Accessible Name and Description Computation
+  - path: https://www.w3.org/TR/core-aam-1.2/
+    label: W3C Core Accessibility API Mappings
+  - path: https://developer.android.com/develop/ui/compose/accessibility/semantics
+    label: Android Compose Semantics
+relates:
+  contracts:
+    - C-FOCUS-0001
+    - C-STATE-INTERACTION-0001
+    - C-STATE-0008
+  prototypes:
+    - P-BASE-BUTTON
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Recorded the cross-platform semantic object direction for the first a11y module pass.
+tags:
+  - a11y
+  - accessibility
+  - semantic-object
+  - adapter

--- a/spec/host-caps/HC-A11Y-0001.yaml
+++ b/spec/host-caps/HC-A11Y-0001.yaml
@@ -1,0 +1,35 @@
+id: HC-A11Y-0001
+type: host-cap
+title: Host can project accessibility semantics
+status: draft
+since: 0.1.0
+summary: The host can receive Proto UI accessibility semantic object IR and project it to its accessibility surface.
+statement:
+  zh-CN: >-
+    Host 可以接收 Proto UI a11y semantic object IR，并将 role、name、description、state、action 等语义投影到自身的 accessibility surface。不同宿主可以投影到 ARIA/native attributes、平台 accessibility API、测试语义树，或保留诊断数据。
+
+
+  en: >-
+    The host can receive Proto UI a11y semantic object IR and project role, name, description, state, action, and related semantics to its accessibility surface. Different hosts may project to ARIA/native attributes, platform accessibility APIs, test semantic trees, or diagnostic data.
+
+
+criteria:
+  - id: HC-A11Y-0001-A
+    text:
+      zh-CN: host-cap 必须允许 adapter 接收完整 a11y IR。
+      en: The host capability must let adapters receive the complete a11y IR.
+  - id: HC-A11Y-0001-B
+    text:
+      zh-CN: host-cap 不要求所有宿主都支持相同的原生投影能力。
+      en: The host capability does not require every host to support the same native projection abilities.
+relates:
+  contracts:
+    - C-A11Y-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Drafted the host projection capability for a11y semantic IR.
+tags:
+  - host-capability
+  - a11y
+  - accessibility

--- a/spec/modules/M-A11Y-0001.yaml
+++ b/spec/modules/M-A11Y-0001.yaml
@@ -1,0 +1,27 @@
+id: M-A11Y-0001
+type: module
+title: A11y module records semantic object IR
+status: draft
+since: 0.1.0
+summary: The a11y module provides the prototype author API and runtime IR storage for host-projectable accessibility semantic objects.
+satisfies:
+  contracts:
+    - C-A11Y-0001
+requires:
+  hostCaps:
+    - HC-A11Y-0001
+verifies:
+  tests:
+    - T-A11Y-0001
+sources:
+  - path: packages/modules/a11y/src/create.ts
+  - path: packages/modules/a11y/src/types.ts
+  - path: packages/modules/a11y/src/web.ts
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Drafted the a11y module entity.
+tags:
+  - a11y
+  - accessibility
+  - module

--- a/spec/prototypes/P-BASE-BUTTON.yaml
+++ b/spec/prototypes/P-BASE-BUTTON.yaml
@@ -18,122 +18,244 @@ criteria:
     text:
       zh-CN: Button 表示一个触发离散 action 的 command control。
       en: Button represents a command control that triggers a discrete action.
+    dependsOn:
+      knowledge:
+        - K-COMPONENT-INTERACTION-0001
   - id: P-BASE-BUTTON-AUTHORING-ENTRIES
     text:
       zh-CN: '`base-button` direct prototype 与 `asButton` authored asHook 是同一 Button protocol 的两个 authoring entries。'
       en: 'The `base-button` direct prototype and the `asButton` authored asHook are two authoring entries of the same Button protocol.'
+    dependsOn:
+      contracts:
+        - C-CORE-SYNTAX-0003
+        - C-AS-HOOK-0001
+      decisions:
+        - D-PROTOTYPE-ENTITY-NAMING-0001
   - id: P-BASE-BUTTON-TRIGGER-SEMANTICS
     text:
       zh-CN: Button 必须通过官方 trigger 能力处理 activation route。
       en: Button must process its activation route through the official trigger capability.
+    dependsOn:
+      contracts:
+        - C-AS-TRIGGER-0001
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
   - id: P-BASE-BUTTON-NESTED-TRIGGER-ROUTE
     text:
       zh-CN: 连续嵌套的 Button/trigger 场景必须遵循官方 trigger route 合并规则。
       en: Continuously nested Button/trigger scenarios must follow the official trigger route merging rules.
+    dependsOn:
+      contracts:
+        - C-AS-TRIGGER-0001
   - id: P-BASE-BUTTON-PROP-DISABLED
     text:
       zh-CN: 'Button 必须接受 `disabled?: boolean` props input，默认值为 `false`。'
       en: 'Button must accept a `disabled?: boolean` props input whose default is `false`.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-PROPS-0003
   - id: P-BASE-BUTTON-PROP-DISABLED-CONTROLLED
     text:
       zh-CN: 当 App Maker 更新 `disabled` props input 时，Button 必须同步自身 disabled state 与相关交互能力。
       en: When the App Maker updates the `disabled` props input, Button must synchronize its disabled state and related interaction capabilities.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-STATE-INTERACTION-0001
+        - C-AS-FOCUSABLE-0001
   - id: P-BASE-BUTTON-DISABLED-EXPOSE
     text:
       zh-CN: Button 必须 expose `disabled` state。
       en: Button must expose `disabled` state.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+        - C-EXPOSE-STATE-0001
+        - C-A11Y-0001
   - id: P-BASE-BUTTON-DISABLED-SUPPRESS-ACTIVATION
     text:
       zh-CN: 当 `disabled` 为 true 时，Button 不得完成 activation，也不得发出 `click` signal。
       en: When `disabled` is true, Button must not complete activation and must not emit the `click` signal.
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
+        - C-EXPOSE-EVENT-0001
   - id: P-BASE-BUTTON-DISABLED-CLEAR-TRANSIENT
     text:
       zh-CN: 当 `disabled` 变为 true 时，Button 必须清理自身 transient interaction state。
       en: When `disabled` becomes true, Button must clear its own transient interaction state.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+        - C-STATE-INTERACTION-0002
+        - C-STATE-INTERACTION-0003
   - id: P-BASE-BUTTON-POINTER-HOVER
     text:
       zh-CN: Button 必须响应指向性设备的 hover 进入与离开，并 expose `hovered` state。
       en: Button must respond to pointer hover enter and leave, and must expose `hovered` state.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+        - C-STATE-INTERACTION-0002
+        - C-EXPOSE-STATE-0001
   - id: P-BASE-BUTTON-FOCUSABLE
     text:
       zh-CN: Button 必须是 focus target，并 expose `focused` 与 `focusVisible` state。
       en: Button must be a focus target and must expose `focused` and `focusVisible` state.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
+        - C-EXPOSE-STATE-0001
+      decisions:
+        - D-FOCUS-STATE-INTERACTION-BOUNDARY-0001
   - id: P-BASE-BUTTON-REQUEST-FOCUS
     text:
       zh-CN: Button 必须提供主动请求焦点的能力。
       en: Button must provide a capability for actively requesting focus.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
   - id: P-BASE-BUTTON-DISABLED-REJECT-FOCUS
     text:
       zh-CN: 当 `disabled` 为 true 时，Button 必须拒绝主动焦点请求。
       en: When `disabled` is true, Button must reject active focus requests.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
   - id: P-BASE-BUTTON-PRESS-LIFECYCLE
     text:
       zh-CN: Button 必须维护 press lifecycle，并 expose `pressed` state。`pressed` 表示被按压住时的状态。
       en: Button must maintain the press lifecycle and expose `pressed` state. `pressed` means the button is being held down.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+        - C-STATE-INTERACTION-0002
+        - C-STATE-INTERACTION-0003
+        - C-EXPOSE-STATE-0001
   - id: P-BASE-BUTTON-CLICK-SIGNAL
     text:
       zh-CN: Button 成功 activation 后必须发出名为 `click` 的 outward signal。
       en: After successful activation, Button must emit an outward signal named `click`.
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
+        - C-EXPOSE-EVENT-0001
   - id: P-BASE-BUTTON-CLICK-PROTOCOL-NAME
     text:
       zh-CN: '`click` 是 Button protocol 约定的 outward signal 名称。'
       en: '`click` is the outward signal name defined by the Button protocol.'
+    dependsOn:
+      contracts:
+        - C-EXPOSE-EVENT-0001
   - id: P-BASE-BUTTON-PROP-NO-EVENT-CALLBACK
     text:
       zh-CN: Button props 不包含 `onClick` 之类事件回调；Button activation 通过 expose event 发出 `click` signal。
       en: Button props do not include event callbacks such as `onClick`; Button activation emits the `click` signal through expose event.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-EXPOSE-EVENT-0001
   - id: P-BASE-BUTTON-KEYBOARD-ACTIVATION
     text:
       zh-CN: Button 必须支持键盘 activation。Space 与 Enter 应触发 Button activation。
       en: Button must support keyboard activation. Space and Enter should trigger Button activation.
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
   - id: P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT
     text:
       zh-CN: 当已聚焦 Button 通过 Space 触发 activation 时，Button 应请求阻止宿主默认副作用。
       en: When a focused Button is activated through Space, Button should request prevention of host default side effects.
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
   - id: P-BASE-BUTTON-ACCESSIBLE-ROLE
     text:
       zh-CN: Button 必须具备可映射到 button role 的可访问语义。
       en: Button must carry accessibility semantics that can be mapped to a button role.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
   - id: P-BASE-BUTTON-ACCESSIBLE-NAME
     text:
       zh-CN: Button 必须支持 accessible name。
       en: Button must support an accessible name.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
   - id: P-BASE-BUTTON-CONTENT-LABEL-SOURCE
     text:
       zh-CN: Button 可以从内容、显式 label 或 accessibility API 获得 label。
       en: Button may obtain its label from content, an explicit label, or an accessibility API.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
   - id: P-BASE-BUTTON-PROP-LABEL-DEFERRED
     text:
       zh-CN: Button 的 accessible name 是核心可访问能力，但第一版 core props 不强制把它定义为 `label` prop。
       en: Button accessible name is a core accessibility capability, but the first core props surface does not force it to be a `label` prop.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-A11Y-0001
   - id: P-BASE-BUTTON-A11Y-ENHANCEMENT
     text:
       zh-CN: ARIA description、disabled reason、tooltip 等辅助表达属于可选 accessibility enhancement。
       en: Auxiliary expressions such as ARIA description, disabled reason, and tooltip belong to optional accessibility enhancement.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
   - id: P-BASE-BUTTON-NO-VISUAL-VARIANT-CORE
     text:
       zh-CN: Button 核心契约不定义 size、variant、tone、shape 等视觉参数。
       en: Button core contract does not define visual parameters such as size, variant, tone, or shape.
+    dependsOn:
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+      knowledge:
+        - K-DESIGN-TRADEOFF-0001
   - id: P-BASE-BUTTON-PROP-VISUAL-DEFERRED
     text:
       zh-CN: '`size`、`variant`、`tone`、`shape` 等视觉配置不进入 Base Button core props。'
       en: Visual configuration such as `size`, `variant`, `tone`, and `shape` does not enter Base Button core props.
+    dependsOn:
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
   - id: P-BASE-BUTTON-ICON-CONTENT
     text:
       zh-CN: Icon 可以作为 Button 内容参与渲染与样式上下文，但不是 Button protocol 的独立结构部分。
       en: An icon may participate in rendering and style context as Button content, but is not an independent structural part of the Button protocol.
+    dependsOn:
+      knowledge:
+        - K-COMPONENT-INTERACTION-0001
   - id: P-BASE-BUTTON-PROP-FORM-DEFERRED
     text:
       zh-CN: '`type`、`name`、`value`、`form` 与 `form*` 类能力属于 Form 联动场景，不进入 Base Button 第一层 core props。'
       en: '`type`, `name`, `value`, `form`, and `form*` capabilities belong to Form integration and do not enter the first Base Button core props surface.'
+    dependsOn:
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
   - id: P-BASE-BUTTON-FORM-EXTENSION
     text:
       zh-CN: Form submit、reset 与 form association 属于 Button 的后续扩展场景。
       en: Form submit, reset, and form association belong to later Button extension scenarios.
+    dependsOn:
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
   - id: P-BASE-BUTTON-PROP-COMMAND-DEFERRED
     text:
       zh-CN: '`command`、`commandfor`、popover/dialog command 等宿主 command 能力不进入 Base Button 第一层 core props。'
       en: '`command`, `commandfor`, popover/dialog command, and similar host command capabilities do not enter the first Base Button core props surface.'
+    dependsOn:
+      contracts:
+        - C-AS-TRIGGER-0001
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
 openQuestions:
   - id: P-BASE-BUTTON-Q-A11Y-API
     question:
@@ -200,6 +322,7 @@ dependsOn:
     - C-EVENT-TYPE-0002
     - C-EXPOSE-STATE-0001
     - C-EXPOSE-EVENT-0001
+    - C-A11Y-0001
 relates:
   decisions:
     - D-PROTOTYPE-ENTITY-NAMING-0001
@@ -216,6 +339,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Introduced the first Base Button prototype contract entity with props, accessibility, interaction, focus, signal, and extension boundaries.
+  - version: 0.1.0
+    change: revised
+    summary: Added criterion-level dependency mapping for Button contract criteria.
 tags:
   - prototype
   - base

--- a/spec/tests/T-A11Y-0001.yaml
+++ b/spec/tests/T-A11Y-0001.yaml
@@ -1,0 +1,79 @@
+id: T-A11Y-0001
+type: test
+title: A11y semantic object contract tests
+status: draft
+since: 0.1.0
+summary: Contract tests for a11y semantic object IR, Button consumption, and Web adapter projection.
+cases:
+  - id: T-A11Y-0001-CASE-IR
+    title: A prototype can declare role, name, state, and action into a stable a11y IR
+    covers:
+      - C-A11Y-0001-A
+      - C-A11Y-0001-B
+      - C-A11Y-0001-C
+      - C-A11Y-0001-D
+      - C-A11Y-0001-E
+      - C-A11Y-0001-F
+    expectation: semantic-object-ir
+  - id: T-A11Y-0001-CASE-BUTTON
+    title: Base Button declares button role, content-derived name policy, disabled state, and activate action
+    covers:
+      - C-A11Y-0001-B
+      - C-A11Y-0001-C
+      - C-A11Y-0001-D
+      - C-A11Y-0001-E
+      - C-A11Y-0001-F
+    expectation: base-button-a11y-consumption
+  - id: T-A11Y-0001-CASE-WEB-PROJECTION
+    title: Web adapter projects supported a11y IR to host attributes
+    covers:
+      - C-A11Y-0001-G
+      - HC-A11Y-0001-A
+      - HC-A11Y-0001-B
+    expectation: web-a11y-projection
+implementations:
+  - id: runtime-a11y-contract
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/a11y.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-A11Y-0001-CASE-IR
+  - id: base-button-a11y-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/as-button.test.ts
+    required: true
+    consumesCases:
+      - T-A11Y-0001-CASE-BUTTON
+  - id: web-component-a11y-contract
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-A11Y-0001-CASE-WEB-PROJECTION
+verifies:
+  contracts:
+    - id: C-A11Y-0001
+      anchors:
+        - C-A11Y-0001-A
+        - C-A11Y-0001-B
+        - C-A11Y-0001-C
+        - C-A11Y-0001-D
+        - C-A11Y-0001-E
+        - C-A11Y-0001-F
+        - C-A11Y-0001-G
+  hostCaps:
+    - id: HC-A11Y-0001
+      anchors:
+        - HC-A11Y-0001-A
+        - HC-A11Y-0001-B
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added the first a11y semantic object test mapping.
+tags:
+  - a11y
+  - accessibility
+  - contract-test


### PR DESCRIPTION
## Summary

- Catalog the initial a11y semantic domain with D/C/HC/M/T entities.
- Add `@proto.ui/module-a11y`, `def.a11y`, runtime registration, and Web projection wiring for Web Component, React, and Vue adapters.
- Wire Base Button to declare button role, content-derived accessible name policy, disabled state, and activate action through `def.a11y`.
- Add runtime, base prototype, and Web Component adapter contract tests for the new a11y surface.

## Validation

- `corepack pnpm@10.32.1 -s check:types:workspace`
- `corepack pnpm@10.32.1 -s test:types`
- `corepack pnpm@10.32.1 -s test:runtime`