### PR TITLE
[codex] catalog and implement base tabs protocol

### DIFF
--- a/internal/records/2026-07-05-focus-entry-delegation.zh-CN.md
+++ b/internal/records/2026-07-05-focus-entry-delegation.zh-CN.md
@@ -1,0 +1,107 @@
+# 2026-07-05 focus entry delegation 与 tabpanel 后代优先策略
+
+> Internal record. Not normative. 本记录整理 Tabs P 实体编目过程中暴露出的 focus entry 断口，并作为 `asFocusEntry()`、host capability 与 Tabs Content 契约修订的讨论基线。
+
+---
+
+## 1）背景
+
+Base Tabs Content 需要满足 tabpanel 的焦点进入语义：
+
+- current panel 应可被顺序导航进入。
+- 如果 panel 内存在可聚焦内容，焦点应优先进入后代内容。
+- 如果 panel 内没有可聚焦内容，panel 自身应作为 fallback focus target。
+- inactive panel 必须隐藏，并且不应留在顺序焦点导航路径中。
+
+早期 Tabs Content 把 tabpanel 是否自动进入 Tab 顺序标记为 deferred。人工测试与 ARIA APG 讨论后，这个断口需要收敛，否则 Tabs 的键盘体验会不完整。
+
+---
+
+## 2）Web 与 native 能力判断
+
+Web 平台没有标准 API 可以直接返回某个容器内第一个符合顺序焦点导航算法的 tabbable descendant。浏览器内部有 sequential focus navigation algorithm，但没有暴露类似 `getFirstTabbableDescendant(container)` 的通用接口。
+
+Web 可用的基础能力主要是：
+
+- `tabindex` 与原生可聚焦元素规则。
+- `HTMLElement.focus()`。
+- `inert` 等 subtree participation 控制。
+- `ShadowRoot.delegatesFocus`，但它只解决 shadow host 的特定委派场景，不是任意容器的通用查询能力。
+
+因此 Proto UI core 不应内建 DOM 查询逻辑。正确边界是：
+
+> 契约表达 focus entry policy；具体宿主通过 host capability 解析 entry target，并决定如何投射顺序焦点参与。
+
+Web adapter 可以用 DOM/flat tree 查询实现这个 capability；原生宿主如果有更强的 focus engine，则可以直接使用宿主原生能力。
+
+---
+
+## 3）为什么不扩展 asFocusable
+
+`asFocusable()` 当前语义是“当前原型实例就是 focus target”。它返回 focused、focusVisible、focusable 等 target-level focus facts，并提供 `focus` / `focusSelf` / `blur`。
+
+Tabs Content 的需求不同：
+
+- Content 自身是一个 focus entry region。
+- 真正的 focus target 可能是内部后代元素。
+- 当后代优先命中时，Content 不应伪装为自身 focused。
+- 该能力不应让 Content 成为 roving focus item。
+
+因此新增 `asFocusEntry()` 比把 entry policy 塞进 `asFocusable().configure(...)` 更清晰。它表达的是“进入区域时如何委派焦点”，而不是“当前实例拥有焦点事实”。
+
+---
+
+## 4）拟定 API 与策略
+
+第一阶段 API：
+
+```ts
+const entry = asFocusEntry();
+entry.configure({
+  strategy: 'descendant-first',
+  fallback: 'self',
+});
+```
+
+核心策略：
+
+- `strategy: 'descendant-first'`：宿主优先解析容器内可参与顺序导航的后代焦点目标。
+- `fallback: 'self'`：当没有合适后代目标时，容器自身可以成为顺序导航 fallback。
+- `disabled` / `setDisabled(...)`：用于 current/inactive panel 这类运行时状态切换。
+
+第一阶段不建模完整 focus trap、restore、active descendant、portal descendant 与跨 shadow root 完整 flat tree 规则。这些仍属于后续 focus scope / host capability 的深化范围。
+
+---
+
+## 5）Tabs Content 的落点
+
+Base Tabs Content 应采用：
+
+```ts
+asFocusEntry().configure({
+  strategy: 'descendant-first',
+  fallback: 'self',
+});
+```
+
+并根据 `current`/`hidden` 状态切换 entry 是否启用：
+
+- current content：启用 focus entry。
+- inactive content：禁用 focus entry。
+
+Web adapter 的预期投射：
+
+- current content 且存在 tabbable descendant：content host 不进入 Tab 顺序，让浏览器顺序导航自然进入 descendant。
+- current content 且不存在 tabbable descendant：content host `tabIndex=0`。
+- inactive content：content host `tabIndex=-1`，并由 hidden 语义移出可见与 accessibility tree。
+
+---
+
+## 6）后续断口
+
+仍需保留的断口：
+
+- Web adapter 的 descendant 查询第一阶段是 pragmatism，不等同于浏览器内部完整 sequential focus navigation algorithm。
+- Shadow DOM、slot、portal、disabled fieldset、CSS visibility/layout 以及 inert ancestor 的完整处理需要继续强化。
+- Native adapter 可以用自身平台能力实现同一 host capability，不需要复制 Web 的 DOM 查询策略。
+- `asFocusScope()` 的 `entry` 策略未来可以与 `asFocusEntry()` 对齐，但本轮只处理 region-level entry。

--- a/internal/records/2026-07-06-tabs-followup-closure.zh-CN.md
+++ b/internal/records/2026-07-06-tabs-followup-closure.zh-CN.md
@@ -1,0 +1,26 @@
+# Tabs P 实体后续收口记录
+
+日期：2026-07-06
+
+## 背景
+
+Tabs P 实体、Focus Entry 与 Focus Roving 的第一轮实现完成后，仍有若干需要在本轮 PR 内或近期工作中收口的断口：
+
+- adapter 在事件归属缺失时的 activeElement fallback 属于 adapter 契约治理缺口，但 A/M/HC 实体尚未系统编目。
+- Tabs selection fallback 不应继续完全 deferred，至少应覆盖非受控 root 的基础缺失与 disabled trigger 场景。
+- Tabs List 需要可访问名称，但原型 API 不应泄漏 Web 专属的 `aria-label` / `aria-labelledby` props。
+- Web Component 之外的 React / Vue adapter 需要补充 Tabs 组合交互验证。
+
+## 决策
+
+1. 新增 `D-ADAPTER-EVENT-OWNER-FALLBACK-0001`，记录事件归属 fallback 是 adapter 侧契约治理缺口，当前只留决策入口，不提前展开 A/M/HC 编目。
+2. Base Tabs root 支持非受控 selection fallback：当当前 selected value 缺失或指向 disabled trigger 时，回落到第一个 enabled trigger。受控 Tabs 不擅自改写外部 value；动态删除 selected trigger 仍保留为断口。
+3. Base Tabs List 新增宿主中立 `a11yLabel?: string` props input。原型只声明 accessible name 语义，Web host 由 a11y module 投射为 `aria-label`。
+4. a11y name/description 支持引用 state handle，以便宿主中立 props 可以动态驱动 semantic object 文本事实。
+5. React / Vue adapter 增加 Tabs compound interaction 覆盖，用来验证 context、anatomy、event 与 a11y/state 投射在框架 adapter 下能协作。
+
+## 后续断口
+
+- adapter event owner fallback 的更正式约束应等待 adapter entity、module entity 与 host capability entity 的编目工作推进。
+- Tabs duplicate value 的选择与 a11y relationship fallback 仍需单独治理。
+- Tabs presence/visibility 与 indicator measurement 仍适合在 Tabs PR 合并后作为近期独立方向推进。

--- a/packages/adapters/base/src/events/web-event-router.ts
+++ b/packages/adapters/base/src/events/web-event-router.ts
@@ -110,7 +110,7 @@ export function createWebProtoEventRouter(opt: {
     return null;
   }
 
-  function resolveOwningTrigger(native: Event) {
+  function resolveOwningTrigger(native: Event, options?: { includeActiveFallback?: boolean }) {
     if (typeof native.composedPath === 'function') {
       for (const entry of native.composedPath()) {
         const owner = getNearestTriggerOwner(entry);
@@ -119,11 +119,15 @@ export function createWebProtoEventRouter(opt: {
     }
     const targetOwner = getNearestTriggerOwner(native.target);
     if (targetOwner) return targetOwner;
+    if (options?.includeActiveFallback === false) return null;
     const active = typeof document !== 'undefined' ? document.activeElement : null;
     return getNearestTriggerOwner(active);
   }
 
-  function resolveOwningProtoInstance(native: Event) {
+  function resolveOwningProtoInstance(
+    native: Event,
+    options?: { includeActiveFallback?: boolean }
+  ) {
     if (typeof native.composedPath === 'function') {
       for (const entry of native.composedPath()) {
         const owner = getNearestProtoInstance(entry);
@@ -132,22 +136,26 @@ export function createWebProtoEventRouter(opt: {
     }
     const targetOwner = getNearestProtoInstance(native.target);
     if (targetOwner) return targetOwner;
+    if (options?.includeActiveFallback === false) return null;
     const active = typeof document !== 'undefined' ? document.activeElement : null;
     return getNearestProtoInstance(active);
   }
 
-  function shouldRouteToCurrentRoot(native: Event) {
-    const triggerOwner = resolveOwningTrigger(native);
+  function shouldRouteToCurrentRoot(native: Event, options?: { includeActiveFallback?: boolean }) {
+    const triggerOwner = resolveOwningTrigger(native, options);
     if (triggerOwner) return triggerOwner === rootEl;
 
-    const owner = resolveOwningProtoInstance(native);
+    const owner = resolveOwningProtoInstance(native, options);
     if (owner) return owner === rootEl;
     return isWithinRoot(native.target);
   }
 
-  function shouldRouteGlobalRootEvent(native: Event) {
+  function shouldRouteGlobalRootEvent(
+    native: Event,
+    options?: { includeActiveFallback?: boolean }
+  ) {
     if (isWithinRoot(native.target)) return false;
-    return shouldRouteToCurrentRoot(native);
+    return shouldRouteToCurrentRoot(native, options);
   }
 
   type KeyboardEventWithSymbols = KeyboardEvent & Record<symbol, Set<EventTarget> | undefined>;
@@ -235,7 +243,7 @@ export function createWebProtoEventRouter(opt: {
   unsubs.push(
     listen(globalEl, 'pointerdown', (e) => {
       if (!opt.isEnabled()) return;
-      if (!shouldRouteGlobalRootEvent(e)) return;
+      if (!shouldRouteGlobalRootEvent(e, { includeActiveFallback: false })) return;
       suppressFollowupDirectClick = false;
       emit(protoRootBus, 'pointer.down', e);
     })
@@ -244,7 +252,7 @@ export function createWebProtoEventRouter(opt: {
   unsubs.push(
     listen(globalEl, 'pointermove', (e) => {
       if (!opt.isEnabled()) return;
-      if (!shouldRouteGlobalRootEvent(e)) return;
+      if (!shouldRouteGlobalRootEvent(e, { includeActiveFallback: false })) return;
       emit(protoRootBus, 'pointer.move', e);
     })
   );
@@ -252,7 +260,7 @@ export function createWebProtoEventRouter(opt: {
   unsubs.push(
     listen(globalEl, 'pointerup', (e) => {
       if (!opt.isEnabled()) return;
-      if (!shouldRouteGlobalRootEvent(e)) return;
+      if (!shouldRouteGlobalRootEvent(e, { includeActiveFallback: false })) return;
       emit(protoRootBus, 'pointer.up', e);
     })
   );
@@ -260,7 +268,7 @@ export function createWebProtoEventRouter(opt: {
   unsubs.push(
     listen(globalEl, 'pointercancel', (e) => {
       if (!opt.isEnabled()) return;
-      if (!shouldRouteGlobalRootEvent(e)) return;
+      if (!shouldRouteGlobalRootEvent(e, { includeActiveFallback: false })) return;
       emit(protoRootBus, 'pointer.cancel', e);
     })
   );
@@ -317,7 +325,7 @@ export function createWebProtoEventRouter(opt: {
     listen(globalEl, 'click', (e) => {
       if (!opt.isEnabled()) return;
       if (!(e instanceof MouseEvent)) return;
-      if (!shouldRouteGlobalRootEvent(e)) return;
+      if (!shouldRouteGlobalRootEvent(e, { includeActiveFallback: false })) return;
       if (shouldSuppressFollowupClick(e)) return;
       suppressFollowupDirectClick = false;
       emit(protoRootBus, 'press.commit', e);
@@ -335,7 +343,7 @@ export function createWebProtoEventRouter(opt: {
   unsubs.push(
     listen(globalEl, 'contextmenu', (e) => {
       if (!opt.isEnabled()) return;
-      if (!shouldRouteGlobalRootEvent(e)) return;
+      if (!shouldRouteGlobalRootEvent(e, { includeActiveFallback: false })) return;
       emit(protoRootBus, 'context.menu', e);
     })
   );

--- a/packages/adapters/react/test/tabs.test.ts
+++ b/packages/adapters/react/test/tabs.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { tabsContent, tabsList, tabsRoot, tabsTrigger } from '../../../prototypes/base/src/tabs';
+
+import { createMountedReactAdapter, createMountedReactAdapterInto } from './utils/fake-react';
+
+function appendHost(parent: HTMLElement): HTMLElement {
+  const host = document.createElement('span');
+  parent.appendChild(host);
+  return host;
+}
+
+describe('adapter-react: base tabs compound protocol', () => {
+  it('coordinates tabs context, anatomy, a11y label, and trigger activation', () => {
+    const root = createMountedReactAdapter(tabsRoot, { defaultValue: 'a' });
+    const rootEl = root.root as HTMLElement;
+    const list = createMountedReactAdapterInto(tabsList, appendHost(rootEl), {
+      a11yLabel: 'React tabs',
+    });
+    const triggerA = createMountedReactAdapterInto(tabsTrigger, appendHost(list.root!), {
+      value: 'a',
+    });
+    const triggerB = createMountedReactAdapterInto(tabsTrigger, appendHost(list.root!), {
+      value: 'b',
+    });
+    const contentA = createMountedReactAdapterInto(tabsContent, appendHost(rootEl), {
+      value: 'a',
+    });
+    const contentB = createMountedReactAdapterInto(tabsContent, appendHost(rootEl), {
+      value: 'b',
+    });
+
+    expect(list.root?.getAttribute('role')).toBe('tablist');
+    expect(list.root?.getAttribute('aria-label')).toBe('React tabs');
+    expect(root.ref.current?.getExposes().value.get()).toBe('a');
+    expect(triggerA.ref.current?.getExposes().selected.get()).toBe(true);
+    expect(contentA.ref.current?.getExposes().current.get()).toBe(true);
+
+    triggerB.root?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(root.ref.current?.getExposes().value.get()).toBe('b');
+    expect(triggerA.ref.current?.getExposes().selected.get()).toBe(false);
+    expect(triggerB.ref.current?.getExposes().selected.get()).toBe(true);
+    expect(contentA.ref.current?.getExposes().current.get()).toBe(false);
+    expect(contentB.ref.current?.getExposes().current.get()).toBe(true);
+
+    contentB.unmount();
+    contentA.unmount();
+    triggerB.unmount();
+    triggerA.unmount();
+    list.unmount();
+    root.unmount();
+  });
+});

--- a/packages/adapters/vue/test/tabs.test.ts
+++ b/packages/adapters/vue/test/tabs.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { tabsContent, tabsList, tabsRoot, tabsTrigger } from '../../../prototypes/base/src/tabs';
+
+import { VueAny, flushVue } from './utils/vue';
+import { createVueAdapter } from '../src/adapt';
+
+describe('adapter-vue: base tabs compound protocol', () => {
+  it('coordinates tabs context, anatomy, a11y label, and trigger activation', async () => {
+    const adapter = createVueAdapter(VueAny);
+    const Root = adapter(tabsRoot);
+    const List = adapter(tabsList);
+    const Trigger = adapter(tabsTrigger);
+    const Content = adapter(tabsContent);
+    const refs: Record<string, any> = {};
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const app = VueAny.createApp({
+      setup() {
+        return () =>
+          VueAny.h(Root, { defaultValue: 'a', ref: (el: any) => (refs.root = el) }, () => [
+            VueAny.h(List, { a11yLabel: 'Vue tabs', ref: (el: any) => (refs.list = el) }, () => [
+              VueAny.h(Trigger, { value: 'a', ref: (el: any) => (refs.triggerA = el) }, () => 'A'),
+              VueAny.h(Trigger, { value: 'b', ref: (el: any) => (refs.triggerB = el) }, () => 'B'),
+            ]),
+            VueAny.h(
+              Content,
+              { value: 'a', ref: (el: any) => (refs.contentA = el) },
+              () => 'A panel'
+            ),
+            VueAny.h(
+              Content,
+              { value: 'b', ref: (el: any) => (refs.contentB = el) },
+              () => 'B panel'
+            ),
+          ]);
+      },
+    });
+
+    app.mount(host);
+    await flushVue();
+    await flushVue();
+
+    expect(refs.list?.$el.getAttribute('role')).toBe('tablist');
+    expect(refs.list?.$el.getAttribute('aria-label')).toBe('Vue tabs');
+    expect(refs.root?.getExposes().value.get()).toBe('a');
+    expect(refs.triggerA?.getExposes().selected.get()).toBe(true);
+    expect(refs.contentA?.getExposes().current.get()).toBe(true);
+
+    refs.triggerB?.$el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushVue();
+    await flushVue();
+
+    expect(refs.root?.getExposes().value.get()).toBe('b');
+    expect(refs.triggerA?.getExposes().selected.get()).toBe(false);
+    expect(refs.triggerB?.getExposes().selected.get()).toBe(true);
+    expect(refs.contentA?.getExposes().current.get()).toBe(false);
+    expect(refs.contentB?.getExposes().current.get()).toBe(true);
+
+    app.unmount();
+    host.remove();
+  });
+});

--- a/packages/adapters/web-component/src/runtime/modules.ts
+++ b/packages/adapters/web-component/src/runtime/modules.ts
@@ -1,5 +1,5 @@
 import { createCapsWiring } from '@proto.ui/adapter-base';
-import { HOST_ELEMENT_CAP, type EffectsPort } from '@proto.ui/core';
+import { HOST_ELEMENT_CAP, type EffectsPort, type FocusEntryConfig } from '@proto.ui/core';
 import {
   createDomOrderObserver,
   ANATOMY_GET_PROTO_CAP,
@@ -34,9 +34,11 @@ import {
   FOCUS_INSTANCE_TOKEN_CAP,
   FOCUS_IS_NATIVELY_FOCUSABLE_CAP,
   FOCUS_PARENT_CAP,
+  FOCUS_RESOLVE_ENTRY_TARGET_CAP,
   FOCUS_REQUEST_FOCUS_CAP,
   FOCUS_ROOT_TARGET_CAP,
   FOCUS_RUN_IN_CALLBACK_CAP,
+  FOCUS_SET_ENTRY_FOCUSABLE_CAP,
   FOCUS_SET_FOCUSABLE_CAP,
 } from '@proto.ui/module-focus';
 import {
@@ -114,6 +116,22 @@ export function createWebComponentModules<Props extends PropsBaseType>(args: {
         FOCUS_SET_FOCUSABLE_CAP,
         (target: HTMLElement, enabled: boolean) => {
           target.tabIndex = enabled ? 0 : -1;
+        },
+      ],
+      [
+        FOCUS_RESOLVE_ENTRY_TARGET_CAP,
+        (target: HTMLElement, config: FocusEntryConfig) => resolveFocusEntryTarget(target, config),
+      ],
+      [
+        FOCUS_SET_ENTRY_FOCUSABLE_CAP,
+        (target: HTMLElement, config: FocusEntryConfig, enabled: boolean) => {
+          if (!enabled) {
+            target.tabIndex = -1;
+            return;
+          }
+
+          const resolved = resolveFocusEntryTarget(target, config);
+          target.tabIndex = resolved === target ? 0 : -1;
         },
       ],
       [
@@ -248,4 +266,49 @@ function isNativelyFocusable(el: HTMLElement): boolean {
     return el.hasAttribute('href');
   }
   return false;
+}
+
+function resolveFocusEntryTarget(
+  container: HTMLElement,
+  config: { strategy: 'self' | 'descendant-first'; fallback: 'self' | 'none' }
+): HTMLElement | null {
+  if (config.strategy === 'descendant-first') {
+    const descendant = findFirstTabbableDescendant(container);
+    if (descendant) return descendant;
+  }
+
+  if (config.fallback === 'self') return container;
+  return null;
+}
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'summary',
+  'iframe',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]',
+  '[tabindex]',
+].join(',');
+
+function findFirstTabbableDescendant(container: HTMLElement): HTMLElement | null {
+  const candidates = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+  return candidates.find((candidate) => isTabbableDescendant(container, candidate)) ?? null;
+}
+
+function isTabbableDescendant(container: HTMLElement, el: HTMLElement): boolean {
+  if (el === container) return false;
+  if (!container.contains(el)) return false;
+  if (el.closest('[hidden],[inert],[aria-hidden="true"]')) return false;
+  if (el.hasAttribute('disabled')) return false;
+  const ariaDisabled = el.getAttribute('aria-disabled');
+  if (ariaDisabled === 'true') return false;
+  const tabIndexAttr = el.getAttribute('tabindex');
+  if (tabIndexAttr !== null && Number(tabIndexAttr) < 0) return false;
+  return isNativelyFocusable(el) || tabIndexAttr !== null || el.isContentEditable;
 }

--- a/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
@@ -15,14 +15,23 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
         def.props.setDefaults({ disabled: false });
 
         const disabled = def.state.bool('button.disabled', false);
+        const id = def.state.string('button.id', 'button-a');
+        const hidden = def.state.bool('button.hidden', false);
+        const controls = def.state.string('button.controls', 'panel-a');
+        def.a11y.id(id);
         def.a11y.role('button');
         def.a11y.name('Save');
         def.a11y.description('Stores changes');
         def.a11y.state('disabled', disabled);
+        def.a11y.state('hidden', hidden);
         def.a11y.action('activate', { event: 'click' });
+        def.a11y.relation('controls', { target: controls });
+        def.a11y.relation('labelledBy', { target: 'label-a' });
         def.a11y.tree({ mergeChildren: true });
         def.props.watch(['disabled'], (_run, next) => {
           disabled.set(next.disabled);
+          hidden.set(next.disabled);
+          controls.set(next.disabled ? 'panel-b' : 'panel-a');
         });
 
         return (r) => r.el('button', 'Save');
@@ -39,15 +48,23 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
     const el = document.createElement(P.name) as HTMLElement;
     document.body.appendChild(el);
 
+    expect(el.getAttribute('id')).toBe('button-a');
     expect(el.getAttribute('role')).toBe('button');
     expect(el.getAttribute('aria-label')).toBe('Save');
     expect(el.getAttribute('aria-description')).toBe('Stores changes');
     expect(el.getAttribute('aria-disabled')).toBe('false');
+    expect(el.getAttribute('aria-hidden')).toBe('false');
+    expect(el.hasAttribute('hidden')).toBe(false);
+    expect(el.getAttribute('aria-controls')).toBe('panel-a');
+    expect(el.getAttribute('aria-labelledby')).toBe('label-a');
     expect(el.getAttribute('data-pui-a11y-actions')).toBe('activate');
     expect(el.getAttribute('data-pui-a11y-merge-children')).toBe('true');
 
     setElementProps(el, { disabled: true });
 
     expect(el.getAttribute('aria-disabled')).toBe('true');
+    expect(el.getAttribute('aria-hidden')).toBe('true');
+    expect(el.hasAttribute('hidden')).toBe(true);
+    expect(el.getAttribute('aria-controls')).toBe('panel-b');
   });
 });

--- a/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
@@ -6,21 +6,23 @@ import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-comp
 describe('contract: adapter-web-component / a11y projection (v0)', () => {
   it('A11Y-WC-0100: projects supported semantic object IR to host attributes', () => {
     // T-A11Y-0001-CASE-WEB-PROJECTION
-    const P: Prototype<{ disabled?: boolean }> = definePrototype({
+    const P: Prototype<{ disabled?: boolean; label?: string }> = definePrototype({
       name: 'x-a11y-wc-projection',
       setup(def) {
         def.props.define({
           disabled: { type: 'boolean', empty: 'fallback' },
+          label: { type: 'string', empty: 'fallback' },
         });
-        def.props.setDefaults({ disabled: false });
+        def.props.setDefaults({ disabled: false, label: 'Save' });
 
         const disabled = def.state.bool('button.disabled', false);
         const id = def.state.string('button.id', 'button-a');
+        const name = def.state.string('button.name', 'Save');
         const hidden = def.state.bool('button.hidden', false);
         const controls = def.state.string('button.controls', 'panel-a');
         def.a11y.id(id);
         def.a11y.role('button');
-        def.a11y.name('Save');
+        def.a11y.name(name);
         def.a11y.description('Stores changes');
         def.a11y.state('disabled', disabled);
         def.a11y.state('hidden', hidden);
@@ -32,6 +34,9 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
           disabled.set(next.disabled);
           hidden.set(next.disabled);
           controls.set(next.disabled ? 'panel-b' : 'panel-a');
+        });
+        def.props.watch(['label'], (_run, next) => {
+          name.set(next.label ?? '');
         });
 
         return (r) => r.el('button', 'Save');
@@ -66,5 +71,11 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
     expect(el.getAttribute('aria-hidden')).toBe('true');
     expect(el.hasAttribute('hidden')).toBe(true);
     expect(el.getAttribute('aria-controls')).toBe('panel-b');
+
+    setElementProps(el, { label: 'Store changes' });
+    expect(el.getAttribute('aria-label')).toBe('Store changes');
+
+    setElementProps(el, { label: '' });
+    expect(el.hasAttribute('aria-label')).toBe(false);
   });
 });

--- a/packages/adapters/web-component/test/focus.test.ts
+++ b/packages/adapters/web-component/test/focus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { definePrototype } from '@proto.ui/core';
-import { asFocusScope } from '@proto.ui/hooks';
+import { asFocusEntry, asFocusScope } from '@proto.ui/hooks';
 import { AdaptToWebComponent } from '@proto.ui/adapter-web-component';
 import { asButton } from '../../../prototypes/base/src/button';
 
@@ -48,5 +48,63 @@ describe('adapter-web-component focus wiring', () => {
 
     expect(el.tabIndex).toBe(-1);
     expect(document.activeElement).not.toBe(el);
+  });
+
+  it('makes focus entry host focusable only when descendant-first needs self fallback', async () => {
+    const P = definePrototype({
+      name: 'x-focus-entry-panel',
+      setup() {
+        const entry = asFocusEntry();
+        entry.configure({ strategy: 'descendant-first', fallback: 'self' });
+        return (r) => [r.slot()];
+      },
+    });
+
+    AdaptToWebComponent(P as any);
+
+    const empty = document.createElement('x-focus-entry-panel') as any;
+    document.body.appendChild(empty);
+    await Promise.resolve();
+
+    expect(empty.tabIndex).toBe(0);
+
+    const withButton = document.createElement('x-focus-entry-panel') as any;
+    const button = document.createElement('button');
+    withButton.appendChild(button);
+    document.body.appendChild(withButton);
+    await Promise.resolve();
+
+    expect(withButton.tabIndex).toBe(-1);
+
+    empty.remove();
+    withButton.remove();
+  });
+
+  it('delegates programmatic focus entry to the first tabbable descendant', async () => {
+    let capturedEntry!: ReturnType<typeof asFocusEntry>;
+    const P = definePrototype({
+      name: 'x-focus-entry-delegate',
+      setup() {
+        capturedEntry = asFocusEntry();
+        capturedEntry.configure({ strategy: 'descendant-first', fallback: 'self' });
+        return (r) => [r.slot()];
+      },
+    });
+
+    AdaptToWebComponent(P as any);
+
+    const el = document.createElement('x-focus-entry-delegate') as any;
+    const disabled = document.createElement('button');
+    const enabled = document.createElement('button');
+    disabled.disabled = true;
+    el.append(disabled, enabled);
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    capturedEntry.focus();
+
+    expect(document.activeElement).toBe(enabled);
+
+    el.remove();
   });
 });

--- a/packages/adapters/web-component/test/router.spec.test.ts
+++ b/packages/adapters/web-component/test/router.spec.test.ts
@@ -152,4 +152,35 @@ describe('WC router: createWebProtoEventRouter', () => {
     portalHost.remove();
     rootEl.remove();
   });
+
+  it('does not route global pointer events to the active root when the pointer target is outside', async () => {
+    const rootEl = document.createElement('button') as unknown as HTMLElement &
+      Record<symbol, unknown>;
+    const outside = document.createElement('button');
+    const triggerOwner = Symbol.for('@proto.ui/as-trigger/confirm-owner');
+
+    rootEl[triggerOwner] = true;
+    document.body.appendChild(rootEl);
+    document.body.appendChild(outside);
+    rootEl.focus();
+
+    const router = createWebProtoEventRouter({
+      rootEl,
+      globalEl: window,
+      isEnabled: () => true,
+    });
+
+    let pointerDownCalls = 0;
+    router.rootTarget.addEventListener('pointer.down', () => {
+      pointerDownCalls += 1;
+    });
+
+    outside.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+
+    expect(pointerDownCalls).toBe(0);
+
+    router.dispose();
+    outside.remove();
+    rootEl.remove();
+  });
 });

--- a/packages/cli/src/legacy/cli.ts
+++ b/packages/cli/src/legacy/cli.ts
@@ -784,6 +784,24 @@ function resolveKnownAsHookStateHandles(node) {
     ]);
   }
 
+  if (hookName === 'asTabsTrigger') {
+    return new Map([
+      ['disabled', 'data-[disabled]'],
+      ['hovered', 'data-[hovered]'],
+      ['focused', 'data-[focused]'],
+      ['focusVisible', 'data-[focus-visible]'],
+      ['pressed', 'data-[pressed]'],
+      ['selected', 'data-[selected]'],
+    ]);
+  }
+
+  if (hookName === 'asTabsContent') {
+    return new Map([
+      ['current', 'data-[current]'],
+      ['hidden', 'data-[hidden]'],
+    ]);
+  }
+
   return null;
 }
 

--- a/packages/cli/src/services/proto-style-css.ts
+++ b/packages/cli/src/services/proto-style-css.ts
@@ -89,13 +89,16 @@ const staticUtilities: Record<string, string[]> = {
   'inset-0': ['inset: 0px;'],
   'opacity-50': ['opacity: 0.5;'],
   'ring-inset': ['--pui-ring-inset: inset;'],
-  'ring-0': ['--pui-ring-width: 0px;', ringShadow()],
-  'ring-2': ['--pui-ring-width: 2px;', ringShadow()],
-  'ring-3': ['--pui-ring-width: 3px;', ringShadow()],
+  'ring-0': ['--pui-ring-width: 0px;', ...ringShadow()],
+  'ring-2': ['--pui-ring-width: 2px;', ...ringShadow()],
+  'ring-3': ['--pui-ring-width: 3px;', ...ringShadow()],
   'ring-offset-2': ['--pui-ring-offset-width: 2px;'],
   'ring-offset-background': ['--pui-ring-offset-color: var(--pui-background);'],
-  'shadow-xs': ['box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);'],
-  'shadow-lg': ['box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);'],
+  'shadow-xs': ['--pui-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);', ...composedShadow()],
+  'shadow-lg': [
+    '--pui-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);',
+    ...composedShadow(),
+  ],
   'backdrop-blur-xs': ['backdrop-filter: blur(4px);'],
   'z-40': ['z-index: 40;'],
   'z-50': ['z-index: 50;'],
@@ -252,7 +255,7 @@ function renderColorUtility(utility: string): string[] | null {
   if (kind === 'bg') return [`background-color: ${color};`];
   if (kind === 'text') return [`color: ${color};`];
   if (kind === 'border') return [`border-color: ${color};`];
-  if (kind === 'ring') return [`--pui-ring-color: ${color};`, ringShadow()];
+  if (kind === 'ring') return [`--pui-ring-color: ${color};`, ...ringShadow()];
   if (kind === 'ring-offset') return [`--pui-ring-offset-color: ${color};`];
   return null;
 }
@@ -370,10 +373,18 @@ function colorValue(name: string, opacity?: string): string {
   return `color-mix(in oklab, ${base} ${Number(opacity)}%, transparent)`;
 }
 
-function ringShadow() {
+function ringShadow(): string[] {
   return [
-    'box-shadow: var(--pui-ring-inset, ) 0 0 0 var(--pui-ring-width, 0px) var(--pui-ring-color, var(--pui-ring));',
-  ].join('');
+    '--pui-ring-offset-shadow: 0 0 0 var(--pui-ring-offset-width, 0px) var(--pui-ring-offset-color, #fff);',
+    '--pui-ring-shadow: var(--pui-ring-inset,) 0 0 0 calc(var(--pui-ring-width, 0px) + var(--pui-ring-offset-width, 0px)) var(--pui-ring-color, var(--pui-ring));',
+    ...composedShadow(),
+  ];
+}
+
+function composedShadow(): string[] {
+  return [
+    'box-shadow: var(--pui-ring-offset-shadow, 0 0 #0000), var(--pui-ring-shadow, 0 0 #0000), var(--pui-shadow, 0 0 #0000);',
+  ];
 }
 
 function transformValue() {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -113,6 +113,15 @@ describe('@proto.ui/cli', () => {
     expect(tokensCss).toContain(`data-[checked]:bg-primary"])[data-checked]`);
     expect(tokensCss).toContain(`data-[selected]:bg-background"])[data-selected]`);
     expect(tokensCss).toContain(`data-[hidden]:hidden"])[data-hidden]`);
+    expect(tokensCss).toContain(
+      `data-[focus-visible]:ring-3"])[data-focus-visible] {\n    --pui-ring-width: 3px;`
+    );
+    expect(tokensCss).toContain(
+      `data-[focus-visible]:shadow-xs"])[data-focus-visible] {\n    --pui-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);`
+    );
+    expect(tokensCss).toContain(
+      'box-shadow: var(--pui-ring-offset-shadow, 0 0 #0000), var(--pui-ring-shadow, 0 0 #0000), var(--pui-shadow, 0 0 #0000);'
+    );
     expect(tokensCss).not.toContain(`aria-checked:bg-muted"])[aria-checked='true']`);
     expect(tokensCss).not.toContain('Unsupported Proto UI style tokens');
   }, 30_000);

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -112,6 +112,7 @@ describe('@proto.ui/cli', () => {
     expect(tokensCss).toContain(`data-[checked]:pl-[20px]"])[data-checked]`);
     expect(tokensCss).toContain(`data-[checked]:bg-primary"])[data-checked]`);
     expect(tokensCss).toContain(`data-[selected]:bg-background"])[data-selected]`);
+    expect(tokensCss).toContain(`data-[hidden]:hidden"])[data-hidden]`);
     expect(tokensCss).not.toContain(`aria-checked:bg-muted"])[aria-checked='true']`);
     expect(tokensCss).not.toContain('Unsupported Proto UI style tokens');
   }, 30_000);

--- a/packages/core/src/a11y.ts
+++ b/packages/core/src/a11y.ts
@@ -2,7 +2,8 @@ import type { State } from './state';
 
 export type A11yRole = string;
 
-export type A11yTextAlternative = { kind: 'content' } | { kind: 'text'; value: string };
+export type A11yTextTarget = string | State<string | null | undefined>;
+export type A11yTextAlternative = { kind: 'content' } | { kind: 'text'; value: A11yTextTarget };
 
 export type A11yStateKey = string;
 export type A11yActionKey = string;
@@ -43,9 +44,9 @@ export type A11ySemanticObjectSnapshot = {
 export type A11yDefAPI = {
   id(target: A11yIdentityTarget): void;
   role(role: A11yRole): void;
-  name(value: string): void;
+  name(value: A11yTextTarget): void;
   nameFromContent(): void;
-  description(value: string): void;
+  description(value: A11yTextTarget): void;
   state<V>(key: A11yStateKey, handle: State<V>): void;
   action(key: A11yActionKey, spec?: A11yActionSpec): void;
   relation(key: A11yRelationKey, spec: A11yRelationSpec): void;

--- a/packages/core/src/a11y.ts
+++ b/packages/core/src/a11y.ts
@@ -6,6 +6,7 @@ export type A11yTextAlternative = { kind: 'content' } | { kind: 'text'; value: s
 
 export type A11yStateKey = string;
 export type A11yActionKey = string;
+export type A11yRelationKey = string;
 
 export type A11yStateBinding<V = unknown> = {
   key: A11yStateKey;
@@ -16,26 +17,37 @@ export type A11yActionSpec = {
   event?: string;
 };
 
+export type A11yRelationTarget = string | State<string | null | undefined>;
+export type A11yIdentityTarget = string | State<string | null | undefined>;
+
+export type A11yRelationSpec = {
+  target: A11yRelationTarget;
+};
+
 export type A11yTreeBehavior = {
   hidden?: boolean;
   mergeChildren?: boolean;
 };
 
 export type A11ySemanticObjectSnapshot = {
+  id?: string | null;
   role?: A11yRole;
   name?: A11yTextAlternative;
   description?: A11yTextAlternative;
   states: Record<A11yStateKey, unknown>;
   actions: Record<A11yActionKey, A11yActionSpec>;
+  relations: Record<A11yRelationKey, string | null | undefined>;
   tree?: A11yTreeBehavior;
 };
 
 export type A11yDefAPI = {
+  id(target: A11yIdentityTarget): void;
   role(role: A11yRole): void;
   name(value: string): void;
   nameFromContent(): void;
   description(value: string): void;
   state<V>(key: A11yStateKey, handle: State<V>): void;
   action(key: A11yActionKey, spec?: A11yActionSpec): void;
+  relation(key: A11yRelationKey, spec: A11yRelationSpec): void;
   tree(patch: A11yTreeBehavior): void;
 };

--- a/packages/core/src/focus.ts
+++ b/packages/core/src/focus.ts
@@ -65,6 +65,23 @@ export type FocusableConfig = Readonly<{
   meta?: Readonly<Record<string, unknown>>;
 }>;
 
+export type FocusEntryStrategy = 'self' | 'descendant-first';
+export type FocusEntryFallback = 'self' | 'none';
+
+export type FocusEntryConfigPatch = Readonly<{
+  strategy?: FocusEntryStrategy;
+  fallback?: FocusEntryFallback;
+  disabled?: boolean;
+  meta?: Readonly<Record<string, unknown>>;
+}>;
+
+export type FocusEntryConfig = Readonly<{
+  strategy: FocusEntryStrategy;
+  fallback: FocusEntryFallback;
+  disabled: boolean;
+  meta?: Readonly<Record<string, unknown>>;
+}>;
+
 export type FocusScopeConfigPatch = Readonly<{
   key?: FocusScopeKey;
   trap?: boolean;
@@ -132,8 +149,15 @@ export interface FocusableHandle<P extends PropsBaseType = PropsBaseType> {
   blur(): void;
   isFocused(): boolean;
   setDisabled(disabled: boolean): void;
+  setNavParticipation(navParticipation: 'auto' | 'none'): void;
 
   configure(patch: FocusableConfigPatch): void;
+}
+
+export interface FocusEntryHandle<P extends PropsBaseType = PropsBaseType> {
+  focus(options?: FocusRequestOptions): void;
+  setDisabled(disabled: boolean): void;
+  configure(patch: FocusEntryConfigPatch): void;
 }
 
 export interface FocusScopeHandle<P extends PropsBaseType = PropsBaseType> {

--- a/packages/hooks/src/as-focus-entry.ts
+++ b/packages/hooks/src/as-focus-entry.ts
@@ -1,0 +1,22 @@
+import type { FocusEntryHandle } from '@proto.ui/core';
+import type { PropsBaseType } from '@proto.ui/types';
+import { definePrivilegedAsHook } from './privileged';
+
+type FocusEntryFacade = {
+  getEntry<P extends PropsBaseType = PropsBaseType>(): FocusEntryHandle<P>;
+};
+
+const getFocusEntry = definePrivilegedAsHook<PropsBaseType, FocusEntryHandle<PropsBaseType>>({
+  name: 'asFocusEntry',
+  setup: ({ facades }) => {
+    const facade = facades.focus as FocusEntryFacade | undefined;
+    if (!facade || typeof facade.getEntry !== 'function') {
+      throw new Error(`[AsHook] focus facade unavailable for asFocusEntry.`);
+    }
+    return facade.getEntry();
+  },
+});
+
+export function asFocusEntry<P extends PropsBaseType = PropsBaseType>(): FocusEntryHandle<P> {
+  return getFocusEntry() as FocusEntryHandle<P>;
+}

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,4 +1,5 @@
 export * from './as-boundary';
+export * from './as-focus-entry';
 export * from './as-focus-roving';
 export * from './as-focusable';
 export * from './as-focus-scope';

--- a/packages/modules/a11y/src/create.ts
+++ b/packages/modules/a11y/src/create.ts
@@ -3,6 +3,8 @@ import type { ModuleFactoryArgs } from '@proto.ui/module-base';
 import type {
   A11yActionKey,
   A11yActionSpec,
+  A11yRelationKey,
+  A11yRelationSpec,
   A11yRole,
   A11ySemanticObjectSnapshot,
   A11yStateKey,
@@ -20,6 +22,7 @@ class A11yModuleImpl extends ModuleBase {
   private readonly ir: A11ySemanticObjectIR = {
     states: new Map(),
     actions: new Map(),
+    relations: new Map(),
   };
   private readonly stateWatchOffs: Unsubscribe[] = [];
   private stateWatchesInstalled = false;
@@ -32,6 +35,11 @@ class A11yModuleImpl extends ModuleBase {
   }
 
   readonly facade: A11yFacade = {
+    id: (target) => {
+      this.ensureSetup('def.a11y.id');
+      this.ir.id = target;
+      this.applyProjection();
+    },
     role: (role) => {
       this.ensureSetup('def.a11y.role');
       this.ir.role = role;
@@ -62,6 +70,11 @@ class A11yModuleImpl extends ModuleBase {
       this.ir.actions.set(key, { ...spec });
       this.applyProjection();
     },
+    relation: (key: A11yRelationKey, spec: A11yRelationSpec) => {
+      this.ensureSetup('def.a11y.relation');
+      this.ir.relations.set(key, { key, spec: { ...spec } });
+      this.applyProjection();
+    },
     tree: (patch: A11yTreeBehavior) => {
       this.ensureSetup('def.a11y.tree');
       this.ir.tree = { ...(this.ir.tree ?? {}), ...patch };
@@ -73,10 +86,12 @@ class A11yModuleImpl extends ModuleBase {
     getSnapshot: () => this.getSnapshot(),
     getIR: () => ({
       role: this.ir.role,
+      id: this.ir.id,
       name: cloneTextAlternative(this.ir.name),
       description: cloneTextAlternative(this.ir.description),
       states: new Map(this.ir.states),
       actions: new Map(this.ir.actions),
+      relations: new Map(this.ir.relations),
       tree: this.ir.tree ? { ...this.ir.tree } : undefined,
     }),
   };
@@ -118,6 +133,21 @@ class A11yModuleImpl extends ModuleBase {
       this.stateWatchOffs.push(off);
     }
 
+    if (isState(this.ir.id)) {
+      const off = this.statePort.watch(this.ir.id as any, () => {
+        this.applyProjection();
+      });
+      this.stateWatchOffs.push(off);
+    }
+
+    for (const binding of this.ir.relations.values()) {
+      if (!isState(binding.spec.target)) continue;
+      const off = this.statePort.watch(binding.spec.target as any, () => {
+        this.applyProjection();
+      });
+      this.stateWatchOffs.push(off);
+    }
+
     this.stateWatchesInstalled = true;
   }
 
@@ -127,12 +157,20 @@ class A11yModuleImpl extends ModuleBase {
       states[key] = binding.handle.get();
     }
 
+    const relations: Record<string, string | null | undefined> = {};
+    for (const [key, binding] of this.ir.relations) {
+      const target = binding.spec.target;
+      relations[key] = isState(target) ? target.get() : target;
+    }
+
     return {
+      id: isState(this.ir.id) ? (this.ir.id.get() as string | null | undefined) : this.ir.id,
       role: this.ir.role,
       name: cloneTextAlternative(this.ir.name),
       description: cloneTextAlternative(this.ir.description),
       states,
       actions: Object.fromEntries(this.ir.actions),
+      relations,
       tree: this.ir.tree ? { ...this.ir.tree } : undefined,
     };
   }
@@ -141,6 +179,12 @@ class A11yModuleImpl extends ModuleBase {
     if (!this.caps.has(A11Y_PROJECT_CAP)) return;
     this.caps.get(A11Y_PROJECT_CAP)(this.getSnapshot());
   }
+}
+
+function isState(value: unknown): value is State<unknown> {
+  return (
+    !!value && typeof value === 'object' && typeof (value as State<unknown>).get === 'function'
+  );
 }
 
 function cloneTextAlternative(

--- a/packages/modules/a11y/src/create.ts
+++ b/packages/modules/a11y/src/create.ts
@@ -140,6 +140,20 @@ class A11yModuleImpl extends ModuleBase {
       this.stateWatchOffs.push(off);
     }
 
+    if (this.ir.name?.kind === 'text' && isState(this.ir.name.value)) {
+      const off = this.statePort.watch(this.ir.name.value as any, () => {
+        this.applyProjection();
+      });
+      this.stateWatchOffs.push(off);
+    }
+
+    if (this.ir.description?.kind === 'text' && isState(this.ir.description.value)) {
+      const off = this.statePort.watch(this.ir.description.value as any, () => {
+        this.applyProjection();
+      });
+      this.stateWatchOffs.push(off);
+    }
+
     for (const binding of this.ir.relations.values()) {
       if (!isState(binding.spec.target)) continue;
       const off = this.statePort.watch(binding.spec.target as any, () => {
@@ -166,8 +180,8 @@ class A11yModuleImpl extends ModuleBase {
     return {
       id: isState(this.ir.id) ? (this.ir.id.get() as string | null | undefined) : this.ir.id,
       role: this.ir.role,
-      name: cloneTextAlternative(this.ir.name),
-      description: cloneTextAlternative(this.ir.description),
+      name: resolveTextAlternative(this.ir.name),
+      description: resolveTextAlternative(this.ir.description),
       states,
       actions: Object.fromEntries(this.ir.actions),
       relations,
@@ -192,6 +206,19 @@ function cloneTextAlternative(
 ): A11yTextAlternative | undefined {
   if (!value) return undefined;
   return value.kind === 'text' ? { kind: 'text', value: value.value } : { kind: 'content' };
+}
+
+function resolveTextAlternative(
+  value: A11yTextAlternative | undefined
+): A11yTextAlternative | undefined {
+  if (!value) return undefined;
+  if (value.kind === 'content') return { kind: 'content' };
+  return {
+    kind: 'text',
+    value: isState(value.value)
+      ? (value.value.get() as string | null | undefined) || ''
+      : value.value,
+  };
 }
 
 export function createA11yModule(ctx: ModuleFactoryArgs): A11yModule {

--- a/packages/modules/a11y/src/types.ts
+++ b/packages/modules/a11y/src/types.ts
@@ -2,6 +2,9 @@ import type {
   A11yActionKey,
   A11yActionSpec,
   A11yDefAPI,
+  A11yIdentityTarget,
+  A11yRelationKey,
+  A11yRelationSpec,
   A11yRole,
   A11ySemanticObjectSnapshot,
   A11yStateKey,
@@ -19,12 +22,19 @@ export type A11yStateBinding = {
   handle: State<unknown>;
 };
 
+export type A11yRelationBinding = {
+  key: A11yRelationKey;
+  spec: A11yRelationSpec;
+};
+
 export type A11ySemanticObjectIR = {
+  id?: A11yIdentityTarget;
   role?: A11yRole;
   name?: A11yTextAlternative;
   description?: A11yTextAlternative;
   states: Map<A11yStateKey, A11yStateBinding>;
   actions: Map<A11yActionKey, A11yActionSpec>;
+  relations: Map<A11yRelationKey, A11yRelationBinding>;
   tree?: A11yTreeBehavior;
 };
 

--- a/packages/modules/a11y/src/web.ts
+++ b/packages/modules/a11y/src/web.ts
@@ -7,8 +7,15 @@ const ARIA_STATE_ATTRS: Record<string, string> = {
   disabled: 'aria-disabled',
   expanded: 'aria-expanded',
   invalid: 'aria-invalid',
+  orientation: 'aria-orientation',
   pressed: 'aria-pressed',
   selected: 'aria-selected',
+};
+
+const ARIA_RELATION_ATTRS: Record<string, string> = {
+  controls: 'aria-controls',
+  describedBy: 'aria-describedby',
+  labelledBy: 'aria-labelledby',
 };
 
 export function createWebA11yProjector(el: HTMLElement): A11yProjector {
@@ -18,6 +25,10 @@ export function createWebA11yProjector(el: HTMLElement): A11yProjector {
 }
 
 export function applyWebA11ySnapshot(el: HTMLElement, snapshot: A11ySemanticObjectSnapshot): void {
+  if (typeof snapshot.id !== 'undefined') {
+    setOptionalAttr(el, 'id', snapshot.id ?? undefined);
+  }
+
   if (typeof snapshot.role !== 'undefined') {
     setOptionalAttr(el, 'role', snapshot.role);
   }
@@ -41,6 +52,17 @@ export function applyWebA11ySnapshot(el: HTMLElement, snapshot: A11ySemanticObje
   for (const [key, attr] of Object.entries(ARIA_STATE_ATTRS)) {
     if (Object.prototype.hasOwnProperty.call(snapshot.states, key)) {
       setNullableBooleanAttr(el, attr, snapshot.states[key]);
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(snapshot.states, 'hidden')) {
+    setNullableBooleanAttr(el, 'aria-hidden', snapshot.states.hidden);
+    setBooleanPresenceAttr(el, 'hidden', snapshot.states.hidden);
+  }
+
+  for (const [key, attr] of Object.entries(ARIA_RELATION_ATTRS)) {
+    if (Object.prototype.hasOwnProperty.call(snapshot.relations, key)) {
+      setOptionalAttr(el, attr, snapshot.relations[key] ?? undefined);
     }
   }
 
@@ -77,4 +99,12 @@ function setNullableBooleanAttr(el: HTMLElement, attr: string, value: unknown): 
     return;
   }
   el.setAttribute(attr, String(value));
+}
+
+function setBooleanPresenceAttr(el: HTMLElement, attr: string, value: unknown): void {
+  if (value === true) {
+    el.setAttribute(attr, '');
+    return;
+  }
+  el.removeAttribute(attr);
 }

--- a/packages/modules/a11y/src/web.ts
+++ b/packages/modules/a11y/src/web.ts
@@ -35,7 +35,7 @@ export function applyWebA11ySnapshot(el: HTMLElement, snapshot: A11ySemanticObje
 
   if (snapshot.name) {
     if (snapshot.name.kind === 'text') {
-      el.setAttribute('aria-label', snapshot.name.value);
+      setOptionalAttr(el, 'aria-label', readTextTarget(snapshot.name.value));
     } else {
       el.removeAttribute('aria-label');
     }
@@ -43,7 +43,7 @@ export function applyWebA11ySnapshot(el: HTMLElement, snapshot: A11ySemanticObje
 
   if (snapshot.description) {
     if (snapshot.description.kind === 'text') {
-      el.setAttribute('aria-description', snapshot.description.value);
+      setOptionalAttr(el, 'aria-description', readTextTarget(snapshot.description.value));
     } else {
       el.removeAttribute('aria-description');
     }
@@ -87,6 +87,19 @@ function setOptionalAttr(el: HTMLElement, attr: string, value: string | undefine
     return;
   }
   el.setAttribute(attr, value);
+}
+
+function readTextTarget(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (
+    value &&
+    typeof value === 'object' &&
+    typeof (value as { get?: unknown }).get === 'function'
+  ) {
+    const next = (value as { get(): unknown }).get();
+    return typeof next === 'string' ? next : undefined;
+  }
+  return undefined;
 }
 
 function setNullableBooleanAttr(el: HTMLElement, attr: string, value: unknown): void {

--- a/packages/modules/focus/src/caps.ts
+++ b/packages/modules/focus/src/caps.ts
@@ -1,5 +1,5 @@
 import { cap } from '@proto.ui/core';
-import type { FocusRequestOptions } from '@proto.ui/core';
+import type { FocusEntryConfig, FocusRequestOptions } from '@proto.ui/core';
 
 export type FocusInstanceToken = unknown;
 export type FocusParentGetter = (instance: FocusInstanceToken) => FocusInstanceToken | null;
@@ -13,6 +13,17 @@ export type FocusSetFocusable = (target: HTMLElement, enabled: boolean) => void;
 export type FocusRequestFocus = (target: HTMLElement, options?: FocusRequestOptions) => void;
 
 export type FocusBlur = (target: HTMLElement) => void;
+
+export type FocusResolveEntryTarget = (
+  container: HTMLElement,
+  config: FocusEntryConfig
+) => HTMLElement | null;
+
+export type FocusSetEntryFocusable = (
+  container: HTMLElement,
+  config: FocusEntryConfig,
+  enabled: boolean
+) => void;
 
 export type FocusRunInCallback = (fn: () => void) => void;
 
@@ -29,5 +40,13 @@ export const FOCUS_SET_FOCUSABLE_CAP = cap<FocusSetFocusable>('@proto.ui/focus/s
 export const FOCUS_REQUEST_FOCUS_CAP = cap<FocusRequestFocus>('@proto.ui/focus/requestFocus');
 
 export const FOCUS_BLUR_CAP = cap<FocusBlur>('@proto.ui/focus/blur');
+
+export const FOCUS_RESOLVE_ENTRY_TARGET_CAP = cap<FocusResolveEntryTarget>(
+  '@proto.ui/focus/resolveEntryTarget'
+);
+
+export const FOCUS_SET_ENTRY_FOCUSABLE_CAP = cap<FocusSetEntryFocusable>(
+  '@proto.ui/focus/setEntryFocusable'
+);
 
 export const FOCUS_RUN_IN_CALLBACK_CAP = cap<FocusRunInCallback>('@proto.ui/focus/runInCallback');

--- a/packages/modules/focus/src/create.ts
+++ b/packages/modules/focus/src/create.ts
@@ -1,5 +1,8 @@
 import {
   type FocusFacts,
+  type FocusEntryConfig,
+  FocusEntryConfigPatch,
+  FocusEntryHandle,
   type FocusRovingConfig,
   FocusRovingConfigPatch,
   FocusRovingHandle,
@@ -27,9 +30,11 @@ import {
   FOCUS_INSTANCE_TOKEN_CAP,
   FOCUS_IS_NATIVELY_FOCUSABLE_CAP,
   FOCUS_PARENT_CAP,
+  FOCUS_RESOLVE_ENTRY_TARGET_CAP,
   FOCUS_REQUEST_FOCUS_CAP,
   FOCUS_ROOT_TARGET_CAP,
   FOCUS_RUN_IN_CALLBACK_CAP,
+  FOCUS_SET_ENTRY_FOCUSABLE_CAP,
   FOCUS_SET_FOCUSABLE_CAP,
 } from './caps';
 import { FOCUS_CENTER, type FocusCenterEntry, type FocusRequestBehavior } from './center';
@@ -38,6 +43,12 @@ const DEFAULT_FOCUSABLE_CONFIG: FocusableConfig = Object.freeze({
   autoFocus: false,
   disabled: false,
   navParticipation: 'auto',
+});
+
+const DEFAULT_ENTRY_CONFIG: FocusEntryConfig = Object.freeze({
+  strategy: 'self',
+  fallback: 'self',
+  disabled: false,
 });
 
 const DEFAULT_SCOPE_CONFIG: FocusScopeConfig = Object.freeze({
@@ -71,7 +82,7 @@ function mergeMeta(
 
 function pushOverrideWarning(
   warnings: string[],
-  owner: 'focusable' | 'scope',
+  owner: 'focusable' | 'entry' | 'scope',
   field: string,
   prev: unknown,
   next: unknown
@@ -83,6 +94,8 @@ function pushOverrideWarning(
 class FocusModuleImpl extends ModuleBase {
   private focusableConfig: FocusableConfig = DEFAULT_FOCUSABLE_CONFIG;
   private focusableDeclared = false;
+  private entryDeclared = false;
+  private entryConfig: FocusEntryConfig = DEFAULT_ENTRY_CONFIG;
   private scopeDeclared = false;
   private rovingDeclared = false;
   private rovingConfig: FocusRovingConfig = DEFAULT_ROVING_CONFIG;
@@ -107,6 +120,7 @@ class FocusModuleImpl extends ModuleBase {
   private readonly hasFocusedState: ObservedStateHandle<boolean, any>;
 
   private readonly focusableHandle: FocusableHandle<any>;
+  private readonly entryHandle: FocusEntryHandle<any>;
   private readonly scopeHandle: FocusScopeHandle<any>;
   private readonly rovingHandle: FocusRovingHandle<any>;
 
@@ -146,7 +160,15 @@ class FocusModuleImpl extends ModuleBase {
       blur: () => this.blur(),
       isFocused: () => this.focusedState.get(),
       setDisabled: (disabled: boolean) => this.setDisabled(disabled),
+      setNavParticipation: (navParticipation: 'auto' | 'none') =>
+        this.setNavParticipation(navParticipation),
       configure: (patch: FocusableConfigPatch) => this.configureFocusable(patch),
+    };
+
+    this.entryHandle = {
+      focus: (options?: FocusRequestOptions) => this.requestEntryFocus(options),
+      setDisabled: (disabled: boolean) => this.setEntryDisabled(disabled),
+      configure: (patch: FocusEntryConfigPatch) => this.configureEntry(patch),
     };
 
     this.scopeHandle = {
@@ -270,7 +292,10 @@ class FocusModuleImpl extends ModuleBase {
     const target = this.getRootTarget();
     if (!target) return;
 
-    const enabled = this.focusableDeclared && !this.focusableConfig.disabled;
+    const enabled =
+      this.focusableDeclared &&
+      !this.focusableConfig.disabled &&
+      this.focusableConfig.navParticipation !== 'none';
     const isNative = this.caps.has(FOCUS_IS_NATIVELY_FOCUSABLE_CAP)
       ? this.caps.get(FOCUS_IS_NATIVELY_FOCUSABLE_CAP)(target)
       : false;
@@ -285,6 +310,27 @@ class FocusModuleImpl extends ModuleBase {
     }
   }
 
+  private syncHostEntry() {
+    const target = this.getRootTarget();
+    if (!target || !this.entryDeclared) return;
+
+    const enabled = !this.entryConfig.disabled;
+    if (this.focusableDeclared && !this.focusableConfig.disabled) return;
+
+    if (this.caps.has(FOCUS_SET_ENTRY_FOCUSABLE_CAP)) {
+      this.caps.get(FOCUS_SET_ENTRY_FOCUSABLE_CAP)(target, this.entryConfig, enabled);
+      return;
+    }
+
+    if (this.caps.has(FOCUS_SET_FOCUSABLE_CAP)) {
+      if (enabled && this.entryConfig.fallback === 'self') {
+        this.caps.get(FOCUS_SET_FOCUSABLE_CAP)(target, true);
+      } else if (!this.focusableDeclared || this.focusableConfig.disabled) {
+        this.caps.get(FOCUS_SET_FOCUSABLE_CAP)(target, false);
+      }
+    }
+  }
+
   private declareFocusable(): void {
     if (!this.focusableDeclared) {
       this.focusableDeclared = true;
@@ -295,6 +341,11 @@ class FocusModuleImpl extends ModuleBase {
     this.wireHostFocusEvents();
     this.syncHostFocusable();
     this.syncCenter();
+  }
+
+  private declareEntry(): void {
+    this.entryDeclared = true;
+    this.syncHostEntry();
   }
 
   private declareScope(): void {
@@ -370,6 +421,11 @@ class FocusModuleImpl extends ModuleBase {
     return this.focusableHandle as FocusableHandle<P>;
   }
 
+  getEntry<P extends PropsBaseType = PropsBaseType>(): FocusEntryHandle<P> {
+    this.declareEntry();
+    return this.entryHandle as FocusEntryHandle<P>;
+  }
+
   getScope<P extends PropsBaseType = PropsBaseType>(): FocusScopeHandle<P> {
     this.declareScope();
     return this.scopeHandle as FocusScopeHandle<P>;
@@ -437,6 +493,45 @@ class FocusModuleImpl extends ModuleBase {
     this.setDisabled(this.focusableConfig.disabled, 'focus config updated');
     this.syncHostFocusable();
     this.syncCenter();
+  }
+
+  configureEntry(patch: FocusEntryConfigPatch): void {
+    this.ensureSetup('focus.configureEntry');
+    this.declareEntry();
+    if (typeof patch.strategy !== 'undefined') {
+      pushOverrideWarning(
+        this.warnings,
+        'entry',
+        'strategy',
+        this.entryConfig.strategy,
+        patch.strategy
+      );
+    }
+    if (typeof patch.fallback !== 'undefined') {
+      pushOverrideWarning(
+        this.warnings,
+        'entry',
+        'fallback',
+        this.entryConfig.fallback,
+        patch.fallback
+      );
+    }
+    if (typeof patch.disabled !== 'undefined') {
+      pushOverrideWarning(
+        this.warnings,
+        'entry',
+        'disabled',
+        this.entryConfig.disabled,
+        patch.disabled
+      );
+    }
+
+    this.entryConfig = Object.freeze({
+      ...this.entryConfig,
+      ...patch,
+      meta: mergeMeta(this.entryConfig.meta, patch.meta),
+    });
+    this.syncHostEntry();
   }
 
   configureScope(patch: FocusScopeConfigPatch): void {
@@ -604,6 +699,20 @@ class FocusModuleImpl extends ModuleBase {
     FOCUS_CENTER.requestFocus(entry, options, { syncFacts: true });
   }
 
+  requestEntryFocus(options?: FocusRequestOptions): void {
+    if (!this.entryDeclared || this.entryConfig.disabled) return;
+    const target = this.getRootTarget();
+    if (!target || !this.caps.has(FOCUS_REQUEST_FOCUS_CAP)) return;
+
+    const resolved = this.caps.has(FOCUS_RESOLVE_ENTRY_TARGET_CAP)
+      ? this.caps.get(FOCUS_RESOLVE_ENTRY_TARGET_CAP)(target, this.entryConfig)
+      : this.entryConfig.fallback === 'self'
+        ? target
+        : null;
+    if (!resolved) return;
+    this.caps.get(FOCUS_REQUEST_FOCUS_CAP)(resolved, options);
+  }
+
   private requestNativeFocusDirect(options?: FocusRequestOptions): void {
     if (!this.focusableDeclared || this.focusableConfig.disabled) return;
     const target = this.getRootTarget();
@@ -732,9 +841,27 @@ class FocusModuleImpl extends ModuleBase {
     this.syncCenter();
   }
 
+  setNavParticipation(navParticipation: 'auto' | 'none'): void {
+    this.focusableConfig = Object.freeze({
+      ...this.focusableConfig,
+      navParticipation,
+    });
+    this.syncHostFocusable();
+    this.syncCenter();
+  }
+
+  setEntryDisabled(disabled: boolean): void {
+    this.entryConfig = Object.freeze({
+      ...this.entryConfig,
+      disabled,
+    });
+    this.syncHostEntry();
+  }
+
   afterRenderCommit(): void {
     this.syncCenter();
     this.syncHostFocusable();
+    this.syncHostEntry();
     if (this.didAutoFocus) return;
     this.didAutoFocus = true;
     if (
@@ -756,6 +883,10 @@ class FocusModuleImpl extends ModuleBase {
 
   getFocusableConfig(): FocusableConfig {
     return this.focusableConfig;
+  }
+
+  getEntryConfig(): FocusEntryConfig {
+    return this.entryConfig;
   }
 
   getScopeConfig(): FocusScopeConfig {
@@ -805,11 +936,15 @@ export function createFocusModule(ctx: ModuleFactoryArgs): FocusModule {
       const impl = new FocusModuleImpl(caps, init.prototypeName, eventPort, statePort, stateFacade);
       const port: FocusPort = {
         configureFocusable: (patch) => impl.configureFocusable(patch),
+        configureEntry: (patch) => impl.configureEntry(patch),
         configureRoving: (patch) => impl.configureRoving(patch),
         configureGroup: (patch) => impl.configureRoving(patch),
         configureScope: (patch) => impl.configureScope(patch),
         setDisabled: (disabled) => impl.setDisabled(disabled),
+        setNavParticipation: (navParticipation) => impl.setNavParticipation(navParticipation),
+        setEntryDisabled: (disabled) => impl.setEntryDisabled(disabled),
         requestFocus: (options) => impl.requestFocus(options),
+        requestEntryFocus: (options) => impl.requestEntryFocus(options),
         blur: () => impl.blur(),
         focusFirst: () => impl.focusFirst(),
         focusLast: () => impl.focusLast(),
@@ -824,6 +959,7 @@ export function createFocusModule(ctx: ModuleFactoryArgs): FocusModule {
         getEffectiveGroupKey: () => impl.getEffectiveRovingKey(),
         getEffectiveScopeKey: () => impl.getEffectiveScopeKey(),
         getFocusableConfig: () => impl.getFocusableConfig(),
+        getEntryConfig: () => impl.getEntryConfig(),
         getRovingConfig: () => impl.getRovingConfig(),
         getGroupConfig: () => impl.getRovingConfig(),
         getScopeConfig: () => impl.getScopeConfig(),
@@ -834,6 +970,7 @@ export function createFocusModule(ctx: ModuleFactoryArgs): FocusModule {
       return {
         facade: {
           getFocusable: () => impl.getFocusable(),
+          getEntry: () => impl.getEntry(),
           getRoving: () => impl.getRoving(),
           getScope: () => impl.getScope(),
         },

--- a/packages/modules/focus/src/types.ts
+++ b/packages/modules/focus/src/types.ts
@@ -1,5 +1,8 @@
 import type {
   FocusFacts,
+  FocusEntryConfig,
+  FocusEntryConfigPatch,
+  FocusEntryHandle,
   FocusRovingConfig,
   FocusRovingConfigPatch,
   FocusRovingHandle,
@@ -18,17 +21,22 @@ import type { PropsBaseType } from '@proto.ui/types';
 
 export type FocusFacade = {
   getFocusable<P extends PropsBaseType = PropsBaseType>(): FocusableHandle<P>;
+  getEntry<P extends PropsBaseType = PropsBaseType>(): FocusEntryHandle<P>;
   getRoving<P extends PropsBaseType = PropsBaseType>(): FocusRovingHandle<P>;
   getScope<P extends PropsBaseType = PropsBaseType>(): FocusScopeHandle<P>;
 };
 
 export type FocusPort = {
   configureFocusable(patch: FocusableConfigPatch): void;
+  configureEntry(patch: FocusEntryConfigPatch): void;
   configureRoving(patch: FocusRovingConfigPatch): void;
   configureGroup(patch: FocusRovingConfigPatch): void;
   configureScope(patch: FocusScopeConfigPatch): void;
   setDisabled(disabled: boolean): void;
+  setNavParticipation(navParticipation: 'auto' | 'none'): void;
+  setEntryDisabled(disabled: boolean): void;
   requestFocus(options?: FocusRequestOptions): void;
+  requestEntryFocus(options?: FocusRequestOptions): void;
   blur(): void;
   focusFirst(): void;
   focusLast(): void;
@@ -43,6 +51,7 @@ export type FocusPort = {
   getEffectiveGroupKey(): FocusRovingKey | undefined;
   getEffectiveScopeKey(): FocusScopeKey | undefined;
   getFocusableConfig(): FocusableConfig;
+  getEntryConfig(): FocusEntryConfig;
   getRovingConfig(): FocusRovingConfig;
   getGroupConfig(): FocusRovingConfig;
   getScopeConfig(): FocusScopeConfig;

--- a/packages/prototypes/base/src/tabs/content.ts
+++ b/packages/prototypes/base/src/tabs/content.ts
@@ -1,4 +1,5 @@
 import { defineAsHook, definePrototype, tw, type DefHandle } from '@proto.ui/core';
+import { asFocusEntry } from '@proto.ui/hooks';
 import { createTabsPartId, TABS_CONTEXT, TABS_FAMILY, type TabsContextValue } from './shared';
 import type { TabsContentAsHookContract, TabsContentExposes, TabsContentProps } from './types';
 
@@ -6,11 +7,13 @@ function syncCurrentFromContext(
   nextValue: string,
   ownValue: string,
   current: { set(value: boolean, reason?: string): void },
-  hidden: { set(value: boolean, reason?: string): void }
+  hidden: { set(value: boolean, reason?: string): void },
+  focusEntry: { setDisabled(disabled: boolean): void }
 ): void {
   const nextCurrent = ownValue === nextValue;
   current.set(nextCurrent, 'reason: tabs context sync => current');
   hidden.set(!nextCurrent, 'reason: tabs context sync => hidden');
+  focusEntry.setDisabled(!nextCurrent);
 }
 
 function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>): void {
@@ -21,6 +24,13 @@ function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>):
   const hidden = def.state.bool('hidden', true);
   const contentId = def.state.string('contentId', '');
   const triggerId = def.state.string('triggerId', '');
+  // P-BASE-TABS-CONTENT-FOCUS-ENTRY
+  const focusEntry = asFocusEntry<TabsContentProps>();
+  focusEntry.configure({
+    strategy: 'descendant-first',
+    fallback: 'self',
+    disabled: true,
+  });
 
   def.props.define({
     value: { type: 'string', empty: 'fallback' },
@@ -52,7 +62,7 @@ function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>):
   const syncContext = (next: TabsContextValue) => {
     rootId = next.rootId;
     syncIds();
-    syncCurrentFromContext(next.value, ownValue, current, hidden);
+    syncCurrentFromContext(next.value, ownValue, current, hidden, focusEntry);
   };
 
   def.context.subscribe(TABS_CONTEXT, (_run, next) => {

--- a/packages/prototypes/base/src/tabs/content.ts
+++ b/packages/prototypes/base/src/tabs/content.ts
@@ -1,18 +1,26 @@
 import { defineAsHook, definePrototype, tw, type DefHandle } from '@proto.ui/core';
-import { TABS_CONTEXT, TABS_FAMILY } from './shared';
+import { createTabsPartId, TABS_CONTEXT, TABS_FAMILY, type TabsContextValue } from './shared';
 import type { TabsContentAsHookContract, TabsContentExposes, TabsContentProps } from './types';
 
 function syncCurrentFromContext(
   nextValue: string,
   ownValue: string,
-  current: { set(value: boolean, reason?: string): void }
+  current: { set(value: boolean, reason?: string): void },
+  hidden: { set(value: boolean, reason?: string): void }
 ): void {
-  current.set(ownValue === nextValue, 'reason: tabs context sync => current');
+  const nextCurrent = ownValue === nextValue;
+  current.set(nextCurrent, 'reason: tabs context sync => current');
+  hidden.set(!nextCurrent, 'reason: tabs context sync => hidden');
 }
 
 function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>): void {
+  // P-BASE-TABS-CONTENT-CLAIM-ROLE, P-BASE-TABS-CONTENT-SAME-DOMAIN
   def.anatomy.claim(TABS_FAMILY, { role: 'content' });
-  const current = def.state.fromAccessibility('current');
+  // P-BASE-TABS-CONTENT-CURRENT-DERIVED
+  const current = def.state.bool('current', false);
+  const hidden = def.state.bool('hidden', true);
+  const contentId = def.state.string('contentId', '');
+  const triggerId = def.state.string('triggerId', '');
 
   def.props.define({
     value: { type: 'string', empty: 'fallback' },
@@ -22,26 +30,51 @@ function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>):
   });
 
   let ownValue = '';
+  let rootId = '';
   def.expose.state('current', current);
+  def.expose.state('hidden', hidden);
+
+  // P-BASE-TABS-CONTENT-A11Y-ROLE, P-BASE-TABS-CONTENT-A11Y-LABELLEDBY-TARGET
+  // P-BASE-TABS-CONTENT-HIDDEN-WHEN-INACTIVE
+  def.a11y.id(contentId);
+  def.a11y.role('tabpanel');
+  def.a11y.state('hidden', hidden);
+  def.a11y.relation('labelledBy', { target: triggerId });
+
+  const syncIds = () => {
+    contentId.set(createTabsPartId(rootId, 'content', ownValue), 'reason: tabs content id sync');
+    triggerId.set(
+      createTabsPartId(rootId, 'trigger', ownValue),
+      'reason: tabs content relation sync'
+    );
+  };
+
+  const syncContext = (next: TabsContextValue) => {
+    rootId = next.rootId;
+    syncIds();
+    syncCurrentFromContext(next.value, ownValue, current, hidden);
+  };
 
   def.context.subscribe(TABS_CONTEXT, (_run, next) => {
-    syncCurrentFromContext(next.value, ownValue, current);
+    syncContext(next);
   });
 
   def.lifecycle.onMounted((run) => {
     ownValue = run.props.get().value ?? '';
-    const ctx = run.context.read(TABS_CONTEXT);
-    syncCurrentFromContext(ctx.value, ownValue, current);
+    syncContext(run.context.read(TABS_CONTEXT));
   });
 
   def.props.watch(['value'], (run, next) => {
     ownValue = next.value ?? '';
-    const ctx = run.context.read(TABS_CONTEXT);
-    syncCurrentFromContext(ctx.value, ownValue, current);
+    syncContext(run.context.read(TABS_CONTEXT));
   });
 
+  // TODO(P-BASE-TABS-CONTENT-HIDDEN-WHEN-INACTIVE): Web currently also receives
+  // a host hidden attribute from a11y state projection; this style fallback
+  // keeps current feedback-style demos stable until hidden is modeled as a
+  // dedicated host capability outside a11y.
   def.rule({
-    when: (w) => w.state(current).eq(false),
+    when: (w) => w.state(hidden).eq(true),
     intent: (i) => i.feedback.style.use(tw('hidden')),
   });
 }

--- a/packages/prototypes/base/src/tabs/index.ts
+++ b/packages/prototypes/base/src/tabs/index.ts
@@ -14,6 +14,10 @@ export type {
   TabsContentExposes,
   TabsContentStateHandles,
   TabsContentAsHookContract,
+  TabsIndicatorProps,
+  TabsIndicatorExposes,
+  TabsIndicatorStateHandles,
+  TabsIndicatorAsHookContract,
 } from './types';
 export type { TabsActivationMode, TabsContextValue, TabsOrientation } from './shared';
 
@@ -22,3 +26,4 @@ export { asTabsRoot, default as tabsRoot } from './root';
 export { asTabsList, default as tabsList } from './list';
 export { asTabsTrigger, default as tabsTrigger } from './trigger';
 export { asTabsContent, default as tabsContent } from './content';
+export { asTabsIndicator, default as tabsIndicator } from './indicator';

--- a/packages/prototypes/base/src/tabs/indicator.ts
+++ b/packages/prototypes/base/src/tabs/indicator.ts
@@ -1,0 +1,70 @@
+import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
+import { TABS_CONTEXT, TABS_FAMILY, type TabsContextValue } from './shared';
+import type {
+  TabsIndicatorAsHookContract,
+  TabsIndicatorExposes,
+  TabsIndicatorProps,
+} from './types';
+
+function setupTabsIndicator(def: DefHandle<TabsIndicatorProps, TabsIndicatorExposes>): void {
+  // P-BASE-TABS-INDICATOR-ROLE-INDICATOR, P-BASE-TABS-INDICATOR-CLAIM-ROLE
+  // P-BASE-TABS-INDICATOR-SAME-DOMAIN
+  def.anatomy.claim(TABS_FAMILY, { role: 'indicator' });
+
+  // P-BASE-TABS-INDICATOR-DERIVED-VALUE, P-BASE-TABS-INDICATOR-DERIVED-ACTIVE-VALUE
+  const value = def.state.string('value', '');
+  const activeValue = def.state.string('activeValue', '');
+  const orientation = def.state.string('orientation', 'horizontal', {
+    options: ['horizontal', 'vertical'],
+  });
+
+  def.expose.state('value', value);
+  def.expose.state('activeValue', activeValue);
+  def.expose.state('orientation', orientation);
+
+  const syncContext = (next: TabsContextValue) => {
+    value.set(next.value ?? '', 'reason: tabs indicator context value sync');
+    activeValue.set(next.activeValue ?? '', 'reason: tabs indicator context active value sync');
+    orientation.set(
+      next.orientation ?? 'horizontal',
+      'reason: tabs indicator context orientation sync'
+    );
+  };
+
+  // P-BASE-TABS-INDICATOR-CONTEXT-CONSUME
+  def.context.subscribe(TABS_CONTEXT, (_run, next) => {
+    syncContext(next);
+  });
+
+  def.lifecycle.onMounted((run) => {
+    syncContext(run.context.read(TABS_CONTEXT));
+  });
+}
+
+/*
+ * P-BASE-TABS-INDICATOR criteria outside Tabs-indicator-internal prototype syntax:
+ * - P-BASE-TABS-INDICATOR-NO-SELECTION-OWNER: absence of value props and valueChange is the implementation.
+ * - P-BASE-TABS-INDICATOR-NO-EVENT-TARGET: absence of def.event usage is the implementation.
+ * - P-BASE-TABS-INDICATOR-NO-FOCUS-TARGET: absence of asFocusable/focusSelf is the implementation.
+ * - P-BASE-TABS-INDICATOR-PRESENTATIONAL-A11Y: absence of def.a11y control syntax is the implementation.
+ * - P-BASE-TABS-INDICATOR-NO-LAYOUT-MEASUREMENT: layout measurement is deferred to downstream styled prototypes.
+ * - P-BASE-TABS-INDICATOR-NO-AUTO-POSITIONING: no position or transform props are accepted.
+ * - P-BASE-TABS-INDICATOR-NO-VISUAL-VARIANT-CORE: visual parameters are owned by downstream styled prototypes.
+ */
+
+// P-BASE-TABS-INDICATOR-AUTHORING-ENTRIES
+export const asTabsIndicator = defineAsHook<
+  TabsIndicatorProps,
+  TabsIndicatorExposes,
+  TabsIndicatorAsHookContract
+>({
+  name: 'as-tabs-indicator',
+  setup: setupTabsIndicator,
+});
+
+const tabsIndicator = definePrototype({
+  name: 'base-tabs-indicator',
+  setup: setupTabsIndicator,
+});
+
+export default tabsIndicator;

--- a/packages/prototypes/base/src/tabs/list.ts
+++ b/packages/prototypes/base/src/tabs/list.ts
@@ -5,6 +5,7 @@ import { TABS_CONTEXT, TABS_FAMILY } from './shared';
 import type { TabsListAsHookContract, TabsListExposes, TabsListProps } from './types';
 
 function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
+  // P-BASE-TABS-LIST-CLAIM-ROLE, P-BASE-TABS-LIST-SAME-DOMAIN
   def.anatomy.claim(TABS_FAMILY, { role: 'list' });
   let activeValue = '';
   let selectedValue = '';
@@ -17,6 +18,13 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
     orientation: 'horizontal',
     loop: false,
   });
+
+  const orientation = def.state.string('orientation', 'horizontal', {
+    options: ['horizontal', 'vertical'],
+  });
+  // P-BASE-TABS-LIST-A11Y-ROLE, P-BASE-TABS-LIST-A11Y-ORIENTATION
+  def.a11y.role('tablist');
+  def.a11y.state('orientation', orientation);
 
   const focusRoving = asFocusRoving<TabsListProps>();
   focusRoving.configure({
@@ -41,12 +49,14 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   def.context.subscribe(TABS_CONTEXT, (_run, next) => {
     activeValue = next.activeValue ?? '';
     selectedValue = next.value ?? '';
+    orientation.set(next.orientation ?? 'horizontal', 'reason: tabs list context orientation sync');
   });
 
   def.lifecycle.onMounted((run) => {
     const ctx = run.context.read(TABS_CONTEXT);
     activeValue = ctx.activeValue ?? '';
     selectedValue = ctx.value ?? '';
+    orientation.set(ctx.orientation ?? 'horizontal', 'reason: tabs list mounted orientation sync');
   });
 
   def.lifecycle.onUnmounted(() => {

--- a/packages/prototypes/base/src/tabs/list.ts
+++ b/packages/prototypes/base/src/tabs/list.ts
@@ -13,17 +13,21 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   def.props.define({
     orientation: { type: 'enum', empty: 'fallback', options: ['horizontal', 'vertical'] },
     loop: { type: 'boolean', empty: 'fallback' },
+    a11yLabel: { type: 'string', empty: 'fallback' },
   });
   def.props.setDefaults({
     orientation: 'horizontal',
     loop: false,
+    a11yLabel: '',
   });
 
   const orientation = def.state.string('orientation', 'horizontal', {
     options: ['horizontal', 'vertical'],
   });
+  const a11yLabel = def.state.string('a11yLabel', '');
   // P-BASE-TABS-LIST-A11Y-ROLE, P-BASE-TABS-LIST-A11Y-ORIENTATION
   def.a11y.role('tablist');
+  def.a11y.name(a11yLabel);
   def.a11y.state('orientation', orientation);
 
   const focusRoving = asFocusRoving<TabsListProps>();
@@ -57,6 +61,11 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
     activeValue = ctx.activeValue ?? '';
     selectedValue = ctx.value ?? '';
     orientation.set(ctx.orientation ?? 'horizontal', 'reason: tabs list mounted orientation sync');
+    a11yLabel.set(run.props.get().a11yLabel ?? '', 'reason: tabs list mounted a11y label sync');
+  });
+
+  def.props.watch(['a11yLabel'], (_run, next) => {
+    a11yLabel.set(next.a11yLabel ?? '', 'reason: tabs list props a11y label sync');
   });
 
   def.lifecycle.onUnmounted(() => {

--- a/packages/prototypes/base/src/tabs/root.ts
+++ b/packages/prototypes/base/src/tabs/root.ts
@@ -1,9 +1,46 @@
-import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
+import { defineAsHook, definePrototype, type DefHandle, type RunHandle } from '@proto.ui/core';
 import { useCollection } from '@proto.ui/hooks';
 import { createTabsRootId, TABS_CONTEXT, TABS_FAMILY } from './shared';
 import type { TabsRootAsHookContract, TabsRootExposes, TabsRootProps } from './types';
 
+type TriggerSnapshot = {
+  value?: unknown;
+  disabled?: unknown;
+};
+
+function readTriggerSnapshot(part: { getExpose(key: string): unknown | null }): TriggerSnapshot {
+  const exposed = part.getExpose('__collectionItem');
+  const disabledExpose = part.getExpose('disabled');
+  const disabled =
+    disabledExpose &&
+    typeof disabledExpose === 'object' &&
+    typeof (disabledExpose as { get?: unknown }).get === 'function'
+      ? (disabledExpose as { get(): unknown }).get()
+      : undefined;
+  const withLiveDisabled = (snapshot: TriggerSnapshot): TriggerSnapshot =>
+    typeof disabled === 'undefined' ? snapshot : { ...snapshot, disabled };
+  if (typeof exposed === 'function') {
+    const next = exposed();
+    return next && typeof next === 'object' ? withLiveDisabled(next as TriggerSnapshot) : {};
+  }
+  return exposed && typeof exposed === 'object' ? withLiveDisabled(exposed as TriggerSnapshot) : {};
+}
+
+function getEnabledTriggerValues(run: RunHandle<TabsRootProps>): string[] {
+  return run.anatomy.order
+    .partsOf(TABS_FAMILY, 'trigger')
+    .map(readTriggerSnapshot)
+    .filter((snapshot) => typeof snapshot.value === 'string' && snapshot.value)
+    .filter((snapshot) => snapshot.disabled !== true)
+    .map((snapshot) => snapshot.value as string);
+}
+
+function hasEnabledTriggerValue(run: RunHandle<TabsRootProps>, target: string): boolean {
+  return getEnabledTriggerValues(run).includes(target);
+}
+
 function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
+  // P-BASE-TABS-ANATOMY-FAMILY, P-BASE-TABS-ROOT-SEMANTIC-OWNER
   def.anatomy.claim(TABS_FAMILY, { role: 'root' });
   useCollection({ family: TABS_FAMILY, itemRole: 'trigger' });
 
@@ -19,6 +56,7 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
     activationMode: 'automatic',
   });
 
+  // P-BASE-TABS-VALUE-EXPOSE, P-BASE-TABS-CONTEXT-VALUE
   def.context.provide(TABS_CONTEXT, {
     rootId: '',
     value: '',
@@ -28,6 +66,7 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
     controlled: false,
     requestedValue: '',
     requestVersion: 0,
+    validationVersion: 0,
   });
   const value = def.state.string('value', '');
   const rootId = createTabsRootId();
@@ -36,9 +75,57 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
   let controlled = false;
   let activeValue = '';
   let lastRequestVersion = 0;
+  let lastValidationVersion = 0;
 
   def.expose.state('value', value);
   def.expose.event('valueChange', { payload: 'json' });
+
+  const resolveSelection = (run: RunHandle<TabsRootProps>, candidate: string): string => {
+    if (candidate && hasEnabledTriggerValue(run, candidate)) return candidate;
+    const fallback = getEnabledTriggerValues(run)[0];
+    return fallback ?? candidate ?? '';
+  };
+
+  const publishContext = (run: RunHandle<TabsRootProps>) => {
+    const next = {
+      rootId,
+      value: value.get(),
+      activeValue,
+      orientation: currentOrientation,
+      activationMode: currentActivationMode,
+      controlled,
+      requestedValue: '',
+      requestVersion: lastRequestVersion,
+      validationVersion: lastValidationVersion,
+    };
+    const current = run.context.read(TABS_CONTEXT);
+    if (
+      current.rootId === next.rootId &&
+      current.value === next.value &&
+      current.activeValue === next.activeValue &&
+      current.orientation === next.orientation &&
+      current.activationMode === next.activationMode &&
+      current.controlled === next.controlled &&
+      current.requestedValue === next.requestedValue &&
+      current.requestVersion === next.requestVersion &&
+      current.validationVersion === next.validationVersion
+    ) {
+      return;
+    }
+    run.context.update(TABS_CONTEXT, next);
+  };
+
+  const validateSelection = (run: RunHandle<TabsRootProps>, reason: string) => {
+    const currentValue = value.get();
+    const nextValue = controlled ? currentValue : resolveSelection(run, currentValue);
+    if (!controlled && nextValue !== currentValue) {
+      value.set(nextValue, reason);
+    }
+    if (!activeValue || !hasEnabledTriggerValue(run, activeValue)) {
+      activeValue = nextValue;
+    }
+    publishContext(run);
+  };
 
   def.context.subscribe(TABS_CONTEXT, (run, next) => {
     activeValue = next.activeValue ?? '';
@@ -49,19 +136,21 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
         value.set(requestedValue, 'reason: tabs value request => uncontrolled value sync');
       }
       run.expose.emit('valueChange', { value: requestedValue });
-      run.context.update(TABS_CONTEXT, {
-        ...next,
-        rootId,
-        value: value.get(),
-        activeValue: requestedValue,
-        orientation: currentOrientation,
-        activationMode: currentActivationMode,
-        controlled,
-      });
+      validateSelection(run, 'reason: tabs value request => uncontrolled fallback sync');
       return;
     }
-    if (controlled) return;
-    value.set(next.value, 'reason: context.subscribe => uncontrolled tabs value sync');
+    if (next.validationVersion !== lastValidationVersion) {
+      lastValidationVersion = next.validationVersion;
+      if (!controlled && next.value !== value.get()) {
+        value.set(next.value, 'reason: tabs part validation request => value sync');
+      }
+      validateSelection(run, 'reason: tabs part validation request => selection fallback');
+      return;
+    }
+    if (!controlled && next.value !== value.get()) {
+      value.set(next.value, 'reason: context.subscribe => uncontrolled tabs value sync');
+    }
+    validateSelection(run, 'reason: tabs context notification => selection fallback');
   });
 
   def.lifecycle.onCreated((run) => {
@@ -73,16 +162,12 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
     currentActivationMode = run.props.get().activationMode ?? 'automatic';
     value.set(initialValue, 'reason: lifecycle.onCreated => initialize tabs value');
     activeValue = initialValue;
-    run.context.update(TABS_CONTEXT, {
-      rootId,
-      value: value.get(),
-      activeValue,
-      orientation: currentOrientation,
-      activationMode: currentActivationMode,
-      controlled,
-      requestedValue: '',
-      requestVersion: lastRequestVersion,
-    });
+    lastValidationVersion = 0;
+    publishContext(run);
+  });
+
+  def.lifecycle.onMounted((run) => {
+    validateSelection(run, 'reason: lifecycle.onMounted => tabs selection fallback');
   });
 
   def.props.watch(['value', 'orientation', 'activationMode'], (run, next) => {
@@ -92,16 +177,7 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
     }
     currentOrientation = next.orientation ?? 'horizontal';
     currentActivationMode = next.activationMode ?? 'automatic';
-    run.context.update(TABS_CONTEXT, {
-      rootId,
-      value: value.get(),
-      activeValue,
-      orientation: currentOrientation,
-      activationMode: currentActivationMode,
-      controlled,
-      requestedValue: '',
-      requestVersion: lastRequestVersion,
-    });
+    validateSelection(run, 'reason: props.watch => tabs selection fallback');
   });
 }
 

--- a/packages/prototypes/base/src/tabs/root.ts
+++ b/packages/prototypes/base/src/tabs/root.ts
@@ -1,6 +1,6 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { useCollection } from '@proto.ui/hooks';
-import { TABS_CONTEXT, TABS_FAMILY } from './shared';
+import { createTabsRootId, TABS_CONTEXT, TABS_FAMILY } from './shared';
 import type { TabsRootAsHookContract, TabsRootExposes, TabsRootProps } from './types';
 
 function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
@@ -20,22 +20,46 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
   });
 
   def.context.provide(TABS_CONTEXT, {
+    rootId: '',
     value: '',
     activeValue: '',
     orientation: 'horizontal',
     activationMode: 'automatic',
     controlled: false,
+    requestedValue: '',
+    requestVersion: 0,
   });
   const value = def.state.string('value', '');
+  const rootId = createTabsRootId();
   let currentOrientation: 'horizontal' | 'vertical' = 'horizontal';
   let currentActivationMode: 'automatic' | 'manual' = 'automatic';
   let controlled = false;
   let activeValue = '';
+  let lastRequestVersion = 0;
 
   def.expose.state('value', value);
+  def.expose.event('valueChange', { payload: 'json' });
 
-  def.context.subscribe(TABS_CONTEXT, (_run, next) => {
+  def.context.subscribe(TABS_CONTEXT, (run, next) => {
     activeValue = next.activeValue ?? '';
+    if (next.requestVersion !== lastRequestVersion) {
+      lastRequestVersion = next.requestVersion;
+      const requestedValue = next.requestedValue ?? '';
+      if (!controlled) {
+        value.set(requestedValue, 'reason: tabs value request => uncontrolled value sync');
+      }
+      run.expose.emit('valueChange', { value: requestedValue });
+      run.context.update(TABS_CONTEXT, {
+        ...next,
+        rootId,
+        value: value.get(),
+        activeValue: requestedValue,
+        orientation: currentOrientation,
+        activationMode: currentActivationMode,
+        controlled,
+      });
+      return;
+    }
     if (controlled) return;
     value.set(next.value, 'reason: context.subscribe => uncontrolled tabs value sync');
   });
@@ -50,11 +74,14 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
     value.set(initialValue, 'reason: lifecycle.onCreated => initialize tabs value');
     activeValue = initialValue;
     run.context.update(TABS_CONTEXT, {
+      rootId,
       value: value.get(),
       activeValue,
       orientation: currentOrientation,
       activationMode: currentActivationMode,
       controlled,
+      requestedValue: '',
+      requestVersion: lastRequestVersion,
     });
   });
 
@@ -66,11 +93,14 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
     currentOrientation = next.orientation ?? 'horizontal';
     currentActivationMode = next.activationMode ?? 'automatic';
     run.context.update(TABS_CONTEXT, {
+      rootId,
       value: value.get(),
       activeValue,
       orientation: currentOrientation,
       activationMode: currentActivationMode,
       controlled,
+      requestedValue: '',
+      requestVersion: lastRequestVersion,
     });
   });
 }

--- a/packages/prototypes/base/src/tabs/shared.ts
+++ b/packages/prototypes/base/src/tabs/shared.ts
@@ -12,6 +12,7 @@ export type TabsContextValue = {
   controlled: boolean;
   requestedValue: string;
   requestVersion: number;
+  validationVersion: number;
 };
 
 let nextTabsRootId = 0;

--- a/packages/prototypes/base/src/tabs/shared.ts
+++ b/packages/prototypes/base/src/tabs/shared.ts
@@ -4,12 +4,32 @@ export type TabsOrientation = 'horizontal' | 'vertical';
 export type TabsActivationMode = 'automatic' | 'manual';
 
 export type TabsContextValue = {
+  rootId: string;
   value: string;
   activeValue: string;
   orientation: TabsOrientation;
   activationMode: TabsActivationMode;
   controlled: boolean;
+  requestedValue: string;
+  requestVersion: number;
 };
+
+let nextTabsRootId = 0;
+
+export function createTabsRootId(): string {
+  nextTabsRootId += 1;
+  return `pui-tabs-${nextTabsRootId}`;
+}
+
+export function createTabsPartId(
+  rootId: string,
+  role: 'trigger' | 'content',
+  value: string
+): string {
+  const normalizedValue = value.trim() ? value.trim() : 'empty';
+  const safeValue = normalizedValue.replace(/[^a-zA-Z0-9_-]+/g, '-');
+  return `${rootId || 'pui-tabs'}-${role}-${safeValue}`;
+}
 
 export const TABS_FAMILY = createAnatomyFamily('base-tabs', {
   roles: {
@@ -17,11 +37,13 @@ export const TABS_FAMILY = createAnatomyFamily('base-tabs', {
     list: { cardinality: { min: 0, max: 1 } },
     trigger: { cardinality: { min: 0, max: 100 } },
     content: { cardinality: { min: 0, max: 100 } },
+    indicator: { cardinality: { min: 0, max: '*' } },
   },
   relations: [
     { kind: 'contains', parent: 'root', child: 'list' },
     { kind: 'contains', parent: 'list', child: 'trigger' },
     { kind: 'contains', parent: 'root', child: 'content' },
+    { kind: 'contains', parent: 'root', child: 'indicator' },
   ],
 });
 export const TABS_CONTEXT = createContextKey<TabsContextValue>('base-tabs');

--- a/packages/prototypes/base/src/tabs/trigger.ts
+++ b/packages/prototypes/base/src/tabs/trigger.ts
@@ -11,6 +11,17 @@ function syncSelectedFromContext(
   selected.set(ownValue === nextValue, 'reason: tabs context sync => selected');
 }
 
+function syncNavParticipationFromContext(
+  ctx: TabsContextValue,
+  ownValue: string,
+  disabled: { get(): boolean },
+  focusable: { setNavParticipation(value: 'auto' | 'none'): void }
+): void {
+  const activeValue = ctx.activeValue || ctx.value;
+  const participates = !!ownValue && ownValue === activeValue && !disabled.get();
+  focusable.setNavParticipation(participates ? 'auto' : 'none');
+}
+
 function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>): void {
   // P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY
   // P-BASE-TABS-TRIGGER-ACTIVATION-REQUESTS-SELECTION
@@ -113,6 +124,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
     rootId = next.rootId;
     syncIds();
     syncSelectedFromContext(next.value, ownValue, selected);
+    syncNavParticipationFromContext(next, ownValue, disabled, focusable);
   });
 
   def.lifecycle.onCreated((run) => {
@@ -125,6 +137,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
     rootId = ctx.rootId;
     syncIds();
     syncSelectedFromContext(ctx.value, ownValue, selected);
+    syncNavParticipationFromContext(ctx, ownValue, disabled, focusable);
   });
 
   def.props.watch(['value'], (run, next) => {
@@ -133,10 +146,12 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
     rootId = ctx.rootId;
     syncIds();
     syncSelectedFromContext(ctx.value, ownValue, selected);
+    syncNavParticipationFromContext(ctx, ownValue, disabled, focusable);
   });
 
-  def.props.watch(['disabled'], (_run, next) => {
+  def.props.watch(['disabled'], (run, next) => {
     syncDisabled(!!next.disabled);
+    syncNavParticipationFromContext(run.context.read(TABS_CONTEXT), ownValue, disabled, focusable);
   });
 
   const updateActiveValue = (run: any) => {

--- a/packages/prototypes/base/src/tabs/trigger.ts
+++ b/packages/prototypes/base/src/tabs/trigger.ts
@@ -22,6 +22,40 @@ function syncNavParticipationFromContext(
   focusable.setNavParticipation(participates ? 'auto' : 'none');
 }
 
+function readTriggerSnapshot(part: { getExpose(key: string): unknown | null }) {
+  const exposed = part.getExpose('__collectionItem');
+  const snapshot =
+    typeof exposed === 'function'
+      ? exposed()
+      : exposed && typeof exposed === 'object'
+        ? exposed
+        : {};
+  const disabledExpose = part.getExpose('disabled');
+  const disabled =
+    disabledExpose &&
+    typeof disabledExpose === 'object' &&
+    typeof (disabledExpose as { get?: unknown }).get === 'function'
+      ? (disabledExpose as { get(): unknown }).get()
+      : undefined;
+  return {
+    ...((snapshot && typeof snapshot === 'object' ? snapshot : {}) as Record<string, unknown>),
+    ...(typeof disabled === 'undefined' ? {} : { disabled }),
+  };
+}
+
+function resolveEnabledTriggerValue(run: any, candidate: string): string {
+  const values = run.anatomy.order
+    .partsOf(TABS_FAMILY, 'trigger')
+    .map(readTriggerSnapshot)
+    .filter(
+      (snapshot: Record<string, unknown>) => typeof snapshot.value === 'string' && snapshot.value
+    )
+    .filter((snapshot: Record<string, unknown>) => snapshot.disabled !== true)
+    .map((snapshot: Record<string, unknown>) => snapshot.value as string);
+  if (candidate && values.includes(candidate)) return candidate;
+  return values[0] ?? candidate ?? '';
+}
+
 function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>): void {
   // P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY
   // P-BASE-TABS-TRIGGER-ACTIVATION-REQUESTS-SELECTION
@@ -138,6 +172,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
     syncIds();
     syncSelectedFromContext(ctx.value, ownValue, selected);
     syncNavParticipationFromContext(ctx, ownValue, disabled, focusable);
+    notifyRootToValidateSelection(run);
   });
 
   def.props.watch(['value'], (run, next) => {
@@ -147,11 +182,13 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
     syncIds();
     syncSelectedFromContext(ctx.value, ownValue, selected);
     syncNavParticipationFromContext(ctx, ownValue, disabled, focusable);
+    notifyRootToValidateSelection(run);
   });
 
   def.props.watch(['disabled'], (run, next) => {
     syncDisabled(!!next.disabled);
     syncNavParticipationFromContext(run.context.read(TABS_CONTEXT), ownValue, disabled, focusable);
+    notifyRootToValidateSelection(run);
   });
 
   const updateActiveValue = (run: any) => {
@@ -160,6 +197,15 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
       if (prev.activeValue === nextValue) return prev;
       return { ...prev, activeValue: nextValue };
     });
+  };
+
+  const notifyRootToValidateSelection = (run: any) => {
+    run.context.update(TABS_CONTEXT, (prev: TabsContextValue) => ({
+      ...prev,
+      value: prev.controlled ? prev.value : resolveEnabledTriggerValue(run, prev.value ?? ''),
+      activeValue: resolveEnabledTriggerValue(run, prev.activeValue || prev.value || ''),
+      validationVersion: (prev.validationVersion ?? 0) + 1,
+    }));
   };
 
   def.event.on('press.commit', (run) => {

--- a/packages/prototypes/base/src/tabs/trigger.ts
+++ b/packages/prototypes/base/src/tabs/trigger.ts
@@ -1,7 +1,6 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asFocusable, useCollectionItem } from '@proto.ui/hooks';
-import { asButton } from '../button';
-import { TABS_CONTEXT, TABS_FAMILY } from './shared';
+import { asFocusable, asTrigger, useCollectionItem } from '@proto.ui/hooks';
+import { createTabsPartId, TABS_CONTEXT, TABS_FAMILY, type TabsContextValue } from './shared';
 import type { TabsTriggerAsHookContract, TabsTriggerExposes, TabsTriggerProps } from './types';
 
 function syncSelectedFromContext(
@@ -13,10 +12,23 @@ function syncSelectedFromContext(
 }
 
 function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>): void {
-  asButton();
+  // P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY
+  // P-BASE-TABS-TRIGGER-ACTIVATION-REQUESTS-SELECTION
+  asTrigger();
+  // P-BASE-TABS-TRIGGER-FOCUSABLE
   const focusable = asFocusable<TabsTriggerProps>();
+  focusable.configure({ disabled: false });
   const focused = focusable.focused;
-  const selected = def.state.fromAccessibility('selected');
+  const focusVisible = focusable.focusVisible;
+  // P-BASE-TABS-TRIGGER-SELECTED-DERIVED, P-BASE-TABS-TRIGGER-SELECTED-EXPOSE
+  const selected = def.state.bool('selected', false);
+  const disabled = def.state.bool('disabled', false);
+  const hovered = def.state.bool('hovered', false);
+  const pressed = def.state.bool('pressed', false);
+  const triggerId = def.state.string('triggerId', '');
+  const contentId = def.state.string('contentId', '');
+
+  // P-BASE-TABS-TRIGGER-CLAIM-ROLE, P-BASE-TABS-TRIGGER-SAME-DOMAIN
   useCollectionItem({
     family: TABS_FAMILY,
     role: 'trigger',
@@ -38,24 +50,93 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
     disabled: false,
   });
 
-  const disabled = def.state.fromInteraction('disabled');
   let ownValue = '';
+  let rootId = '';
+
+  def.expose.state('disabled', disabled);
+  def.expose.state('hovered', hovered);
+  def.expose.state('focused', focused);
+  def.expose.state('focusVisible', focusVisible);
+  def.expose.state('pressed', pressed);
   def.expose.state('selected', selected);
+  def.expose.method('focusSelf', (options) => {
+    if (disabled.get()) return;
+    focusable.focusSelf(options);
+  });
+  def.expose.event('click', { payload: 'void' });
+
+  // P-BASE-TABS-TRIGGER-A11Y-ROLE, P-BASE-TABS-TRIGGER-A11Y-SELECTED
+  // P-BASE-TABS-TRIGGER-A11Y-CONTROLS-TARGET
+  def.a11y.id(triggerId);
+  def.a11y.role('tab');
+  def.a11y.nameFromContent();
+  def.a11y.state('selected', selected);
+  def.a11y.state('disabled', disabled);
+  def.a11y.relation('controls', { target: contentId });
+  def.a11y.action('activate', { event: 'click' });
+
+  const syncIds = () => {
+    triggerId.set(createTabsPartId(rootId, 'trigger', ownValue), 'reason: tabs trigger id sync');
+    contentId.set(
+      createTabsPartId(rootId, 'content', ownValue),
+      'reason: tabs trigger relation sync'
+    );
+  };
+
+  const syncDisabled = (nextDisabled: boolean) => {
+    disabled.set(nextDisabled, 'reason: tabs trigger sync disabled');
+    focusable.setDisabled(nextDisabled);
+    if (nextDisabled) {
+      hovered.set(false, 'reason: tabs trigger disabled => hovered');
+      pressed.set(false, 'reason: tabs trigger disabled => pressed');
+    }
+  };
+
+  const requestSelection = (run: any, ctx: TabsContextValue) => {
+    const nextValue = run.props.get().value ?? '';
+    run.context.update(TABS_CONTEXT, {
+      ...ctx,
+      activeValue: nextValue,
+    });
+    if (ctx.value === nextValue) return false;
+    run.context.update(TABS_CONTEXT, {
+      ...ctx,
+      value: ctx.controlled ? ctx.value : nextValue,
+      activeValue: nextValue,
+      requestedValue: nextValue,
+      requestVersion: ctx.requestVersion + 1,
+    });
+    return true;
+  };
 
   def.context.subscribe(TABS_CONTEXT, (_run, next) => {
+    rootId = next.rootId;
+    syncIds();
     syncSelectedFromContext(next.value, ownValue, selected);
+  });
+
+  def.lifecycle.onCreated((run) => {
+    syncDisabled(!!run.props.get().disabled);
   });
 
   def.lifecycle.onMounted((run) => {
     ownValue = run.props.get().value ?? '';
     const ctx = run.context.read(TABS_CONTEXT);
+    rootId = ctx.rootId;
+    syncIds();
     syncSelectedFromContext(ctx.value, ownValue, selected);
   });
 
   def.props.watch(['value'], (run, next) => {
     ownValue = next.value ?? '';
     const ctx = run.context.read(TABS_CONTEXT);
+    rootId = ctx.rootId;
+    syncIds();
     syncSelectedFromContext(ctx.value, ownValue, selected);
+  });
+
+  def.props.watch(['disabled'], (_run, next) => {
+    syncDisabled(!!next.disabled);
   });
 
   const updateActiveValue = (run: any) => {
@@ -67,12 +148,11 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   };
 
   def.event.on('press.commit', (run) => {
+    pressed.set(false, 'reason: tabs trigger press.commit => pressed');
     if (disabled.get()) return;
-    const nextValue = run.props.get().value ?? '';
     const ctx = run.context.read(TABS_CONTEXT);
-    updateActiveValue(run);
-    if (ctx.controlled) return;
-    run.context.update(TABS_CONTEXT, (prev) => ({ ...prev, value: nextValue }));
+    run.expose.emit('click');
+    requestSelection(run, ctx);
   });
 
   focused.watch((run, event) => {
@@ -81,10 +161,37 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
     const nextValue = run.props.get().value ?? '';
     const ctx = run.context.read(TABS_CONTEXT);
     updateActiveValue(run);
-    if (ctx.controlled) return;
     if (ctx.activationMode !== 'automatic') return;
     if (ctx.value === nextValue) return;
-    run.context.update(TABS_CONTEXT, (prev) => ({ ...prev, value: nextValue }));
+    requestSelection(run, ctx);
+  });
+
+  def.event.onGlobal('key.down', (_run, ev) => {
+    const detail = ev?.detail;
+    if (disabled.get()) return;
+    if (!focused.get()) return;
+    if (detail?.key !== ' ') return;
+    detail?.preventDefault?.();
+  });
+
+  def.event.on('pointer.enter', () => {
+    if (disabled.get()) return;
+    hovered.set(true, 'reason: tabs trigger pointer.enter => hovered');
+  });
+  def.event.on('pointer.leave', () => {
+    hovered.set(false, 'reason: tabs trigger pointer.leave => hovered');
+    pressed.set(false, 'reason: tabs trigger pointer.leave => pressed');
+  });
+  def.event.on('pointer.cancel', () => {
+    hovered.set(false, 'reason: tabs trigger pointer.cancel => hovered');
+    pressed.set(false, 'reason: tabs trigger pointer.cancel => pressed');
+  });
+  def.event.on('pointer.down', () => {
+    if (disabled.get()) return;
+    pressed.set(true, 'reason: tabs trigger pointer.down => pressed');
+  });
+  def.event.on('pointer.up', () => {
+    pressed.set(false, 'reason: tabs trigger pointer.up => pressed');
   });
 
   def.event.onGlobal('key.down', (run, ev) => {

--- a/packages/prototypes/base/src/tabs/types.ts
+++ b/packages/prototypes/base/src/tabs/types.ts
@@ -1,4 +1,4 @@
-import { ExposeEvent, ExposeMethod, ExposeState, State } from '@proto.ui/core';
+import { ExposeEvent, ExposeMethod, ExposeState, FocusRequestOptions, State } from '@proto.ui/core';
 import type { TabsActivationMode, TabsOrientation } from './shared';
 
 export interface TabsRootProps {
@@ -10,6 +10,7 @@ export interface TabsRootProps {
 
 export type TabsRootExposes = {
   value: ExposeState<string>;
+  valueChange: ExposeEvent<{ value: string }>;
 };
 
 export type TabsRootStateHandles = {
@@ -18,7 +19,9 @@ export type TabsRootStateHandles = {
 
 export type TabsRootAsHookContract = {
   state: TabsRootStateHandles;
-  event: {};
+  event: {
+    valueChange: { value: string };
+  };
 };
 
 export interface TabsListProps {
@@ -46,7 +49,7 @@ export type TabsTriggerExposes = {
   focusVisible: ExposeState<boolean>;
   pressed: ExposeState<boolean>;
   selected: ExposeState<boolean>;
-  focusSelf: ExposeMethod<() => void>;
+  focusSelf: ExposeMethod<(options?: FocusRequestOptions) => void>;
   click: ExposeEvent<void>;
 };
 
@@ -72,12 +75,32 @@ export interface TabsContentProps {
 
 export type TabsContentExposes = {
   current: ExposeState<boolean>;
+  hidden: ExposeState<boolean>;
 };
 
 export type TabsContentStateHandles = {
   current: State<boolean>;
+  hidden: State<boolean>;
 };
 
 export type TabsContentAsHookContract = {
   state: TabsContentStateHandles;
+};
+
+export interface TabsIndicatorProps {}
+
+export type TabsIndicatorExposes = {
+  value: ExposeState<string>;
+  activeValue: ExposeState<string>;
+  orientation: ExposeState<string>;
+};
+
+export type TabsIndicatorStateHandles = {
+  value: State<string>;
+  activeValue: State<string>;
+  orientation: State<string>;
+};
+
+export type TabsIndicatorAsHookContract = {
+  state: TabsIndicatorStateHandles;
 };

--- a/packages/prototypes/base/src/tabs/types.ts
+++ b/packages/prototypes/base/src/tabs/types.ts
@@ -27,6 +27,7 @@ export type TabsRootAsHookContract = {
 export interface TabsListProps {
   orientation?: TabsOrientation;
   loop?: boolean;
+  a11yLabel?: string;
 }
 
 export type TabsListExposes = {

--- a/packages/prototypes/base/test/tabs.test.ts
+++ b/packages/prototypes/base/test/tabs.test.ts
@@ -1,21 +1,52 @@
 import { describe, expect, it } from 'vitest';
-import { styleContains } from '../../test-utils/style';
 import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
-import { tabsContent, tabsList, tabsRoot, tabsTrigger } from '../src/tabs';
+import {
+  TABS_FAMILY,
+  tabsContent,
+  tabsIndicator,
+  tabsList,
+  tabsRoot,
+  tabsTrigger,
+} from '../src/tabs';
 
 AdaptToWebComponent(tabsRoot as any);
 AdaptToWebComponent(tabsList as any);
 AdaptToWebComponent(tabsTrigger as any);
 AdaptToWebComponent(tabsContent as any);
+AdaptToWebComponent(tabsIndicator as any);
 
 describe('prototypes/base: tabs', () => {
+  it('declares tabs anatomy family including optional indicator', () => {
+    // T-BASE-TABS-0001-CASE-ANATOMY-FAMILY
+    expect(TABS_FAMILY.debugName).toBe('base-tabs');
+    expect(TABS_FAMILY.decl.roles.root.cardinality).toEqual({ min: 1, max: 1 });
+    expect(TABS_FAMILY.decl.roles.list.cardinality).toEqual({ min: 0, max: 1 });
+    expect(TABS_FAMILY.decl.roles.trigger.cardinality).toEqual({ min: 0, max: 100 });
+    expect(TABS_FAMILY.decl.roles.content.cardinality).toEqual({ min: 0, max: 100 });
+    expect(TABS_FAMILY.decl.roles.indicator.cardinality).toEqual({ min: 0, max: '*' });
+    expect(TABS_FAMILY.decl.relations).toEqual([
+      { kind: 'contains', parent: 'root', child: 'list' },
+      { kind: 'contains', parent: 'list', child: 'trigger' },
+      { kind: 'contains', parent: 'root', child: 'content' },
+      { kind: 'contains', parent: 'root', child: 'indicator' },
+    ]);
+  });
+
   it('tabs root, trigger, and content stay in sync in uncontrolled mode', async () => {
+    // T-BASE-TABS-0001-CASE-UNCONTROLLED-VALUE-CHANGE
+    // T-BASE-TABS-TRIGGER-0001-CASE-SELECTION
+    // T-BASE-TABS-CONTENT-0001-CASE-HIDDEN
+    // T-BASE-TABS-0001-CASE-A11Y-RELATIONS
     const root = document.createElement('base-tabs-root') as any;
     const list = document.createElement('base-tabs-list') as any;
     const triggerA = document.createElement('base-tabs-trigger') as any;
     const triggerB = document.createElement('base-tabs-trigger') as any;
     const contentA = document.createElement('base-tabs-content') as any;
     const contentB = document.createElement('base-tabs-content') as any;
+    const valueChanges: Array<{ value: string }> = [];
+    root.addEventListener('valueChange', (event: Event) => {
+      valueChanges.push((event as CustomEvent).detail);
+    });
 
     setElementProps(root, { defaultValue: 'a' });
     setElementProps(triggerA, { value: 'a' });
@@ -38,24 +69,38 @@ describe('prototypes/base: tabs', () => {
     expect(triggerB.getExposes().selected.get()).toBe(false);
     expect(contentA.getExposes().current.get()).toBe(true);
     expect(contentB.getExposes().current.get()).toBe(false);
-    expect(styleContains(contentA, 'hidden')).toBe(false);
-    expect(styleContains(contentB, 'hidden')).toBe(true);
+    expect(contentA.getExposes().hidden.get()).toBe(false);
+    expect(contentB.getExposes().hidden.get()).toBe(true);
+    expect(contentA.hasAttribute('hidden')).toBe(false);
+    expect(contentB.hasAttribute('hidden')).toBe(true);
+    expect(list.getAttribute('role')).toBe('tablist');
+    expect(list.getAttribute('aria-orientation')).toBe('horizontal');
+    expect(triggerA.getAttribute('role')).toBe('tab');
+    expect(triggerA.getAttribute('aria-selected')).toBe('true');
+    expect(triggerB.getAttribute('aria-selected')).toBe('false');
+    expect(contentA.getAttribute('role')).toBe('tabpanel');
+    expect(triggerA.getAttribute('aria-controls')).toBe(contentA.getAttribute('id'));
+    expect(contentA.getAttribute('aria-labelledby')).toBe(triggerA.getAttribute('id'));
 
     triggerB.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
     expect(root.getExposes().value.get()).toBe('b');
+    expect(valueChanges).toEqual([{ value: 'b' }]);
     expect(triggerA.getExposes().selected.get()).toBe(false);
     expect(triggerB.getExposes().selected.get()).toBe(true);
     expect(contentA.getExposes().current.get()).toBe(false);
     expect(contentB.getExposes().current.get()).toBe(true);
-    expect(styleContains(contentA, 'hidden')).toBe(true);
-    expect(styleContains(contentB, 'hidden')).toBe(false);
+    expect(contentA.getExposes().hidden.get()).toBe(true);
+    expect(contentB.getExposes().hidden.get()).toBe(false);
+    expect(contentA.hasAttribute('hidden')).toBe(true);
+    expect(contentB.hasAttribute('hidden')).toBe(false);
 
     root.remove();
     await Promise.resolve();
   });
 
   it('controlled tabs root synchronizes from props updates', async () => {
+    // T-BASE-TABS-0001-CASE-CONTROLLED-VALUE
     const root = document.createElement('base-tabs-root') as any;
     const triggerA = document.createElement('base-tabs-trigger') as any;
     const triggerB = document.createElement('base-tabs-trigger') as any;
@@ -83,6 +128,7 @@ describe('prototypes/base: tabs', () => {
   });
 
   it('disabled trigger does not change the selected tab', async () => {
+    // T-BASE-TABS-TRIGGER-0001-CASE-DISABLED-GATING
     const root = document.createElement('base-tabs-root') as any;
     const triggerA = document.createElement('base-tabs-trigger') as any;
     const triggerB = document.createElement('base-tabs-trigger') as any;
@@ -109,6 +155,7 @@ describe('prototypes/base: tabs', () => {
   });
 
   it('arrow key roving moves focus and selection across triggers in automatic mode', async () => {
+    // T-BASE-TABS-LIST-0001-CASE-ROVING-AUTOMATIC
     const root = document.createElement('base-tabs-root') as any;
     const list = document.createElement('base-tabs-list') as any;
     const triggerA = document.createElement('base-tabs-trigger') as any;
@@ -142,6 +189,7 @@ describe('prototypes/base: tabs', () => {
   });
 
   it('manual activation mode keeps selection stable while roving focus, then commits on click', async () => {
+    // T-BASE-TABS-LIST-0001-CASE-ROVING-MANUAL
     const root = document.createElement('base-tabs-root') as any;
     const list = document.createElement('base-tabs-list') as any;
     const triggerA = document.createElement('base-tabs-trigger') as any;
@@ -199,6 +247,41 @@ describe('prototypes/base: tabs', () => {
     expect(root.getExposes().value.get()).toBe('c');
     expect(triggerC.getExposes().selected.get()).toBe(true);
     expect(contentC.getExposes().current.get()).toBe(true);
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('indicator consumes tabs context without interaction or focus surfaces', async () => {
+    // T-BASE-TABS-INDICATOR-0001-CASE-CONTEXT-CONSUMPTION
+    // T-BASE-TABS-INDICATOR-0001-CASE-NO-INTERACTION-SURFACES
+    const root = document.createElement('base-tabs-root') as any;
+    const triggerA = document.createElement('base-tabs-trigger') as any;
+    const triggerB = document.createElement('base-tabs-trigger') as any;
+    const indicator = document.createElement('base-tabs-indicator') as any;
+
+    setElementProps(root, { defaultValue: 'a', orientation: 'vertical' });
+    setElementProps(triggerA, { value: 'a' });
+    setElementProps(triggerB, { value: 'b' });
+
+    root.append(triggerA, triggerB, indicator);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const exposes = indicator.getExposes();
+    expect(exposes.value.get()).toBe('a');
+    expect(exposes.activeValue.get()).toBe('a');
+    expect(exposes.orientation.get()).toBe('vertical');
+    expect(exposes.valueChange).toBeUndefined();
+    expect(exposes.focusSelf).toBeUndefined();
+    expect(indicator.getAttribute('role')).toBeNull();
+
+    triggerB.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(exposes.value.get()).toBe('b');
+    expect(exposes.activeValue.get()).toBe('b');
 
     root.remove();
     await Promise.resolve();

--- a/packages/prototypes/base/test/tabs.test.ts
+++ b/packages/prototypes/base/test/tabs.test.ts
@@ -73,6 +73,8 @@ describe('prototypes/base: tabs', () => {
     expect(contentB.getExposes().hidden.get()).toBe(true);
     expect(contentA.hasAttribute('hidden')).toBe(false);
     expect(contentB.hasAttribute('hidden')).toBe(true);
+    expect(contentA.tabIndex).toBe(0);
+    expect(contentB.tabIndex).toBe(-1);
     expect(list.getAttribute('role')).toBe('tablist');
     expect(list.getAttribute('aria-orientation')).toBe('horizontal');
     expect(triggerA.getAttribute('role')).toBe('tab');
@@ -94,6 +96,34 @@ describe('prototypes/base: tabs', () => {
     expect(contentB.getExposes().hidden.get()).toBe(false);
     expect(contentA.hasAttribute('hidden')).toBe(true);
     expect(contentB.hasAttribute('hidden')).toBe(false);
+    expect(contentA.tabIndex).toBe(-1);
+    expect(contentB.tabIndex).toBe(0);
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('current tab content delegates focus entry to tabbable descendants before self fallback', async () => {
+    // T-BASE-TABS-CONTENT-0001-CASE-FOCUS-ENTRY
+    const root = document.createElement('base-tabs-root') as any;
+    const contentA = document.createElement('base-tabs-content') as any;
+    const contentB = document.createElement('base-tabs-content') as any;
+    const innerButton = document.createElement('button');
+
+    setElementProps(root, { defaultValue: 'a' });
+    setElementProps(contentA, { value: 'a' });
+    setElementProps(contentB, { value: 'b' });
+
+    contentA.appendChild(innerButton);
+    root.append(contentA, contentB);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(contentA.getExposes().current.get()).toBe(true);
+    expect(contentA.tabIndex).toBe(-1);
+    expect(contentB.tabIndex).toBe(-1);
 
     root.remove();
     await Promise.resolve();
@@ -177,12 +207,28 @@ describe('prototypes/base: tabs', () => {
     await Promise.resolve();
     await Promise.resolve();
 
+    expect(triggerA.tabIndex).toBe(0);
+    expect(triggerB.tabIndex).toBe(-1);
+
     triggerA.focus();
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true });
+    window.dispatchEvent(tabEvent);
+    await Promise.resolve();
+
+    expect(tabEvent.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(triggerA);
+    expect(triggerA.tabIndex).toBe(0);
+    expect(triggerB.tabIndex).toBe(-1);
+
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(document.activeElement).toBe(triggerB);
     expect(root.getExposes().value.get()).toBe('b');
     expect(triggerB.getExposes().selected.get()).toBe(true);
+    expect(triggerA.tabIndex).toBe(-1);
+    expect(triggerB.tabIndex).toBe(0);
 
     root.remove();
     await Promise.resolve();
@@ -223,6 +269,10 @@ describe('prototypes/base: tabs', () => {
     await Promise.resolve();
     await Promise.resolve();
 
+    expect(triggerA.tabIndex).toBe(0);
+    expect(triggerB.tabIndex).toBe(-1);
+    expect(triggerC.tabIndex).toBe(-1);
+
     triggerA.focus();
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
     await Promise.resolve();
@@ -232,6 +282,17 @@ describe('prototypes/base: tabs', () => {
     expect(root.getExposes().value.get()).toBe('a');
     expect(triggerA.getExposes().selected.get()).toBe(true);
     expect(triggerB.getExposes().selected.get()).toBe(false);
+    expect(triggerA.tabIndex).toBe(-1);
+    expect(triggerB.tabIndex).toBe(0);
+    expect(triggerC.tabIndex).toBe(-1);
+
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true });
+    window.dispatchEvent(tabEvent);
+    await Promise.resolve();
+
+    expect(tabEvent.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(triggerB);
+    expect(root.getExposes().value.get()).toBe('a');
 
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
     await Promise.resolve();
@@ -239,6 +300,9 @@ describe('prototypes/base: tabs', () => {
 
     expect(document.activeElement).toBe(triggerC);
     expect(root.getExposes().value.get()).toBe('a');
+    expect(triggerA.tabIndex).toBe(-1);
+    expect(triggerB.tabIndex).toBe(-1);
+    expect(triggerC.tabIndex).toBe(0);
 
     triggerC.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await Promise.resolve();

--- a/packages/prototypes/base/test/tabs.test.ts
+++ b/packages/prototypes/base/test/tabs.test.ts
@@ -49,6 +49,7 @@ describe('prototypes/base: tabs', () => {
     });
 
     setElementProps(root, { defaultValue: 'a' });
+    setElementProps(list, { a11yLabel: 'Account sections' });
     setElementProps(triggerA, { value: 'a' });
     setElementProps(triggerB, { value: 'b' });
     setElementProps(contentA, { value: 'a' });
@@ -76,6 +77,7 @@ describe('prototypes/base: tabs', () => {
     expect(contentA.tabIndex).toBe(0);
     expect(contentB.tabIndex).toBe(-1);
     expect(list.getAttribute('role')).toBe('tablist');
+    expect(list.getAttribute('aria-label')).toBe('Account sections');
     expect(list.getAttribute('aria-orientation')).toBe('horizontal');
     expect(triggerA.getAttribute('role')).toBe('tab');
     expect(triggerA.getAttribute('aria-selected')).toBe('true');
@@ -98,6 +100,50 @@ describe('prototypes/base: tabs', () => {
     expect(contentB.hasAttribute('hidden')).toBe(false);
     expect(contentA.tabIndex).toBe(-1);
     expect(contentB.tabIndex).toBe(0);
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('uncontrolled tabs falls back to the first enabled trigger when selection is invalid', async () => {
+    // T-BASE-TABS-0001-CASE-SELECTION-FALLBACK
+    const root = document.createElement('base-tabs-root') as any;
+    const triggerA = document.createElement('base-tabs-trigger') as any;
+    const triggerB = document.createElement('base-tabs-trigger') as any;
+    const triggerC = document.createElement('base-tabs-trigger') as any;
+    const contentB = document.createElement('base-tabs-content') as any;
+    const contentC = document.createElement('base-tabs-content') as any;
+
+    setElementProps(root, { defaultValue: 'missing' });
+    setElementProps(triggerA, { value: 'a', disabled: true });
+    setElementProps(triggerB, { value: 'b' });
+    setElementProps(triggerC, { value: 'c' });
+    setElementProps(contentB, { value: 'b' });
+    setElementProps(contentC, { value: 'c' });
+
+    root.append(triggerA, triggerB, triggerC, contentB, contentC);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(root.getExposes().value.get()).toBe('b');
+    expect(triggerA.getExposes().selected.get()).toBe(false);
+    expect(triggerB.getExposes().selected.get()).toBe(true);
+    expect(triggerC.getExposes().selected.get()).toBe(false);
+    expect(contentB.getExposes().current.get()).toBe(true);
+
+    setElementProps(triggerB, { value: 'b', disabled: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(root.getExposes().value.get()).toBe('c');
+    expect(triggerB.getExposes().selected.get()).toBe(false);
+    expect(triggerC.getExposes().selected.get()).toBe(true);
+    expect(contentB.getExposes().current.get()).toBe(false);
+    expect(contentC.getExposes().current.get()).toBe(true);
 
     root.remove();
     await Promise.resolve();

--- a/packages/prototypes/shadcn/src/tabs/content.ts
+++ b/packages/prototypes/shadcn/src/tabs/content.ts
@@ -5,15 +5,20 @@ import type { ShadcnTabsContentExposes, ShadcnTabsContentProps } from './types';
 const tabsContent = definePrototype<ShadcnTabsContentProps, ShadcnTabsContentExposes>({
   name: 'shadcn-tabs-content',
   setup(def) {
-    asTabsContent();
-    const current = def.state.fromAccessibility('current');
+    const contentState = asTabsContent().stateHandles;
+    if (!contentState) {
+      throw new Error(
+        '[shadcn-tabs-content] asTabsContent must project Tabs content state handles.'
+      );
+    }
+    const { hidden } = contentState;
     def.feedback.style.use(
       tw(
         'block w-full min-h-28 rounded-xl border border-border/60 bg-background p-4 text-sm leading-6 shadow-xs outline-none'
       )
     );
     def.rule({
-      when: (w) => w.state(current).eq(false),
+      when: (w) => w.state(hidden).eq(true),
       intent: (i) => i.feedback.style.use(tw('hidden')),
     });
   },

--- a/packages/prototypes/shadcn/src/tabs/trigger.ts
+++ b/packages/prototypes/shadcn/src/tabs/trigger.ts
@@ -23,12 +23,13 @@ const BASE_TOKENS = [
 const tabsTrigger = definePrototype<ShadcnTabsTriggerProps, ShadcnTabsTriggerExposes>({
   name: 'shadcn-tabs-trigger',
   setup(def) {
-    asTabsTrigger();
-    const disabled = def.state.fromInteraction('disabled');
-    const hovered = def.state.fromInteraction('hovered');
-    const focusVisible = def.state.fromInteraction('focusVisible');
-    const pressed = def.state.fromInteraction('pressed');
-    const selected = def.state.fromAccessibility('selected');
+    const triggerState = asTabsTrigger().stateHandles;
+    if (!triggerState) {
+      throw new Error(
+        '[shadcn-tabs-trigger] asTabsTrigger must project Tabs trigger state handles.'
+      );
+    }
+    const { disabled, hovered, focusVisible, pressed, selected } = triggerState;
 
     def.feedback.style.use(tw(BASE_TOKENS));
 

--- a/packages/prototypes/shadcn/test/tabs.test.ts
+++ b/packages/prototypes/shadcn/test/tabs.test.ts
@@ -57,4 +57,49 @@ describe('prototypes/shadcn: tabs', () => {
     root.remove();
     await Promise.resolve();
   });
+
+  it('does not leave a trigger pressed after pointer activity outside the tabs trigger', async () => {
+    const root = document.createElement('shadcn-tabs-root') as any;
+    const list = document.createElement('shadcn-tabs-list') as any;
+    const triggerA = document.createElement('shadcn-tabs-trigger') as any;
+    const triggerB = document.createElement('shadcn-tabs-trigger') as any;
+    const outside = document.createElement('button');
+
+    setElementProps(root, {
+      defaultValue: 'a',
+      orientation: 'horizontal',
+      activationMode: 'manual',
+    });
+    setElementProps(triggerA, { value: 'a' });
+    setElementProps(triggerB, { value: 'b' });
+
+    list.appendChild(triggerA);
+    list.appendChild(triggerB);
+    root.appendChild(list);
+    document.body.append(root, outside);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    triggerA.focus();
+    outside.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    outside.focus();
+    outside.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+
+    expect(triggerA.getExposes().pressed.get()).toBe(false);
+    expect(triggerA.hasAttribute('data-pressed')).toBe(false);
+
+    triggerA.focus();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(triggerB);
+    expect(triggerA.getExposes().pressed.get()).toBe(false);
+    expect(triggerB.getExposes().pressed.get()).toBe(false);
+
+    root.remove();
+    outside.remove();
+    await Promise.resolve();
+  });
 });

--- a/packages/prototypes/shadcn/test/tabs.test.ts
+++ b/packages/prototypes/shadcn/test/tabs.test.ts
@@ -58,6 +58,37 @@ describe('prototypes/shadcn: tabs', () => {
     await Promise.resolve();
   });
 
+  it('applies focus-visible ring styles while keeping trigger shadow tokens', async () => {
+    const root = document.createElement('shadcn-tabs-root') as any;
+    const list = document.createElement('shadcn-tabs-list') as any;
+    const trigger = document.createElement('shadcn-tabs-trigger') as any;
+
+    setElementProps(root, { defaultValue: 'a' });
+    setElementProps(trigger, { value: 'a' });
+
+    list.appendChild(trigger);
+    root.appendChild(list);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(styleContains(trigger, 'ring-3')).toBe(false);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    trigger.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    await Promise.resolve();
+
+    expect(trigger.getExposes().focusVisible.get()).toBe(true);
+    expect(styleContains(trigger, 'data-[focus-visible]:ring-3')).toBe(true);
+    expect(styleContains(trigger, 'data-[focus-visible]:ring-ring/50')).toBe(true);
+    expect(styleContains(trigger, 'data-[focus-visible]:ring-offset-2')).toBe(true);
+    expect(styleContains(trigger, 'data-[focus-visible]:shadow-xs')).toBe(true);
+
+    root.remove();
+    await Promise.resolve();
+  });
+
   it('does not leave a trigger pressed after pointer activity outside the tabs trigger', async () => {
     const root = document.createElement('shadcn-tabs-root') as any;
     const list = document.createElement('shadcn-tabs-list') as any;

--- a/packages/prototypes/shadcn/test/tabs.test.ts
+++ b/packages/prototypes/shadcn/test/tabs.test.ts
@@ -37,10 +37,11 @@ describe('prototypes/shadcn: tabs', () => {
     expect(triggerA.getExposes().selected.get()).toBe(true);
     expect(contentA.getExposes().current.get()).toBe(true);
     expect(triggerA.hasAttribute('data-selected')).toBe(true);
-    expect(triggerA.getAttribute('aria-selected')).toBe(null);
+    expect(triggerA.getAttribute('aria-selected')).toBe('true');
     expect(styleContains(triggerA, 'data-[selected]:bg-background')).toBe(true);
     expect(styleContains(contentA, 'block')).toBe(true);
-    expect(styleContains(contentB, 'hidden')).toBe(true);
+    expect(styleContains(contentB, 'data-[hidden]:hidden')).toBe(true);
+    expect(contentB.hasAttribute('hidden')).toBe(true);
 
     triggerB.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
@@ -48,9 +49,10 @@ describe('prototypes/shadcn: tabs', () => {
     expect(triggerB.getExposes().selected.get()).toBe(true);
     expect(contentB.getExposes().current.get()).toBe(true);
     expect(triggerB.hasAttribute('data-selected')).toBe(true);
-    expect(triggerB.getAttribute('aria-selected')).toBe(null);
+    expect(triggerB.getAttribute('aria-selected')).toBe('true');
     expect(styleContains(triggerB, 'data-[selected]:bg-background')).toBe(true);
-    expect(styleContains(contentA, 'hidden')).toBe(true);
+    expect(styleContains(contentA, 'data-[hidden]:hidden')).toBe(true);
+    expect(contentA.hasAttribute('hidden')).toBe(true);
 
     root.remove();
     await Promise.resolve();

--- a/packages/runtime/src/kernel/handles/def.ts
+++ b/packages/runtime/src/kernel/handles/def.ts
@@ -347,6 +347,12 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
     },
 
     a11y: {
+      id(target) {
+        ensureSetup('def.a11y.id');
+        if (!a11y) throw new Error(`[A11y] module unavailable.`);
+        a11y.id(target);
+        recordCaptured(def, 'context', { op: 'a11y.id', target });
+      },
       role(role) {
         ensureSetup('def.a11y.role');
         if (!a11y) throw new Error(`[A11y] module unavailable.`);
@@ -382,6 +388,12 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
         if (!a11y) throw new Error(`[A11y] module unavailable.`);
         a11y.action(key, spec);
         recordCaptured(def, 'event', { op: 'a11y.action', key, spec });
+      },
+      relation(key, spec) {
+        ensureSetup('def.a11y.relation');
+        if (!a11y) throw new Error(`[A11y] module unavailable.`);
+        a11y.relation(key, spec);
+        recordCaptured(def, 'context', { op: 'a11y.relation', key, spec });
       },
       tree(patch) {
         ensureSetup('def.a11y.tree');

--- a/packages/runtime/test/contract/a11y.v0.contract.test.ts
+++ b/packages/runtime/test/contract/a11y.v0.contract.test.ts
@@ -50,11 +50,16 @@ describe('runtime contract: a11y (v0)', () => {
         def.props.setDefaults({ disabled: false });
 
         const disabled = def.state.bool('button.disabled', false);
+        const id = def.state.string('button.id', 'button-a');
+        const controls = def.state.string('button.controls', 'panel-a');
+        def.a11y.id(id);
         def.a11y.role('button');
         def.a11y.name('Save');
         def.a11y.description('Stores changes');
         def.a11y.state('disabled', disabled);
         def.a11y.action('activate', { event: 'click' });
+        def.a11y.relation('controls', { target: controls });
+        def.a11y.relation('describedBy', { target: 'help-a' });
         def.a11y.tree({ mergeChildren: true });
 
         def.lifecycle.onCreated((run) => {
@@ -73,11 +78,13 @@ describe('runtime contract: a11y (v0)', () => {
     const port = caps.getPort<A11yPort>('a11y');
 
     expect(port?.getSnapshot()).toEqual({
+      id: 'button-a',
       role: 'button',
       name: { kind: 'text', value: 'Save' },
       description: { kind: 'text', value: 'Stores changes' },
       states: { disabled: false },
       actions: { activate: { event: 'click' } },
+      relations: { controls: 'panel-a', describedBy: 'help-a' },
       tree: { mergeChildren: true },
     });
 

--- a/packages/runtime/test/contract/focus.v0.contract.test.ts
+++ b/packages/runtime/test/contract/focus.v0.contract.test.ts
@@ -6,7 +6,7 @@ import {
   type FocusScopeHandle,
   type FocusableHandle,
 } from '@proto.ui/core';
-import { asFocusable, asFocusScope } from '@proto.ui/hooks';
+import { asFocusable, asFocusEntry, asFocusScope } from '@proto.ui/hooks';
 import type { RuntimeHost } from '../../src';
 import { executeWithHost } from '../../src';
 import { EVENT_GLOBAL_TARGET_CAP, EVENT_ROOT_TARGET_CAP } from '@proto.ui/module-event';
@@ -15,6 +15,7 @@ import {
   FOCUS_PARENT_CAP,
   FOCUS_REQUEST_FOCUS_CAP,
   FOCUS_ROOT_TARGET_CAP,
+  FOCUS_SET_FOCUSABLE_CAP,
   type FocusPort,
 } from '@proto.ui/module-focus';
 import type { PropsBaseType } from '@proto.ui/types';
@@ -232,6 +233,68 @@ describe('runtime contract: focus (v0)', () => {
     expect(String(thrown)).toMatch(/setup/i);
   });
 
+  it('FOCUS-0800: repeated asFocusEntry calls reuse one handle and configure through that handle', () => {
+    let entryA!: ReturnType<typeof asFocusEntry<PropsBaseType>>;
+    let entryB!: ReturnType<typeof asFocusEntry<PropsBaseType>>;
+
+    const P = definePrototype({
+      name: 'x-focus-0800',
+      setup() {
+        entryA = asFocusEntry<PropsBaseType>();
+        entryA.configure({ strategy: 'self' });
+        entryB = asFocusEntry<PropsBaseType>();
+        entryB.configure({ strategy: 'descendant-first', fallback: 'self', disabled: true });
+        return (r) => r.el('div', 'ok');
+      },
+    });
+
+    const { host } = createHost(P.name);
+    const result = executeWithHost(P as any, host as any);
+    const port = result.caps.getPort<FocusPort>('focus');
+
+    expect(entryA).toBe(entryB);
+    expect(port?.getEntryConfig()).toMatchObject({
+      strategy: 'descendant-first',
+      fallback: 'self',
+      disabled: true,
+    });
+    expect(port?.getWarnings()).toEqual(
+      expect.arrayContaining([expect.stringContaining('entry.strategy overridden')])
+    );
+    expect((P as any).__asHooks).toEqual([
+      { name: 'asFocusEntry', order: 0, privileged: true, mode: 'once' },
+    ]);
+  });
+
+  it('FOCUS-0810: asFocusEntry configure is setup-only while setDisabled stays runtime-safe', () => {
+    let entry!: ReturnType<typeof asFocusEntry<PropsBaseType>>;
+    let thrown: unknown;
+
+    const P = definePrototype({
+      name: 'x-focus-0810',
+      setup(def) {
+        entry = asFocusEntry<PropsBaseType>();
+        def.lifecycle.onCreated(() => {
+          entry.setDisabled(false);
+          try {
+            entry.configure({ fallback: 'none' });
+          } catch (error) {
+            thrown = error;
+          }
+        });
+        return (r) => r.el('div', 'ok');
+      },
+    });
+
+    const { host } = createHost(P.name);
+    const result = executeWithHost(P as any, host as any);
+    const port = result.caps.getPort<FocusPort>('focus');
+
+    expect(thrown).toBeTruthy();
+    expect(String(thrown)).toMatch(/setup/i);
+    expect(port?.getEntryConfig().disabled).toBe(false);
+  });
+
   it('FOCUS-0400: focus commands update minimal facts snapshot', () => {
     let focusable!: FocusableHandle<PropsBaseType>;
 
@@ -400,6 +463,69 @@ describe('runtime contract: focus (v0)', () => {
       active: false,
       hasFocused: false,
     });
+  });
+
+  it('FOCUS-0520: navParticipation=none leaves explicit focus requests enabled', () => {
+    let focusable!: FocusableHandle<PropsBaseType>;
+    const target = new FocusTarget('target', new Map([['target', 0]]));
+    const focusableUpdates: boolean[] = [];
+    const focused: string[] = [];
+
+    const P = definePrototype({
+      name: 'x-focus-0520',
+      setup(def) {
+        focusable = asFocusable<PropsBaseType>();
+        def.lifecycle.onCreated(() => {
+          focusable.setNavParticipation('none');
+          focusable.focus({ reason: 'keyboard' });
+        });
+        return (r) => r.el('button', 'ok');
+      },
+    });
+
+    const host: RuntimeHost<PropsBaseType> = {
+      prototypeName: P.name,
+      getRawProps: () => ({}),
+      commit(_children, signal) {
+        signal?.done();
+      },
+      schedule(task) {
+        task();
+      },
+      onRuntimeReady(wiring) {
+        wiring.attach('event', [
+          [EVENT_ROOT_TARGET_CAP, () => target],
+          [EVENT_GLOBAL_TARGET_CAP, () => target],
+        ]);
+        wiring.attach('focus', [
+          [FOCUS_ROOT_TARGET_CAP, () => target as any],
+          [
+            FOCUS_SET_FOCUSABLE_CAP,
+            (_target: HTMLElement, enabled: boolean) => {
+              focusableUpdates.push(enabled);
+            },
+          ],
+          [
+            FOCUS_REQUEST_FOCUS_CAP,
+            (nextTarget: FocusTarget) => {
+              focused.push(nextTarget.id);
+            },
+          ],
+        ]);
+      },
+    };
+
+    const result = executeWithHost(P as any, host as any);
+    const port = result.caps.getPort<FocusPort>('focus');
+
+    expect(focusableUpdates).toContain(false);
+    expect(focused).toEqual(['target']);
+    expect(port?.getFacts()).toMatchObject({
+      focused: true,
+      focusVisible: true,
+      focusable: true,
+    });
+    expect(port?.getFocusableConfig().navParticipation).toBe('none');
   });
 
   it('FOCUS-0600: autoFocus requests focus after first render commit', () => {

--- a/spec/contracts/C-A11Y-0001.yaml
+++ b/spec/contracts/C-A11Y-0001.yaml
@@ -3,14 +3,14 @@ type: contract
 title: Accessibility exposes projectable semantic objects
 status: draft
 since: 0.1.0
-summary: The a11y domain records projectable semantic object facts such as role, name, description, state, action, relation, and semantic tree behavior.
+summary: The a11y domain records projectable semantic object facts such as identity, role, name, description, state, action, relation, and semantic tree behavior.
 statement:
   zh-CN: >-
-    Accessibility 是一个可由宿主投影的 semantic object domain。原型通过 a11y API 声明当前交互对象的 role、name、description、state、action、relation 与 semantic tree behavior；runtime 将这些声明保存为稳定 IR，adapter 负责把 IR 投影到宿主的无障碍表达。a11y IR 可以引用 state/focus/event/anatomy 等其它域事实，但 a11y 不重新拥有这些域。
+    Accessibility 是一个可由宿主投影的 semantic object domain。原型通过 a11y API 声明当前交互对象的 identity、role、name、description、state、action、relation 与 semantic tree behavior；runtime 将这些声明保存为稳定 IR，adapter 负责把 IR 投影到宿主的无障碍表达。a11y IR 可以引用 state/focus/event/anatomy 等其它域事实，但 a11y 不重新拥有这些域。
 
 
   en: >-
-    Accessibility is a host-projectable semantic object domain. A prototype declares role, name, description, state, action, relation, and semantic tree behavior for the current interaction object through a11y APIs; the runtime stores these declarations as stable IR, and adapters project the IR to host accessibility output. A11y IR may reference facts from state, focus, event, anatomy, and other domains, but a11y does not re-own those domains.
+    Accessibility is a host-projectable semantic object domain. A prototype declares identity, role, name, description, state, action, relation, and semantic tree behavior for the current interaction object through a11y APIs; the runtime stores these declarations as stable IR, and adapters project the IR to host accessibility output. A11y IR may reference facts from state, focus, event, anatomy, and other domains, but a11y does not re-own those domains.
 
 
 criteria:
@@ -20,8 +20,8 @@ criteria:
       en: The a11y domain must output semantic object IR that adapters can project.
   - id: C-A11Y-0001-B
     text:
-      zh-CN: semantic object 至少应能表达 role、name、description、state 与 action。
-      en: A semantic object should at least be able to express role, name, description, state, and action.
+      zh-CN: semantic object 至少应能表达 identity、role、name、description、state、action 与 relation。
+      en: A semantic object should at least be able to express identity, role, name, description, state, action, and relation.
   - id: C-A11Y-0001-C
     text:
       zh-CN: role 表达交互对象是什么，不得直接等同于某个宿主 attribute 名称。
@@ -40,8 +40,12 @@ criteria:
       en: A11y action may reference expose events or other interaction routes; the action itself does not redefine the event route.
   - id: C-A11Y-0001-G
     text:
-      zh-CN: adapter 可以按宿主能力选择原生 role/name/state/action 投影、降级投影或仅保留诊断 IR。
-      en: Adapters may choose native role/name/state/action projection, degraded projection, or diagnostic-only IR based on host capabilities.
+      zh-CN: adapter 可以按宿主能力选择原生 identity/role/name/state/action/relation 投影、降级投影或仅保留诊断 IR。
+      en: Adapters may choose native identity/role/name/state/action/relation projection, degraded projection, or diagnostic-only IR based on host capabilities.
+  - id: C-A11Y-0001-H
+    text:
+      zh-CN: a11y relation 可以引用字符串目标或 state handle；其语义表示对象关系，宿主 adapter 负责投影为宿主可表达的关系机制。
+      en: A11y relation may reference a string target or state handle; it represents an object relationship, and host adapters are responsible for projecting it to host-expressible relationship mechanisms.
 sources:
   - path: internal/records/2026-06-30-a11y-module-planning-for-button.zh-CN.md
   - path: packages/modules/a11y/src/types.ts

--- a/spec/contracts/C-A11Y-0001.yaml
+++ b/spec/contracts/C-A11Y-0001.yaml
@@ -46,6 +46,10 @@ criteria:
     text:
       zh-CN: a11y relation 可以引用字符串目标或 state handle；其语义表示对象关系，宿主 adapter 负责投影为宿主可表达的关系机制。
       en: A11y relation may reference a string target or state handle; it represents an object relationship, and host adapters are responsible for projecting it to host-expressible relationship mechanisms.
+  - id: C-A11Y-0001-I
+    text:
+      zh-CN: a11y name 与 description 可以引用字符串或 state handle；当引用 state handle 时，adapter 投射必须随 state 值变化更新。
+      en: A11y name and description may reference a string or a state handle; when they reference a state handle, adapter projection must update as the state value changes.
 sources:
   - path: internal/records/2026-06-30-a11y-module-planning-for-button.zh-CN.md
   - path: packages/modules/a11y/src/types.ts
@@ -73,6 +77,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Introduced the minimal semantic object contract for the a11y module.
+  - version: 0.1.1
+    change: refined
+    summary: Allowed a11y name and description text facts to reference state handles for dynamic host-neutral labels.
 tags:
   - a11y
   - accessibility

--- a/spec/contracts/C-AS-FOCUS-ENTRY-0001.yaml
+++ b/spec/contracts/C-AS-FOCUS-ENTRY-0001.yaml
@@ -1,0 +1,85 @@
+id: C-AS-FOCUS-ENTRY-0001
+type: contract
+title: asFocusEntry declares a host-mediated focus entry region
+status: draft
+since: 0.1.0
+summary: asFocusEntry is a privileged no-arg singleton asHook for declaring that the current prototype instance is an enterable focus region whose concrete entry target is resolved by host capability from an entry policy.
+statement:
+  zh-CN: >-
+    `asFocusEntry()` 是 focus domain 的特权 no-arg asHook，用于声明当前原型实例是 focus entry region。它不声明当前实例自身是 focus target，也不拥有 target-level focus facts；它只提供 setup 期 entry policy 配置，以及运行时启用、禁用和请求 entry focus 的能力。宿主必须根据 entry policy 解析实际 focus target，并负责将顺序焦点参与投射到宿主能力上。
+
+
+  en: >-
+    `asFocusEntry()` is the focus-domain privileged no-arg asHook for declaring that the current prototype instance is a focus entry region. It does not declare the current instance itself as a focus target and does not own target-level focus facts; it only provides setup-time entry policy configuration plus runtime enable, disable, and entry focus request capabilities. The host must resolve the actual focus target from the entry policy and project sequential focus participation through host capabilities.
+
+
+criteria:
+  - id: C-AS-FOCUS-ENTRY-0001-A
+    text:
+      zh-CN: '`asFocusEntry()` 必须是特权 asHook，并必须以 no-arg caller 形态调用。'
+      en: '`asFocusEntry()` must be a privileged asHook and must be called as a no-arg caller.'
+    dependsOn:
+      contracts:
+        - C-AS-HOOK-PRIVILEGED-0001
+  - id: C-AS-FOCUS-ENTRY-0001-B
+    text:
+      zh-CN: 同一 setup 中重复调用 `asFocusEntry()` 必须复用同一个 focus entry handle，不得重复安装 focus entry capability。
+      en: Repeated `asFocusEntry()` calls in the same setup must reuse the same focus entry handle and must not reinstall the focus entry capability.
+  - id: C-AS-FOCUS-ENTRY-0001-C
+    text:
+      zh-CN: '`asFocusEntry().configure(...)` 必须限制在 setup 期使用。'
+      en: '`asFocusEntry().configure(...)` must be restricted to setup-time use.'
+  - id: C-AS-FOCUS-ENTRY-0001-D
+    text:
+      zh-CN: focus entry handle 必须支持 descendant-first entry strategy 与 self fallback policy。
+      en: The focus entry handle must support descendant-first entry strategy and self fallback policy.
+    dependsOn:
+      decisions:
+        - D-FOCUS-ENTRY-DELEGATION-0001
+  - id: C-AS-FOCUS-ENTRY-0001-E
+    text:
+      zh-CN: focus entry handle 必须支持运行时禁用与启用，以便由 current、hidden、disabled 等状态控制顺序焦点参与。
+      en: The focus entry handle must support runtime disabling and enabling so states such as current, hidden, and disabled can control sequential focus participation.
+  - id: C-AS-FOCUS-ENTRY-0001-F
+    text:
+      zh-CN: focus entry 不得自动声明 `focused`、`focusVisible`、`active` 或 roving membership；需要这些 target-level facts 的原型必须显式使用 `asFocusable()` 或其他对应能力。
+      en: Focus entry must not automatically declare `focused`, `focusVisible`, `active`, or roving membership; prototypes that need those target-level facts must explicitly use `asFocusable()` or another corresponding capability.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
+        - C-AS-FOCUS-ROVING-0001
+  - id: C-AS-FOCUS-ENTRY-0001-G
+    text:
+      zh-CN: 程序化 entry focus request 必须通过宿主 capability 解析真实 focus target；当策略无可用目标时，不得伪造 focus facts。
+      en: Programmatic entry focus requests must resolve the real focus target through host capability; when the policy has no available target, focus facts must not be faked.
+    dependsOn:
+      contracts:
+        - C-FOCUS-0001
+sources:
+  - path: internal/records/2026-07-05-focus-entry-delegation.zh-CN.md
+  - path: packages/hooks/src/as-focus-entry.ts
+  - path: packages/modules/focus/src/create.ts
+    sections:
+      - FocusModuleImpl.getEntry
+      - FocusModuleImpl.configureEntry
+  - path: packages/runtime/test/contract/focus.v0.contract.test.ts
+    sections:
+      - FOCUS-0800
+dependsOn:
+  contracts:
+    - C-FOCUS-0001
+    - C-AS-HOOK-PRIVILEGED-0001
+  decisions:
+    - D-FOCUS-ENTRY-DELEGATION-0001
+verifies:
+  tests:
+    - T-FOCUS-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added asFocusEntry as the first focus entry region hook for descendant-first tabpanel behavior.
+tags:
+  - focus
+  - focus-entry
+  - as-hook
+  - privileged

--- a/spec/contracts/C-AS-FOCUS-ROVING-0001.yaml
+++ b/spec/contracts/C-AS-FOCUS-ROVING-0001.yaml
@@ -34,6 +34,17 @@ criteria:
     text:
       zh-CN: 内部 `FocusGroup*` 名称只能作为兼容 alias 或迁移断口存在，新的实现命名应优先使用 `FocusRoving*`。
       en: Internal `FocusGroup*` names may only exist as compatibility aliases or migration fractures; new implementation naming should prefer `FocusRoving*`.
+  - id: C-AS-FOCUS-ROVING-0001-F
+    text:
+      zh-CN: roving focus 的同级集合内移动必须与宿主顺序焦点导航区分；方向键、Home、End 或显式 roving request 可在集合内移动，Tab 不得被解释为同一 roving 集合内的 next/prev movement。
+      en: Sibling movement inside a roving focus set must be distinguished from host sequential focus navigation; arrow keys, Home, End, or explicit roving requests may move within the set, but Tab must not be interpreted as next/previous movement inside the same roving set.
+  - id: C-AS-FOCUS-ROVING-0001-G
+    text:
+      zh-CN: 在支持顺序焦点参与投射的宿主中，同一 roving set 应只让当前 active/current roving item 参与自然 Tab 顺序，其余 eligible item 仍可通过 roving request 被程序化聚焦。
+      en: In hosts that support sequential focus participation projection, a roving set should keep only the current active/current roving item in the natural Tab sequence while other eligible items remain programmatically focusable through roving requests.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
 sources:
   - path: internal/contracts/focus/base-text/focus-roving.v0.md
   - path: internal/contracts/focus/base-text/focus-model.v0.md
@@ -61,6 +72,9 @@ revisions:
   - version: 0.1.1
     change: refined
     summary: Clarified that asFocusRoving is a no-arg caller and setup-time configuration goes through the returned roving handle.
+  - version: 0.1.2
+    change: refined
+    summary: Clarified that Tab is sequential focus navigation, not roving next/previous movement, and that only the active/current item should participate in natural Tab order.
 tags:
   - focus
   - as-hook

--- a/spec/contracts/C-AS-FOCUSABLE-0001.yaml
+++ b/spec/contracts/C-AS-FOCUSABLE-0001.yaml
@@ -34,6 +34,10 @@ criteria:
     text:
       zh-CN: disabled focusable 不得接受 focus request 并激活 focus facts。
       en: A disabled focusable must not accept focus requests that activate focus facts.
+  - id: C-AS-FOCUSABLE-0001-F
+    text:
+      zh-CN: '`asFocusable()` 必须允许运行时切换自然导航参与状态；`navParticipation: none` 应将 target 排除出宿主顺序焦点导航，但不得等同于 disabled，也不得阻止显式 focus request。'
+      en: '`asFocusable()` must allow runtime switching of natural navigation participation; `navParticipation: none` should remove the target from host sequential focus navigation, but must not be equivalent to disabled and must not block explicit focus requests.'
 sources:
   - path: internal/contracts/focus/base-text/as-focusable.v0.md
   - path: packages/hooks/src/as-focusable.ts
@@ -65,6 +69,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Captured asFocusable as the no-arg focus target privileged hook.
+  - version: 0.1.1
+    change: refined
+    summary: Added runtime natural navigation participation switching for roving focus item tab-order control.
 tags:
   - focus
   - as-hook

--- a/spec/contracts/C-FOCUS-0001.yaml
+++ b/spec/contracts/C-FOCUS-0001.yaml
@@ -38,6 +38,13 @@ criteria:
     text:
       zh-CN: 焦点事实唯一性不得完全依赖宿主一定会投递 blur；adapter、commit gate 或宿主差异导致 blur 缺失时，focus center 仍必须维持内部事实一致性。
       en: Focus fact uniqueness must not rely entirely on the host always delivering blur; if adapter, commit gate, or host variance causes blur to be missed, the focus center must still preserve internal fact consistency.
+  - id: C-FOCUS-0001-G
+    text:
+      zh-CN: Focus domain 必须区分 focus target identity 与 focus entry region；entry region 可以将真实 focus target 委派给后代或 fallback 到自身，但不得因此伪造自身 target-level focus facts。
+      en: The focus domain must distinguish focus target identity from focus entry regions; an entry region may delegate the real focus target to a descendant or fall back to itself, but must not fake its own target-level focus facts because of that delegation.
+    dependsOn:
+      decisions:
+        - D-FOCUS-ENTRY-DELEGATION-0001
 sources:
   - path: internal/contracts/focus/base-text/focus-domain.v0.md
   - path: internal/contracts/focus/base-text/focus-model.v0.md
@@ -60,6 +67,7 @@ dependsOn:
 relates:
   decisions:
     - D-FOCUS-STATE-INTERACTION-BOUNDARY-0001
+    - D-FOCUS-ENTRY-DELEGATION-0001
 revisions:
   - version: 0.1.0
     change: introduced
@@ -67,6 +75,9 @@ revisions:
   - version: 0.1.1
     change: refined
     summary: Added focus fact uniqueness and stale fact cleanup requirements learned from cross-adapter dialog focus behavior.
+  - version: 0.1.2
+    change: refined
+    summary: Added focus entry region as distinct from focus target identity.
 tags:
   - focus
   - domain

--- a/spec/decisions/D-A11Y-PART-RELATIONSHIP-PROJECTION-0001.yaml
+++ b/spec/decisions/D-A11Y-PART-RELATIONSHIP-PROJECTION-0001.yaml
@@ -1,0 +1,92 @@
+id: D-A11Y-PART-RELATIONSHIP-PROJECTION-0001
+type: decision
+title: Anatomy part relationships must be projectable as accessibility relationships
+status: draft
+since: 0.1.0
+summary: Proto UI needs a contract-level way for prototypes to declare semantic relationships between anatomy parts so Web adapters can project ARIA relationships such as `aria-controls` and `aria-labelledby` without guessing component-specific structure.
+statement:
+  zh-CN: >-
+    Proto UI 需要一种 contract-level 的 anatomy part relationship projection 能力。复合原型应能声明同一 anatomy domain 内 part 与 part 之间的 accessibility relationship，例如 Tabs 中 `trigger(value=x)` controls `content(value=x)`，以及 `content(value=x)` labelledBy `trigger(value=x)`。Web adapter 应根据这些跨平台语义关系生成稳定的宿主标识，并投射为 `aria-controls`、`aria-labelledby` 等 Web ARIA 属性；adapter 不应通过 prototype name、DOM 结构或样式 token 猜测特定组件场景。
+
+
+  en: >-
+    Proto UI needs a contract-level anatomy part relationship projection capability. Compound prototypes should be able to declare accessibility relationships between parts in the same anatomy domain, such as `trigger(value=x)` controls `content(value=x)` and `content(value=x)` labelledBy `trigger(value=x)` in Tabs. Web adapters should generate stable host identifiers from those cross-platform semantic relationships and project them to Web ARIA attributes such as `aria-controls` and `aria-labelledby`; adapters should not guess component-specific scenarios from prototype names, DOM structure, or style tokens.
+
+
+criteria:
+  - id: D-A11Y-PART-RELATIONSHIP-PROJECTION-0001-A
+    text:
+      zh-CN: a11y relationship 必须表达跨平台语义关系；Web ARIA attribute 只是 Web adapter 的投射目标。
+      en: A11y relationships must express cross-platform semantic relationships; Web ARIA attributes are only projection targets for the Web adapter.
+    dependsOn:
+      decisions:
+        - D-A11Y-SEMANTIC-DOMAIN-0001
+      contracts:
+        - C-A11Y-0001
+  - id: D-A11Y-PART-RELATIONSHIP-PROJECTION-0001-B
+    text:
+      zh-CN: 复合 prototype 必须能够基于 anatomy family、part role、same-domain scope 与 protocol match key 声明 part-to-part relationship。
+      en: Compound prototypes must be able to declare part-to-part relationships based on anatomy family, part role, same-domain scope, and protocol match keys.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0001
+        - C-ANATOMY-0005
+        - C-A11Y-0001
+  - id: D-A11Y-PART-RELATIONSHIP-PROJECTION-0001-C
+    text:
+      zh-CN: relationship matching key 可以来自 protocol value，例如 Tabs trigger/content 的 `value`；该 value 是协议匹配依据，不应被直接等同为宿主 `id`。
+      en: The relationship matching key may come from a protocol value such as Tabs trigger/content `value`; that value is a protocol matching key and should not be directly equated with a host `id`.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-ANATOMY-0005
+  - id: D-A11Y-PART-RELATIONSHIP-PROJECTION-0001-D
+    text:
+      zh-CN: Web adapter 负责在 same-domain scope 内生成稳定且唯一的 host id，并处理 value escaping、重复 value、缺失匹配与动态增删 part 的降级策略。
+      en: The Web adapter is responsible for generating stable and unique host ids within the same-domain scope and for handling value escaping, duplicate values, missing matches, and dynamic part addition/removal fallback policies.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+      decisions:
+        - D-A11Y-SEMANTIC-DOMAIN-0001
+  - id: D-A11Y-PART-RELATIONSHIP-PROJECTION-0001-E
+    text:
+      zh-CN: Adapter 不得通过 prototype name、DOM child order、CSS class、style token 或 demo-specific 行为来推断 a11y relationship；relationship 必须来自 prototype/runtime 暴露的结构化语义。
+      en: Adapters must not infer a11y relationships from prototype names, DOM child order, CSS classes, style tokens, or demo-specific behavior; relationships must come from structured semantics exposed by the prototype/runtime.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+        - C-ANATOMY-0001
+  - id: D-A11Y-PART-RELATIONSHIP-PROJECTION-0001-F
+    text:
+      zh-CN: Tabs 是该能力的首个明确牵引场景，但该能力不得被设计为 Tabs 专属补丁；Dialog title/description、Select、Combobox、Accordion 等复合组件也应可复用。
+      en: Tabs is the first explicit driving scenario for this capability, but the capability must not be designed as a Tabs-only patch; compound components such as Dialog title/description, Select, Combobox, and Accordion should also be able to reuse it.
+    references:
+      prototypes:
+        - id: P-BASE-TABS
+          anchors:
+            - P-BASE-TABS-A11Y-RELATIONSHIP-TARGET
+sources:
+  - path: spec/decisions/D-A11Y-SEMANTIC-DOMAIN-0001.yaml
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+    label: WAI-ARIA Authoring Practices Guide - Tabs Pattern
+  - path: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tab_role
+    label: MDN ARIA tab role
+relates:
+  decisions:
+    - D-A11Y-SEMANTIC-DOMAIN-0001
+  contracts:
+    - C-A11Y-0001
+    - C-ANATOMY-0005
+  prototypes:
+    - P-BASE-TABS
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Recorded the need for structured part-to-part a11y relationship projection before Tabs P entity cataloging.
+tags:
+  - a11y
+  - anatomy
+  - relationship
+  - adapter
+  - tabs

--- a/spec/decisions/D-ADAPTER-EVENT-OWNER-FALLBACK-0001.yaml
+++ b/spec/decisions/D-ADAPTER-EVENT-OWNER-FALLBACK-0001.yaml
@@ -1,0 +1,60 @@
+id: D-ADAPTER-EVENT-OWNER-FALLBACK-0001
+type: decision
+title: Adapter event owner fallback needs an explicit contract surface
+status: draft
+since: 0.1.0
+summary: Event routers may need a host-specific fallback when the native event target cannot be mapped to a Proto UI instance, but that rule belongs to adapter contract governance rather than component prototypes.
+statement:
+  zh-CN: >-
+    Proto UI 的事件路由需要明确“事件归属”解析失败时的 adapter fallback 策略。例如 Web 场景中，某些键盘事件可能需要在 target 无法解析到原型实例时参考 host activeElement。该能力不应写入 Tabs、Focus Roving 或其它 P 实体作为组件补丁；它属于 adapter 侧的事件归属契约与 host capability 治理。由于 A/M/HC 编目尚未完整推进，本轮只记录决策入口与问题边界。
+
+
+  en: >-
+    Proto UI event routing needs an explicit adapter fallback policy for failed event-owner resolution. For example, in Web hosts, some keyboard events may need to consult the host activeElement when the native event target cannot be mapped to a prototype instance. This capability should not be encoded in Tabs, Focus Roving, or other P entities as a component patch; it belongs to adapter-side event-owner contracts and host capability governance. Because A/M/HC cataloging is not complete yet, this pass records only the decision entry and boundary.
+
+
+criteria:
+  - id: D-ADAPTER-EVENT-OWNER-FALLBACK-0001-A
+    text:
+      zh-CN: 事件归属 fallback 必须被建模为 adapter/host 能力问题，不得由具体原型通过组件专属逻辑猜测宿主事件目标。
+      en: Event-owner fallback must be modeled as an adapter/host capability issue and must not be guessed by a specific prototype through component-specific logic.
+    dependsOn:
+      contracts:
+        - C-EVENT-0001
+        - C-EVENT-0002
+  - id: D-ADAPTER-EVENT-OWNER-FALLBACK-0001-B
+    text:
+      zh-CN: Web activeElement fallback 可以作为候选策略保留，但在 adapter 契约实体完善前不得升级为通用硬性要求。
+      en: Web activeElement fallback may remain a candidate strategy, but it must not be promoted to a general hard requirement before adapter contract entities are cataloged.
+    dependsOn:
+      decisions:
+        - D-FOCUS-ENTRY-DELEGATION-0001
+  - id: D-ADAPTER-EVENT-OWNER-FALLBACK-0001-C
+    text:
+      zh-CN: Focus Roving 与 Tabs 的键盘交互测试可以暴露该问题，但测试失败不应直接迫使 P 实体引入 adapter-specific props 或 DOM 查询逻辑。
+      en: Focus Roving and Tabs keyboard interaction tests may expose this issue, but their failures should not force P entities to introduce adapter-specific props or DOM query logic.
+    references:
+      prototypes:
+        - id: P-BASE-TABS-LIST
+          anchors:
+            - P-BASE-TABS-LIST-FOCUS-ROVING
+sources:
+  - path: internal/records/2026-07-06-tabs-followup-closure.zh-CN.md
+  - path: packages/adapters/base/src/index.ts
+  - path: packages/adapters/web-component/test/router.spec.test.ts
+relates:
+  contracts:
+    - C-EVENT-0001
+    - C-EVENT-0002
+    - C-AS-FOCUS-ROVING-0001
+  prototypes:
+    - P-BASE-TABS-LIST
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Recorded adapter event-owner fallback as a pending adapter contract governance surface discovered during Tabs/Focus work.
+tags:
+  - adapter
+  - event
+  - focus
+  - tabs

--- a/spec/decisions/D-FOCUS-ENTRY-DELEGATION-0001.yaml
+++ b/spec/decisions/D-FOCUS-ENTRY-DELEGATION-0001.yaml
@@ -1,0 +1,76 @@
+id: D-FOCUS-ENTRY-DELEGATION-0001
+type: decision
+title: Focus entry delegation is distinct from focus target identity
+status: draft
+since: 0.1.0
+summary: Proto UI should model region-level focus entry delegation separately from focus target identity so prototypes such as Tabs Content can use descendant-first entry with fallback self without pretending the region itself owns focus facts.
+statement:
+  zh-CN: >-
+    Proto UI 应将 focus entry delegation 建模为独立于 focus target identity 的 focus-domain 能力。`asFocusable()` 表示当前原型实例自身是 focus target，并拥有 target-level focus facts；`asFocusEntry()` 表示当前原型实例是一个可进入区域，进入时的真实 focus target 可由宿主按照策略解析为后代目标或 fallback 到自身。宿主负责通过 host capability 实现 entry target 解析与顺序焦点参与投射，core 契约不得绑定 Web DOM 查询或 CSS 机制。
+
+
+  en: >-
+    Proto UI should model focus entry delegation as a focus-domain capability distinct from focus target identity. `asFocusable()` means the current prototype instance itself is a focus target and owns target-level focus facts; `asFocusEntry()` means the current prototype instance is an enterable region whose actual focus target may be resolved by the host according to policy as a descendant target or a self fallback. Hosts are responsible for resolving entry targets and projecting sequential focus participation through host capabilities; core contracts must not bind this to Web DOM queries or CSS mechanisms.
+
+
+criteria:
+  - id: D-FOCUS-ENTRY-DELEGATION-0001-A
+    text:
+      zh-CN: '`asFocusEntry()` 不得被解释为 `asFocusable()` 的别名；它不声明当前实例拥有 `focused`、`focusVisible` 或 roving item 身份。'
+      en: '`asFocusEntry()` must not be treated as an alias of `asFocusable()`; it does not declare that the current instance owns `focused`, `focusVisible`, or roving item identity.'
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
+        - C-FOCUS-0001
+  - id: D-FOCUS-ENTRY-DELEGATION-0001-B
+    text:
+      zh-CN: focus entry policy 必须表达跨宿主策略，例如 descendant-first 与 fallback self；Web DOM 查询只是 Web adapter 的实现方式。
+      en: Focus entry policy must express cross-host strategy such as descendant-first and fallback self; Web DOM querying is only a Web adapter implementation detail.
+    dependsOn:
+      contracts:
+        - C-FOCUS-0001
+  - id: D-FOCUS-ENTRY-DELEGATION-0001-C
+    text:
+      zh-CN: 宿主必须可以通过 capability 解析 entry target，并决定当前容器是否需要作为顺序导航 fallback target 参与焦点顺序。
+      en: Hosts must be able to resolve the entry target through a capability and decide whether the current container should participate in sequential focus order as a fallback target.
+    dependsOn:
+      contracts:
+        - C-FOCUS-0001
+  - id: D-FOCUS-ENTRY-DELEGATION-0001-D
+    text:
+      zh-CN: 当 entry policy 命中后代目标时，不得因此伪造 entry 容器自身的 focus facts；focus facts 仍属于实际 focus target 或宿主焦点系统。
+      en: When entry policy resolves to a descendant target, the entry container's own focus facts must not be faked; focus facts remain owned by the actual focus target or the host focus system.
+    dependsOn:
+      contracts:
+        - C-FOCUS-0001
+  - id: D-FOCUS-ENTRY-DELEGATION-0001-E
+    text:
+      zh-CN: Tabs Content 是该能力的首个明确牵引场景，但该能力不得设计为 Tabs 专属；Dialog body、Popover content、Composite panel 等可进入区域也应可复用。
+      en: Tabs Content is the first explicit driving scenario for this capability, but the capability must not be designed as Tabs-specific; enterable regions such as Dialog body, Popover content, and composite panels should also be able to reuse it.
+    references:
+      prototypes:
+        - id: P-BASE-TABS-CONTENT
+          anchors:
+            - P-BASE-TABS-CONTENT-FOCUS-ENTRY
+sources:
+  - path: internal/records/2026-07-05-focus-entry-delegation.zh-CN.md
+  - path: spec/contracts/C-AS-FOCUSABLE-0001.yaml
+  - path: spec/prototypes/P-BASE-TABS-CONTENT.yaml
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+    label: WAI-ARIA Authoring Practices Guide - Tabs Pattern
+relates:
+  contracts:
+    - C-FOCUS-0001
+    - C-AS-FOCUSABLE-0001
+    - C-AS-FOCUS-ENTRY-0001
+  prototypes:
+    - P-BASE-TABS-CONTENT
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Recorded focus entry delegation as a separate focus-domain concept before implementing asFocusEntry and tabpanel descendant-first behavior.
+tags:
+  - focus
+  - focus-entry
+  - host-capability
+  - tabs

--- a/spec/prototypes/P-BASE-TABS-CONTENT.yaml
+++ b/spec/prototypes/P-BASE-TABS-CONTENT.yaml
@@ -1,0 +1,168 @@
+id: P-BASE-TABS-CONTENT
+type: prototype
+title: Base Tabs Content is a value-matched tabpanel part
+status: draft
+since: 0.1.0
+summary: Base Tabs Content is the repeatable tabpanel part that provides a protocol value, derives current state from Tabs context, and is hidden when inactive without being unmounted by the Tabs core protocol.
+statement:
+  zh-CN: >-
+    Base Tabs Content 是 Base Tabs anatomy family 中可重复的 content/tabpanel part。Content 必须提供用于 Tabs selection matching 的 protocol `value`，消费 Tabs context，并在自身 value 与 context selected value 相等时派生 current state。Current content 应显示；非 current content 必须隐藏但不得因此由 Tabs core protocol 自动 unmount。`base-tabs-content` direct prototype 与 `asTabsContent` authored asHook 是同一 Tabs content protocol 的两个 authoring entries。
+
+
+  en: >-
+    Base Tabs Content is the repeatable content/tabpanel part in the Base Tabs anatomy family. Content must provide a protocol `value` used for Tabs selection matching, consume Tabs context, and derive current state when its own value equals the context selected value. Current content should be visible; non-current content must be hidden but must not be automatically unmounted by the Tabs core protocol. The `base-tabs-content` direct prototype and the `asTabsContent` authored asHook are two authoring entries of the same Tabs content protocol.
+
+
+criteria:
+  - id: P-BASE-TABS-CONTENT-ROLE-PANEL
+    text:
+      zh-CN: Tabs Content 是 selected value 对应的 tabpanel content part，不拥有 selected value 或 activation 语义。
+      en: Tabs Content is the tabpanel content part corresponding to selected value and does not own selected value or activation semantics.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-CONTENT-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-tabs-content` direct prototype 与 `asTabsContent` authored asHook 是同一 Tabs content protocol 的两个 authoring entries。'
+      en: 'The `base-tabs-content` direct prototype and the `asTabsContent` authored asHook are two authoring entries of the same Tabs content protocol.'
+    dependsOn:
+      contracts:
+        - C-CORE-SYNTAX-0003
+        - C-AS-HOOK-0001
+      decisions:
+        - D-PROTOTYPE-ENTITY-NAMING-0001
+  - id: P-BASE-TABS-CONTENT-PROTOCOL-DEPENDENCY
+    text:
+      zh-CN: Tabs Content 的语义成立依赖 `P-BASE-TABS` 定义的 Tabs anatomy family 与 Tabs context；它不得脱离 Tabs root 自行定义 current panel 语义。
+      en: Tabs Content semantics depend on the Tabs anatomy family and Tabs context defined by `P-BASE-TABS`; it must not define current panel semantics independently from Tabs root.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-CONTENT-CLAIM-ROLE
+    text:
+      zh-CN: Tabs Content 必须 claim `base-tabs` anatomy family 的 `content` role。
+      en: Tabs Content must claim the `content` role in the `base-tabs` anatomy family.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0004
+        - C-ANATOMY-0005
+  - id: P-BASE-TABS-CONTENT-SAME-DOMAIN
+    text:
+      zh-CN: Tabs Content 必须解析到同一 Tabs domain 中的 Tabs root；跨 Tabs domain 的 context 不得被消费。
+      en: Tabs Content must resolve to the Tabs root in the same Tabs domain; context from another Tabs domain must not be consumed.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0005
+        - C-CONTEXT-0002
+  - id: P-BASE-TABS-CONTENT-PROP-VALUE
+    text:
+      zh-CN: 'Tabs Content 必须接受 `value?: string` props input；可靠参与 Tabs selection matching 需要提供有效 value。'
+      en: 'Tabs Content must accept a `value?: string` props input; reliably participating in Tabs selection matching requires a valid value.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+  - id: P-BASE-TABS-CONTENT-CONTEXT-CONSUME
+    text:
+      zh-CN: Tabs Content 必须读取或订阅 Tabs context，以获得 selected value。
+      en: Tabs Content must read or subscribe to Tabs context to obtain selected value.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0006
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-CONTENT-CURRENT-DERIVED
+    text:
+      zh-CN: Tabs Content 的 `current` state 必须由自身 protocol value 与 Tabs context selected value 的相等关系派生。
+      en: Tabs Content `current` state must be derived from equality between its own protocol value and Tabs context selected value.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-CONTENT-CURRENT-EXPOSE
+    text:
+      zh-CN: Tabs Content 必须 expose `current` state；`current=true` 表示该 content 对应当前 selected Tabs value。
+      en: Tabs Content must expose `current` state; `current=true` means the content corresponds to the current selected Tabs value.
+    dependsOn:
+      contracts:
+        - C-EXPOSE-STATE-0001
+        - C-STATE-0001
+  - id: P-BASE-TABS-CONTENT-HIDDEN-WHEN-INACTIVE
+    text:
+      zh-CN: 非 current Tabs Content 必须隐藏；具体 hidden 机制由宿主能力或 prototype implementation 投射，契约不绑定 CSS。
+      en: Non-current Tabs Content must be hidden; the concrete hidden mechanism is projected by host capabilities or prototype implementation, and the contract is not bound to CSS.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+  - id: P-BASE-TABS-CONTENT-NOT-UNMOUNTED-BY-DEFAULT
+    text:
+      zh-CN: 非 current Tabs Content 不得因为 Tabs core protocol 的默认 hidden 行为而自动 unmount。
+      en: Non-current Tabs Content must not be automatically unmounted by the default hidden behavior of the Tabs core protocol.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-CONTENT-PRESENCE-DEFERRED
+    text:
+      zh-CN: Tabs Content 的 keepMounted、lazyMount、forceMount、presence transition 与 inactive panel unmount 策略暂缓。
+      en: Tabs Content keepMounted, lazyMount, forceMount, presence transition, and inactive panel unmount policies are deferred.
+    references:
+      prototypes:
+        - id: P-BASE-TABS
+          anchors:
+            - P-BASE-TABS-PRESENCE-DEFERRED
+  - id: P-BASE-TABS-CONTENT-A11Y-ROLE
+    text:
+      zh-CN: 在具备 accessibility projection 的宿主中，Tabs Content 必须投射 tabpanel 语义。
+      en: In hosts with accessibility projection, Tabs Content must project tabpanel semantics.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+  - id: P-BASE-TABS-CONTENT-A11Y-LABELLEDBY-TARGET
+    text:
+      zh-CN: Tabs Content 必须声明它被具有相同 protocol value 的 Tabs Trigger label；Web 宿主应将该关系投射为 `aria-labelledby`。
+      en: Tabs Content must declare that it is labelled by the Tabs Trigger with the same protocol value; Web hosts should project that relationship as `aria-labelledby`.
+    dependsOn:
+      decisions:
+        - D-A11Y-PART-RELATIONSHIP-PROJECTION-0001
+    note:
+      zh-CN: 第一阶段通过 a11y relation target 投射为 Web `aria-labelledby`；后续仍可演进 adapter 生成目标 identity 的方式。
+      en: The first phase projects the a11y relation target to Web `aria-labelledby`; later work may still evolve how adapters generate target identity.
+  - id: P-BASE-TABS-CONTENT-A11Y-HIDDEN
+    text:
+      zh-CN: 在具备 accessibility projection 的宿主中，非 current Tabs Content 的 hidden 状态必须被投射到 accessibility semantic tree。
+      en: In hosts with accessibility projection, hidden state for non-current Tabs Content must be projected to the accessibility semantic tree.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+  - id: P-BASE-TABS-CONTENT-TABINDEX-DEFERRED
+    text:
+      zh-CN: Tabpanel 在缺少内部 focusable 内容时是否自动进入 Tab 顺序暂缓；第一轮不要求 Content 自动设置 focus target。
+      en: Whether tabpanel automatically enters the Tab sequence when it lacks internal focusable content is deferred; the first pass does not require Content to automatically set a focus target.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
+sources:
+  - path: spec/prototypes/P-BASE-TABS.yaml
+  - path: packages/prototypes/base/src/tabs/content.ts
+  - path: packages/prototypes/base/src/tabs/types.ts
+  - path: packages/prototypes/base/test/tabs.test.ts
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+    label: WAI-ARIA Authoring Practices Guide - Tabs Pattern
+dependsOn:
+  prototypes:
+    - P-BASE-TABS
+  contracts:
+    - C-ANATOMY-0004
+    - C-CONTEXT-0006
+    - C-STATE-0001
+    - C-A11Y-0001
+  decisions:
+    - D-A11Y-PART-RELATIONSHIP-PROJECTION-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added the first Base Tabs Content protocol catalog.
+tags:
+  - prototype
+  - base
+  - tabs
+  - content
+  - tabpanel

--- a/spec/prototypes/P-BASE-TABS-CONTENT.yaml
+++ b/spec/prototypes/P-BASE-TABS-CONTENT.yaml
@@ -134,11 +134,24 @@ criteria:
         - C-A11Y-0001
   - id: P-BASE-TABS-CONTENT-TABINDEX-DEFERRED
     text:
-      zh-CN: Tabpanel 在缺少内部 focusable 内容时是否自动进入 Tab 顺序暂缓；第一轮不要求 Content 自动设置 focus target。
-      en: Whether tabpanel automatically enters the Tab sequence when it lacks internal focusable content is deferred; the first pass does not require Content to automatically set a focus target.
+      zh-CN: 已废弃的第一轮断口：tabpanel 是否自动进入 Tab 顺序不再暂缓；由 `P-BASE-TABS-CONTENT-FOCUS-ENTRY` 接管。
+      en: 'Deprecated first-pass gap: whether tabpanel automatically enters the Tab sequence is no longer deferred; `P-BASE-TABS-CONTENT-FOCUS-ENTRY` now owns this requirement.'
     dependsOn:
       contracts:
         - C-AS-FOCUSABLE-0001
+    status: deprecated
+  - id: P-BASE-TABS-CONTENT-FOCUS-ENTRY
+    text:
+      zh-CN: Current Tabs Content 必须声明 focus entry region，并采用 descendant-first 与 fallback self 策略；inactive Content 必须禁用该 entry。
+      en: Current Tabs Content must declare a focus entry region using descendant-first with fallback self policy; inactive Content must disable that entry.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUS-ENTRY-0001
+      decisions:
+        - D-FOCUS-ENTRY-DELEGATION-0001
+    note:
+      zh-CN: 该准则表达跨宿主行为，不绑定 Web `tabIndex`、CSS 或具体 DOM 查询实现。
+      en: This criterion expresses cross-host behavior and is not bound to Web `tabIndex`, CSS, or a concrete DOM query implementation.
 sources:
   - path: spec/prototypes/P-BASE-TABS.yaml
   - path: packages/prototypes/base/src/tabs/content.ts
@@ -154,12 +167,17 @@ dependsOn:
     - C-CONTEXT-0006
     - C-STATE-0001
     - C-A11Y-0001
+    - C-AS-FOCUS-ENTRY-0001
   decisions:
     - D-A11Y-PART-RELATIONSHIP-PROJECTION-0001
+    - D-FOCUS-ENTRY-DELEGATION-0001
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Added the first Base Tabs Content protocol catalog.
+  - version: 0.1.1
+    change: refined
+    summary: Replaced deferred tabpanel focus entry gap with descendant-first focus entry requirement.
 tags:
   - prototype
   - base

--- a/spec/prototypes/P-BASE-TABS-INDICATOR.yaml
+++ b/spec/prototypes/P-BASE-TABS-INDICATOR.yaml
@@ -1,0 +1,161 @@
+id: P-BASE-TABS-INDICATOR
+type: prototype
+title: Base Tabs Indicator is a context-driven tabs indicator
+status: draft
+since: 0.1.0
+summary: Base Tabs Indicator is the optional and repeatable indicator part of Base Tabs. It consumes Tabs context for selected value, active value, orientation, and activation mode, but does not own selection, activation, focus, accessibility control, layout measurement, or event semantics.
+statement:
+  zh-CN: >-
+    Base Tabs Indicator 是 Base Tabs anatomy family 中可选且可重复的 indicator part。它通过 Tabs context 消费 selected value、activeValue、orientation 与 activationMode，将这些信息作为视觉展示依据；它不拥有 selected value，不处理 activation，不参与 roving focus，不作为 event target，也不承诺读取 trigger/content 的真实布局尺寸或自动定位。`base-tabs-indicator` direct prototype 与 `asTabsIndicator` authored asHook 是同一 Tabs indicator protocol 的两个 authoring entries。
+
+
+  en: >-
+    Base Tabs Indicator is the optional and repeatable indicator part in the Base Tabs anatomy family. It consumes selected value, activeValue, orientation, and activationMode through Tabs context and uses them as visual display inputs; it does not own selected value, process activation, participate in roving focus, act as an event target, or promise real trigger/content layout measurement or automatic positioning. The `base-tabs-indicator` direct prototype and the `asTabsIndicator` authored asHook are two authoring entries of the same Tabs indicator protocol.
+
+
+criteria:
+  - id: P-BASE-TABS-INDICATOR-ROLE-INDICATOR
+    text:
+      zh-CN: Tabs Indicator 只能作为 Tabs context 的 visual indicator；它不是 tab、tabpanel、input control、value owner 或 command control。
+      en: Tabs Indicator may only be a visual indicator for Tabs context; it is not a tab, tabpanel, input control, value owner, or command control.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-INDICATOR-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-tabs-indicator` direct prototype 与 `asTabsIndicator` authored asHook 是同一 Tabs indicator protocol 的两个 authoring entries。'
+      en: 'The `base-tabs-indicator` direct prototype and the `asTabsIndicator` authored asHook are two authoring entries of the same Tabs indicator protocol.'
+    dependsOn:
+      contracts:
+        - C-CORE-SYNTAX-0003
+        - C-AS-HOOK-0001
+      decisions:
+        - D-PROTOTYPE-ENTITY-NAMING-0001
+  - id: P-BASE-TABS-INDICATOR-PROTOCOL-DEPENDENCY
+    text:
+      zh-CN: Tabs Indicator 的语义成立依赖 `P-BASE-TABS` 定义的 Tabs anatomy family 与 Tabs context；它不得脱离 Tabs root 自行定义 tabs 语义。
+      en: Tabs Indicator semantics depend on the Tabs anatomy family and Tabs context defined by `P-BASE-TABS`; it must not define tabs semantics independently from Tabs root.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-INDICATOR-CLAIM-ROLE
+    text:
+      zh-CN: Tabs Indicator 必须 claim `base-tabs` anatomy family 的 `indicator` role。
+      en: Tabs Indicator must claim the `indicator` role in the `base-tabs` anatomy family.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0004
+        - C-ANATOMY-0005
+  - id: P-BASE-TABS-INDICATOR-SAME-DOMAIN
+    text:
+      zh-CN: Tabs Indicator 必须解析到同一 Tabs domain 中的 Tabs root；跨 Tabs domain 的 context 不得被消费。
+      en: Tabs Indicator must resolve to the Tabs root in the same Tabs domain; context from another Tabs domain must not be consumed.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0005
+        - C-CONTEXT-0002
+  - id: P-BASE-TABS-INDICATOR-CONTEXT-CONSUME
+    text:
+      zh-CN: Tabs Indicator 必须通过 Tabs context 读取或订阅 selected value、activeValue、orientation 与 activationMode。
+      en: Tabs Indicator must read or subscribe to selected value, activeValue, orientation, and activationMode through Tabs context.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0006
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-INDICATOR-DERIVED-VALUE
+    text:
+      zh-CN: Tabs Indicator 可以 expose 或提供派生的 selected `value` display state，但该 state 必须来源于 Tabs context，且不得成为 selected value 的 source of truth。
+      en: Tabs Indicator may expose or provide derived selected `value` display state, but that state must come from Tabs context and must not become the source of truth for selected value.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0007
+        - C-STATE-0001
+  - id: P-BASE-TABS-INDICATOR-DERIVED-ACTIVE-VALUE
+    text:
+      zh-CN: Tabs Indicator 可以 expose 或提供派生的 `activeValue` display state，用于表达 roving-focus active item 或最近活跃 trigger。
+      en: Tabs Indicator may expose or provide derived `activeValue` display state to represent the roving-focus active item or most recently active trigger.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0007
+        - C-STATE-0001
+  - id: P-BASE-TABS-INDICATOR-DERIVED-ORIENTATION
+    text:
+      zh-CN: Tabs Indicator 可以读取 orientation 作为派生展示状态。
+      en: Tabs Indicator may read orientation as derived display state.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-INDICATOR-NO-SELECTION-OWNER
+    text:
+      zh-CN: Tabs Indicator 不得接受 `value`、`defaultValue` 或 value-change callback props，也不得发出 `valueChange`。
+      en: Tabs Indicator must not accept `value`, `defaultValue`, or value-change callback props, and must not emit `valueChange`.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-EXPOSE-EVENT-0001
+  - id: P-BASE-TABS-INDICATOR-NO-EVENT-TARGET
+    text:
+      zh-CN: Tabs Indicator 不得作为独立 event target，不得注册 activation route，也不得使用 Event 通路表达自身行为。
+      en: Tabs Indicator must not act as an independent event target, must not register activation routes, and must not use the Event channel to express its own behavior.
+    dependsOn:
+      contracts:
+        - C-EVENT-TYPE-0001
+        - C-EXPOSE-EVENT-0001
+  - id: P-BASE-TABS-INDICATOR-NO-FOCUS-TARGET
+    text:
+      zh-CN: Tabs Indicator 不得成为独立 focus target；Tabs trigger/list 负责 tab focus 与 roving focus。
+      en: Tabs Indicator must not become an independent focus target; Tabs trigger/list owns tab focus and roving focus.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
+        - C-AS-FOCUS-ROVING-0001
+  - id: P-BASE-TABS-INDICATOR-PRESENTATIONAL-A11Y
+    text:
+      zh-CN: Tabs Indicator 不得成为独立 accessible control；它必须作为 Tabs 语义的呈现结构。
+      en: Tabs Indicator must not become an independent accessible control; it must remain presentational structure for Tabs semantics.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+  - id: P-BASE-TABS-INDICATOR-NO-LAYOUT-MEASUREMENT
+    text:
+      zh-CN: 第一轮 Tabs Indicator 不承诺读取 trigger/content 的 host rect、字体渲染结果、容器布局尺寸或滚动位置。
+      en: The first Tabs Indicator pass does not promise reading trigger/content host rects, font rendering results, container layout sizes, or scroll positions.
+    dependsOn:
+      knowledge:
+        - K-DESIGN-TRADEOFF-0001
+  - id: P-BASE-TABS-INDICATOR-NO-AUTO-POSITIONING
+    text:
+      zh-CN: 第一轮 Tabs Indicator 不承诺根据 selected trigger 自动定位、自动设定尺寸或自动执行动画；这些能力归下游 styled prototype、App Maker 或未来 layout measurement hostcap。
+      en: The first Tabs Indicator pass does not promise automatic positioning, sizing, or animation from the selected trigger; those capabilities belong to downstream styled prototypes, the App Maker, or future layout measurement host capabilities.
+    dependsOn:
+      knowledge:
+        - K-DESIGN-TRADEOFF-0001
+  - id: P-BASE-TABS-INDICATOR-NO-VISUAL-VARIANT-CORE
+    text:
+      zh-CN: Tabs Indicator core contract 不定义 size、motion、shape、tone、placement、transition curve 等视觉参数。
+      en: Tabs Indicator core contract does not define visual parameters such as size, motion, shape, tone, placement, or transition curve.
+    dependsOn:
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+sources:
+  - path: spec/prototypes/P-BASE-TABS.yaml
+  - path: packages/prototypes/base/src/tabs/shared.ts
+  - path: https://base-ui.com/react/components/tabs
+    label: Base UI Tabs
+dependsOn:
+  prototypes:
+    - P-BASE-TABS
+  contracts:
+    - C-ANATOMY-0004
+    - C-CONTEXT-0006
+    - C-STATE-0001
+    - C-A11Y-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added the first Base Tabs Indicator protocol catalog as a context-driven visual consumer.
+tags:
+  - prototype
+  - base
+  - tabs
+  - indicator

--- a/spec/prototypes/P-BASE-TABS-LIST.yaml
+++ b/spec/prototypes/P-BASE-TABS-LIST.yaml
@@ -1,0 +1,157 @@
+id: P-BASE-TABS-LIST
+type: prototype
+title: Base Tabs List is the tab trigger collection and roving focus container
+status: draft
+since: 0.1.0
+summary: Base Tabs List is the optional at-most-one Tabs anatomy part that owns the trigger collection surface and roving focus methods while consuming Tabs context for orientation, selected value, and active value.
+statement:
+  zh-CN: >-
+    Base Tabs List 是 Base Tabs anatomy family 中可选且至多一个的 list part。它承载 trigger collection 与 roving focus 方法，消费 Tabs context 中的 orientation、selected value 与 activeValue，但不拥有 selected value，也不处理 tabpanel visibility。`base-tabs-list` direct prototype 与 `asTabsList` authored asHook 是同一 Tabs list protocol 的两个 authoring entries。
+
+
+  en: >-
+    Base Tabs List is the optional and at-most-one list part in the Base Tabs anatomy family. It hosts the trigger collection and roving focus methods, consumes orientation, selected value, and activeValue from Tabs context, but does not own selected value or handle tabpanel visibility. The `base-tabs-list` direct prototype and the `asTabsList` authored asHook are two authoring entries of the same Tabs list protocol.
+
+
+criteria:
+  - id: P-BASE-TABS-LIST-ROLE-COLLECTION
+    text:
+      zh-CN: Tabs List 是 trigger collection 与 roving focus 的结构承载者，不是 selected value owner。
+      en: Tabs List is the structural host for trigger collection and roving focus, not the selected value owner.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-LIST-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-tabs-list` direct prototype 与 `asTabsList` authored asHook 是同一 Tabs list protocol 的两个 authoring entries。'
+      en: 'The `base-tabs-list` direct prototype and the `asTabsList` authored asHook are two authoring entries of the same Tabs list protocol.'
+    dependsOn:
+      contracts:
+        - C-CORE-SYNTAX-0003
+        - C-AS-HOOK-0001
+      decisions:
+        - D-PROTOTYPE-ENTITY-NAMING-0001
+  - id: P-BASE-TABS-LIST-PROTOCOL-DEPENDENCY
+    text:
+      zh-CN: Tabs List 的语义成立依赖 `P-BASE-TABS` 定义的 Tabs anatomy family 与 Tabs context；它不得脱离 Tabs root 自行定义 tablist 语义。
+      en: Tabs List semantics depend on the Tabs anatomy family and Tabs context defined by `P-BASE-TABS`; it must not define tablist semantics independently from Tabs root.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-LIST-CLAIM-ROLE
+    text:
+      zh-CN: Tabs List 必须 claim `base-tabs` anatomy family 的 `list` role。
+      en: Tabs List must claim the `list` role in the `base-tabs` anatomy family.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0004
+        - C-ANATOMY-0005
+  - id: P-BASE-TABS-LIST-SAME-DOMAIN
+    text:
+      zh-CN: Tabs List 必须解析到同一 Tabs domain 中的 Tabs root；跨 Tabs domain 的 context 不得被消费。
+      en: Tabs List must resolve to the Tabs root in the same Tabs domain; context from another Tabs domain must not be consumed.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0005
+        - C-CONTEXT-0002
+  - id: P-BASE-TABS-LIST-CONTEXT-CONSUME
+    text:
+      zh-CN: Tabs List 必须读取或订阅 Tabs context，以获得 orientation、selected value 与 activeValue。
+      en: Tabs List must read or subscribe to Tabs context to obtain orientation, selected value, and activeValue.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0006
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-LIST-FOCUS-ROVING
+    text:
+      zh-CN: Tabs List 必须为 trigger collection 提供 roving focus 能力。
+      en: Tabs List must provide roving focus capability for the trigger collection.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUS-ROVING-0001
+  - id: P-BASE-TABS-LIST-FOCUS-METHODS
+    text:
+      zh-CN: Tabs List 必须 expose `focusFirst`、`focusLast`、`focusNext`、`focusPrev` 与 `focusSelected` 等 focus navigation 方法。
+      en: Tabs List must expose focus navigation methods such as `focusFirst`, `focusLast`, `focusNext`, `focusPrev`, and `focusSelected`.
+    dependsOn:
+      contracts:
+        - C-EXPOSE-0001
+        - C-AS-FOCUS-ROVING-0001
+      decisions:
+        - D-EXPOSE-METHOD-CALL-0001
+  - id: P-BASE-TABS-LIST-SKIP-DISABLED
+    text:
+      zh-CN: Tabs List 的 roving focus 必须跳过 disabled trigger。
+      en: Tabs List roving focus must skip disabled triggers.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUS-ROVING-0001
+  - id: P-BASE-TABS-LIST-ORIENTATION-KEYS
+    text:
+      zh-CN: Tabs List 必须使用 Tabs orientation 解释方向键：horizontal 使用 ArrowLeft/ArrowRight，vertical 使用 ArrowUp/ArrowDown。
+      en: 'Tabs List must interpret arrow keys using Tabs orientation: horizontal uses ArrowLeft/ArrowRight and vertical uses ArrowUp/ArrowDown.'
+    dependsOn:
+      contracts:
+        - C-AS-FOCUS-ROVING-0001
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-LIST-HOME-END
+    text:
+      zh-CN: Tabs List 必须支持 Home/End 将 focus 移动到第一个/最后一个 eligible trigger。
+      en: Tabs List must support Home/End to move focus to the first/last eligible trigger.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUS-ROVING-0001
+  - id: P-BASE-TABS-LIST-PROP-LOOP
+    text:
+      zh-CN: 'Tabs List 可以接受 `loop?: boolean` props input 控制 roving focus 是否首尾循环；第一轮默认值为 `false`。'
+      en: 'Tabs List may accept a `loop?: boolean` props input controlling whether roving focus wraps; the first-pass default is `false`.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+  - id: P-BASE-TABS-LIST-A11Y-ROLE
+    text:
+      zh-CN: 在具备 accessibility projection 的宿主中，Tabs List 必须投射 tablist 语义。
+      en: In hosts with accessibility projection, Tabs List must project tablist semantics.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+      decisions:
+        - D-A11Y-SEMANTIC-DOMAIN-0001
+  - id: P-BASE-TABS-LIST-A11Y-ORIENTATION
+    text:
+      zh-CN: 在具备 accessibility projection 的宿主中，vertical Tabs List 必须投射 vertical orientation 语义；horizontal 可使用宿主默认或显式投射。
+      en: In hosts with accessibility projection, vertical Tabs List must project vertical orientation semantics; horizontal may use the host default or explicit projection.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+  - id: P-BASE-TABS-LIST-LABEL-DEFERRED
+    text:
+      zh-CN: Tabs List 的 explicit accessible label API 暂缓；第一轮不要求 `label`、`aria-label` 或 `labelledBy` props。
+      en: Explicit accessible label API for Tabs List is deferred; the first pass does not require `label`, `aria-label`, or `labelledBy` props.
+    dependsOn:
+      decisions:
+        - D-A11Y-SEMANTIC-DOMAIN-0001
+sources:
+  - path: spec/prototypes/P-BASE-TABS.yaml
+  - path: packages/prototypes/base/src/tabs/list.ts
+  - path: packages/prototypes/base/src/tabs/shared.ts
+  - path: packages/prototypes/base/test/tabs.test.ts
+dependsOn:
+  prototypes:
+    - P-BASE-TABS
+  contracts:
+    - C-ANATOMY-0004
+    - C-CONTEXT-0006
+    - C-AS-FOCUS-ROVING-0001
+    - C-A11Y-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added the first Base Tabs List protocol catalog.
+tags:
+  - prototype
+  - base
+  - tabs
+  - list
+  - focus-roving

--- a/spec/prototypes/P-BASE-TABS-LIST.yaml
+++ b/spec/prototypes/P-BASE-TABS-LIST.yaml
@@ -125,11 +125,21 @@ criteria:
     dependsOn:
       contracts:
         - C-A11Y-0001
-  - id: P-BASE-TABS-LIST-LABEL-DEFERRED
+  - id: P-BASE-TABS-LIST-PROP-A11Y-LABEL
     text:
-      zh-CN: Tabs List 的 explicit accessible label API 暂缓；第一轮不要求 `label`、`aria-label` 或 `labelledBy` props。
-      en: Explicit accessible label API for Tabs List is deferred; the first pass does not require `label`, `aria-label`, or `labelledBy` props.
+      zh-CN: 'Tabs List 可以接受宿主中立的 `a11yLabel?: string` props input 表达 explicit accessible label；原型 API 不暴露 `aria-label` 或 `aria-labelledby`。'
+      en: 'Tabs List may accept a host-neutral `a11yLabel?: string` props input for an explicit accessible label; the prototype API does not expose `aria-label` or `aria-labelledby`.'
     dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-A11Y-0001
+  - id: P-BASE-TABS-LIST-A11Y-LABEL
+    text:
+      zh-CN: 在具备 accessibility projection 的宿主中，非空 `a11yLabel` 必须投射为 Tabs List 的 accessible name。
+      en: In hosts with accessibility projection, a non-empty `a11yLabel` must be projected as the Tabs List accessible name.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
       decisions:
         - D-A11Y-SEMANTIC-DOMAIN-0001
 sources:
@@ -149,6 +159,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added the first Base Tabs List protocol catalog.
+  - version: 0.1.1
+    change: refined
+    summary: Added host-neutral a11yLabel as the Tabs List accessible name input.
 tags:
   - prototype
   - base

--- a/spec/prototypes/P-BASE-TABS-TRIGGER.yaml
+++ b/spec/prototypes/P-BASE-TABS-TRIGGER.yaml
@@ -1,0 +1,258 @@
+id: P-BASE-TABS-TRIGGER
+type: prototype
+title: Base Tabs Trigger is a value-matched tab activation item
+status: draft
+since: 0.1.0
+summary: Base Tabs Trigger is the repeatable tab item part that provides a protocol value, derives selected state from Tabs context, participates in the list collection and roving focus, and requests root selection through activation.
+statement:
+  zh-CN: >-
+    Base Tabs Trigger 是 Base Tabs anatomy family 中可重复的 trigger part。Trigger 必须提供用于 Tabs selection matching 的 protocol `value`，消费 Tabs context，并在自身 value 与 context selected value 相等时派生 selected state。Enabled trigger 在成功 activation 后向 root 请求 selection；automatic activation mode 下，trigger 获得 focus 也可以请求 selection。Trigger 可以暴露局部 `click` signal 供 App Maker 观察 trigger activation，但 Tabs selected value 的 outward signal 属于 root `valueChange`。
+
+
+  en: >-
+    Base Tabs Trigger is the repeatable trigger part in the Base Tabs anatomy family. Trigger must provide a protocol `value` used for Tabs selection matching, consume Tabs context, and derive selected state when its own value equals the context selected value. An enabled trigger requests root selection after successful activation; in automatic activation mode, focus may also request selection. Trigger may expose a local `click` signal for App Maker observation of trigger activation, but the outward signal for Tabs selected value belongs to root `valueChange`.
+
+
+criteria:
+  - id: P-BASE-TABS-TRIGGER-ROLE-TAB
+    text:
+      zh-CN: Tabs Trigger 是 tab activation item，不是 selected value owner 或 tabpanel content owner。
+      en: Tabs Trigger is a tab activation item, not the selected value owner or tabpanel content owner.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-TRIGGER-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-tabs-trigger` direct prototype 与 `asTabsTrigger` authored asHook 是同一 Tabs trigger protocol 的两个 authoring entries。'
+      en: 'The `base-tabs-trigger` direct prototype and the `asTabsTrigger` authored asHook are two authoring entries of the same Tabs trigger protocol.'
+    dependsOn:
+      contracts:
+        - C-CORE-SYNTAX-0003
+        - C-AS-HOOK-0001
+      decisions:
+        - D-PROTOTYPE-ENTITY-NAMING-0001
+  - id: P-BASE-TABS-TRIGGER-PROTOCOL-DEPENDENCY
+    text:
+      zh-CN: Tabs Trigger 的语义成立依赖 `P-BASE-TABS` 定义的 Tabs anatomy family 与 Tabs context；它不得脱离 Tabs root 自行定义 tab selection 语义。
+      en: Tabs Trigger semantics depend on the Tabs anatomy family and Tabs context defined by `P-BASE-TABS`; it must not define tab selection semantics independently from Tabs root.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY
+    text:
+      zh-CN: Tabs Trigger 不应通过消费 Button protocol 获得 tab 语义；它可以参考 Button 的 activation、focus、disabled 与 press lifecycle 准则。
+      en: Tabs Trigger should not obtain tab semantics by consuming the Button protocol; it may reference Button activation, focus, disabled, and press lifecycle criteria.
+    dependsOn:
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            - P-BASE-BUTTON-TRIGGER-SEMANTICS
+            - P-BASE-BUTTON-PRESS-LIFECYCLE
+  - id: P-BASE-TABS-TRIGGER-CLAIM-ROLE
+    text:
+      zh-CN: Tabs Trigger 必须 claim `base-tabs` anatomy family 的 `trigger` role。
+      en: Tabs Trigger must claim the `trigger` role in the `base-tabs` anatomy family.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0004
+        - C-ANATOMY-0005
+  - id: P-BASE-TABS-TRIGGER-SAME-DOMAIN
+    text:
+      zh-CN: Tabs Trigger 必须解析到同一 Tabs domain 中的 Tabs root 与 list；跨 Tabs domain 的 context 或 collection 不得被消费。
+      en: Tabs Trigger must resolve to the Tabs root and list in the same Tabs domain; context or collection from another Tabs domain must not be consumed.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0005
+        - C-CONTEXT-0002
+  - id: P-BASE-TABS-TRIGGER-PROP-VALUE
+    text:
+      zh-CN: 'Tabs Trigger 必须接受 `value?: string` props input；可靠参与 Tabs selection matching 需要提供有效 value。'
+      en: 'Tabs Trigger must accept a `value?: string` props input; reliably participating in Tabs selection matching requires a valid value.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+  - id: P-BASE-TABS-TRIGGER-PROP-DISABLED
+    text:
+      zh-CN: 'Tabs Trigger 必须接受 `disabled?: boolean` props input，默认值为 `false`。'
+      en: 'Tabs Trigger must accept a `disabled?: boolean` props input whose default is `false`.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+  - id: P-BASE-TABS-TRIGGER-CONTEXT-CONSUME
+    text:
+      zh-CN: Tabs Trigger 必须读取或订阅 Tabs context，以获得 selected value、activeValue、orientation、activationMode 与 controlled 状态。
+      en: Tabs Trigger must read or subscribe to Tabs context to obtain selected value, activeValue, orientation, activationMode, and controlled state.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0006
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-TRIGGER-SELECTED-DERIVED
+    text:
+      zh-CN: Tabs Trigger 的 `selected` state 必须由自身 protocol value 与 Tabs context selected value 的相等关系派生。
+      en: Tabs Trigger `selected` state must be derived from equality between its own protocol value and Tabs context selected value.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-TRIGGER-SELECTED-EXPOSE
+    text:
+      zh-CN: Tabs Trigger 必须 expose `selected` state；`selected=true` 表示该 trigger 对应当前 selected Tabs value。
+      en: Tabs Trigger must expose `selected` state; `selected=true` means the trigger corresponds to the current selected Tabs value.
+    dependsOn:
+      contracts:
+        - C-EXPOSE-STATE-0001
+        - C-STATE-0001
+  - id: P-BASE-TABS-TRIGGER-NO-ACTIVE-EXPOSE-FIRST-PASS
+    text:
+      zh-CN: 第一轮 Tabs Trigger 不要求 expose `active` state；roving-focus active item 语义保留在 Tabs context `activeValue` 中，以避免与 Toggle active state 混淆。
+      en: The first Tabs Trigger pass does not require exposing an `active` state; roving-focus active item semantics remain in Tabs context `activeValue` to avoid conflating with Toggle active state.
+    references:
+      prototypes:
+        - id: P-BASE-TOGGLE
+          anchors:
+            - P-BASE-TOGGLE-ACTIVE-SCOPED-NAME
+  - id: P-BASE-TABS-TRIGGER-DISABLED-EXPOSE
+    text:
+      zh-CN: Tabs Trigger 必须 expose `disabled` state。
+      en: Tabs Trigger must expose `disabled` state.
+    dependsOn:
+      contracts:
+        - C-EXPOSE-STATE-0001
+        - C-STATE-INTERACTION-0001
+  - id: P-BASE-TABS-TRIGGER-INTERACTION-STATES
+    text:
+      zh-CN: Tabs Trigger 应 expose `hovered`、`focused`、`focusVisible` 与 `pressed` transient interaction states。
+      en: Tabs Trigger should expose transient interaction states `hovered`, `focused`, `focusVisible`, and `pressed`.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+        - C-EXPOSE-STATE-0001
+  - id: P-BASE-TABS-TRIGGER-FOCUSABLE
+    text:
+      zh-CN: Tabs Trigger 必须作为可聚焦 tab item，并支持 `focusSelf`。
+      en: Tabs Trigger must act as a focusable tab item and support `focusSelf`.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
+  - id: P-BASE-TABS-TRIGGER-COLLECTION-ITEM
+    text:
+      zh-CN: Tabs Trigger 必须注册为 Tabs trigger collection item，collection meta 至少包含 value 与 disabled。
+      en: Tabs Trigger must register as a Tabs trigger collection item whose collection metadata includes at least value and disabled.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0005
+        - C-AS-FOCUS-ROVING-0001
+  - id: P-BASE-TABS-TRIGGER-ACTIVATION-REQUESTS-SELECTION
+    text:
+      zh-CN: Enabled Tabs Trigger 在成功 activation 后必须以自身 value 请求 root selection。
+      en: An enabled Tabs Trigger must request root selection with its own value after successful activation.
+    dependsOn:
+      contracts:
+        - C-AS-TRIGGER-0001
+        - C-EVENT-TYPE-0001
+  - id: P-BASE-TABS-TRIGGER-DISABLED-SUPPRESS-ACTIVATION
+    text:
+      zh-CN: Disabled Tabs Trigger 不得请求 root selection，也不得更新 Tabs context activeValue。
+      en: A disabled Tabs Trigger must not request root selection or update Tabs context activeValue.
+    dependsOn:
+      contracts:
+        - C-STATE-INTERACTION-0001
+  - id: P-BASE-TABS-TRIGGER-AUTOMATIC-FOCUS-SELECTION
+    text:
+      zh-CN: 在 `activationMode="automatic"` 时，enabled trigger 获得 focus 可以请求 root selection。
+      en: When `activationMode="automatic"`, an enabled trigger may request root selection when it receives focus.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+      contracts:
+        - C-AS-FOCUSABLE-0001
+  - id: P-BASE-TABS-TRIGGER-MANUAL-FOCUS-STABLE
+    text:
+      zh-CN: 在 `activationMode="manual"` 时，roving focus 移动不得自行改变 root selected value；selection 需要 activation 提交。
+      en: When `activationMode="manual"`, roving focus movement must not by itself change root selected value; selection requires activation commit.
+    dependsOn:
+      prototypes:
+        - P-BASE-TABS
+  - id: P-BASE-TABS-TRIGGER-CLICK-SIGNAL
+    text:
+      zh-CN: Tabs Trigger 可以 expose `click` event 作为局部 activation observation signal；该 signal 不得替代 root `valueChange` 作为 selection outward signal。
+      en: Tabs Trigger may expose a `click` event as a local activation observation signal; that signal must not replace root `valueChange` as the selection outward signal.
+    dependsOn:
+      contracts:
+        - C-EXPOSE-EVENT-0001
+    references:
+      prototypes:
+        - id: P-BASE-TABS
+          anchors:
+            - P-BASE-TABS-VALUE-CHANGE-SIGNAL
+  - id: P-BASE-TABS-TRIGGER-A11Y-ROLE
+    text:
+      zh-CN: 在具备 accessibility projection 的宿主中，Tabs Trigger 必须投射 tab 语义。
+      en: In hosts with accessibility projection, Tabs Trigger must project tab semantics.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+  - id: P-BASE-TABS-TRIGGER-A11Y-SELECTED
+    text:
+      zh-CN: 在具备 accessibility projection 的宿主中，Tabs Trigger 必须投射 selected state；Web 宿主应将 selected/未 selected 投射为 `aria-selected` true/false。
+      en: In hosts with accessibility projection, Tabs Trigger must project selected state; Web hosts should project selected/not selected to `aria-selected` true/false.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+  - id: P-BASE-TABS-TRIGGER-A11Y-DISABLED
+    text:
+      zh-CN: 在具备 accessibility projection 的宿主中，disabled Tabs Trigger 必须投射 disabled 语义。
+      en: In hosts with accessibility projection, disabled Tabs Trigger must project disabled semantics.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+  - id: P-BASE-TABS-TRIGGER-A11Y-CONTROLS-TARGET
+    text:
+      zh-CN: Tabs Trigger 必须声明它 controls 具有相同 protocol value 的 Tabs Content；Web 宿主应将该关系投射为 `aria-controls`。
+      en: Tabs Trigger must declare that it controls the Tabs Content with the same protocol value; Web hosts should project that relationship as `aria-controls`.
+    dependsOn:
+      decisions:
+        - D-A11Y-PART-RELATIONSHIP-PROJECTION-0001
+    note:
+      zh-CN: 第一阶段通过 a11y relation target 投射为 Web `aria-controls`；后续仍可演进 adapter 生成目标 identity 的方式。
+      en: The first phase projects the a11y relation target to Web `aria-controls`; later work may still evolve how adapters generate target identity.
+  - id: P-BASE-TABS-TRIGGER-ACCESSIBLE-NAME
+    text:
+      zh-CN: Tabs Trigger 必须允许从内容或宿主 projection 获得 accessible name。
+      en: Tabs Trigger must allow an accessible name from content or host projection.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+sources:
+  - path: spec/prototypes/P-BASE-TABS.yaml
+  - path: packages/prototypes/base/src/tabs/trigger.ts
+  - path: packages/prototypes/base/src/tabs/types.ts
+  - path: packages/prototypes/base/test/tabs.test.ts
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+    label: WAI-ARIA Authoring Practices Guide - Tabs Pattern
+dependsOn:
+  prototypes:
+    - P-BASE-TABS
+  contracts:
+    - C-ANATOMY-0004
+    - C-CONTEXT-0006
+    - C-STATE-0001
+    - C-AS-TRIGGER-0001
+    - C-AS-FOCUSABLE-0001
+    - C-A11Y-0001
+  decisions:
+    - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+    - D-A11Y-PART-RELATIONSHIP-PROJECTION-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added the first Base Tabs Trigger protocol catalog.
+tags:
+  - prototype
+  - base
+  - tabs
+  - trigger
+  - tab

--- a/spec/prototypes/P-BASE-TABS.yaml
+++ b/spec/prototypes/P-BASE-TABS.yaml
@@ -1,0 +1,393 @@
+id: P-BASE-TABS
+type: prototype
+title: Base Tabs is a compound single-selection protocol
+status: draft
+since: 0.1.0
+summary: Base Tabs is the root-owned compound single-selection protocol for a tablist, tab triggers, tab panels, and optional indicators. The root owns the selected value, provides Tabs context, coordinates controlled and uncontrolled value changes, and defines the Tabs anatomy family.
+statement:
+  zh-CN: >-
+    Base Tabs 是一个 compound single-selection protocol。Root 持有同一 Tabs domain 内唯一的 selected value，并通过 Tabs context 将 `value`、`activeValue`、`orientation`、`activationMode` 与 controlled 状态提供给 list、trigger、content 与 indicator parts。Trigger 与 Content 通过各自 props 提供的 protocol `value` 和 context `value` 进行匹配：匹配的 trigger 处于 selected 状态，匹配的 content 处于 current/visible 状态。Base Tabs 不在第一轮承诺 indicator layout measurement、tabpanel unmount/presence 策略、动态缺失 selected value fallback 或完整 part-to-part a11y relationship 投射实现。
+
+
+  en: >-
+    Base Tabs is a compound single-selection protocol. The root owns the single selected value within the same Tabs domain and provides `value`, `activeValue`, `orientation`, `activationMode`, and controlled state through Tabs context to list, trigger, content, and indicator parts. Trigger and Content match their own protocol `value` props against context `value`: the matching trigger is selected and the matching content is current/visible. The first Base Tabs pass does not promise indicator layout measurement, tabpanel unmount/presence policy, dynamic missing selected value fallback, or full part-to-part a11y relationship projection implementation.
+
+
+anatomy:
+  family: base-tabs
+  roles:
+    root:
+      cardinality:
+        min: 1
+        max: 1
+      summary:
+        zh-CN: Tabs 的 semantic owner、selected value owner、context provider 与 anatomy domain anchor。
+        en: Tabs semantic owner, selected value owner, context provider, and anatomy domain anchor.
+    list:
+      cardinality:
+        min: 0
+        max: 1
+      summary:
+        zh-CN: 可选且至多一个的 trigger collection 与 roving focus 容器。
+        en: Optional and at-most-one trigger collection and roving focus container.
+    trigger:
+      cardinality:
+        min: 0
+        max: '*'
+      summary:
+        zh-CN: 可重复的 tab trigger item，使用自身 protocol value 与 root selected value 匹配。
+        en: Repeatable tab trigger item that matches its protocol value against the root selected value.
+    content:
+      cardinality:
+        min: 0
+        max: '*'
+      summary:
+        zh-CN: 可重复的 tabpanel content item，使用自身 protocol value 与 root selected value 匹配。
+        en: Repeatable tabpanel content item that matches its protocol value against the root selected value.
+    indicator:
+      cardinality:
+        min: 0
+        max: '*'
+      summary:
+        zh-CN: 可选且可重复的 context-driven visual indicator，不拥有 selection、focus 或 event 语义。
+        en: Optional and repeatable context-driven visual indicator that does not own selection, focus, or event semantics.
+  relations:
+    - kind: contains
+      parent: root
+      child: list
+    - kind: contains
+      parent: list
+      child: trigger
+    - kind: contains
+      parent: root
+      child: content
+    - kind: contains
+      parent: root
+      child: indicator
+criteria:
+  - id: P-BASE-TABS-ROLE-SINGLE-SELECTION
+    text:
+      zh-CN: Tabs 表示 compound single-selection protocol；同一 Tabs domain 内最多一个 protocol value 是 selected/current。
+      en: Tabs represents a compound single-selection protocol; at most one protocol value is selected/current within the same Tabs domain.
+    dependsOn:
+      knowledge:
+        - K-COMPONENT-INTERACTION-0001
+  - id: P-BASE-TABS-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-tabs-root` direct prototype 与 `asTabsRoot` authored asHook 是同一 Tabs root protocol 的两个 authoring entries。'
+      en: 'The `base-tabs-root` direct prototype and the `asTabsRoot` authored asHook are two authoring entries of the same Tabs root protocol.'
+    dependsOn:
+      contracts:
+        - C-CORE-SYNTAX-0003
+        - C-AS-HOOK-0001
+      decisions:
+        - D-PROTOTYPE-ENTITY-NAMING-0001
+  - id: P-BASE-TABS-PROTOCOL-INDEPENDENCE
+    text:
+      zh-CN: Tabs 不应通过消费 Button、Toggle 或其他基础原型的 protocol-specific authored asHook 获得自身 selection、tablist、tab 或 tabpanel 语义。
+      en: Tabs should not obtain its own selection, tablist, tab, or tabpanel semantics by consuming protocol-specific authored asHooks from Button, Toggle, or other base prototypes.
+    dependsOn:
+      decisions:
+        - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+  - id: P-BASE-TABS-ROOT-SEMANTIC-OWNER
+    text:
+      zh-CN: Tabs root 是 Tabs protocol 的 semantic owner，负责持有 selected value、处理 selection request、对外 expose 状态与 signal，并提供 Tabs context。
+      en: Tabs root is the semantic owner of the Tabs protocol and is responsible for owning selected value, processing selection requests, exposing state and signals, and providing Tabs context.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+        - C-EXPOSE-STATE-0001
+        - C-EXPOSE-EVENT-0001
+        - C-CONTEXT-0001
+  - id: P-BASE-TABS-ANATOMY-FAMILY
+    text:
+      zh-CN: Tabs anatomy family 的 canonical structure 由顶层 `anatomy` 字段定义；anatomy 不得创建 part 或注入行为。
+      en: The canonical structure of the Tabs anatomy family is defined by the top-level `anatomy` field; anatomy must not create parts or inject behavior.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0001
+        - C-ANATOMY-0002
+        - C-ANATOMY-0004
+  - id: P-BASE-TABS-FAMILY-ROLES
+    text:
+      zh-CN: Tabs anatomy family 第一轮必须定义 `root`、`list`、`trigger`、`content` 与 `indicator` roles。
+      en: The first Tabs anatomy family must define `root`, `list`, `trigger`, `content`, and `indicator` roles.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+        - C-ANATOMY-0004
+  - id: P-BASE-TABS-ROOT-CARDINALITY
+    text:
+      zh-CN: Tabs anatomy family 中 `root` role 的 cardinality 必须是 `1..1`。
+      en: The `root` role cardinality in the Tabs anatomy family must be `1..1`.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+  - id: P-BASE-TABS-LIST-CARDINALITY
+    text:
+      zh-CN: Tabs anatomy family 中 `list` role 的 cardinality 必须是 `0..1`；第一轮不支持多个 tablist 协调同一 root selection。
+      en: The `list` role cardinality in the Tabs anatomy family must be `0..1`; the first pass does not support multiple tablists coordinating the same root selection.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+  - id: P-BASE-TABS-TRIGGER-CARDINALITY
+    text:
+      zh-CN: Tabs anatomy family 中 `trigger` role 的 cardinality 必须是 `0..*`。
+      en: The `trigger` role cardinality in the Tabs anatomy family must be `0..*`.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+  - id: P-BASE-TABS-CONTENT-CARDINALITY
+    text:
+      zh-CN: Tabs anatomy family 中 `content` role 的 cardinality 必须是 `0..*`。
+      en: The `content` role cardinality in the Tabs anatomy family must be `0..*`.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+  - id: P-BASE-TABS-INDICATOR-CARDINALITY
+    text:
+      zh-CN: Tabs anatomy family 中 `indicator` role 的 cardinality 必须是 `0..*`；indicator 是可选且可重复的 context-driven visual consumer。
+      en: The `indicator` role cardinality in the Tabs anatomy family must be `0..*`; indicator is an optional and repeatable context-driven visual consumer.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+    references:
+      prototypes:
+        - id: P-BASE-TABS-INDICATOR
+          anchors:
+            - P-BASE-TABS-INDICATOR-ROLE-INDICATOR
+  - id: P-BASE-TABS-ROOT-CONTAINS-LIST
+    text:
+      zh-CN: Tabs anatomy family 必须声明 `root contains list` 的结构关系。
+      en: The Tabs anatomy family must declare the structural relation `root contains list`.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+  - id: P-BASE-TABS-LIST-CONTAINS-TRIGGER
+    text:
+      zh-CN: Tabs anatomy family 必须声明 `list contains trigger` 的结构关系；trigger 的 collection 与 roving focus 归属 list。
+      en: The Tabs anatomy family must declare the structural relation `list contains trigger`; trigger collection and roving focus belong to the list.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+  - id: P-BASE-TABS-ROOT-CONTAINS-CONTENT
+    text:
+      zh-CN: Tabs anatomy family 必须声明 `root contains content` 的结构关系。
+      en: The Tabs anatomy family must declare the structural relation `root contains content`.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+  - id: P-BASE-TABS-ROOT-CONTAINS-INDICATOR
+    text:
+      zh-CN: Tabs anatomy family 必须声明 `root contains indicator` 的结构关系；第一轮不要求 indicator 位于 list 内。
+      en: The Tabs anatomy family must declare the structural relation `root contains indicator`; the first pass does not require indicator to be inside the list.
+    dependsOn:
+      contracts:
+        - C-ANATOMY-0002
+  - id: P-BASE-TABS-PROP-VALUE
+    text:
+      zh-CN: 'Tabs root 必须接受 `value?: string` props input，用于受控 selected value。'
+      en: 'Tabs root must accept a `value?: string` props input for controlled selected value.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-STATE-0001
+  - id: P-BASE-TABS-PROP-DEFAULT-VALUE
+    text:
+      zh-CN: 'Tabs root 必须接受 `defaultValue?: string` props input，用于非受控初始 selected value，默认值为空字符串。'
+      en: 'Tabs root must accept a `defaultValue?: string` props input for uncontrolled initial selected value whose default is the empty string.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-STATE-0001
+  - id: P-BASE-TABS-PROP-ORIENTATION
+    text:
+      zh-CN: 'Tabs root 必须接受 `orientation?: "horizontal" | "vertical"` props input，默认值为 `horizontal`。'
+      en: 'Tabs root must accept an `orientation?: "horizontal" | "vertical"` props input whose default is `horizontal`.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+  - id: P-BASE-TABS-PROP-ACTIVATION-MODE
+    text:
+      zh-CN: 'Tabs root 必须接受 `activationMode?: "automatic" | "manual"` props input，默认值为 `automatic`。'
+      en: 'Tabs root must accept an `activationMode?: "automatic" | "manual"` props input whose default is `automatic`.'
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+  - id: P-BASE-TABS-PROP-NO-EVENT-CALLBACK
+    text:
+      zh-CN: Tabs props 不包含 `onValueChange` 之类事件回调；selection request 通过 expose event 发出 `valueChange` signal。
+      en: Tabs props do not include event callbacks such as `onValueChange`; selection requests emit the `valueChange` signal through expose event.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-EXPOSE-EVENT-0001
+  - id: P-BASE-TABS-VALUE-EXPOSE
+    text:
+      zh-CN: Tabs root 必须 expose `value` state；该 state 表示当前 selected protocol value。
+      en: Tabs root must expose `value` state; that state represents the current selected protocol value.
+    dependsOn:
+      contracts:
+        - C-EXPOSE-STATE-0001
+        - C-STATE-0001
+  - id: P-BASE-TABS-VALUE-CHANGE-SIGNAL
+    text:
+      zh-CN: Tabs root 必须 expose `valueChange` event；payload 必须至少包含请求的 next selected value。
+      en: Tabs root must expose a `valueChange` event; the payload must include at least the requested next selected value.
+    dependsOn:
+      contracts:
+        - C-EXPOSE-EVENT-0001
+  - id: P-BASE-TABS-CONTROLLED-VALUE
+    text:
+      zh-CN: 当 App Maker 提供或更新 `value` props input 时，Tabs root 必须以该 input 同步 selected value。
+      en: When the App Maker provides or updates the `value` props input, Tabs root must synchronize selected value from that input.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-STATE-0001
+  - id: P-BASE-TABS-UNCONTROLLED-UPDATES-VALUE
+    text:
+      zh-CN: 非受控 Tabs 在 enabled trigger 成功请求 selection 后必须更新 root selected value。
+      en: Uncontrolled Tabs must update root selected value after an enabled trigger successfully requests selection.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-CONTROLLED-EMITS-NEXT
+    text:
+      zh-CN: 受控 Tabs 在 trigger 成功请求 selection 后不得自行最终拥有 selected value；它必须发出包含 next value 的 `valueChange` outward signal。
+      en: Controlled Tabs must not finally own selected value after a trigger successfully requests selection; it must emit a `valueChange` outward signal carrying the next value.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-EXPOSE-EVENT-0001
+  - id: P-BASE-TABS-CONTEXT-KEY
+    text:
+      zh-CN: Tabs root 必须提供 canonical Tabs context key，供 same-domain parts 消费。
+      en: Tabs root must provide the canonical Tabs context key for same-domain parts to consume.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0001
+        - C-CONTEXT-0002
+  - id: P-BASE-TABS-CONTEXT-VALUE
+    text:
+      zh-CN: Tabs context value 必须至少包含 `value`、`activeValue`、`orientation`、`activationMode` 与 `controlled`。
+      en: Tabs context value must contain at least `value`, `activeValue`, `orientation`, `activationMode`, and `controlled`.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0001
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-CONTEXT-SYNC
+    text:
+      zh-CN: Root selected value、active value、orientation、activation mode 或 controlled 状态变化时，Tabs root 必须同步更新 Tabs context。
+      en: When root selected value, active value, orientation, activation mode, or controlled state changes, Tabs root must synchronize Tabs context.
+    dependsOn:
+      contracts:
+        - C-CONTEXT-0007
+        - C-CONTEXT-0008
+  - id: P-BASE-TABS-VALUE-MATCHING
+    text:
+      zh-CN: Trigger 与 Content 的协议匹配依据必须是各自 props 提供的 protocol `value` 与 root context `value` 的相等关系。
+      en: Trigger and Content protocol matching must be based on equality between their own protocol `value` props and root context `value`.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+        - C-CONTEXT-0007
+  - id: P-BASE-TABS-VALID-VALUE-REQUIRED
+    text:
+      zh-CN: Trigger 与 Content 要可靠参与 Tabs selection matching，必须提供有效 protocol value；缺失或空 value 的语义第一轮不作为可靠 authoring pattern。
+      en: Trigger and Content must provide valid protocol values to reliably participate in Tabs selection matching; missing or empty values are not reliable authoring patterns in the first pass.
+    dependsOn:
+      contracts:
+        - C-PROPS-0001
+  - id: P-BASE-TABS-ACTIVE-VALUE
+    text:
+      zh-CN: Tabs context 的 `activeValue` 表示当前 roving-focus active item 或最近活跃 trigger value；它不得替代 selected `value`。
+      en: Tabs context `activeValue` represents the current roving-focus active item or most recently active trigger value; it must not replace selected `value`.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+        - C-AS-FOCUS-ROVING-0001
+  - id: P-BASE-TABS-A11Y-ROLE-TARGETS
+    text:
+      zh-CN: 在具备 accessibility projection 的宿主中，Tabs list、trigger 与 content 应分别投射为 tablist、tab 与 tabpanel 语义。
+      en: In hosts with accessibility projection, Tabs list, trigger, and content should project tablist, tab, and tabpanel semantics respectively.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+      decisions:
+        - D-A11Y-SEMANTIC-DOMAIN-0001
+  - id: P-BASE-TABS-A11Y-RELATIONSHIP-TARGET
+    text:
+      zh-CN: Tabs 必须以 trigger/content 的 protocol value 匹配为依据声明 accessible control/labelling relationship；Web 宿主应将其投射为 `aria-controls` 与 `aria-labelledby` 等关系。
+      en: Tabs must declare accessible control/labelling relationships based on trigger/content protocol value matching; Web hosts should project them to relationships such as `aria-controls` and `aria-labelledby`.
+    dependsOn:
+      decisions:
+        - D-A11Y-PART-RELATIONSHIP-PROJECTION-0001
+      contracts:
+        - C-A11Y-0001
+    note:
+      zh-CN: 第一阶段由 a11y identity/relation IR 与 Web adapter 投射支持；跨宿主自动 ID 生成与更复杂的动态 part 关系仍可继续演进。
+      en: The first phase is supported by a11y identity/relation IR and Web adapter projection; cross-host automatic ID generation and more complex dynamic part relationships may continue to evolve.
+  - id: P-BASE-TABS-HIDDEN-NOT-UNMOUNT
+    text:
+      zh-CN: 非 current content 必须隐藏但不得因此被 Tabs core protocol 自动 unmount；具体 hidden 方式由宿主能力或实现策略投射。
+      en: Non-current content must be hidden but must not be automatically unmounted by the Tabs core protocol; the concrete hidden mechanism is projected by host capabilities or implementation policy.
+    dependsOn:
+      contracts:
+        - C-A11Y-0001
+  - id: P-BASE-TABS-PRESENCE-DEFERRED
+    text:
+      zh-CN: keepMounted、lazyMount、forceMount、presence transition 与 inactive panel unmount 策略暂缓到通用 visibility/presence 治理。
+      en: keepMounted, lazyMount, forceMount, presence transition, and inactive panel unmount policies are deferred to general visibility/presence governance.
+    dependsOn:
+      knowledge:
+        - K-DESIGN-TRADEOFF-0001
+  - id: P-BASE-TABS-INDICATOR-MEASUREMENT-DEFERRED
+    text:
+      zh-CN: Indicator 的真实布局测量、trigger rect 读取、字体渲染稳定性与自动定位能力暂缓；第一轮 indicator 只作为 context consumer。
+      en: Indicator real layout measurement, trigger rect reading, font rendering stability, and automatic positioning are deferred; first-pass indicator is only a context consumer.
+    references:
+      prototypes:
+        - id: P-BASE-TABS-INDICATOR
+          anchors:
+            - P-BASE-TABS-INDICATOR-NO-LAYOUT-MEASUREMENT
+  - id: P-BASE-TABS-SELECTION-FALLBACK-DEFERRED
+    text:
+      zh-CN: selected value 缺失、指向 disabled trigger、对应 trigger 被动态删除或出现重复 value 时的 fallback 策略暂缓。
+      en: Fallback policy is deferred when selected value is missing, points to a disabled trigger, has its trigger dynamically removed, or encounters duplicate values.
+sources:
+  - path: internal/contracts/prototype-base/tabs.v0.md
+  - path: packages/prototypes/base/src/tabs/root.ts
+  - path: packages/prototypes/base/src/tabs/shared.ts
+  - path: packages/prototypes/base/test/tabs.test.ts
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+    label: WAI-ARIA Authoring Practices Guide - Tabs Pattern
+  - path: https://www.radix-ui.com/primitives/docs/components/tabs
+    label: Radix UI Tabs
+  - path: https://base-ui.com/react/components/tabs
+    label: Base UI Tabs
+dependsOn:
+  contracts:
+    - C-ANATOMY-0001
+    - C-CONTEXT-0001
+    - C-PROPS-0001
+    - C-STATE-0001
+    - C-EXPOSE-STATE-0001
+    - C-EXPOSE-EVENT-0001
+    - C-A11Y-0001
+  decisions:
+    - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+    - D-A11Y-SEMANTIC-DOMAIN-0001
+    - D-A11Y-PART-RELATIONSHIP-PROJECTION-0001
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added the first Base Tabs root/compound protocol catalog with anatomy, context, selection, a11y, indicator, and presence boundaries.
+tags:
+  - prototype
+  - base
+  - tabs
+  - anatomy
+  - context
+  - selection

--- a/spec/prototypes/P-BASE-TABS.yaml
+++ b/spec/prototypes/P-BASE-TABS.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: Base Tabs is the root-owned compound single-selection protocol for a tablist, tab triggers, tab panels, and optional indicators. The root owns the selected value, provides Tabs context, coordinates controlled and uncontrolled value changes, and defines the Tabs anatomy family.
 statement:
   zh-CN: >-
-    Base Tabs 是一个 compound single-selection protocol。Root 持有同一 Tabs domain 内唯一的 selected value，并通过 Tabs context 将 `value`、`activeValue`、`orientation`、`activationMode` 与 controlled 状态提供给 list、trigger、content 与 indicator parts。Trigger 与 Content 通过各自 props 提供的 protocol `value` 和 context `value` 进行匹配：匹配的 trigger 处于 selected 状态，匹配的 content 处于 current/visible 状态。Base Tabs 不在第一轮承诺 indicator layout measurement、tabpanel unmount/presence 策略、动态缺失 selected value fallback 或完整 part-to-part a11y relationship 投射实现。
+    Base Tabs 是一个 compound single-selection protocol。Root 持有同一 Tabs domain 内唯一的 selected value，并通过 Tabs context 将 `value`、`activeValue`、`orientation`、`activationMode` 与 controlled 状态提供给 list、trigger、content 与 indicator parts。Trigger 与 Content 通过各自 props 提供的 protocol `value` 和 context `value` 进行匹配：匹配的 trigger 处于 selected 状态，匹配的 content 处于 current/visible 状态。非受控 Tabs 在 selected value 缺失或指向 disabled trigger 时，回落到第一个 enabled trigger。Base Tabs 不在第一轮承诺 indicator layout measurement、tabpanel unmount/presence 策略、动态删除 selected trigger、重复 value fallback 或完整 part-to-part a11y relationship 投射实现。
 
 
   en: >-
-    Base Tabs is a compound single-selection protocol. The root owns the single selected value within the same Tabs domain and provides `value`, `activeValue`, `orientation`, `activationMode`, and controlled state through Tabs context to list, trigger, content, and indicator parts. Trigger and Content match their own protocol `value` props against context `value`: the matching trigger is selected and the matching content is current/visible. The first Base Tabs pass does not promise indicator layout measurement, tabpanel unmount/presence policy, dynamic missing selected value fallback, or full part-to-part a11y relationship projection implementation.
+    Base Tabs is a compound single-selection protocol. The root owns the single selected value within the same Tabs domain and provides `value`, `activeValue`, `orientation`, `activationMode`, and controlled state through Tabs context to list, trigger, content, and indicator parts. Trigger and Content match their own protocol `value` props against context `value`: the matching trigger is selected and the matching content is current/visible. Uncontrolled Tabs fall back to the first enabled trigger when the selected value is missing or points to a disabled trigger. The first Base Tabs pass does not promise indicator layout measurement, tabpanel unmount/presence policy, dynamically removed selected-trigger fallback, duplicate value fallback, or full part-to-part a11y relationship projection implementation.
 
 
 anatomy:
@@ -352,10 +352,20 @@ criteria:
         - id: P-BASE-TABS-INDICATOR
           anchors:
             - P-BASE-TABS-INDICATOR-NO-LAYOUT-MEASUREMENT
-  - id: P-BASE-TABS-SELECTION-FALLBACK-DEFERRED
+  - id: P-BASE-TABS-SELECTION-FALLBACK
     text:
-      zh-CN: selected value 缺失、指向 disabled trigger、对应 trigger 被动态删除或出现重复 value 时的 fallback 策略暂缓。
-      en: Fallback policy is deferred when selected value is missing, points to a disabled trigger, has its trigger dynamically removed, or encounters duplicate values.
+      zh-CN: 非受控 Tabs 的 selected value 缺失或指向 disabled trigger 时，root 必须回落到第一个 enabled trigger；受控 Tabs 不得擅自改写外部 value。
+      en: When uncontrolled Tabs have a missing selected value or a selected value pointing to a disabled trigger, the root must fall back to the first enabled trigger; controlled Tabs must not rewrite the external value on their own.
+    dependsOn:
+      contracts:
+        - C-STATE-0001
+        - C-CONTEXT-0007
+      prototypes:
+        - P-BASE-TABS-TRIGGER
+  - id: P-BASE-TABS-DUPLICATE-VALUE-FALLBACK-DEFERRED
+    text:
+      zh-CN: 动态删除 selected trigger、重复 trigger value 的 selection 与 a11y relationship fallback 策略暂缓；第一轮 authoring pattern 不应依赖这些场景。
+      en: Selection and a11y relationship fallback policies for dynamically removed selected triggers and duplicate trigger values are deferred; first-pass authoring patterns should not rely on these cases.
 sources:
   - path: internal/contracts/prototype-base/tabs.v0.md
   - path: packages/prototypes/base/src/tabs/root.ts
@@ -384,6 +394,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added the first Base Tabs root/compound protocol catalog with anatomy, context, selection, a11y, indicator, and presence boundaries.
+  - version: 0.1.1
+    change: refined
+    summary: Added first-pass uncontrolled selection fallback for missing or disabled selected triggers.
 tags:
   - prototype
   - base

--- a/spec/tests/T-A11Y-0001.yaml
+++ b/spec/tests/T-A11Y-0001.yaml
@@ -15,6 +15,7 @@ cases:
       - C-A11Y-0001-E
       - C-A11Y-0001-F
       - C-A11Y-0001-H
+      - C-A11Y-0001-I
     expectation: semantic-object-ir
   - id: T-A11Y-0001-CASE-BUTTON
     title: Base Button declares button role, content-derived name policy, disabled state, and activate action
@@ -30,6 +31,7 @@ cases:
     covers:
       - C-A11Y-0001-G
       - C-A11Y-0001-H
+      - C-A11Y-0001-I
       - HC-A11Y-0001-A
       - HC-A11Y-0001-B
     expectation: web-a11y-projection
@@ -67,6 +69,7 @@ verifies:
         - C-A11Y-0001-F
         - C-A11Y-0001-G
         - C-A11Y-0001-H
+        - C-A11Y-0001-I
   hostCaps:
     - id: HC-A11Y-0001
       anchors:
@@ -76,6 +79,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added the first a11y semantic object test mapping.
+  - version: 0.1.1
+    change: refined
+    summary: Added coverage for dynamic a11y name projection from state-backed text facts.
 tags:
   - a11y
   - accessibility

--- a/spec/tests/T-A11Y-0001.yaml
+++ b/spec/tests/T-A11Y-0001.yaml
@@ -3,10 +3,10 @@ type: test
 title: A11y semantic object contract tests
 status: draft
 since: 0.1.0
-summary: Contract tests for a11y semantic object IR, Button consumption, and Web adapter projection.
+summary: Contract tests for a11y semantic object IR, Button consumption, identity/relation projection, and Web adapter projection.
 cases:
   - id: T-A11Y-0001-CASE-IR
-    title: A prototype can declare role, name, state, and action into a stable a11y IR
+    title: A prototype can declare identity, role, name, state, action, and relation into a stable a11y IR
     covers:
       - C-A11Y-0001-A
       - C-A11Y-0001-B
@@ -14,6 +14,7 @@ cases:
       - C-A11Y-0001-D
       - C-A11Y-0001-E
       - C-A11Y-0001-F
+      - C-A11Y-0001-H
     expectation: semantic-object-ir
   - id: T-A11Y-0001-CASE-BUTTON
     title: Base Button declares button role, content-derived name policy, disabled state, and activate action
@@ -25,9 +26,10 @@ cases:
       - C-A11Y-0001-F
     expectation: base-button-a11y-consumption
   - id: T-A11Y-0001-CASE-WEB-PROJECTION
-    title: Web adapter projects supported a11y IR to host attributes
+    title: Web adapter projects supported a11y IR identity and relation facts to host attributes
     covers:
       - C-A11Y-0001-G
+      - C-A11Y-0001-H
       - HC-A11Y-0001-A
       - HC-A11Y-0001-B
     expectation: web-a11y-projection
@@ -64,6 +66,7 @@ verifies:
         - C-A11Y-0001-E
         - C-A11Y-0001-F
         - C-A11Y-0001-G
+        - C-A11Y-0001-H
   hostCaps:
     - id: HC-A11Y-0001
       anchors:

--- a/spec/tests/T-BASE-TABS-0001.yaml
+++ b/spec/tests/T-BASE-TABS-0001.yaml
@@ -1,0 +1,87 @@
+id: T-BASE-TABS-0001
+type: test
+title: Base Tabs root and compound protocol contract tests
+status: draft
+since: 0.1.0
+summary: Contract test coverage for the Base Tabs compound protocol, including anatomy family, root value ownership, controlled and uncontrolled value flow, context synchronization, hidden panel behavior, and Web a11y relationships.
+cases:
+  - id: T-BASE-TABS-0001-CASE-ANATOMY-FAMILY
+    title: Tabs root owns the base-tabs anatomy family and defines list, trigger, content, and indicator parts
+    covers:
+      - P-BASE-TABS-ANATOMY-FAMILY
+      - P-BASE-TABS-FAMILY-ROLES
+      - P-BASE-TABS-ROOT-CARDINALITY
+      - P-BASE-TABS-LIST-CARDINALITY
+      - P-BASE-TABS-TRIGGER-CARDINALITY
+      - P-BASE-TABS-CONTENT-CARDINALITY
+      - P-BASE-TABS-INDICATOR-CARDINALITY
+      - P-BASE-TABS-ROOT-CONTAINS-LIST
+      - P-BASE-TABS-LIST-CONTAINS-TRIGGER
+      - P-BASE-TABS-ROOT-CONTAINS-CONTENT
+      - P-BASE-TABS-ROOT-CONTAINS-INDICATOR
+    expectation: tabs-root-owns-base-tabs-anatomy-family
+  - id: T-BASE-TABS-0001-CASE-UNCONTROLLED-VALUE-CHANGE
+    title: uncontrolled Tabs initializes selected value, updates it from trigger activation, emits valueChange, and synchronizes parts
+    covers:
+      - P-BASE-TABS-ROLE-SINGLE-SELECTION
+      - P-BASE-TABS-PROP-DEFAULT-VALUE
+      - P-BASE-TABS-VALUE-EXPOSE
+      - P-BASE-TABS-VALUE-CHANGE-SIGNAL
+      - P-BASE-TABS-UNCONTROLLED-UPDATES-VALUE
+      - P-BASE-TABS-CONTEXT-KEY
+      - P-BASE-TABS-CONTEXT-VALUE
+      - P-BASE-TABS-CONTEXT-SYNC
+      - P-BASE-TABS-VALUE-MATCHING
+      - P-BASE-TABS-ACTIVE-VALUE
+    expectation: uncontrolled-tabs-updates-selected-value-and-emits-value-change
+  - id: T-BASE-TABS-0001-CASE-CONTROLLED-VALUE
+    title: controlled Tabs mirrors value props and leaves final selection ownership outside the root
+    covers:
+      - P-BASE-TABS-PROP-VALUE
+      - P-BASE-TABS-CONTROLLED-VALUE
+      - P-BASE-TABS-CONTROLLED-EMITS-NEXT
+      - P-BASE-TABS-PROP-NO-EVENT-CALLBACK
+    expectation: controlled-tabs-mirrors-value-prop
+  - id: T-BASE-TABS-0001-CASE-A11Y-RELATIONS
+    title: Tabs projects tablist, tab, tabpanel, selected, hidden, and trigger-content relations in Web
+    covers:
+      - P-BASE-TABS-A11Y-ROLE-TARGETS
+      - P-BASE-TABS-A11Y-RELATIONSHIP-TARGET
+      - P-BASE-TABS-HIDDEN-NOT-UNMOUNT
+    expectation: tabs-web-a11y-roles-and-relations
+implementations:
+  - id: prototypes-base-tabs-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-0001-CASE-ANATOMY-FAMILY
+      - T-BASE-TABS-0001-CASE-UNCONTROLLED-VALUE-CHANGE
+      - T-BASE-TABS-0001-CASE-CONTROLLED-VALUE
+      - T-BASE-TABS-0001-CASE-A11Y-RELATIONS
+    exercises:
+      - P-BASE-TABS
+    notes:
+      - Covers the current Web component execution path for Base Tabs root and anatomy parts.
+      - Presence, indicator layout measurement, dynamic selection fallback, and form integration remain deferred surfaces.
+verifies:
+  prototypes:
+    - id: P-BASE-TABS
+      anchors:
+        - P-BASE-TABS-ANATOMY-FAMILY
+        - P-BASE-TABS-VALUE-CHANGE-SIGNAL
+        - P-BASE-TABS-CONTEXT-VALUE
+        - P-BASE-TABS-A11Y-RELATIONSHIP-TARGET
+exercises:
+  prototypes:
+    - P-BASE-TABS
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced Base Tabs root and compound protocol test entity aligned to P-BASE-TABS criteria.
+tags:
+  - prototype
+  - base
+  - tabs
+  - test

--- a/spec/tests/T-BASE-TABS-0001.yaml
+++ b/spec/tests/T-BASE-TABS-0001.yaml
@@ -42,6 +42,14 @@ cases:
       - P-BASE-TABS-CONTROLLED-EMITS-NEXT
       - P-BASE-TABS-PROP-NO-EVENT-CALLBACK
     expectation: controlled-tabs-mirrors-value-prop
+  - id: T-BASE-TABS-0001-CASE-SELECTION-FALLBACK
+    title: uncontrolled Tabs falls back to the first enabled trigger when the selected value is missing or disabled
+    covers:
+      - P-BASE-TABS-SELECTION-FALLBACK
+      - P-BASE-TABS-VALID-VALUE-REQUIRED
+      - P-BASE-TABS-UNCONTROLLED-UPDATES-VALUE
+      - P-BASE-TABS-CONTEXT-SYNC
+    expectation: uncontrolled-tabs-falls-back-to-first-enabled-trigger
   - id: T-BASE-TABS-0001-CASE-A11Y-RELATIONS
     title: Tabs projects tablist, tab, tabpanel, selected, hidden, and trigger-content relations in Web
     covers:
@@ -59,12 +67,39 @@ implementations:
       - T-BASE-TABS-0001-CASE-ANATOMY-FAMILY
       - T-BASE-TABS-0001-CASE-UNCONTROLLED-VALUE-CHANGE
       - T-BASE-TABS-0001-CASE-CONTROLLED-VALUE
+      - T-BASE-TABS-0001-CASE-SELECTION-FALLBACK
       - T-BASE-TABS-0001-CASE-A11Y-RELATIONS
     exercises:
       - P-BASE-TABS
     notes:
       - Covers the current Web component execution path for Base Tabs root and anatomy parts.
-      - Presence, indicator layout measurement, dynamic selection fallback, and form integration remain deferred surfaces.
+      - Presence, indicator layout measurement, duplicate value fallback, and form integration remain deferred surfaces.
+  - id: adapter-react-tabs-contract
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-0001-CASE-UNCONTROLLED-VALUE-CHANGE
+      - T-BASE-TABS-0001-CASE-A11Y-RELATIONS
+    exercises:
+      - P-BASE-TABS
+      - P-BASE-TABS-LIST
+      - P-BASE-TABS-TRIGGER
+      - P-BASE-TABS-CONTENT
+  - id: adapter-vue-tabs-contract
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-0001-CASE-UNCONTROLLED-VALUE-CHANGE
+      - T-BASE-TABS-0001-CASE-A11Y-RELATIONS
+    exercises:
+      - P-BASE-TABS
+      - P-BASE-TABS-LIST
+      - P-BASE-TABS-TRIGGER
+      - P-BASE-TABS-CONTENT
 verifies:
   prototypes:
     - id: P-BASE-TABS
@@ -72,6 +107,7 @@ verifies:
         - P-BASE-TABS-ANATOMY-FAMILY
         - P-BASE-TABS-VALUE-CHANGE-SIGNAL
         - P-BASE-TABS-CONTEXT-VALUE
+        - P-BASE-TABS-SELECTION-FALLBACK
         - P-BASE-TABS-A11Y-RELATIONSHIP-TARGET
 exercises:
   prototypes:
@@ -80,6 +116,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Introduced Base Tabs root and compound protocol test entity aligned to P-BASE-TABS criteria.
+  - version: 0.1.1
+    change: refined
+    summary: Added Base Tabs uncontrolled selection fallback coverage.
 tags:
   - prototype
   - base

--- a/spec/tests/T-BASE-TABS-CONTENT-0001.yaml
+++ b/spec/tests/T-BASE-TABS-CONTENT-0001.yaml
@@ -1,0 +1,55 @@
+id: T-BASE-TABS-CONTENT-0001
+type: test
+title: Base Tabs Content protocol contract tests
+status: draft
+since: 0.1.0
+summary: Contract test coverage for the Base Tabs Content part, including value-matched current state, hidden-without-unmount behavior, and Web tabpanel a11y projection.
+cases:
+  - id: T-BASE-TABS-CONTENT-0001-CASE-HIDDEN
+    title: Tabs Content derives current state by value matching and hides inactive panels without unmounting them
+    covers:
+      - P-BASE-TABS-CONTENT-ROLE-PANEL
+      - P-BASE-TABS-CONTENT-AUTHORING-ENTRIES
+      - P-BASE-TABS-CONTENT-PROTOCOL-DEPENDENCY
+      - P-BASE-TABS-CONTENT-CLAIM-ROLE
+      - P-BASE-TABS-CONTENT-SAME-DOMAIN
+      - P-BASE-TABS-CONTENT-PROP-VALUE
+      - P-BASE-TABS-CONTENT-CONTEXT-CONSUME
+      - P-BASE-TABS-CONTENT-CURRENT-DERIVED
+      - P-BASE-TABS-CONTENT-CURRENT-EXPOSE
+      - P-BASE-TABS-CONTENT-HIDDEN-WHEN-INACTIVE
+      - P-BASE-TABS-CONTENT-NOT-UNMOUNTED-BY-DEFAULT
+      - P-BASE-TABS-CONTENT-A11Y-ROLE
+      - P-BASE-TABS-CONTENT-A11Y-LABELLEDBY-TARGET
+      - P-BASE-TABS-CONTENT-A11Y-HIDDEN
+    expectation: tabs-content-current-and-hidden-state-follow-selected-value
+implementations:
+  - id: prototypes-base-tabs-content-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-CONTENT-0001-CASE-HIDDEN
+    exercises:
+      - P-BASE-TABS-CONTENT
+verifies:
+  prototypes:
+    - id: P-BASE-TABS-CONTENT
+      anchors:
+        - P-BASE-TABS-CONTENT-CURRENT-DERIVED
+        - P-BASE-TABS-CONTENT-HIDDEN-WHEN-INACTIVE
+        - P-BASE-TABS-CONTENT-A11Y-LABELLEDBY-TARGET
+exercises:
+  prototypes:
+    - P-BASE-TABS-CONTENT
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced Base Tabs Content protocol test entity aligned to P-BASE-TABS-CONTENT criteria.
+tags:
+  - prototype
+  - base
+  - tabs
+  - content
+  - test

--- a/spec/tests/T-BASE-TABS-CONTENT-0001.yaml
+++ b/spec/tests/T-BASE-TABS-CONTENT-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Base Tabs Content protocol contract tests
 status: draft
 since: 0.1.0
-summary: Contract test coverage for the Base Tabs Content part, including value-matched current state, hidden-without-unmount behavior, and Web tabpanel a11y projection.
+summary: Contract test coverage for the Base Tabs Content part, including value-matched current state, hidden-without-unmount behavior, focus entry behavior, and Web tabpanel a11y projection.
 cases:
   - id: T-BASE-TABS-CONTENT-0001-CASE-HIDDEN
     title: Tabs Content derives current state by value matching and hides inactive panels without unmounting them
@@ -23,6 +23,11 @@ cases:
       - P-BASE-TABS-CONTENT-A11Y-LABELLEDBY-TARGET
       - P-BASE-TABS-CONTENT-A11Y-HIDDEN
     expectation: tabs-content-current-and-hidden-state-follow-selected-value
+  - id: T-BASE-TABS-CONTENT-0001-CASE-FOCUS-ENTRY
+    title: Current Tabs Content uses descendant-first focus entry with self fallback while inactive content is removed from focus entry
+    covers:
+      - P-BASE-TABS-CONTENT-FOCUS-ENTRY
+    expectation: tabs-content-focus-entry-descendant-first-fallback-self
 implementations:
   - id: prototypes-base-tabs-content-contract
     kind: module-test
@@ -31,6 +36,7 @@ implementations:
     required: true
     consumesCases:
       - T-BASE-TABS-CONTENT-0001-CASE-HIDDEN
+      - T-BASE-TABS-CONTENT-0001-CASE-FOCUS-ENTRY
     exercises:
       - P-BASE-TABS-CONTENT
 verifies:
@@ -40,6 +46,7 @@ verifies:
         - P-BASE-TABS-CONTENT-CURRENT-DERIVED
         - P-BASE-TABS-CONTENT-HIDDEN-WHEN-INACTIVE
         - P-BASE-TABS-CONTENT-A11Y-LABELLEDBY-TARGET
+        - P-BASE-TABS-CONTENT-FOCUS-ENTRY
 exercises:
   prototypes:
     - P-BASE-TABS-CONTENT
@@ -47,6 +54,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Introduced Base Tabs Content protocol test entity aligned to P-BASE-TABS-CONTENT criteria.
+  - version: 0.1.1
+    change: refined
+    summary: Added focus entry coverage for current tabpanel descendant-first behavior and inactive panel disablement.
 tags:
   - prototype
   - base

--- a/spec/tests/T-BASE-TABS-INDICATOR-0001.yaml
+++ b/spec/tests/T-BASE-TABS-INDICATOR-0001.yaml
@@ -1,0 +1,62 @@
+id: T-BASE-TABS-INDICATOR-0001
+type: test
+title: Base Tabs Indicator protocol contract tests
+status: draft
+since: 0.1.0
+summary: Contract test coverage for the Base Tabs Indicator part, including context consumption, derived display state, absence of event/focus ownership, and deferred layout measurement.
+cases:
+  - id: T-BASE-TABS-INDICATOR-0001-CASE-CONTEXT-CONSUMPTION
+    title: Tabs Indicator consumes Tabs context and exposes derived value, activeValue, and orientation
+    covers:
+      - P-BASE-TABS-INDICATOR-ROLE-INDICATOR
+      - P-BASE-TABS-INDICATOR-AUTHORING-ENTRIES
+      - P-BASE-TABS-INDICATOR-PROTOCOL-DEPENDENCY
+      - P-BASE-TABS-INDICATOR-CLAIM-ROLE
+      - P-BASE-TABS-INDICATOR-SAME-DOMAIN
+      - P-BASE-TABS-INDICATOR-CONTEXT-CONSUME
+      - P-BASE-TABS-INDICATOR-DERIVED-VALUE
+      - P-BASE-TABS-INDICATOR-DERIVED-ACTIVE-VALUE
+      - P-BASE-TABS-INDICATOR-DERIVED-ORIENTATION
+    expectation: tabs-indicator-consumes-context-for-display-state
+  - id: T-BASE-TABS-INDICATOR-0001-CASE-NO-INTERACTION-SURFACES
+    title: Tabs Indicator does not own selection, event target, focus target, a11y control semantics, measurement, or positioning
+    covers:
+      - P-BASE-TABS-INDICATOR-NO-SELECTION-OWNER
+      - P-BASE-TABS-INDICATOR-NO-EVENT-TARGET
+      - P-BASE-TABS-INDICATOR-NO-FOCUS-TARGET
+      - P-BASE-TABS-INDICATOR-PRESENTATIONAL-A11Y
+      - P-BASE-TABS-INDICATOR-NO-LAYOUT-MEASUREMENT
+      - P-BASE-TABS-INDICATOR-NO-AUTO-POSITIONING
+      - P-BASE-TABS-INDICATOR-NO-VISUAL-VARIANT-CORE
+    expectation: tabs-indicator-has-no-interaction-or-layout-ownership
+implementations:
+  - id: prototypes-base-tabs-indicator-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-INDICATOR-0001-CASE-CONTEXT-CONSUMPTION
+      - T-BASE-TABS-INDICATOR-0001-CASE-NO-INTERACTION-SURFACES
+    exercises:
+      - P-BASE-TABS-INDICATOR
+verifies:
+  prototypes:
+    - id: P-BASE-TABS-INDICATOR
+      anchors:
+        - P-BASE-TABS-INDICATOR-CONTEXT-CONSUME
+        - P-BASE-TABS-INDICATOR-NO-SELECTION-OWNER
+        - P-BASE-TABS-INDICATOR-NO-LAYOUT-MEASUREMENT
+exercises:
+  prototypes:
+    - P-BASE-TABS-INDICATOR
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced Base Tabs Indicator protocol test entity aligned to P-BASE-TABS-INDICATOR criteria.
+tags:
+  - prototype
+  - base
+  - tabs
+  - indicator
+  - test

--- a/spec/tests/T-BASE-TABS-LIST-0001.yaml
+++ b/spec/tests/T-BASE-TABS-LIST-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Base Tabs List protocol contract tests
 status: draft
 since: 0.1.0
-summary: Contract test coverage for the Base Tabs List part, including optional collection ownership, roving focus, orientation, disabled item skipping, and manual versus automatic activation behavior.
+summary: Contract test coverage for the Base Tabs List part, including optional collection ownership, roving focus, orientation, disabled item skipping, manual versus automatic activation behavior, and the Tab/arrow navigation boundary.
 cases:
   - id: T-BASE-TABS-LIST-0001-CASE-ROVING-AUTOMATIC
     title: Tabs List roves focus across triggers and automatic mode selects the focused trigger
@@ -27,6 +27,11 @@ cases:
       - P-BASE-TABS-LIST-PROP-LOOP
       - P-BASE-TABS-TRIGGER-MANUAL-FOCUS-STABLE
     expectation: tabs-list-manual-mode-keeps-selection-stable-while-roving-focus
+  - id: T-BASE-TABS-LIST-0001-CASE-TAB-SEQUENTIAL
+    title: Tabs List keeps only the active trigger in sequential Tab order while arrow keys move inside the trigger set
+    covers:
+      - P-BASE-TABS-LIST-FOCUS-ROVING
+    expectation: tabs-list-tab-leaves-roving-set
 implementations:
   - id: prototypes-base-tabs-list-contract
     kind: module-test
@@ -36,6 +41,7 @@ implementations:
     consumesCases:
       - T-BASE-TABS-LIST-0001-CASE-ROVING-AUTOMATIC
       - T-BASE-TABS-LIST-0001-CASE-ROVING-MANUAL
+      - T-BASE-TABS-LIST-0001-CASE-TAB-SEQUENTIAL
     exercises:
       - P-BASE-TABS-LIST
 verifies:
@@ -52,6 +58,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Introduced Base Tabs List protocol test entity aligned to P-BASE-TABS-LIST criteria.
+  - version: 0.1.1
+    change: refined
+    summary: Added coverage that Tabs roving focus distinguishes arrow movement from sequential Tab navigation.
 tags:
   - prototype
   - base

--- a/spec/tests/T-BASE-TABS-LIST-0001.yaml
+++ b/spec/tests/T-BASE-TABS-LIST-0001.yaml
@@ -18,6 +18,8 @@ cases:
       - P-BASE-TABS-LIST-ORIENTATION-KEYS
       - P-BASE-TABS-LIST-A11Y-ROLE
       - P-BASE-TABS-LIST-A11Y-ORIENTATION
+      - P-BASE-TABS-LIST-PROP-A11Y-LABEL
+      - P-BASE-TABS-LIST-A11Y-LABEL
     expectation: tabs-list-roves-focus-and-automatic-mode-selects-focused-trigger
   - id: T-BASE-TABS-LIST-0001-CASE-ROVING-MANUAL
     title: manual activation mode roves focus without changing selected value until trigger activation
@@ -32,6 +34,12 @@ cases:
     covers:
       - P-BASE-TABS-LIST-FOCUS-ROVING
     expectation: tabs-list-tab-leaves-roving-set
+  - id: T-BASE-TABS-LIST-0001-CASE-A11Y-LABEL
+    title: Tabs List projects a host-neutral a11yLabel as its accessible name
+    covers:
+      - P-BASE-TABS-LIST-PROP-A11Y-LABEL
+      - P-BASE-TABS-LIST-A11Y-LABEL
+    expectation: tabs-list-projects-a11y-label-as-accessible-name
 implementations:
   - id: prototypes-base-tabs-list-contract
     kind: module-test
@@ -42,6 +50,25 @@ implementations:
       - T-BASE-TABS-LIST-0001-CASE-ROVING-AUTOMATIC
       - T-BASE-TABS-LIST-0001-CASE-ROVING-MANUAL
       - T-BASE-TABS-LIST-0001-CASE-TAB-SEQUENTIAL
+      - T-BASE-TABS-LIST-0001-CASE-A11Y-LABEL
+    exercises:
+      - P-BASE-TABS-LIST
+  - id: adapter-react-tabs-list-contract
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/react/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-LIST-0001-CASE-A11Y-LABEL
+    exercises:
+      - P-BASE-TABS-LIST
+  - id: adapter-vue-tabs-list-contract
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/vue/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-LIST-0001-CASE-A11Y-LABEL
     exercises:
       - P-BASE-TABS-LIST
 verifies:
@@ -51,6 +78,7 @@ verifies:
         - P-BASE-TABS-LIST-FOCUS-ROVING
         - P-BASE-TABS-LIST-FOCUS-METHODS
         - P-BASE-TABS-LIST-A11Y-ORIENTATION
+        - P-BASE-TABS-LIST-A11Y-LABEL
 exercises:
   prototypes:
     - P-BASE-TABS-LIST
@@ -61,6 +89,9 @@ revisions:
   - version: 0.1.1
     change: refined
     summary: Added coverage that Tabs roving focus distinguishes arrow movement from sequential Tab navigation.
+  - version: 0.1.2
+    change: refined
+    summary: Added Tabs List a11yLabel accessible-name coverage.
 tags:
   - prototype
   - base

--- a/spec/tests/T-BASE-TABS-LIST-0001.yaml
+++ b/spec/tests/T-BASE-TABS-LIST-0001.yaml
@@ -1,0 +1,60 @@
+id: T-BASE-TABS-LIST-0001
+type: test
+title: Base Tabs List protocol contract tests
+status: draft
+since: 0.1.0
+summary: Contract test coverage for the Base Tabs List part, including optional collection ownership, roving focus, orientation, disabled item skipping, and manual versus automatic activation behavior.
+cases:
+  - id: T-BASE-TABS-LIST-0001-CASE-ROVING-AUTOMATIC
+    title: Tabs List roves focus across triggers and automatic mode selects the focused trigger
+    covers:
+      - P-BASE-TABS-LIST-ROLE-COLLECTION
+      - P-BASE-TABS-LIST-CLAIM-ROLE
+      - P-BASE-TABS-LIST-SAME-DOMAIN
+      - P-BASE-TABS-LIST-CONTEXT-CONSUME
+      - P-BASE-TABS-LIST-FOCUS-ROVING
+      - P-BASE-TABS-LIST-FOCUS-METHODS
+      - P-BASE-TABS-LIST-SKIP-DISABLED
+      - P-BASE-TABS-LIST-ORIENTATION-KEYS
+      - P-BASE-TABS-LIST-A11Y-ROLE
+      - P-BASE-TABS-LIST-A11Y-ORIENTATION
+    expectation: tabs-list-roves-focus-and-automatic-mode-selects-focused-trigger
+  - id: T-BASE-TABS-LIST-0001-CASE-ROVING-MANUAL
+    title: manual activation mode roves focus without changing selected value until trigger activation
+    covers:
+      - P-BASE-TABS-LIST-FOCUS-ROVING
+      - P-BASE-TABS-LIST-HOME-END
+      - P-BASE-TABS-LIST-PROP-LOOP
+      - P-BASE-TABS-TRIGGER-MANUAL-FOCUS-STABLE
+    expectation: tabs-list-manual-mode-keeps-selection-stable-while-roving-focus
+implementations:
+  - id: prototypes-base-tabs-list-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-LIST-0001-CASE-ROVING-AUTOMATIC
+      - T-BASE-TABS-LIST-0001-CASE-ROVING-MANUAL
+    exercises:
+      - P-BASE-TABS-LIST
+verifies:
+  prototypes:
+    - id: P-BASE-TABS-LIST
+      anchors:
+        - P-BASE-TABS-LIST-FOCUS-ROVING
+        - P-BASE-TABS-LIST-FOCUS-METHODS
+        - P-BASE-TABS-LIST-A11Y-ORIENTATION
+exercises:
+  prototypes:
+    - P-BASE-TABS-LIST
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced Base Tabs List protocol test entity aligned to P-BASE-TABS-LIST criteria.
+tags:
+  - prototype
+  - base
+  - tabs
+  - list
+  - test

--- a/spec/tests/T-BASE-TABS-TRIGGER-0001.yaml
+++ b/spec/tests/T-BASE-TABS-TRIGGER-0001.yaml
@@ -1,0 +1,66 @@
+id: T-BASE-TABS-TRIGGER-0001
+type: test
+title: Base Tabs Trigger protocol contract tests
+status: draft
+since: 0.1.0
+summary: Contract test coverage for the Base Tabs Trigger part, including value matching, selected and interaction state exposure, disabled gating, local click signal, focus participation, and Web tab a11y projection.
+cases:
+  - id: T-BASE-TABS-TRIGGER-0001-CASE-SELECTION
+    title: Tabs Trigger derives selected state from value matching and requests root selection on activation
+    covers:
+      - P-BASE-TABS-TRIGGER-ROLE-TAB
+      - P-BASE-TABS-TRIGGER-AUTHORING-ENTRIES
+      - P-BASE-TABS-TRIGGER-PROTOCOL-DEPENDENCY
+      - P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY
+      - P-BASE-TABS-TRIGGER-PROP-VALUE
+      - P-BASE-TABS-TRIGGER-CONTEXT-CONSUME
+      - P-BASE-TABS-TRIGGER-SELECTED-DERIVED
+      - P-BASE-TABS-TRIGGER-SELECTED-EXPOSE
+      - P-BASE-TABS-TRIGGER-ACTIVATION-REQUESTS-SELECTION
+      - P-BASE-TABS-TRIGGER-CLICK-SIGNAL
+      - P-BASE-TABS-TRIGGER-A11Y-ROLE
+      - P-BASE-TABS-TRIGGER-A11Y-SELECTED
+      - P-BASE-TABS-TRIGGER-A11Y-CONTROLS-TARGET
+    expectation: tabs-trigger-selects-by-value-and-projects-tab-a11y
+  - id: T-BASE-TABS-TRIGGER-0001-CASE-DISABLED-GATING
+    title: disabled Tabs Trigger exposes disabled state and suppresses selection requests
+    covers:
+      - P-BASE-TABS-TRIGGER-PROP-DISABLED
+      - P-BASE-TABS-TRIGGER-DISABLED-EXPOSE
+      - P-BASE-TABS-TRIGGER-INTERACTION-STATES
+      - P-BASE-TABS-TRIGGER-FOCUSABLE
+      - P-BASE-TABS-TRIGGER-COLLECTION-ITEM
+      - P-BASE-TABS-TRIGGER-DISABLED-SUPPRESS-ACTIVATION
+      - P-BASE-TABS-TRIGGER-A11Y-DISABLED
+    expectation: disabled-tabs-trigger-suppresses-selection
+implementations:
+  - id: prototypes-base-tabs-trigger-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-TRIGGER-0001-CASE-SELECTION
+      - T-BASE-TABS-TRIGGER-0001-CASE-DISABLED-GATING
+    exercises:
+      - P-BASE-TABS-TRIGGER
+verifies:
+  prototypes:
+    - id: P-BASE-TABS-TRIGGER
+      anchors:
+        - P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY
+        - P-BASE-TABS-TRIGGER-SELECTED-DERIVED
+        - P-BASE-TABS-TRIGGER-A11Y-CONTROLS-TARGET
+exercises:
+  prototypes:
+    - P-BASE-TABS-TRIGGER
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Introduced Base Tabs Trigger protocol test entity aligned to P-BASE-TABS-TRIGGER criteria.
+tags:
+  - prototype
+  - base
+  - tabs
+  - trigger
+  - test

--- a/spec/tests/T-FOCUS-0001.yaml
+++ b/spec/tests/T-FOCUS-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Focus target and scope runtime contract tests
 status: draft
 since: 0.1.0
-summary: Runtime contract tests for asFocusable target facts, setup-only configuration, disabled focus requests, autofocus, and asFocusScope singleton/empty-container behavior.
+summary: Runtime contract tests for asFocusable target facts, asFocusEntry region policy, setup-only configuration, disabled focus requests, autofocus, and asFocusScope singleton/empty-container behavior.
 cases:
   - id: T-FOCUS-0001-CASE-FOCUSABLE-ONCE
     title: Repeated asFocusable calls reuse one handle and record privileged once trace
@@ -21,7 +21,28 @@ cases:
     covers:
       - C-AS-FOCUSABLE-0001-D
       - C-AS-FOCUS-SCOPE-0001-C
+      - C-AS-FOCUS-ENTRY-0001-C
     expectation: configure-after-setup-rejected
+  - id: T-FOCUS-0001-CASE-ENTRY-ONCE
+    title: Repeated asFocusEntry calls reuse one handle and configure through the returned handle
+    covers:
+      - C-AS-FOCUS-ENTRY-0001-A
+      - C-AS-FOCUS-ENTRY-0001-B
+      - C-AS-FOCUS-ENTRY-0001-D
+    expectation: focus-entry-singleton-config
+  - id: T-FOCUS-0001-CASE-ENTRY-DISABLE
+    title: Focus entry can be disabled and re-enabled at runtime without declaring target focus facts
+    covers:
+      - C-AS-FOCUS-ENTRY-0001-E
+      - C-AS-FOCUS-ENTRY-0001-F
+      - C-FOCUS-0001-G
+    expectation: focus-entry-runtime-disable-without-target-facts
+  - id: T-FOCUS-0001-CASE-ENTRY-HOST-DELEGATION
+    title: Focus entry delegates programmatic focus and sequential participation through host capability
+    covers:
+      - C-AS-FOCUS-ENTRY-0001-G
+      - C-FOCUS-0001-G
+    expectation: focus-entry-host-mediated-delegation
   - id: T-FOCUS-0001-CASE-FACT-HANDLES
     title: Focus facts are state-backed observed handles and rule-consumable
     covers:
@@ -39,6 +60,11 @@ cases:
     covers:
       - C-AS-FOCUSABLE-0001-E
     expectation: disabled-focus-request-rejected
+  - id: T-FOCUS-0001-CASE-NAV-PARTICIPATION
+    title: Runtime navParticipation can remove a focusable from sequential navigation without disabling explicit focus requests
+    covers:
+      - C-AS-FOCUSABLE-0001-F
+    expectation: nav-participation-none-does-not-disable-explicit-focus
   - id: T-FOCUS-0001-CASE-SCOPE-CONTAINER
     title: Scope emptyPolicy=container activates boundary without node focus
     covers:
@@ -55,10 +81,20 @@ implementations:
       - T-FOCUS-0001-CASE-FOCUSABLE-ONCE
       - T-FOCUS-0001-CASE-SCOPE-ONCE
       - T-FOCUS-0001-CASE-SETUP-ONLY
+      - T-FOCUS-0001-CASE-ENTRY-ONCE
+      - T-FOCUS-0001-CASE-ENTRY-DISABLE
       - T-FOCUS-0001-CASE-FACT-HANDLES
       - T-FOCUS-0001-CASE-UNIQUE-OWNER
       - T-FOCUS-0001-CASE-DISABLED
+      - T-FOCUS-0001-CASE-NAV-PARTICIPATION
       - T-FOCUS-0001-CASE-SCOPE-CONTAINER
+  - id: adapter-web-component-focus-entry
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/focus.test.ts
+    required: true
+    consumesCases:
+      - T-FOCUS-0001-CASE-ENTRY-HOST-DELEGATION
   - id: adapter-react-focus-unique-owner
     kind: adapter-test
     status: passing
@@ -81,6 +117,7 @@ verifies:
         - C-FOCUS-0001-D
         - C-FOCUS-0001-E
         - C-FOCUS-0001-F
+        - C-FOCUS-0001-G
     - id: C-AS-FOCUSABLE-0001
       anchors:
         - C-AS-FOCUSABLE-0001-A
@@ -88,12 +125,22 @@ verifies:
         - C-AS-FOCUSABLE-0001-C
         - C-AS-FOCUSABLE-0001-D
         - C-AS-FOCUSABLE-0001-E
+        - C-AS-FOCUSABLE-0001-F
     - id: C-AS-FOCUS-SCOPE-0001
       anchors:
         - C-AS-FOCUS-SCOPE-0001-A
         - C-AS-FOCUS-SCOPE-0001-B
         - C-AS-FOCUS-SCOPE-0001-C
         - C-AS-FOCUS-SCOPE-0001-D
+    - id: C-AS-FOCUS-ENTRY-0001
+      anchors:
+        - C-AS-FOCUS-ENTRY-0001-A
+        - C-AS-FOCUS-ENTRY-0001-B
+        - C-AS-FOCUS-ENTRY-0001-C
+        - C-AS-FOCUS-ENTRY-0001-D
+        - C-AS-FOCUS-ENTRY-0001-E
+        - C-AS-FOCUS-ENTRY-0001-F
+        - C-AS-FOCUS-ENTRY-0001-G
 revisions:
   - version: 0.1.0
     change: introduced
@@ -101,8 +148,15 @@ revisions:
   - version: 0.1.1
     change: refined
     summary: Added unique focus owner coverage and cross-adapter focus fact cleanup implementations.
+  - version: 0.1.2
+    change: refined
+    summary: Added asFocusEntry singleton/configuration, runtime disable, and Web host delegation coverage.
+  - version: 0.1.3
+    change: refined
+    summary: Added runtime navParticipation coverage for sequential focus navigation control.
 tags:
   - focus
   - as-focusable
+  - focus-entry
   - focus-scope
   - contract-test

--- a/spec/tests/T-FOCUS-ROVING-0001.yaml
+++ b/spec/tests/T-FOCUS-ROVING-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Focus roving runtime contract tests
 status: draft
 since: 0.1.0
-summary: Runtime contract tests for asFocusRoving singleton behavior, scope getRoving integration, and logical-parent roving membership without groupKey.
+summary: Runtime contract tests for asFocusRoving singleton behavior, scope getRoving integration, logical-parent roving membership without groupKey, and the boundary between roving movement and sequential Tab navigation.
 cases:
   - id: T-FOCUS-ROVING-0001-CASE-ROVING-ONCE
     title: Repeated asFocusRoving calls reuse one handle and configure through the returned handle
@@ -24,6 +24,12 @@ cases:
       - C-FOCUS-0002-B
       - C-AS-FOCUS-ROVING-0001-C
     expectation: logical-parent-roving-membership
+  - id: T-FOCUS-ROVING-0001-CASE-TAB-SEQUENTIAL
+    title: Tab leaves the roving set instead of acting like next/previous roving movement
+    covers:
+      - C-AS-FOCUS-ROVING-0001-F
+      - C-AS-FOCUS-ROVING-0001-G
+    expectation: tab-is-sequential-navigation-not-roving-movement
 implementations:
   - id: runtime-focus-roving-contract
     kind: runtime-test
@@ -34,6 +40,13 @@ implementations:
       - T-FOCUS-ROVING-0001-CASE-ROVING-ONCE
       - T-FOCUS-ROVING-0001-CASE-SCOPE-GET-ROVING
       - T-FOCUS-ROVING-0001-CASE-LOGICAL-MEMBERSHIP
+  - id: prototypes-base-tabs-roving-tab-boundary
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-FOCUS-ROVING-0001-CASE-TAB-SEQUENTIAL
 verifies:
   contracts:
     - id: C-FOCUS-0002
@@ -48,10 +61,15 @@ verifies:
         - C-AS-FOCUS-ROVING-0001-A
         - C-AS-FOCUS-ROVING-0001-B
         - C-AS-FOCUS-ROVING-0001-C
+        - C-AS-FOCUS-ROVING-0001-F
+        - C-AS-FOCUS-ROVING-0001-G
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Mapped focus-roving runtime tests to logical-topology and asFocusRoving contracts.
+  - version: 0.1.1
+    change: refined
+    summary: Added coverage for Tab as sequential navigation rather than roving movement.
 tags:
   - focus
   - focus-roving


### PR DESCRIPTION
## Summary

- Catalogs the Base Tabs P entities and related test entities, including root, list, trigger, content, and indicator anatomy.
- Implements and aligns the base/shadcn tabs prototypes with the cataloged criteria, including selection fallback, list a11y labeling, trigger/content state projection, and indicator support.
- Adds focus-entry/focus-roving followups needed by Tabs keyboard behavior, including Tab-boundary handling and descendant focus delegation records/contracts.
- Fixes generated Proto UI style token composition so focus-visible ring styles are not overwritten by shadow utilities.

## Root Cause / Context

Tabs pushed several unresolved areas at once: anatomy/context criteria, a11y relationship projection, focus roving semantics, and generated style token composition. The final focus-visible issue was not missing token generation; `ring-*` and `shadow-*` both emitted direct `box-shadow`, so `shadow-xs` could overwrite the ring on shadcn tabs triggers.

## Validation

- `corepack pnpm@10.32.1 --filter @proto.ui/cli build`
- `corepack pnpm@10.32.1 vitest run packages/cli/test/cli.test.ts`
- `corepack pnpm@10.32.1 vitest run packages/prototypes/shadcn/test/tabs.test.ts packages/prototypes/shadcn/test/switch.test.ts`
- `corepack pnpm@10.32.1 -s check:types:workspace`
- `corepack pnpm@10.32.1 vitest run packages/adapters/web-component/test/contract/rule.expose-state-web.optimize.v0.contract.test.ts packages/prototypes/base/test/tabs.test.ts`