### PR TITLE
[codex] Catalog base toggle protocol

### DIFF
--- a/apps/www/src/content/docs/zh-cn/demo-shadcn-toggle.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-shadcn-toggle.demo.ts
@@ -19,7 +19,7 @@ export default {
       {
         kind: 'proto',
         prototypeId: 'shadcn-toggle',
-        props: { variant: 'outline', defaultChecked: true },
+        props: { variant: 'outline', defaultActive: true },
         children: [
           {
             kind: 'proto',
@@ -45,7 +45,7 @@ export default {
       {
         kind: 'proto',
         prototypeId: 'shadcn-toggle',
-        props: { disabled: true, defaultChecked: true },
+        props: { disabled: true, defaultActive: true },
         children: [
           {
             kind: 'proto',

--- a/internal/records/2026-07-05-toggle-catalog-before-tabs.zh-CN.md
+++ b/internal/records/2026-07-05-toggle-catalog-before-tabs.zh-CN.md
@@ -1,0 +1,199 @@
+# 2026-07-05 Switch 后续编目方向：Toggle Before Tabs
+
+> Internal record. Not normative. 本文记录 `P-BASE-SWITCH` 编目闭环之后，下一轮 prototype cataloging 的阶段性方向选择。本文不直接新增 `P-*` 实体，也不替代后续 Toggle 契约草案、测试实体或实现校准。
+
+---
+
+## 1）背景
+
+`P-BASE-SWITCH` 与 `P-BASE-SWITCH-THUMB` 编目已经完成一个新的小型 value-control 闭环，并在过程中压实了若干基础能力：
+
+- `asHook` 返回命名 state handle。
+- 嵌套 `asHook` 结果自动收集。
+- `fromInteraction` / `fromAccessibility` 进入 deprecated 路径。
+- ARIA 投射从 state-web 样式投射中切出，归入 a11y API / module / host capability。
+- Switch root 与 thumb 的 anatomy / context / indicator 边界已有第一轮实践。
+
+因此，下一轮可以继续用现存原型牵引 P 实体编目。但此时直接进入 Tabs 会显著扩大问题面。
+
+Tabs 会同时牵引：
+
+- root / list / trigger / content 多 part anatomy。
+- selection model 与 active value。
+- collection / item registry。
+- roving focus 与 keyboard navigation policy。
+- `tablist` / `tab` / `tabpanel` 的 a11y 关系。
+- content visibility 与 mounting / presence 策略。
+
+这些问题都重要，但它们更适合作为下一阶段复合组件牵引点，而不是紧接 Switch 之后立刻展开。
+
+---
+
+## 2）当前方向
+
+下一轮建议先编目：
+
+```text
+P-BASE-TOGGLE first, P-BASE-CHECKBOX next, P-BASE-TABS deferred.
+```
+
+也就是说：
+
+1. 先做 Toggle，用它收束 Switch / Button / Toggle 的边界。
+2. 再做 Checkbox，用它扩展 checked state 到 mixed / form-adjacent 输入语义。
+3. 最后进入 Tabs，集中处理 collection、roving focus 与 composite widget。
+
+---
+
+## 3）为什么先 Toggle
+
+Toggle 是 Switch 之后最自然的对照原型。
+
+它与 Switch 的共同点：
+
+- 都可能拥有持久二值状态。
+- 都会在 activation 后切换状态。
+- 都需要区分 disabled、pressed、hovered、focusVisible 等状态。
+- 都可以检验 state handle、asHook result、state-web style projection 与 a11y projection 的边界。
+
+但它与 Switch 的差异也足够关键：
+
+- Switch 的核心语义是 on/off value control。
+- Toggle 更接近 button family 的持久状态变体。
+- Toggle 通常不表达“开/关”设置语义。
+- Toggle 更适合成组组合，例如 toggle group。
+- Toggle 不应与 Form 产生联动。
+- Toggle 的 a11y 语义更可能靠近 `aria-pressed` / toggle button，而不是 `role=switch` + `aria-checked`。
+
+因此，Toggle 适合回答一个 Switch 阶段故意留下的问题：
+
+> 共享底层二值切换行为的原型，是否仍应在 P 实体层保持独立协议边界？
+
+当前倾向是：应保持独立。Switch 与 Toggle 可以共享底层 helper、module 能力或未来抽象出的 value/toggle 核心，但 P 实体不应互相吞并。
+
+---
+
+## 4）为什么 Checkbox 放在 Toggle 之后
+
+Checkbox 与 Switch / Toggle 都共享 `checked` 这类状态表面，但它比 Toggle 更早引入额外复杂度：
+
+- `indeterminate` / mixed state。
+- form association。
+- checkbox group 与集合语义。
+- root / indicator anatomy。
+- `aria-checked="mixed"` 等 a11y 特例。
+
+因此，Checkbox 很适合作为 Toggle 之后的第二个同级原型：
+
+- Toggle 先压实“持久二值 button-like state”。
+- Checkbox 再压实“checked 输入语义 + mixed state + indicator anatomy”。
+
+这会让二值 / 三值输入类原型在进入 Tabs 前形成更完整的对照组。
+
+---
+
+## 5）为什么 Tabs 继续延后
+
+Tabs 是高价值目标，但它不是当前最小增量。
+
+如果现在直接进入 Tabs，容易把以下问题捆在一起：
+
+- P 实体按 anatomy part 拆分的规则。
+- collection / item identity 的契约归属。
+- roving focus 与 active descendant 的策略。
+- controlled / uncontrolled active value。
+- content part 的 visibility、mounting 与 presence。
+- a11y role / state / relationship projection。
+
+这些问题很可能需要单独的 D 实体与基础契约修订。先完成 Toggle / Checkbox，可以让 Tabs 编目时拥有更稳定的基础样本：Button、Switch、Toggle、Checkbox。
+
+---
+
+## 6）Toggle 契约讨论入口
+
+正式起草 `P-BASE-TOGGLE` 前，建议先讨论以下问题。
+
+### 6.1 Toggle 是什么
+
+工作性定义可以从这里开始：
+
+> Toggle is a button-like control that represents a persistent binary active state and toggles that state on successful activation.
+
+中文表述：
+
+> Toggle 是一种 button-like control。它表示一个持久二值 active state，并在成功 activation 后切换该状态。
+
+需要讨论：
+
+- 这个持久状态应命名为 `checked`、`pressed`、`selected`，还是其他 protocol-specific 名称。
+- P 实体是否应明确 Toggle 不是 on/off value control。
+- P 实体是否应明确 Toggle 不参与 Form。
+- Toggle 是否应被视为单一交互主体，还是为 ToggleGroup 预留 part / item 边界。
+
+### 6.2 与 Button 的边界
+
+Button 的 `pressed` 是 transient press lifecycle。
+
+Toggle 的核心状态如果也叫 pressed，需要明确：
+
+- Button pressed 与 Toggle pressed 是否同名但不同持久性。
+- Toggle 是否应复用 Button 的 activation / disabled / focus / hover / press 准则。
+- Toggle 是否应依赖 `asButton`，还是像 Switch 一样保持 P 实体独立。
+
+当前倾向：
+
+- Toggle 可以参考 Button 的 activation、focus、disabled、interaction feedback 准则。
+- Toggle 不应通过消费 Button P 实体获得自身语义。
+- 如果实现层继续复用 helper，应确保 P 实体上表达的是 Toggle 自身协议。
+
+### 6.3 与 Switch 的边界
+
+Switch 与 Toggle 的关键差异应至少覆盖：
+
+- Switch 是 on/off setting-like value control。
+- Toggle 是 button-like persistent active control。
+- Switch 的 a11y 应走 `role=switch` / checked state。
+- Toggle 的 a11y 更可能走 button / `aria-pressed`。
+- Switch 可能保留 form integration open question。
+- Toggle 当前应明确不与 Form 联动。
+
+这部分很适合形成 `P-BASE-TOGGLE` 对 `P-BASE-SWITCH` 的 `references` 关系，而不是 `dependsOn` 或继承关系。
+
+### 6.4 与 ToggleGroup 的关系
+
+ToggleGroup 不应抢跑，但 Toggle 需要为它保留边界。
+
+需要讨论：
+
+- 单个 Toggle 是否只拥有自身 binary state。
+- ToggleGroup 是否未来负责 exclusive / multiple selection。
+- Toggle 在 group 中的状态是否应仍由 Toggle 自身持有，还是由 group 提供 controlled value。
+- Toggle 的 P 实体是否需要提前声明 group membership 是 deferred。
+
+第一轮可以只落单个 Toggle，避免把 group selection 与 collection 提前拉入。
+
+---
+
+## 7）下一步
+
+建议下一轮按以下顺序推进：
+
+1. 阅读现有 `base toggle` 与 `shadcn toggle` 实现、测试和已使用的 state / a11y API。
+2. 对照 Button、Switch 的 P 实体，列出 Toggle 可参考准则。
+3. 对照 ARIA toggle button、Radix Toggle、Base UI Toggle、React Aria ToggleButton 等资料，确认 Toggle / Switch / Checkbox 边界。
+4. 先在对话中形成 `P-BASE-TOGGLE` 草案结构，不直接落实体。
+5. 决定 Toggle 状态命名、signal 命名、props 最小面、a11y 投射与 Form 非目标。
+6. 草案确认后再落 `P-BASE-TOGGLE`、测试实体与实现校准。
+
+---
+
+## 8）非目标
+
+本记录不决定以下问题：
+
+- `P-BASE-TOGGLE` 的最终 criteria 文本。
+- Toggle 状态最终命名。
+- Toggle outward signal 最终命名。
+- ToggleGroup 是否进入同轮编目。
+- Checkbox 的 mixed state 契约。
+- Tabs / collection / roving focus 的最终模型。

--- a/packages/cli/src/legacy/cli.ts
+++ b/packages/cli/src/legacy/cli.ts
@@ -773,6 +773,17 @@ function resolveKnownAsHookStateHandles(node) {
     ]);
   }
 
+  if (hookName === 'asToggle') {
+    return new Map([
+      ['active', 'data-[active]'],
+      ['disabled', 'data-[disabled]'],
+      ['hovered', 'data-[hovered]'],
+      ['focused', 'data-[focused]'],
+      ['focusVisible', 'data-[focus-visible]'],
+      ['pressed', 'data-[pressed]'],
+    ]);
+  }
+
   return null;
 }
 

--- a/packages/cli/src/legacy/type.ts
+++ b/packages/cli/src/legacy/type.ts
@@ -27,6 +27,8 @@ export const SHADCN_STYLE_TOKENS = [
   'active:shadow-xs',
   'active:text-foreground',
   'active:translate-y-px',
+  'data-[active]:bg-muted',
+  'data-[active]:text-foreground',
   'data-[checked]:bg-accent',
   'data-[checked]:bg-muted',
   'data-[checked]:bg-primary',

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -79,6 +79,7 @@ describe('@proto.ui/cli', () => {
     const themeCss = await fs.readFile(path.join(cwd, 'src/styles/shadcn-theme.css'), 'utf8');
 
     expect(tokensCss).toContain(`[data-pui-style~="bg-primary"]`);
+    expect(tokensCss).toContain(`data-[active]:bg-muted"])[data-active]`);
     expect(tokensCss).toContain(`data-[checked]:bg-primary"])[data-checked]`);
     expect(tokensCss).not.toContain(`aria-checked:bg-primary"])[aria-checked='true']`);
     expect(tokensCss).not.toContain('@source');
@@ -107,6 +108,7 @@ describe('@proto.ui/cli', () => {
     const tokensCss = await fs.readFile(outFile, 'utf8');
     expect(tokensCss).toContain(`[data-pui-style~="bg-primary"]`);
     expect(tokensCss).toContain(`[data-pui-style~="rounded-md"]`);
+    expect(tokensCss).toContain(`data-[active]:bg-muted"])[data-active]`);
     expect(tokensCss).toContain(`data-[checked]:pl-[20px]"])[data-checked]`);
     expect(tokensCss).toContain(`data-[checked]:bg-primary"])[data-checked]`);
     expect(tokensCss).toContain(`data-[selected]:bg-background"])[data-selected]`);

--- a/packages/prototypes/base/src/checkbox/types.ts
+++ b/packages/prototypes/base/src/checkbox/types.ts
@@ -1,34 +1,46 @@
-import { ExposeEvent, ExposeMethod, ExposeState, State } from '@proto.ui/core';
-import type {
-  ToggleAsHookContract,
-  ToggleExposes,
-  ToggleProps,
-  ToggleStateHandles,
-} from '../toggle/types';
+import { ExposeEvent, ExposeMethod, ExposeState, FocusRequestOptions, State } from '@proto.ui/core';
 
 export type CheckboxCheckedChangeDetail = {
   checked: boolean;
   indeterminate: boolean;
 };
 
-export interface CheckboxRootProps extends ToggleProps {
+export interface CheckboxRootProps {
+  checked?: boolean;
+  defaultChecked?: boolean;
+  disabled?: boolean;
   indeterminate?: boolean;
   defaultIndeterminate?: boolean;
 }
 
-export type CheckboxRootExposes = Omit<ToggleExposes, 'checkedChange'> & {
+export type CheckboxRootExposes = {
+  disabled: ExposeState<boolean>;
+  hovered: ExposeState<boolean>;
+  focused: ExposeState<boolean>;
+  focusVisible: ExposeState<boolean>;
+  pressed: ExposeState<boolean>;
+  checked: ExposeState<boolean>;
+  focusSelf: ExposeMethod<(options?: FocusRequestOptions) => void>;
+  click: ExposeEvent<void>;
   indeterminate: ExposeState<boolean>;
   checkedChange: ExposeEvent<CheckboxCheckedChangeDetail>;
   indeterminateChange: ExposeEvent<{ indeterminate: boolean }>;
 };
 
-export type CheckboxRootStateHandles = ToggleStateHandles & {
+export type CheckboxRootStateHandles = {
+  disabled: State<boolean>;
+  hovered: State<boolean>;
+  focused: State<boolean>;
+  focusVisible: State<boolean>;
+  pressed: State<boolean>;
+  checked: State<boolean>;
   indeterminate: State<boolean>;
 };
 
-export type CheckboxRootAsHookContract = Omit<ToggleAsHookContract, 'event'> & {
-  state: ToggleStateHandles & { indeterminate: State<boolean> };
+export type CheckboxRootAsHookContract = {
+  state: CheckboxRootStateHandles;
   event: {
+    click: void;
     checkedChange: CheckboxCheckedChangeDetail;
     indeterminateChange: { indeterminate: boolean };
   };

--- a/packages/prototypes/base/src/toggle/toggle.ts
+++ b/packages/prototypes/base/src/toggle/toggle.ts
@@ -1,59 +1,162 @@
 import type { DefHandle } from '@proto.ui/core';
 import { defineAsHook, definePrototype } from '@proto.ui/core';
-import { asButton } from '../button';
+import { asFocusable, asTrigger } from '@proto.ui/hooks';
 import type { ToggleAsHookContract, ToggleExposes, ToggleProps, ToggleStateHandles } from './types';
 
 export type { ToggleProps, ToggleExposes, ToggleStateHandles, ToggleAsHookContract } from './types';
 
 function setupToggle(def: DefHandle<ToggleProps, ToggleExposes>): void {
-  asButton();
+  // P-BASE-TOGGLE-ROLE-ACTIVE-CONTROL, P-BASE-TOGGLE-PROTOCOL-INDEPENDENCE
+  // P-BASE-TOGGLE-TRIGGER-SEMANTICS
+  asTrigger();
 
+  // P-BASE-TOGGLE-PROP-ACTIVE, P-BASE-TOGGLE-PROP-DEFAULT-ACTIVE
+  // P-BASE-TOGGLE-PROP-DISABLED, P-BASE-TOGGLE-PROP-NO-EVENT-CALLBACK
   def.props.define({
-    checked: { type: 'boolean', empty: 'fallback' },
-    defaultChecked: { type: 'boolean', empty: 'fallback' },
+    active: { type: 'boolean', empty: 'fallback' },
+    defaultActive: { type: 'boolean', empty: 'fallback' },
     disabled: { type: 'boolean', empty: 'fallback' },
   });
   def.props.setDefaults({
-    defaultChecked: false,
+    defaultActive: false,
     disabled: false,
   });
 
-  const checked = def.state.fromAccessibility('checked');
-  const disabled = def.state.fromInteraction('disabled');
-  def.expose.state('checked', checked);
-  def.expose.event('checkedChange', { payload: 'json' });
+  // P-BASE-TOGGLE-ACTIVE-EXPOSE, P-BASE-TOGGLE-ACTIVE-SCOPED-NAME
+  // P-BASE-TOGGLE-ACTIVE-NOT-CHECKED, P-BASE-TOGGLE-ACTIVE-NOT-TRANSIENT-PRESSED
+  const active = def.state.bool('active', false);
+  // P-BASE-TOGGLE-DISABLED-EXPOSE
+  const disabled = def.state.bool('disabled', false);
+  // P-BASE-TOGGLE-POINTER-HOVER
+  const hovered = def.state.bool('hovered', false);
+  // P-BASE-TOGGLE-PRESS-LIFECYCLE
+  const pressed = def.state.bool('pressed', false);
+  // P-BASE-TOGGLE-FOCUSABLE, P-BASE-TOGGLE-DISABLED-REJECT-FOCUS
+  const focusable = asFocusable<ToggleProps>();
+  focusable.configure({ disabled: false });
+
+  const focused = focusable.focused;
+  const focusVisible = focusable.focusVisible;
+
+  def.expose.state('active', active);
+  def.expose.state('disabled', disabled);
+  def.expose.state('hovered', hovered);
+  def.expose.state('focused', focused);
+  def.expose.state('focusVisible', focusVisible);
+  def.expose.state('pressed', pressed);
+  // P-BASE-TOGGLE-REQUEST-FOCUS, P-BASE-TOGGLE-DISABLED-REJECT-FOCUS
+  def.expose.method('focusSelf', (options) => {
+    if (disabled.get()) return;
+    focusable.focusSelf(options);
+  });
+  // P-BASE-TOGGLE-ACTIVE-CHANGE-SIGNAL, P-BASE-TOGGLE-ACTIVE-CHANGE-PROTOCOL-NAME
+  def.expose.event('activeChange', { payload: 'json' });
+
+  // P-BASE-TOGGLE-ACCESSIBLE-ROLE
+  def.a11y.role('button');
+  // P-BASE-TOGGLE-ACCESSIBLE-NAME
+  def.a11y.nameFromContent();
+  // P-BASE-TOGGLE-A11Y-PRESSED
+  def.a11y.state('pressed', active);
+  def.a11y.state('disabled', disabled);
+  def.a11y.action('activate', { event: 'activeChange' });
 
   let controlled = false;
 
+  const clearTransientInteraction = (reason: string) => {
+    hovered.set(false, reason);
+    pressed.set(false, reason);
+  };
+
+  // P-BASE-TOGGLE-DISABLED-EXPOSE, P-BASE-TOGGLE-DISABLED-CLEAR-TRANSIENT
+  const syncDisabled = (nextDisabled: boolean) => {
+    disabled.set(nextDisabled, 'reason: toggle sync disabled');
+    focusable.setDisabled(nextDisabled);
+    if (nextDisabled) {
+      clearTransientInteraction('reason: toggle disabled => reset transient interaction');
+    }
+  };
+
+  // P-BASE-TOGGLE-CONTROLLED-ACTIVE, P-BASE-TOGGLE-CONTROLLED-EMITS-NEXT
+  // P-BASE-TOGGLE-UNCONTROLLED-UPDATES-ACTIVE
   def.lifecycle.onCreated((run) => {
-    controlled = run.props.isProvided('checked');
-    checked.set(
-      controlled ? !!run.props.get().checked : !!run.props.get().defaultChecked,
-      'reason: lifecycle.onCreated => initialize checked'
+    controlled = run.props.isProvided('active');
+    active.set(
+      controlled ? !!run.props.get().active : !!run.props.get().defaultActive,
+      'reason: toggle initialize active'
     );
+    syncDisabled(!!run.props.get().disabled);
   });
 
-  def.props.watch(['checked'], (run, next) => {
-    controlled = run.props.isProvided('checked');
+  // P-BASE-TOGGLE-CONTROLLED-ACTIVE
+  def.props.watch(['active'], (run, next) => {
+    controlled = run.props.isProvided('active');
     if (!controlled) return;
-    checked.set(!!next.checked, 'reason: props.watch(checked) => controlled sync');
+    active.set(!!next.active, 'reason: toggle controlled active sync');
   });
 
+  // P-BASE-TOGGLE-DISABLED-EXPOSE, P-BASE-TOGGLE-DISABLED-CLEAR-TRANSIENT
+  def.props.watch(['disabled'], (_run, next) => {
+    syncDisabled(!!next.disabled);
+  });
+
+  // P-BASE-TOGGLE-KEYBOARD-ACTIVATION, P-BASE-TOGGLE-KEYBOARD-SPACE-PREVENT-DEFAULT
+  def.event.onGlobal('key.down', (_run, ev) => {
+    const detail = ev?.detail;
+    if (disabled.get()) return;
+    if (!focused.get()) return;
+    if (detail?.key !== ' ') return;
+    detail?.preventDefault?.();
+  });
+
+  // P-BASE-TOGGLE-POINTER-HOVER
+  def.event.on('pointer.enter', () => {
+    if (disabled.get()) return;
+    hovered.set(true, 'reason: toggle pointer.enter => hovered');
+  });
+  def.event.on('pointer.leave', () => {
+    hovered.set(false, 'reason: toggle pointer.leave => hovered');
+    pressed.set(false, 'reason: toggle pointer.leave => pressed');
+  });
+  def.event.on('pointer.cancel', () => {
+    hovered.set(false, 'reason: toggle pointer.cancel => hovered');
+    pressed.set(false, 'reason: toggle pointer.cancel => pressed');
+  });
+
+  // P-BASE-TOGGLE-PRESS-LIFECYCLE
+  def.event.on('pointer.down', () => {
+    if (disabled.get()) return;
+    pressed.set(true, 'reason: toggle pointer.down => pressed');
+  });
+  def.event.on('pointer.up', () => {
+    pressed.set(false, 'reason: toggle pointer.up => pressed');
+  });
+
+  // P-BASE-TOGGLE-ACTIVATION-FLIPS-ACTIVE, P-BASE-TOGGLE-DISABLED-SUPPRESS-ACTIVATION
+  // P-BASE-TOGGLE-UNCONTROLLED-UPDATES-ACTIVE, P-BASE-TOGGLE-CONTROLLED-EMITS-NEXT
   def.event.on('press.commit', (run) => {
+    pressed.set(false, 'reason: toggle press.commit => pressed');
     if (disabled.get()) return;
 
-    if (controlled) {
-      const nextChecked = !checked.get();
-      run.expose.emit('checkedChange', { checked: nextChecked });
-      return;
+    const nextActive = !active.get();
+    if (!controlled) {
+      active.set(nextActive, 'reason: toggle press.commit => active');
     }
-
-    const nextChecked = !checked.get();
-    checked.set(nextChecked, 'reason: event.on(press.commit) => toggle checked');
-    run.expose.emit('checkedChange', { checked: nextChecked });
+    run.expose.emit('activeChange', { active: nextActive });
   });
 }
 
+/*
+ * P-BASE-TOGGLE criteria outside Toggle-internal prototype syntax:
+ * - P-BASE-TOGGLE-SINGLE-SUBJECT: absence of group membership and collection syntax is the implementation.
+ * - P-BASE-TOGGLE-NO-ANATOMY-PARTS: absence of anatomy roles is the implementation.
+ * - P-BASE-TOGGLE-CLICK-DEFERRED: absence of a `click` expose event is the implementation.
+ * - P-BASE-TOGGLE-PROP-LABEL-DEFERRED: accessible naming uses content/a11y projection; no `label` prop is accepted.
+ * - P-BASE-TOGGLE-NO-FORM-INTEGRATION: no form props or form submission surface are accepted.
+ * - P-BASE-TOGGLE-NO-VISUAL-VARIANT-CORE: visual parameters are owned by downstream styled prototypes.
+ */
+
+// P-BASE-TOGGLE-AUTHORING-ENTRIES
 export const asToggle = defineAsHook<ToggleProps, ToggleExposes, ToggleAsHookContract>({
   name: 'as-toggle',
   setup: setupToggle,

--- a/packages/prototypes/base/src/toggle/types.ts
+++ b/packages/prototypes/base/src/toggle/types.ts
@@ -1,8 +1,8 @@
-import { ExposeEvent, ExposeState, State } from '@proto.ui/core';
+import { ExposeEvent, ExposeMethod, ExposeState, FocusRequestOptions, State } from '@proto.ui/core';
 
 export interface ToggleProps {
-  checked?: boolean;
-  defaultChecked?: boolean;
+  active?: boolean;
+  defaultActive?: boolean;
   disabled?: boolean;
 }
 
@@ -12,9 +12,9 @@ export type ToggleExposes = {
   focused: ExposeState<boolean>;
   focusVisible: ExposeState<boolean>;
   pressed: ExposeState<boolean>;
-  checked: ExposeState<boolean>;
-  click: ExposeEvent<void>;
-  checkedChange: ExposeEvent<{ checked: boolean }>;
+  active: ExposeState<boolean>;
+  focusSelf: ExposeMethod<(options?: FocusRequestOptions) => void>;
+  activeChange: ExposeEvent<{ active: boolean }>;
 };
 
 export type ToggleStateHandles = {
@@ -23,13 +23,12 @@ export type ToggleStateHandles = {
   focused: State<boolean>;
   focusVisible: State<boolean>;
   pressed: State<boolean>;
-  checked: State<boolean>;
+  active: State<boolean>;
 };
 
 export type ToggleAsHookContract = {
   state: ToggleStateHandles;
   event: {
-    click: void;
-    checkedChange: { checked: boolean };
+    activeChange: { active: boolean };
   };
 };

--- a/packages/prototypes/base/test/toggle.test.ts
+++ b/packages/prototypes/base/test/toggle.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import type { Prototype } from '@proto.ui/core';
 import { definePrototype } from '@proto.ui/core';
+import type { A11ySemanticObjectSnapshot } from '@proto.ui/core';
 import type { RuntimeHost } from '@proto.ui/runtime';
 import { executeWithHost } from '@proto.ui/runtime';
+import {
+  FOCUS_REQUEST_FOCUS_CAP,
+  FOCUS_ROOT_TARGET_CAP,
+  FOCUS_SET_FOCUSABLE_CAP,
+} from '@proto.ui/module-focus';
 import {
   EVENT_EMIT_CAP,
   EVENT_GLOBAL_TARGET_CAP,
@@ -13,6 +19,7 @@ import {
   AS_TRIGGER_INSTANCE_CAP,
   AS_TRIGGER_PARENT_CAP,
 } from '@proto.ui/module-as-trigger';
+import { A11Y_PROJECT_CAP } from '@proto.ui/module-a11y';
 import { EXPOSE_STATE_SET_EXPOSES_CAP } from '@proto.ui/module-expose-state';
 import toggle from '../src/toggle';
 import { asToggle } from '../src/toggle';
@@ -22,6 +29,9 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
   const rootTarget = new EventTarget();
   const globalTarget = new EventTarget();
   const emitted: Array<{ key: string; payload: unknown }> = [];
+  const a11ySnapshots: A11ySemanticObjectSnapshot[] = [];
+  const focusRequests: unknown[] = [];
+  const focusableFlags: boolean[] = [];
   let exposes: Record<string, any> | null = null;
 
   const host: RuntimeHost<any> = {
@@ -39,10 +49,29 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
         [EVENT_GLOBAL_TARGET_CAP, () => globalTarget],
         [EVENT_EMIT_CAP, (key: string, payload: unknown) => emitted.push({ key, payload })],
       ]);
+      wiring.attach('focus', [
+        [FOCUS_ROOT_TARGET_CAP, () => rootTarget],
+        [
+          FOCUS_SET_FOCUSABLE_CAP,
+          (_target: unknown, enabled: boolean) => focusableFlags.push(enabled),
+        ],
+        [
+          FOCUS_REQUEST_FOCUS_CAP,
+          (_target: unknown, options: unknown) => focusRequests.push(options),
+        ],
+      ]);
       wiring.attach('as-trigger', [
         [AS_TRIGGER_INSTANCE_CAP, rootTarget],
         [AS_TRIGGER_PARENT_CAP, () => null],
         [AS_TRIGGER_GET_PROTO_CAP, () => null],
+      ]);
+      wiring.attach('a11y', [
+        [
+          A11Y_PROJECT_CAP,
+          (snapshot: A11ySemanticObjectSnapshot) => {
+            a11ySnapshots.push(snapshot);
+          },
+        ],
       ]);
       wiring.attach('expose-state', [
         [EXPOSE_STATE_SET_EXPOSES_CAP, (next: Record<string, unknown>) => (exposes = next)],
@@ -53,37 +82,52 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
   return {
     host,
     rootTarget,
+    globalTarget,
     emitted,
+    focusRequests,
+    focusableFlags,
     applyRawProps(next: Record<string, unknown>) {
       raw = { ...next };
     },
     getExposes() {
       return exposes;
     },
+    getA11ySnapshot() {
+      return a11ySnapshots.at(-1);
+    },
   };
 }
 
 describe('prototypes/base: toggle', () => {
-  it('base-toggle initializes from defaultChecked and flips checked on press.commit', () => {
-    const ctx = createHost({ defaultChecked: true });
+  it('base-toggle initializes from defaultActive and flips active on press.commit', () => {
+    // T-BASE-TOGGLE-0001-CASE-UNCONTROLLED-ACTIVE-CHANGE
+    // T-BASE-TOGGLE-0001-CASE-A11Y-AND-DEFERRED-SURFACES
+    const ctx = createHost({ defaultActive: true });
     const { invokeUnmounted } = executeWithHost(toggle as any, ctx.host as any);
 
     const exposes = ctx.getExposes() as any;
-    expect(exposes.checked.get()).toBe(true);
+    expect(exposes.active.get()).toBe(true);
+    expect(exposes.checked).toBeUndefined();
+    expect(exposes.click).toBeUndefined();
+    expect(ctx.getA11ySnapshot()).toMatchObject({
+      role: 'button',
+      name: { kind: 'content' },
+      states: { pressed: true, disabled: false },
+      actions: { activate: { event: 'activeChange' } },
+    });
 
     ctx.rootTarget.dispatchEvent(new CustomEvent('press.commit'));
 
-    expect(exposes.checked.get()).toBe(false);
-    expect(ctx.emitted).toEqual([
-      { key: 'click', payload: undefined },
-      { key: 'checkedChange', payload: { checked: false } },
-    ]);
+    expect(exposes.active.get()).toBe(false);
+    expect(ctx.emitted).toEqual([{ key: 'activeChange', payload: { active: false } }]);
 
     invokeUnmounted();
   });
 
-  it('asToggle mirrors controlled checked prop and emits next checked without mutating local state', () => {
-    const P: Prototype<{ checked?: boolean }> = definePrototype({
+  it('asToggle mirrors controlled active prop and emits next active without mutating local state', () => {
+    // T-BASE-TOGGLE-0001-CASE-AUTHORING-ENTRIES
+    // T-BASE-TOGGLE-0001-CASE-CONTROLLED-ACTIVE
+    const P: Prototype<{ active?: boolean }> = definePrototype({
       name: 'x-base-as-toggle',
       setup() {
         asToggle();
@@ -91,38 +135,85 @@ describe('prototypes/base: toggle', () => {
       },
     });
 
-    const ctx = createHost({ checked: true });
+    const ctx = createHost({ active: true });
+    const directCtx = createHost({ active: true });
     const { controller, invokeUnmounted } = executeWithHost(P as any, ctx.host as any);
+    const { invokeUnmounted: invokeDirectUnmounted } = executeWithHost(
+      toggle as any,
+      directCtx.host as any
+    );
 
     const exposes = ctx.getExposes() as any;
-    expect(exposes.checked.get()).toBe(true);
+    const directExposes = directCtx.getExposes() as any;
+    expect(Object.keys(exposes).sort()).toEqual(Object.keys(directExposes).sort());
+    expect(exposes.active.get()).toBe(true);
+    expect(exposes.checked).toBeUndefined();
+    expect(exposes.click).toBeUndefined();
 
     ctx.rootTarget.dispatchEvent(new CustomEvent('press.commit'));
 
-    expect(exposes.checked.get()).toBe(true);
-    expect(ctx.emitted).toEqual([
-      { key: 'click', payload: undefined },
-      { key: 'checkedChange', payload: { checked: false } },
-    ]);
+    expect(exposes.active.get()).toBe(true);
+    expect(ctx.emitted).toEqual([{ key: 'activeChange', payload: { active: false } }]);
 
-    ctx.applyRawProps({ checked: false });
-    controller.applyRawProps({ checked: false } as any);
-    expect(exposes.checked.get()).toBe(false);
+    ctx.applyRawProps({ active: false });
+    controller.applyRawProps({ active: false } as any);
+    expect(exposes.active.get()).toBe(false);
 
     invokeUnmounted();
+    invokeDirectUnmounted();
   });
 
-  it('disabled toggle keeps checked stable and suppresses click/checkedChange', () => {
-    const ctx = createHost({ defaultChecked: false, disabled: true });
+  it('disabled toggle keeps active stable and suppresses activeChange', () => {
+    // T-BASE-TOGGLE-0001-CASE-DISABLED-GATING
+    const ctx = createHost({ defaultActive: false, disabled: true });
     executeWithHost(toggle as any, ctx.host as any);
 
     const exposes = ctx.getExposes() as any;
-    expect(exposes.checked.get()).toBe(false);
+    expect(exposes.active.get()).toBe(false);
 
     ctx.rootTarget.dispatchEvent(new CustomEvent('pointer.down'));
     ctx.rootTarget.dispatchEvent(new CustomEvent('press.commit'));
 
-    expect(exposes.checked.get()).toBe(false);
+    expect(exposes.active.get()).toBe(false);
+    expect(exposes.pressed.get()).toBe(false);
+    expect(ctx.focusableFlags.at(-1)).toBe(false);
     expect(ctx.emitted).toEqual([]);
+  });
+
+  it('toggle exposes pointer, focus, press, and keyboard activation behavior', () => {
+    // T-BASE-TOGGLE-0001-CASE-INTERACTION-FOCUS-KEYBOARD
+    const ctx = createHost({ defaultActive: false, disabled: false });
+    executeWithHost(toggle as any, ctx.host as any);
+
+    const exposes = ctx.getExposes() as any;
+    expect(exposes.hovered.get()).toBe(false);
+    expect(exposes.pressed.get()).toBe(false);
+    expect(exposes.focused.get()).toBe(false);
+    expect(exposes.focusVisible.get()).toBe(false);
+
+    ctx.rootTarget.dispatchEvent(new CustomEvent('pointer.enter'));
+    expect(exposes.hovered.get()).toBe(true);
+
+    ctx.rootTarget.dispatchEvent(new CustomEvent('pointer.down'));
+    expect(exposes.pressed.get()).toBe(true);
+
+    ctx.rootTarget.dispatchEvent(new CustomEvent('pointer.leave'));
+    expect(exposes.hovered.get()).toBe(false);
+    expect(exposes.pressed.get()).toBe(false);
+
+    exposes.focusSelf({ preventScroll: true });
+    expect(ctx.focusRequests).toEqual([{ preventScroll: true }]);
+
+    const preventDefaultCalls: string[] = [];
+    ctx.rootTarget.dispatchEvent(new CustomEvent('host:focus'));
+    ctx.globalTarget.dispatchEvent(
+      new CustomEvent('key.down', {
+        detail: {
+          key: ' ',
+          preventDefault: () => preventDefaultCalls.push('space'),
+        },
+      })
+    );
+    expect(preventDefaultCalls).toEqual(['space']);
   });
 });

--- a/packages/prototypes/shadcn/src/toggle/index.ts
+++ b/packages/prototypes/shadcn/src/toggle/index.ts
@@ -34,23 +34,22 @@ const toggle = definePrototype<ShadcnToggleProps, ShadcnToggleExposes>({
     def.props.define({
       variant: { type: 'enum', empty: 'fallback', options: ['default', 'outline'] },
       size: { type: 'enum', empty: 'fallback', options: ['default', 'sm', 'lg'] },
-      checked: { type: 'boolean', empty: 'fallback' },
-      defaultChecked: { type: 'boolean', empty: 'fallback' },
+      active: { type: 'boolean', empty: 'fallback' },
+      defaultActive: { type: 'boolean', empty: 'fallback' },
       disabled: { type: 'boolean', empty: 'fallback' },
     });
     def.props.setDefaults({
       variant: 'default',
       size: 'default',
-      defaultChecked: false,
+      defaultActive: false,
       disabled: false,
     });
 
-    asToggle();
-
-    const checked = def.state.fromAccessibility('checked');
-    const disabled = def.state.fromInteraction('disabled');
-    const hovered = def.state.fromInteraction('hovered');
-    const focusVisible = def.state.fromInteraction('focusVisible');
+    const toggleState = asToggle().stateHandles;
+    if (!toggleState) {
+      throw new Error('[shadcn-toggle] asToggle must project Toggle state handles.');
+    }
+    const { active, disabled, hovered, focusVisible } = toggleState;
 
     def.feedback.style.use(tw(TOGGLE_BASE_TOKENS));
 
@@ -71,12 +70,12 @@ const toggle = definePrototype<ShadcnToggleProps, ShadcnToggleExposes>({
     });
 
     def.rule({
-      when: (w) => w.state(checked).eq(true),
+      when: (w) => w.state(active).eq(true),
       intent: (i) => i.feedback.style.use(tw('bg-muted')),
     });
 
     def.rule({
-      when: (w) => w.all(w.state(hovered).eq(true), w.state(checked).eq(false)),
+      when: (w) => w.all(w.state(hovered).eq(true), w.state(active).eq(false)),
       intent: (i) => i.feedback.style.use(tw('bg-muted text-foreground')),
     });
 

--- a/packages/prototypes/shadcn/test/toggle.test.ts
+++ b/packages/prototypes/shadcn/test/toggle.test.ts
@@ -1,25 +1,38 @@
 import { describe, expect, it } from 'vitest';
+import type { A11ySemanticObjectSnapshot } from '@proto.ui/core';
 import type { RuntimeHost } from '@proto.ui/runtime';
 import { executeWithHost } from '@proto.ui/runtime';
-import { EVENT_GLOBAL_TARGET_CAP, EVENT_ROOT_TARGET_CAP } from '@proto.ui/module-event';
+import {
+  FOCUS_REQUEST_FOCUS_CAP,
+  FOCUS_ROOT_TARGET_CAP,
+  FOCUS_SET_FOCUSABLE_CAP,
+} from '@proto.ui/module-focus';
+import {
+  EVENT_EMIT_CAP,
+  EVENT_GLOBAL_TARGET_CAP,
+  EVENT_ROOT_TARGET_CAP,
+} from '@proto.ui/module-event';
 import {
   AS_TRIGGER_GET_PROTO_CAP,
   AS_TRIGGER_INSTANCE_CAP,
   AS_TRIGGER_PARENT_CAP,
 } from '@proto.ui/module-as-trigger';
+import { A11Y_PROJECT_CAP } from '@proto.ui/module-a11y';
 import toggle from '../src/toggle';
 
 describe('prototypes/shadcn: toggle', () => {
-  it('maps variant, size, checked and disabled to style tokens', () => {
+  it('maps variant, size, active and disabled to style tokens', () => {
     let rawProps: Record<string, unknown> = {
       variant: 'default',
       size: 'default',
-      defaultChecked: false,
+      defaultActive: false,
       disabled: false,
     };
 
     const rootTarget = new EventTarget();
     const globalTarget = new EventTarget();
+    const activeChanges: Array<{ active: boolean }> = [];
+    const a11ySnapshots: A11ySemanticObjectSnapshot[] = [];
 
     const host: RuntimeHost<any> = {
       prototypeName: 'x-shadcn-toggle-style',
@@ -36,11 +49,30 @@ describe('prototypes/shadcn: toggle', () => {
         wiring.attach('event', [
           [EVENT_ROOT_TARGET_CAP, () => rootTarget],
           [EVENT_GLOBAL_TARGET_CAP, () => globalTarget],
+          [
+            EVENT_EMIT_CAP,
+            (key: string, payload: unknown) => {
+              if (key === 'activeChange') activeChanges.push(payload as { active: boolean });
+            },
+          ],
+        ]);
+        wiring.attach('focus', [
+          [FOCUS_ROOT_TARGET_CAP, () => rootTarget],
+          [FOCUS_SET_FOCUSABLE_CAP, () => undefined],
+          [FOCUS_REQUEST_FOCUS_CAP, () => undefined],
         ]);
         wiring.attach('as-trigger', [
           [AS_TRIGGER_INSTANCE_CAP, rootTarget],
           [AS_TRIGGER_PARENT_CAP, () => null],
           [AS_TRIGGER_GET_PROTO_CAP, () => null],
+        ]);
+        wiring.attach('a11y', [
+          [
+            A11Y_PROJECT_CAP,
+            (snapshot: A11ySemanticObjectSnapshot) => {
+              a11ySnapshots.push(snapshot);
+            },
+          ],
         ]);
       },
     };
@@ -58,8 +90,13 @@ describe('prototypes/shadcn: toggle', () => {
     expect(tokens).toContain('text-foreground');
     expect(tokens).not.toContain('bg-muted/60');
     expect(tokens).not.toContain('text-muted-foreground');
+    expect(activeChanges).toEqual([{ active: true }]);
+    expect(a11ySnapshots.at(-1)).toMatchObject({
+      role: 'button',
+      states: { pressed: true, disabled: false },
+    });
 
-    rawProps = { variant: 'outline', size: 'sm', defaultChecked: false, disabled: true };
+    rawProps = { variant: 'outline', size: 'sm', defaultActive: false, disabled: true };
     controller.applyRawProps(rawProps as any);
     tokens = controller.getRuleStyleTokens();
     expect(tokens).toContain('border-input');

--- a/spec/contracts/C-EVENT-TYPE-0002.yaml
+++ b/spec/contracts/C-EVENT-TYPE-0002.yaml
@@ -42,6 +42,17 @@ criteria:
     text:
       zh-CN: Adapter 负责解释宿主输入并产生 core event；core event 不得被定义为 DOM `click`、`keydown`、`keyup` 或任一具体宿主事件的别名。
       en: Adapters are responsible for interpreting host input and producing core events; core events must not be defined as aliases for DOM `click`, `keydown`, `keyup`, or any concrete host event.
+openQuestions:
+  - id: C-EVENT-TYPE-0002-Q-ACTIVATION-NAMING
+    question:
+      zh-CN: '`press.*` core event family 是否应在未来版本中迁移为 `activation.*`，以降低被误解为具体 press gesture 的风险？'
+      en: Should the `press.*` core event family migrate to `activation.*` in a future version to reduce the risk of being misread as a concrete press gesture?
+    context:
+      zh-CN: 当前契约已经把 `press.*` 定义为 activation intent lifecycle，而不是 pointer、keyboard 或触摸等具体 gesture。`activation.*` 更贴近现有语义，但更名会牵动 event type、adapter router、prototype implementation、fixtures 与 P/T/C 实体；它也不能解决 Toggle、Tabs、Select 等原型层的状态命名冲突。
+      en: The current contract already defines `press.*` as the activation intent lifecycle rather than a concrete pointer, keyboard, touch, or other gesture. `activation.*` would align more closely with the existing semantics, but the rename would affect event types, adapter routers, prototype implementations, fixtures, and P/T/C entities; it also would not solve prototype-level state naming collisions across Toggle, Tabs, Select, and similar protocols.
+    blocks:
+      - event core type naming migration
+      - v0 event compatibility policy
 sources:
   - path: internal/contracts/event/event-type.v0.md
     sections:

--- a/spec/prototypes/P-BASE-TOGGLE.yaml
+++ b/spec/prototypes/P-BASE-TOGGLE.yaml
@@ -510,10 +510,9 @@ openQuestions:
       zh-CN: Toggle 作为 button-like control 是否应同时暴露 Button-style `click` outward signal，还是第一层只暴露 `activeChange`？
       en: Should Toggle, as a button-like control, also expose a Button-style `click` outward signal, or should the first layer expose only `activeChange`?
     context:
-      zh-CN: 当前实现因消费 `asButton()` 会同时 emit `click` 与 `checkedChange`，但草案将 Toggle 的核心 outward signal 定为 `activeChange`，以避免混淆 host click、Button `click` 与 Toggle state-change signal。
-      en: The current implementation emits both `click` and `checkedChange` because it consumes `asButton()`, but this draft defines Toggle's core outward signal as `activeChange` to avoid conflating host click, Button `click`, and Toggle state-change signal.
+      zh-CN: 当前第一轮实现只 emit `activeChange`，不 emit Button-style `click`。该断口保留 host click、Button `click` 与 Toggle state-change signal 是否需要桥接的后续决策空间。
+      en: The current first implementation emits only `activeChange` and does not emit a Button-style `click`. This gap preserves room for a later decision about whether host click, Button `click`, and Toggle state-change signals need a bridge.
     blocks:
-      - toggle implementation alignment
       - toggle outward signal surface
   - id: P-BASE-TOGGLE-Q-TOGGLE-GROUP
     question:
@@ -535,9 +534,10 @@ sources:
   - path: packages/prototypes/base/src/toggle/types.ts
   - path: packages/prototypes/base/test/toggle.test.ts
     sections:
-      - base-toggle initializes from defaultChecked and flips checked on press.commit
-      - asToggle mirrors controlled checked prop and emits next checked without mutating local state
-      - disabled toggle keeps checked stable and suppresses click/checkedChange
+      - base-toggle initializes from defaultActive and flips active on press.commit
+      - asToggle mirrors controlled active prop and emits next active without mutating local state
+      - disabled toggle keeps active stable and suppresses activeChange
+  - path: spec/tests/T-BASE-TOGGLE-0001.yaml
   - path: packages/prototypes/shadcn/src/toggle/index.ts
   - path: packages/prototypes/shadcn/test/toggle.test.ts
   - path: https://www.w3.org/WAI/ARIA/apg/patterns/button/
@@ -580,6 +580,9 @@ relates:
   knowledge:
     - K-COMPONENT-INTERACTION-0001
     - K-DESIGN-TRADEOFF-0001
+verifies:
+  tests:
+    - T-BASE-TOGGLE-0001
 revisions:
   - version: 0.1.0
     change: introduced

--- a/spec/prototypes/P-BASE-TOGGLE.yaml
+++ b/spec/prototypes/P-BASE-TOGGLE.yaml
@@ -1,0 +1,593 @@
+id: P-BASE-TOGGLE
+type: prototype
+title: Base Toggle is a button-like persistent active control
+status: draft
+since: 0.1.0
+summary: Base Toggle is the base prototype protocol for a focusable button-like control whose root owns a persistent active state, flips that state through activation, and emits an `activeChange` outward signal when the active state changes or is requested to change.
+statement:
+  zh-CN: >-
+    Base Toggle 是一个可聚焦、可禁用、button-like 的持久 active control。它表示一个由自身 protocol 拥有的二值 active state，并在成功 activation 后切换该状态，向 App Maker 发出名为 `activeChange` 的 outward signal。`base-toggle` direct prototype 与 `asToggle` authored asHook 是同一 Toggle protocol 的两个 authoring entries。Toggle 不表达 Switch 的 on/off value 语义，也不表达 Checkbox 的 checked input 语义。
+
+
+  en: >-
+    Base Toggle is a focusable, disable-able, button-like persistent active control. It represents a binary active state owned by its own protocol, flips that state after successful activation, and emits an outward signal named `activeChange` to the App Maker. The `base-toggle` direct prototype and the `asToggle` authored asHook are two authoring entries of the same Toggle protocol. Toggle does not express Switch on/off value semantics or Checkbox checked input semantics.
+
+
+criteria:
+  - id: P-BASE-TOGGLE-ROLE-ACTIVE-CONTROL
+    text:
+      zh-CN: Toggle 表示一个 button-like persistent active control，而不是触发离散 action 的纯 command control，也不是 on/off value control。
+      en: Toggle represents a button-like persistent active control, not a pure command control that triggers a discrete action and not an on/off value control.
+    dependsOn:
+      knowledge:
+        - K-COMPONENT-INTERACTION-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-ROLE-COMMAND
+          note: Toggle contrasts with Button command semantics by owning persistent active state.
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-ROLE-ON-OFF-VALUE
+          note: Toggle contrasts with Switch on/off value semantics.
+  - id: P-BASE-TOGGLE-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-toggle` direct prototype 与 `asToggle` authored asHook 是同一 Toggle protocol 的两个 authoring entries。'
+      en: 'The `base-toggle` direct prototype and the `asToggle` authored asHook are two authoring entries of the same Toggle protocol.'
+    dependsOn:
+      contracts:
+        - C-CORE-SYNTAX-0003
+        - C-AS-HOOK-0001
+      decisions:
+        - D-PROTOTYPE-ENTITY-NAMING-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-AUTHORING-ENTRIES
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-AUTHORING-ENTRIES
+  - id: P-BASE-TOGGLE-PROTOCOL-INDEPENDENCE
+    text:
+      zh-CN: Toggle 不应通过消费 Button、Switch 或 Checkbox 这类其他基础原型的 protocol-specific authored asHook 获得自身核心语义。
+      en: Toggle should not obtain its own core semantics by consuming protocol-specific authored asHooks from other base prototypes such as Button, Switch, or Checkbox.
+    dependsOn:
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-AUTHORING-ENTRIES
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-PROTOCOL-INDEPENDENCE
+  - id: P-BASE-TOGGLE-SINGLE-SUBJECT
+    text:
+      zh-CN: Base Toggle 第一轮应作为单一交互主体编目；ToggleGroup、exclusive/multiple selection 与 collection membership 不进入 Base Toggle core protocol。
+      en: The first Base Toggle protocol should be cataloged as a single interaction subject; ToggleGroup, exclusive or multiple selection, and collection membership do not enter the Base Toggle core protocol.
+    dependsOn:
+      knowledge:
+        - K-PROTOTYPE-COMPOSITION-0001
+  - id: P-BASE-TOGGLE-NO-ANATOMY-PARTS
+    text:
+      zh-CN: Base Toggle 第一轮不定义独立 anatomy part；图标、文本与视觉 indicator 作为内容或模板结构参与，不构成 Toggle protocol 的 part。
+      en: The first Base Toggle protocol does not define independent anatomy parts; icons, text, and visual indicators participate as content or template structure and do not become Toggle protocol parts.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-ICON-CONTENT
+  - id: P-BASE-TOGGLE-PROP-ACTIVE
+    text:
+      zh-CN: 'Toggle 必须接受 `active?: boolean` props input，用于受控 persistent active state。'
+      en: 'Toggle must accept an `active?: boolean` props input for controlled persistent active state.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-PROPS-0003
+        - C-STATE-0001
+  - id: P-BASE-TOGGLE-PROP-DEFAULT-ACTIVE
+    text:
+      zh-CN: 'Toggle 必须接受 `defaultActive?: boolean` props input，用于非受控初始 active state，默认值为 `false`。'
+      en: 'Toggle must accept a `defaultActive?: boolean` props input for uncontrolled initial active state whose default is `false`.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-PROPS-0003
+        - C-STATE-0001
+  - id: P-BASE-TOGGLE-CONTROLLED-ACTIVE
+    text:
+      zh-CN: 当 App Maker 提供或更新 `active` props input 时，Toggle 必须以该 input 同步 active state。
+      en: When the App Maker provides or updates the `active` props input, Toggle must synchronize active state from that input.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-STATE-0001
+        - C-EXPOSE-STATE-0001
+    references:
+      prototypes:
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-CONTROLLED-CHECKED
+  - id: P-BASE-TOGGLE-PROP-DISABLED
+    text:
+      zh-CN: 'Toggle 必须接受 `disabled?: boolean` props input，默认值为 `false`。'
+      en: 'Toggle must accept a `disabled?: boolean` props input whose default is `false`.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-PROPS-0003
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-PROP-DISABLED
+  - id: P-BASE-TOGGLE-PROP-NO-EVENT-CALLBACK
+    text:
+      zh-CN: Toggle props 不包含 `onActiveChange` 之类事件回调；Toggle active state change 通过 expose event 发出 `activeChange` signal。
+      en: Toggle props do not include event callbacks such as `onActiveChange`; Toggle active state changes emit the `activeChange` signal through expose event.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-EXPOSE-EVENT-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-PROP-NO-EVENT-CALLBACK
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-PROP-NO-EVENT-CALLBACK
+  - id: P-BASE-TOGGLE-ACTIVE-EXPOSE
+    text:
+      zh-CN: Toggle 必须 expose `active` state；`active=true` 表示 Toggle 处于持久激活状态。
+      en: Toggle must expose `active` state; `active=true` means the Toggle is in its persistent active state.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+        - C-EXPOSE-STATE-0001
+  - id: P-BASE-TOGGLE-ACTIVE-SCOPED-NAME
+    text:
+      zh-CN: Toggle 的 `active` 是 Toggle protocol-scoped state name；不得被解释为 Tabs、Select 或其他集合协议中的 active item / current item 语义。
+      en: Toggle `active` is a Toggle protocol-scoped state name; it must not be interpreted as active-item or current-item semantics from Tabs, Select, or other collection protocols.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+  - id: P-BASE-TOGGLE-ACTIVE-NOT-CHECKED
+    text:
+      zh-CN: Toggle core state 不应命名为 `checked`；`checked` 留给 Switch、Checkbox 或其他 checked input/value 语义。
+      en: Toggle core state should not be named `checked`; `checked` is reserved for Switch, Checkbox, or other checked input/value semantics.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+    references:
+      prototypes:
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-CHECKED-EXPOSE
+  - id: P-BASE-TOGGLE-ACTIVE-NOT-TRANSIENT-PRESSED
+    text:
+      zh-CN: Toggle 的 `active` 是持久协议状态，不得与 Button、Switch 或 Toggle 自身的 transient `pressed` interaction state 混同。
+      en: Toggle `active` is persistent protocol state and must not be conflated with Button, Switch, or Toggle's own transient `pressed` interaction state.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+        - C-STATE-INTERACTION-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-PRESS-LIFECYCLE
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-PRESS-LIFECYCLE
+  - id: P-BASE-TOGGLE-DISABLED-EXPOSE
+    text:
+      zh-CN: Toggle 必须 expose `disabled` state。
+      en: Toggle must expose `disabled` state.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+        - C-EXPOSE-STATE-0001
+        - C-A11Y-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-DISABLED-EXPOSE
+  - id: P-BASE-TOGGLE-TRIGGER-SEMANTICS
+    text:
+      zh-CN: Toggle 必须通过官方 trigger 能力处理 activation route，但不得依赖 Button protocol 来获得 Toggle active 语义。
+      en: Toggle must process its activation route through the official trigger capability, but must not depend on the Button protocol to obtain Toggle active semantics.
+    dependsOn:
+      contracts:
+        - C-AS-TRIGGER-0001
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-TRIGGER-SEMANTICS
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-TRIGGER-SEMANTICS
+  - id: P-BASE-TOGGLE-ACTIVATION-FLIPS-ACTIVE
+    text:
+      zh-CN: Toggle 在 enabled 状态下成功 activation 后，必须计算与当前 active 相反的 next active value。
+      en: After successful activation while enabled, Toggle must compute a next active value opposite to the current active value.
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
+        - C-STATE-0001
+    references:
+      prototypes:
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-ACTIVATION-FLIPS-CHECKED
+  - id: P-BASE-TOGGLE-UNCONTROLLED-UPDATES-ACTIVE
+    text:
+      zh-CN: 非受控 Toggle 在成功 activation 后必须更新 active state，并 expose 更新后的 active value。
+      en: An uncontrolled Toggle must update active state after successful activation and expose the updated active value.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+        - C-EXPOSE-STATE-0001
+    references:
+      prototypes:
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-UNCONTROLLED-UPDATES-CHECKED
+  - id: P-BASE-TOGGLE-CONTROLLED-EMITS-NEXT
+    text:
+      zh-CN: 受控 Toggle 在成功 activation 后不得自行最终拥有 active state；它必须发出包含 next active value 的 outward signal。
+      en: A controlled Toggle must not finally own active state after successful activation; it must emit an outward signal carrying the next active value.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-EXPOSE-EVENT-0001
+    references:
+      prototypes:
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-CONTROLLED-EMITS-NEXT
+  - id: P-BASE-TOGGLE-ACTIVE-CHANGE-SIGNAL
+    text:
+      zh-CN: 'Toggle active state 成功变化或请求变化时，必须发出名为 `activeChange` 的 outward signal，payload 必须包含 `{ active: boolean }`。'
+      en: 'When Toggle active state changes or requests a change successfully, it must emit an outward signal named `activeChange` whose payload contains `{ active: boolean }`.'
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
+        - C-EXPOSE-EVENT-0001
+    references:
+      prototypes:
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-CHECKED-CHANGE-SIGNAL
+  - id: P-BASE-TOGGLE-ACTIVE-CHANGE-PROTOCOL-NAME
+    text:
+      zh-CN: '`activeChange` 是 Toggle protocol 约定的 state-change outward signal 名称。'
+      en: '`activeChange` is the state-change outward signal name defined by the Toggle protocol.'
+    dependsOn:
+      contracts:
+        - C-EXPOSE-EVENT-0001
+  - id: P-BASE-TOGGLE-CLICK-DEFERRED
+    text:
+      zh-CN: '`click` 不属于 Base Toggle 第一层 active state-change signal；宿主 click、press commit、Button `click` 与 Toggle `activeChange` 的关系应保持可区分。'
+      en: '`click` does not belong to the first Base Toggle active state-change signal surface; host click, press commit, Button `click`, and Toggle `activeChange` should remain distinguishable.'
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EXPOSE-EVENT-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-CLICK-SIGNAL
+            - P-BASE-BUTTON-CLICK-PROTOCOL-NAME
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-CLICK-DEFERRED
+  - id: P-BASE-TOGGLE-DISABLED-SUPPRESS-ACTIVATION
+    text:
+      zh-CN: 当 `disabled` 为 true 时，Toggle 不得完成 activation，不得改变 active state，也不得发出 `activeChange` signal。
+      en: When `disabled` is true, Toggle must not complete activation, change active state, or emit the `activeChange` signal.
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
+        - C-EXPOSE-EVENT-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-DISABLED-SUPPRESS-ACTIVATION
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-DISABLED-SUPPRESS-ACTIVATION
+  - id: P-BASE-TOGGLE-DISABLED-CLEAR-TRANSIENT
+    text:
+      zh-CN: 当 `disabled` 变为 true 时，Toggle 必须清理自身 transient interaction state，但不得因此改变 active state。
+      en: When `disabled` becomes true, Toggle must clear its own transient interaction state without changing active state.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+        - C-STATE-INTERACTION-0002
+        - C-STATE-INTERACTION-0003
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-DISABLED-CLEAR-TRANSIENT
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-DISABLED-CLEAR-TRANSIENT
+  - id: P-BASE-TOGGLE-POINTER-HOVER
+    text:
+      zh-CN: Toggle 必须响应指向性设备的 hover 进入与离开，并 expose `hovered` state。
+      en: Toggle must respond to pointer hover enter and leave, and must expose `hovered` state.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+        - C-STATE-INTERACTION-0002
+        - C-EXPOSE-STATE-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-POINTER-HOVER
+  - id: P-BASE-TOGGLE-FOCUSABLE
+    text:
+      zh-CN: Toggle 必须是 focus target，并 expose `focused` 与 `focusVisible` state。
+      en: Toggle must be a focus target and must expose `focused` and `focusVisible` state.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
+        - C-EXPOSE-STATE-0001
+      decisions:
+        - D-FOCUS-STATE-INTERACTION-BOUNDARY-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-FOCUSABLE
+  - id: P-BASE-TOGGLE-REQUEST-FOCUS
+    text:
+      zh-CN: Toggle 必须提供主动请求焦点的能力。
+      en: Toggle must provide a capability for actively requesting focus.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-REQUEST-FOCUS
+  - id: P-BASE-TOGGLE-DISABLED-REJECT-FOCUS
+    text:
+      zh-CN: 当 `disabled` 为 true 时，Toggle 必须拒绝主动焦点请求。
+      en: When `disabled` is true, Toggle must reject active focus requests.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-DISABLED-REJECT-FOCUS
+  - id: P-BASE-TOGGLE-PRESS-LIFECYCLE
+    text:
+      zh-CN: Toggle 必须维护 transient press lifecycle，并 expose `pressed` state；该 `pressed` 不表示持久 active state。
+      en: Toggle must maintain the transient press lifecycle and expose `pressed` state; this `pressed` does not represent persistent active state.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+        - C-STATE-INTERACTION-0002
+        - C-STATE-INTERACTION-0003
+        - C-EXPOSE-STATE-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-PRESS-LIFECYCLE
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-PRESS-LIFECYCLE
+  - id: P-BASE-TOGGLE-KEYBOARD-ACTIVATION
+    text:
+      zh-CN: Toggle 必须支持键盘 activation。Space 与 Enter 应触发 Toggle activation。
+      en: Toggle must support keyboard activation. Space and Enter should trigger Toggle activation.
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-KEYBOARD-ACTIVATION
+  - id: P-BASE-TOGGLE-KEYBOARD-SPACE-PREVENT-DEFAULT
+    text:
+      zh-CN: 当已聚焦 Toggle 通过 Space 触发 activation 时，Toggle 应请求阻止宿主默认副作用。
+      en: When a focused Toggle is activated through Space, Toggle should request prevention of host default side effects.
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EVENT-TYPE-0002
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-KEYBOARD-SPACE-PREVENT-DEFAULT
+  - id: P-BASE-TOGGLE-ACCESSIBLE-ROLE
+    text:
+      zh-CN: Toggle 必须具备可映射到 button role 的可访问语义。
+      en: Toggle must carry accessibility semantics that can be mapped to the button role.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-ACCESSIBLE-ROLE
+  - id: P-BASE-TOGGLE-ACCESSIBLE-NAME
+    text:
+      zh-CN: Toggle 必须支持 accessible name。
+      en: Toggle must support an accessible name.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-ACCESSIBLE-NAME
+  - id: P-BASE-TOGGLE-A11Y-PRESSED
+    text:
+      zh-CN: Toggle 必须将 persistent active state 投射为可访问 pressed state；`active=true` 对应 `aria-pressed=true`，`active=false` 对应 `aria-pressed=false`。
+      en: Toggle must project persistent active state as accessible pressed state; `active=true` maps to `aria-pressed=true`, and `active=false` maps to `aria-pressed=false`.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+        - C-EXPOSE-STATE-0001
+  - id: P-BASE-TOGGLE-PROP-LABEL-DEFERRED
+    text:
+      zh-CN: Toggle 的 accessible name 是核心可访问能力，但第一版 core props 不强制把它定义为 `label` prop。
+      en: Toggle accessible name is a core accessibility capability, but the first core props surface does not force it to be a `label` prop.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-A11Y-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-PROP-LABEL-DEFERRED
+  - id: P-BASE-TOGGLE-NO-FORM-INTEGRATION
+    text:
+      zh-CN: Toggle 不与 Form 产生联动；`name`、`value`、`form`、`required` 与提交值不进入 Base Toggle core props 或 deferred form extension。
+      en: Toggle does not integrate with Form; `name`, `value`, `form`, `required`, and submission value do not enter Base Toggle core props or a deferred form extension.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-PROP-FORM-DEFERRED
+        - id: P-BASE-SWITCH
+          anchors:
+            - P-BASE-SWITCH-FORM-INTEGRATION-DEFERRED
+  - id: P-BASE-TOGGLE-NO-VISUAL-VARIANT-CORE
+    text:
+      zh-CN: Toggle 核心契约不定义 size、variant、tone、shape、icon placement 等视觉参数。
+      en: Toggle core contract does not define visual parameters such as size, variant, tone, shape, or icon placement.
+    dependsOn:
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+      knowledge:
+        - K-DESIGN-TRADEOFF-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-NO-VISUAL-VARIANT-CORE
+            - P-BASE-BUTTON-PROP-VISUAL-DEFERRED
+openQuestions:
+  - id: P-BASE-TOGGLE-Q-CLICK-SIGNAL
+    question:
+      zh-CN: Toggle 作为 button-like control 是否应同时暴露 Button-style `click` outward signal，还是第一层只暴露 `activeChange`？
+      en: Should Toggle, as a button-like control, also expose a Button-style `click` outward signal, or should the first layer expose only `activeChange`?
+    context:
+      zh-CN: 当前实现因消费 `asButton()` 会同时 emit `click` 与 `checkedChange`，但草案将 Toggle 的核心 outward signal 定为 `activeChange`，以避免混淆 host click、Button `click` 与 Toggle state-change signal。
+      en: The current implementation emits both `click` and `checkedChange` because it consumes `asButton()`, but this draft defines Toggle's core outward signal as `activeChange` to avoid conflating host click, Button `click`, and Toggle state-change signal.
+    blocks:
+      - toggle implementation alignment
+      - toggle outward signal surface
+  - id: P-BASE-TOGGLE-Q-TOGGLE-GROUP
+    question:
+      zh-CN: ToggleGroup 是否应通过 controlled active props 控制单个 Toggle，还是定义独立的 item membership 与 selection ownership 机制？
+      en: Should ToggleGroup control individual Toggles through controlled active props, or define independent item membership and selection ownership mechanics?
+    context:
+      zh-CN: Base Toggle 第一轮只处理单个 Toggle；group membership、exclusive/multiple selection 与 collection identity 留给 ToggleGroup 编目。
+      en: The first Base Toggle layer only handles an individual Toggle; group membership, exclusive or multiple selection, and collection identity are left to ToggleGroup cataloging.
+    blocks:
+      - toggle group catalog
+      - collection membership design
+sources:
+  - path: internal/records/2026-07-05-toggle-catalog-before-tabs.zh-CN.md
+  - path: packages/prototypes/base/src/toggle/toggle.ts
+    sections:
+      - setupToggle
+      - asToggle
+      - base-toggle
+  - path: packages/prototypes/base/src/toggle/types.ts
+  - path: packages/prototypes/base/test/toggle.test.ts
+    sections:
+      - base-toggle initializes from defaultChecked and flips checked on press.commit
+      - asToggle mirrors controlled checked prop and emits next checked without mutating local state
+      - disabled toggle keeps checked stable and suppresses click/checkedChange
+  - path: packages/prototypes/shadcn/src/toggle/index.ts
+  - path: packages/prototypes/shadcn/test/toggle.test.ts
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/button/
+    label: WAI-ARIA APG Button Pattern
+  - path: https://www.w3.org/TR/wai-aria-1.2/#button
+    label: WAI-ARIA button role
+  - path: https://www.radix-ui.com/primitives/docs/components/toggle
+    label: Radix UI Toggle
+  - path: https://base-ui.com/react/components/toggle
+    label: Base UI Toggle
+  - path: https://react-spectrum.adobe.com/react-aria/ToggleButton.html
+    label: React Aria ToggleButton
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0003
+    - C-PROPS-0001
+    - C-PROPS-0003
+    - C-AS-HOOK-0001
+    - C-AS-TRIGGER-0001
+    - C-AS-FOCUSABLE-0001
+    - C-STATE-0001
+    - C-STATE-INTERACTION-0001
+    - C-STATE-INTERACTION-0002
+    - C-STATE-INTERACTION-0003
+    - C-EVENT-TYPE-0001
+    - C-EVENT-TYPE-0002
+    - C-EXPOSE-STATE-0001
+    - C-EXPOSE-EVENT-0001
+    - C-A11Y-0001
+relates:
+  prototypes:
+    - P-BASE-BUTTON
+    - P-BASE-SWITCH
+  decisions:
+    - D-PROTOTYPE-ENTITY-NAMING-0001
+    - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+    - D-AS-HOOK-CALLER-NAME-0001
+    - D-FOCUS-STATE-INTERACTION-BOUNDARY-0001
+    - D-STATE-SEMANTIC-ACCESSORS-DEPRECATION-0001
+  knowledge:
+    - K-COMPONENT-INTERACTION-0001
+    - K-DESIGN-TRADEOFF-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced the first Base Toggle prototype contract draft with active state naming, button-like activation, accessibility pressed projection, and Button/Switch boundaries.
+tags:
+  - prototype
+  - base
+  - toggle
+  - trigger
+  - focus
+  - accessibility

--- a/spec/tests/T-BASE-TOGGLE-0001.yaml
+++ b/spec/tests/T-BASE-TOGGLE-0001.yaml
@@ -1,0 +1,107 @@
+id: T-BASE-TOGGLE-0001
+type: test
+title: Base Toggle protocol contract tests
+status: draft
+since: 0.1.0
+summary: Contract test coverage for the Base Toggle prototype protocol, including active state ownership, independent authoring entries, activation, focus and interaction state, accessibility pressed projection, and deferred extension surfaces.
+cases:
+  - id: T-BASE-TOGGLE-0001-CASE-AUTHORING-ENTRIES
+    title: base-toggle and asToggle remain authoring entries of one independent Toggle protocol
+    covers:
+      - P-BASE-TOGGLE-AUTHORING-ENTRIES
+      - P-BASE-TOGGLE-PROTOCOL-INDEPENDENCE
+      - P-BASE-TOGGLE-SINGLE-SUBJECT
+      - P-BASE-TOGGLE-NO-ANATOMY-PARTS
+    expectation: base-toggle-and-as-toggle-share-an-independent-protocol-surface
+  - id: T-BASE-TOGGLE-0001-CASE-UNCONTROLLED-ACTIVE-CHANGE
+    title: uncontrolled Toggle initializes active state, flips on activation, and emits activeChange
+    covers:
+      - P-BASE-TOGGLE-ROLE-ACTIVE-CONTROL
+      - P-BASE-TOGGLE-PROP-DEFAULT-ACTIVE
+      - P-BASE-TOGGLE-ACTIVE-EXPOSE
+      - P-BASE-TOGGLE-ACTIVE-SCOPED-NAME
+      - P-BASE-TOGGLE-ACTIVE-NOT-CHECKED
+      - P-BASE-TOGGLE-ACTIVE-NOT-TRANSIENT-PRESSED
+      - P-BASE-TOGGLE-TRIGGER-SEMANTICS
+      - P-BASE-TOGGLE-ACTIVATION-FLIPS-ACTIVE
+      - P-BASE-TOGGLE-UNCONTROLLED-UPDATES-ACTIVE
+      - P-BASE-TOGGLE-ACTIVE-CHANGE-SIGNAL
+      - P-BASE-TOGGLE-ACTIVE-CHANGE-PROTOCOL-NAME
+      - P-BASE-TOGGLE-CLICK-DEFERRED
+    expectation: uncontrolled-toggle-flips-active-and-emits-active-change
+  - id: T-BASE-TOGGLE-0001-CASE-CONTROLLED-ACTIVE
+    title: controlled Toggle mirrors active props and emits next active without claiming final state ownership
+    covers:
+      - P-BASE-TOGGLE-PROP-ACTIVE
+      - P-BASE-TOGGLE-CONTROLLED-ACTIVE
+      - P-BASE-TOGGLE-CONTROLLED-EMITS-NEXT
+      - P-BASE-TOGGLE-PROP-NO-EVENT-CALLBACK
+    expectation: controlled-toggle-emits-next-active-without-mutating-source-of-truth
+  - id: T-BASE-TOGGLE-0001-CASE-DISABLED-GATING
+    title: disabled Toggle exposes disabled state and suppresses activation-driven active changes
+    covers:
+      - P-BASE-TOGGLE-PROP-DISABLED
+      - P-BASE-TOGGLE-DISABLED-EXPOSE
+      - P-BASE-TOGGLE-DISABLED-SUPPRESS-ACTIVATION
+      - P-BASE-TOGGLE-DISABLED-CLEAR-TRANSIENT
+    expectation: disabled-toggle-suppresses-active-change-and-clears-transient-state
+  - id: T-BASE-TOGGLE-0001-CASE-INTERACTION-FOCUS-KEYBOARD
+    title: Toggle exposes pointer, focus, press, and keyboard activation behavior
+    covers:
+      - P-BASE-TOGGLE-POINTER-HOVER
+      - P-BASE-TOGGLE-FOCUSABLE
+      - P-BASE-TOGGLE-REQUEST-FOCUS
+      - P-BASE-TOGGLE-DISABLED-REJECT-FOCUS
+      - P-BASE-TOGGLE-PRESS-LIFECYCLE
+      - P-BASE-TOGGLE-KEYBOARD-ACTIVATION
+      - P-BASE-TOGGLE-KEYBOARD-SPACE-PREVENT-DEFAULT
+    expectation: toggle-exposes-interaction-focus-and-keyboard-behavior
+  - id: T-BASE-TOGGLE-0001-CASE-A11Y-AND-DEFERRED-SURFACES
+    title: Toggle accessibility and deferred label, form, click, and visual surfaces remain catalog-visible
+    covers:
+      - P-BASE-TOGGLE-ACCESSIBLE-ROLE
+      - P-BASE-TOGGLE-ACCESSIBLE-NAME
+      - P-BASE-TOGGLE-A11Y-PRESSED
+      - P-BASE-TOGGLE-PROP-LABEL-DEFERRED
+      - P-BASE-TOGGLE-NO-FORM-INTEGRATION
+      - P-BASE-TOGGLE-NO-VISUAL-VARIANT-CORE
+    expectation: toggle-a11y-and-deferred-surfaces-remain-explicit
+implementations:
+  - id: prototypes-base-toggle-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/toggle.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TOGGLE-0001-CASE-AUTHORING-ENTRIES
+      - T-BASE-TOGGLE-0001-CASE-UNCONTROLLED-ACTIVE-CHANGE
+      - T-BASE-TOGGLE-0001-CASE-CONTROLLED-ACTIVE
+      - T-BASE-TOGGLE-0001-CASE-DISABLED-GATING
+      - T-BASE-TOGGLE-0001-CASE-INTERACTION-FOCUS-KEYBOARD
+      - T-BASE-TOGGLE-0001-CASE-A11Y-AND-DEFERRED-SURFACES
+    exercises:
+      - P-BASE-TOGGLE
+    notes:
+      - Covers current executable Toggle behavior through the direct base-toggle prototype and the asToggle authoring entry.
+      - Deferred label, form, click, visual, group, and anatomy surfaces are covered as absence/declaration checks rather than positive host integration behavior.
+verifies:
+  prototypes:
+    - id: P-BASE-TOGGLE
+      anchors:
+        - P-BASE-TOGGLE-ROLE-ACTIVE-CONTROL
+        - P-BASE-TOGGLE-PROTOCOL-INDEPENDENCE
+        - P-BASE-TOGGLE-ACTIVE-EXPOSE
+        - P-BASE-TOGGLE-ACTIVE-CHANGE-SIGNAL
+        - P-BASE-TOGGLE-A11Y-PRESSED
+exercises:
+  prototypes:
+    - P-BASE-TOGGLE
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced Base Toggle protocol test entity aligned to P-BASE-TOGGLE criteria.
+tags:
+  - prototype
+  - base
+  - toggle
+  - test


### PR DESCRIPTION
## Summary

- Add the Base Toggle planning record and draft `P-BASE-TOGGLE` contract, including the `press.*` naming open question on the event type contract.
- Add `T-BASE-TOGGLE-0001` and align executable tests with Toggle criteria.
- Rework `base-toggle` / `asToggle` around `active`, `defaultActive`, and `activeChange` without depending on `asButton()`.
- Update shadcn-toggle, CLI token collection, and the zh-CN demo to use `data-[active]` / `defaultActive`; keep Checkbox runtime behavior intact by decoupling its types from Toggle.

## Validation

- `corepack pnpm@10.32.1 -s check:types:workspace`
- `corepack pnpm@10.32.1 -s test:types`
- `corepack pnpm@10.32.1 -s test:runtime`
- `corepack pnpm@10.32.1 exec vitest run packages/prototypes/base/test/toggle.test.ts packages/prototypes/base/test/checkbox.test.ts packages/prototypes/shadcn/test/toggle.test.ts packages/cli/test/cli.test.ts`

## Notes

`apps/workspace/public/spec-workspace.json` was regenerated locally so the workspace GUI can see `T-BASE-TOGGLE-0001`, but it is ignored by the repository and is not included in this PR.