### PR TITLE
fix: hide tabs views until materialization settles

### DIFF
--- a/apps/www/src/content/docs/en/ui-libraries/shadcn/tabs.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/shadcn/tabs.mdx
@@ -45,10 +45,10 @@ import { getCode } from '@/utils/conversionUtils';
 
 ## Content mount policy
 
-`TabsContent` accepts `lazyMount`, `unmountOnExit`, and `keepMounted`:
+`TabsContent` uses a lazy L1 view by default:
 
-- `lazyMount` delays the React/Vue host view until the panel is selected for the first time.
-- `unmountOnExit` detaches that view whenever the panel becomes inactive, while preserving the Proto instance and its state.
-- `keepMounted` takes precedence over both options and keeps the view present.
+- only the current panel materializes a host view;
+- an inactive panel detaches its view while preserving its Proto instance, state, and exposes;
+- `keepMounted={true}` is the only view-retention option and keeps the complete inactive view mounted.
 
-Web Component disconnection is a terminal ownership boundary. A custom element cannot remove itself and later observe its parent Tabs context, so full-element lazy/destroy composition must be owned by the WC consumer or a future compound host wrapper; the element still projects the inactive/hidden semantics today.
+Web Component keeps the custom element as the owner and hides that owner while its internal view is detached. Reactivating the panel materializes a new view inside the same Proto instance owner.

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/shadcn/tabs.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/shadcn/tabs.mdx
@@ -48,10 +48,10 @@ import { getCode } from '@/utils/conversionUtils';
 
 ## Content mount 策略
 
-`TabsContent` 支持 `lazyMount`、`unmountOnExit` 与 `keepMounted`：
+`TabsContent` 默认采用 lazy L1 view：
 
-- `lazyMount` 在 panel 第一次被选中前推迟 React/Vue host view 的创建。
-- `unmountOnExit` 在 panel 失活时 detach view，但保留 Proto instance 及其状态。
-- `keepMounted` 的优先级最高，会覆盖前两项并始终保留 view。
+- 只有当前 panel 会物化 host view。
+- panel 失活时会 detach view，但保留 Proto instance、状态与 exposes。
+- `keepMounted={true}` 是唯一的 view retention 选项，会让 inactive panel 继续保留完整 view。
 
-Web Component 的 disconnect 是终止所有权边界。Custom element 无法移除自身后继续观察父 Tabs context，因此整元素级 lazy/destroy 组合必须由 WC 使用方或未来的 compound host wrapper 持有；当前 element 仍会投射 inactive/hidden 语义。
+Web Component 会保留 custom element 作为 owner，并在 internal view detached 时隐藏该 owner；重新激活后，同一个 Proto instance 会在该 owner 内物化新的 view。

--- a/internal/contracts/lifecycle/view-intent-l1.md
+++ b/internal/contracts/lifecycle/view-intent-l1.md
@@ -51,6 +51,8 @@ Intent versions and lifecycle epochs make stale asynchronous attach, detach, and
 
 A newly attached host root is not yet a perceptually usable view. The adapter may create it internally, but must keep it visually hidden until the first runtime commit and view-effect projection for that epoch are coherent. If materialization misses the current frame, the correct fallback is to reveal it in a later frame, not to expose partially styled DOM.
 
+Instance-owned feedback state is replayed to the fresh view EffectsPort when the epoch enters `mounting`, before the host commit. The adapter must not depend on a post-commit framework update to recover baseline style tokens for the first visible frame.
+
 When a platform must retain a detached owner shell, such as a Web Component preserving consumer light DOM, that shell must also remain visually hidden while no host view epoch is attached.
 
 ## Prototype author boundary

--- a/internal/contracts/lifecycle/view-intent-l1.md
+++ b/internal/contracts/lifecycle/view-intent-l1.md
@@ -49,6 +49,10 @@ terminal owner teardown
 
 Intent versions and lifecycle epochs make stale asynchronous attach, detach, and commit work inert.
 
+A newly attached host root is not yet a perceptually usable view. The adapter may create it internally, but must keep it visually hidden until the first runtime commit and view-effect projection for that epoch are coherent. If materialization misses the current frame, the correct fallback is to reveal it in a later frame, not to expose partially styled DOM.
+
+When a platform must retain a detached owner shell, such as a Web Component preserving consumer light DOM, that shell must also remain visually hidden while no host view epoch is attached.
+
 ## Prototype author boundary
 
 Prototype authors update intent from callback-time `run` APIs:

--- a/packages/adapters/base/src/host/view-visibility.ts
+++ b/packages/adapters/base/src/host/view-visibility.ts
@@ -1,0 +1,18 @@
+export const PUI_VIEW_PENDING_ATTR = 'data-pui-view-pending';
+
+const VIEW_VISIBILITY_STYLE_ID = 'proto-ui-view-visibility';
+const RULES_BY_DOCUMENT = new WeakMap<Document, boolean>();
+
+export function installViewVisibilityRule(doc: Document): void {
+  if (RULES_BY_DOCUMENT.get(doc)) return;
+
+  let styleEl = doc.getElementById(VIEW_VISIBILITY_STYLE_ID) as HTMLStyleElement | null;
+  if (!styleEl) {
+    styleEl = doc.createElement('style');
+    styleEl.id = VIEW_VISIBILITY_STYLE_ID;
+    (doc.head ?? doc.documentElement).appendChild(styleEl);
+  }
+
+  styleEl.textContent = `${styleEl.textContent ?? ''}\n:where([${PUI_VIEW_PENDING_ATTR}]) { visibility: hidden !important; }\n`;
+  RULES_BY_DOCUMENT.set(doc, true);
+}

--- a/packages/adapters/base/src/index.ts
+++ b/packages/adapters/base/src/index.ts
@@ -6,6 +6,7 @@ export * from './lifecycle/teardown';
 export * from './lifecycle/soft-unmount';
 export * from './host/adapter-host';
 export * from './host/view-epoch-owner';
+export * from './host/view-visibility';
 export * from './events/web-event-router';
 export * from './platform/instance-tree';
 export * from './types';

--- a/packages/adapters/base/test/view-visibility.test.ts
+++ b/packages/adapters/base/test/view-visibility.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { installViewVisibilityRule, PUI_VIEW_PENDING_ATTR } from '../src';
+
+describe('adapter-base: view visibility', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('keeps a pending host root hidden until the adapter reveals it', () => {
+    const root = document.createElement('div');
+    root.setAttribute(PUI_VIEW_PENDING_ATTR, '');
+    document.body.appendChild(root);
+
+    installViewVisibilityRule(document);
+
+    expect(getComputedStyle(root).visibility).toBe('hidden');
+
+    root.removeAttribute(PUI_VIEW_PENDING_ATTR);
+    expect(getComputedStyle(root).visibility).not.toBe('hidden');
+  });
+});

--- a/packages/adapters/react/src/adapt.ts
+++ b/packages/adapters/react/src/adapt.ts
@@ -11,6 +11,8 @@ import {
   createSoftUnmountScheduler,
   createViewEpochOwner,
   createWebProtoEventRouter,
+  installViewVisibilityRule,
+  PUI_VIEW_PENDING_ATTR,
 } from '@proto.ui/adapter-base';
 import type { ExposeStateWebMode } from '@proto.ui/module-expose-state-web';
 import {
@@ -145,6 +147,7 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
       const [renderChildren, setRenderChildren] = runtime.useState<any>(null);
       const [hostTokens, setHostTokens] = runtime.useState<string[]>([]);
       const [shouldExist, setShouldExist] = runtime.useState(!supportsOwnerContext);
+      const viewReadyRef = runtime.useRef(false);
 
       const controllerRef = runtime.useRef<RuntimeController | null>(null);
       const eventGateRef = runtime.useRef<ReturnType<typeof createEventGate> | null>(null);
@@ -338,11 +341,14 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
           eventGateRef.current?.disable?.();
           if (ownerRef.current?.hasView) void ownerRef.current.detachView();
           setHostTokens([]);
+          viewReadyRef.current = false;
           return;
         }
 
         const rootEl = rootRef.current;
         if (!rootEl) return;
+
+        installViewVisibilityRule(rootEl.ownerDocument);
 
         markProtoInstance(rootEl, proto as Prototype<any>, instanceTokenRef.current);
         boundRootRef.current = rootEl;
@@ -423,6 +429,8 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
           softUnmount.cancel();
           cancelBaselineFrames();
           resolveBaselineSignal();
+          viewReadyRef.current = false;
+          rootRef.current?.setAttribute(PUI_VIEW_PENDING_ATTR, '');
           void ownerRef.current?.detachView();
           ownerDisposalRef.current?.release();
         };
@@ -431,6 +439,8 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
       runtime.useLayoutEffect(() => {
         if (!pendingCommitRef.current) return;
         pendingCommitRef.current = false;
+        viewReadyRef.current = true;
+        rootRef.current?.removeAttribute(PUI_VIEW_PENDING_ATTR);
 
         const rootEl = rootRef.current;
         const needsBaseline =
@@ -511,6 +521,7 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
               className: mergeHostClassName([props.hostClassName, props.className]),
               style: mergeHostStyle([props.hostStyle, props.style]),
               'data-pui-root': '',
+              [PUI_VIEW_PENDING_ATTR]: viewReadyRef.current ? undefined : '',
               'data-pui-style': serializeStyleTokens(hostTokens),
               'data-demo-ref': props['data-demo-ref' as keyof typeof props] as string | undefined,
             },

--- a/packages/adapters/react/test/lifecycle-view-intent.test.ts
+++ b/packages/adapters/react/test/lifecycle-view-intent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { definePrototype, type RunHandle } from '@proto.ui/core';
+import { definePrototype, tw, type RunHandle } from '@proto.ui/core';
 import { createReactAdapter } from '../src/adapt';
 import { createFakeReactRuntime } from './utils/fake-react';
 
@@ -23,6 +23,7 @@ describe('adapter-react: L1 view intent', () => {
       name: 'react-view-intent',
       setup(def) {
         calls.setup += 1;
+        def.feedback.style.use(tw('rounded-md p-4'));
         def.lifecycle.onCreated((nextRun) => {
           calls.created += 1;
           run = nextRun;
@@ -65,6 +66,8 @@ describe('adapter-react: L1 view intent', () => {
       await Promise.resolve();
       mounted.update();
       expect(mounted.root).not.toBeNull();
+      expect(mounted.root?.hasAttribute('data-pui-view-pending')).toBe(false);
+      expect(mounted.root?.getAttribute('data-pui-style')).toBe('rounded-md p-4');
       expect(calls.mounted).toBe(1);
 
       // Reversal before React renders keeps the current view attached.
@@ -92,6 +95,8 @@ describe('adapter-react: L1 view intent', () => {
         mounted.update();
       }
       expect(mounted.root).not.toBeNull();
+      expect(mounted.root?.hasAttribute('data-pui-view-pending')).toBe(false);
+      expect(mounted.root?.getAttribute('data-pui-style')).toBe('rounded-md p-4');
       expect(calls.setup).toBe(1);
       expect(calls.created).toBe(1);
       expect(calls.mounted).toBe(2);

--- a/packages/adapters/vue/src/adapt.ts
+++ b/packages/adapters/vue/src/adapt.ts
@@ -10,6 +10,8 @@ import {
   createSoftUnmountScheduler,
   createViewEpochOwner,
   createWebProtoEventRouter,
+  installViewVisibilityRule,
+  PUI_VIEW_PENDING_ATTR,
 } from '@proto.ui/adapter-base';
 import type { ExposeStateWebMode } from '@proto.ui/module-expose-state-web';
 import {
@@ -153,6 +155,7 @@ export function createVueAdapter(runtime: VueRuntime) {
           runtime.provide!(logicalOwnerKey, instanceToken);
         }
         const shouldExist = runtime.ref(!supportsOwnerContext);
+        let viewReady = false;
         let hasBeenUnmounted = false;
 
         const subs = new Set<() => void>();
@@ -310,6 +313,8 @@ export function createVueAdapter(runtime: VueRuntime) {
             if (!pendingCommit) return;
             pendingCommit = false;
             await runtime.nextTick();
+            viewReady = true;
+            rootRef.value?.removeAttribute(PUI_VIEW_PENDING_ATTR);
 
             const rootEl = rootRef.value;
             const eventGate = eventGateRef.value;
@@ -449,11 +454,17 @@ export function createVueAdapter(runtime: VueRuntime) {
           }
         };
 
-        runtime.onMounted(initSession);
+        runtime.onMounted(() => {
+          const rootEl = rootRef.value;
+          if (rootEl) installViewVisibilityRule(rootEl.ownerDocument);
+          initSession();
+        });
         runtime.onDeactivated?.(() => {
           softUnmount.cancel();
           cancelBaselineFrames();
           resolveBaselineSignal();
+          viewReady = false;
+          rootRef.value?.setAttribute(PUI_VIEW_PENDING_ATTR, '');
           if (owner.hasView) void owner.detachView();
           lastInitRoot = null;
         });
@@ -465,6 +476,7 @@ export function createVueAdapter(runtime: VueRuntime) {
           () => shouldExist.value,
           async (val: boolean) => {
             if (val) {
+              viewReady = false;
               await runtime.nextTick();
               initSession();
             } else {
@@ -477,6 +489,7 @@ export function createVueAdapter(runtime: VueRuntime) {
               eventGateRef.value?.disable?.();
               if (owner.hasView) void owner.detachView();
               hostTokens.value = [];
+              viewReady = false;
             }
           },
           { flush: 'post' }
@@ -522,6 +535,7 @@ export function createVueAdapter(runtime: VueRuntime) {
               class: mergeHostClass([props.hostClass, ctx.attrs.class]),
               style: mergeHostStyle([props.hostStyle, ctx.attrs.style]),
               'data-pui-root': '',
+              [PUI_VIEW_PENDING_ATTR]: viewReady ? undefined : '',
               'data-pui-style': serializeStyleTokens(hostTokens.value),
               'data-demo-ref': ctx.attrs['data-demo-ref'] as string | undefined,
             },

--- a/packages/adapters/vue/test/lifecycle-view-intent.test.ts
+++ b/packages/adapters/vue/test/lifecycle-view-intent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { definePrototype, type RunHandle } from '@proto.ui/core';
+import { definePrototype, tw, type RunHandle } from '@proto.ui/core';
 import { createVueAdapter } from '../src/adapt';
 import { VueAny, flushVue } from './utils/vue';
 
@@ -23,6 +23,7 @@ describe('adapter-vue: L1 view intent', () => {
       name: 'vue-view-intent',
       setup(def) {
         calls.setup += 1;
+        def.feedback.style.use(tw('rounded-md p-4'));
         def.lifecycle.onCreated((nextRun) => {
           calls.created += 1;
           run = nextRun;
@@ -64,13 +65,19 @@ describe('adapter-vue: L1 view intent', () => {
       vm.invokeInCallbackScope(() => run.lifecycle.setPresent(true));
       await flushVue();
       await flushVue();
-      expect(host.querySelector('[data-pui-root]')).not.toBeNull();
+      const firstRoot = host.querySelector<HTMLElement>('[data-pui-root]');
+      expect(firstRoot).not.toBeNull();
+      expect(firstRoot?.hasAttribute('data-pui-view-pending')).toBe(false);
+      expect(firstRoot?.getAttribute('data-pui-style')).toBe('rounded-md p-4');
       expect(calls.mounted).toBe(1);
 
       vm.invokeInCallbackScope(() => run.lifecycle.setPresent(false));
       vm.invokeInCallbackScope(() => run.lifecycle.setPresent(true));
       await flushVue();
-      expect(host.querySelector('[data-pui-root]')).not.toBeNull();
+      const remountedRoot = host.querySelector<HTMLElement>('[data-pui-root]');
+      expect(remountedRoot).not.toBeNull();
+      expect(remountedRoot?.hasAttribute('data-pui-view-pending')).toBe(false);
+      expect(remountedRoot?.getAttribute('data-pui-style')).toBe('rounded-md p-4');
       expect(calls.unmounted).toBe(0);
 
       vm.invokeInCallbackScope(() => run.lifecycle.setPresent(false));

--- a/packages/adapters/web-component/src/adapt.ts
+++ b/packages/adapters/web-component/src/adapt.ts
@@ -21,7 +21,11 @@ import { bindController, getElementProps, setElementProps, unbindController } fr
 import { SlotProjector } from './slot-projector';
 import { createOwnedTwTokenApplier } from './feedback-style';
 import { installDebugHooks, removeDebugHooks } from './debug/hooks';
-import { installDefaultHostDisplay, type HostDisplayController } from './host-display';
+import {
+  installDefaultHostDisplay,
+  PUI_VIEW_DETACHED_ATTR,
+  type HostDisplayController,
+} from './host-display';
 import { createDefaultMetaGetter } from './platform/meta';
 import {
   createLogicalInstance,
@@ -216,6 +220,10 @@ export function AdaptToWebComponent<Props extends PropsBaseType>(
         this._slotProjector = null;
       };
 
+      const setViewDetached = (detached: boolean) => {
+        thisEl.toggleAttribute(PUI_VIEW_DETACHED_ATTR, detached);
+      };
+
       const releaseRenderedChildren = () => {
         if (shadow) {
           thisRoot.replaceChildren();
@@ -272,7 +280,10 @@ export function AdaptToWebComponent<Props extends PropsBaseType>(
         });
 
       const attachView = () => {
-        if (owner.hasView) return;
+        if (owner.hasView) {
+          setViewDetached(false);
+          return;
+        }
 
         const eventGate = createEventGate();
         const router = createWebProtoEventRouter({
@@ -321,6 +332,7 @@ export function AdaptToWebComponent<Props extends PropsBaseType>(
           disposeView,
           createSession: createHostSession,
         });
+        setViewDetached(false);
       };
 
       let latestIntentVersion = 0;
@@ -332,6 +344,7 @@ export function AdaptToWebComponent<Props extends PropsBaseType>(
           initialPresent = snapshot.present;
           return;
         }
+        if (!snapshot.present) setViewDetached(true);
         const requestVersion = ++latestIntentVersion;
         queueMicrotask(() => {
           reconciliation = reconciliation
@@ -377,6 +390,7 @@ export function AdaptToWebComponent<Props extends PropsBaseType>(
       runFocusCallbackScope = hostSession.invokeInCallbackScope;
 
       if (initialPresent) attachView();
+      else setViewDetached(true);
 
       const { controller, kernel } = hostSession;
       if (kernel && kernel.run) {

--- a/packages/adapters/web-component/src/host-display.ts
+++ b/packages/adapters/web-component/src/host-display.ts
@@ -1,6 +1,7 @@
 const HOST_DISPLAY_STYLE_ID = 'proto-ui-wc-host-display';
 const HOST_DISPLAY_CLASS = 'pui-host-root';
 const PUI_STYLE_ATTR = 'data-pui-style';
+export const PUI_VIEW_DETACHED_ATTR = 'data-pui-view-detached';
 
 const RULES_BY_DOCUMENT = new WeakMap<Document, boolean>();
 
@@ -59,7 +60,7 @@ function ensureDefaultHostDisplayRule(doc: Document) {
   if (RULES_BY_DOCUMENT.get(doc)) return;
 
   const styleEl = getOrCreateStyleElement(doc);
-  styleEl.textContent = `${styleEl.textContent ?? ''}\n:where(.${HOST_DISPLAY_CLASS}) { display: block; }\n`;
+  styleEl.textContent = `${styleEl.textContent ?? ''}\n:where(.${HOST_DISPLAY_CLASS}) { display: block; }\n:where([${PUI_VIEW_DETACHED_ATTR}]) { display: none !important; }\n`;
   RULES_BY_DOCUMENT.set(doc, true);
 }
 

--- a/packages/adapters/web-component/test/lifecycle-view-intent.test.ts
+++ b/packages/adapters/web-component/test/lifecycle-view-intent.test.ts
@@ -112,14 +112,19 @@ describe('adapter-web-component: L1 view intent', () => {
     document.body.appendChild(el);
 
     expect(el.innerHTML).toBe('<span>consumer</span>');
+    expect(el.hasAttribute('data-pui-view-detached')).toBe(true);
+    expect(getComputedStyle(el).display).toBe('none');
 
     el.getExposes().view.show();
     await flushReconciliation();
     expect(el.innerHTML).toBe('<div><span>consumer</span></div>');
+    expect(el.hasAttribute('data-pui-view-detached')).toBe(false);
 
     el.getExposes().view.hide();
     await flushReconciliation();
     expect(el.innerHTML).toBe('<span>consumer</span>');
+    expect(el.hasAttribute('data-pui-view-detached')).toBe(true);
+    expect(getComputedStyle(el).display).toBe('none');
 
     el.remove();
     await flushReconciliation();

--- a/packages/modules/feedback/src/create.ts
+++ b/packages/modules/feedback/src/create.ts
@@ -138,6 +138,12 @@ export function createFeedbackModule(ctx: ModuleFactoryArgs): FeedbackModule {
 
         override onMountPhase(phase: MountPhase, epoch: number): void {
           super.onMountPhase(phase, epoch);
+          if (phase === 'mounting') {
+            // A fresh view epoch owns a fresh EffectsPort. Replay the retained
+            // instance style before the host commit so the first materialized
+            // frame already carries its baseline tokens.
+            this.replayStyleForViewEpoch();
+          }
         }
 
         protected override onCapsEpoch(_epoch: number): void {
@@ -186,6 +192,17 @@ export function createFeedbackModule(ctx: ModuleFactoryArgs): FeedbackModule {
           const effects = this.caps.get(EFFECTS_CAP);
           const merged = this.exportMerged();
           effects.queueStyle(merged);
+          effects.requestFlush();
+          this.flushRequested = true;
+        }
+
+        private replayStyleForViewEpoch(): void {
+          // Runtime ProtoPhase intentionally remains `setup` until the first
+          // commit completes. Mounting is nevertheless after prototype setup,
+          // so replay must not use flushIfPossible's setup-phase guard.
+          if (!this.caps.has(EFFECTS_CAP)) return;
+          const effects = this.caps.get(EFFECTS_CAP);
+          effects.queueStyle(this.exportMerged());
           effects.requestFlush();
           this.flushRequested = true;
         }

--- a/packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts
+++ b/packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts
@@ -38,6 +38,7 @@ function createImmediateHost(
 describe('runtime contract: lifecycle module resource ownership (v1)', () => {
   it('keeps Feedback logical style state while suppressing detached host flushes', async () => {
     const queued: unknown[] = [];
+    const stylesSeenAtCommit: unknown[] = [];
     const effects: EffectsPort = {
       queueStyle: (style) => queued.push(style),
       requestFlush: vi.fn(),
@@ -49,22 +50,42 @@ describe('runtime contract: lifecycle module resource ownership (v1)', () => {
         return (run) => run.el('div', 'ok');
       },
     });
-    const session = createRuntimeSession(
-      proto,
-      createImmediateHost((wiring) => wiring.attach('feedback', [[EFFECTS_CAP, effects]]))
+    const host = createImmediateHost((wiring) =>
+      wiring.attach('feedback', [[EFFECTS_CAP, effects]])
     );
+    host.commit = (_children, signal) => {
+      stylesSeenAtCommit.push(queued.at(-1));
+      signal?.done();
+    };
+    const session = createRuntimeSession(proto, host);
 
     expect(queued).toEqual([]);
     await session.mount();
     expect(queued.length).toBeGreaterThan(0);
+    expect(stylesSeenAtCommit.at(-1)).toMatchObject({
+      kind: 'tw',
+      tokens: expect.arrayContaining(['base-token']),
+    });
     queued.length = 0;
 
+    await session.unmount();
+    await session.mount();
+    expect(stylesSeenAtCommit.at(-1)).toMatchObject({
+      kind: 'tw',
+      tokens: expect.arrayContaining(['base-token']),
+    });
+
+    queued.length = 0;
     await session.unmount();
     const feedback = session.caps.getPort<FeedbackPort>('feedback')!;
     session.invokeInCallbackScope(() => feedback.patchStyle(tw('detached-token')));
     expect(queued).toEqual([]);
 
     await session.mount();
+    expect(stylesSeenAtCommit.at(-1)).toMatchObject({
+      kind: 'tw',
+      tokens: expect.arrayContaining(['base-token', 'detached-token']),
+    });
     expect(queued.at(-1)).toMatchObject({
       kind: 'tw',
       tokens: expect.arrayContaining(['base-token', 'detached-token']),

--- a/spec/contracts/C-LIFECYCLE-0008.yaml
+++ b/spec/contracts/C-LIFECYCLE-0008.yaml
@@ -50,6 +50,10 @@ criteria:
     text:
       zh-CN: L1 只保证当前 Proto instance 的逻辑状态跨 view epoch 保留；被 detached view 包含的宿主子组件实例与原生 view state 不属于该保证。
       en: L1 only guarantees preservation of the current Proto instance's logical state across view epochs; host child-component instances and native view state contained by the detached view are outside this guarantee.
+  - id: C-LIFECYCLE-0008-J
+    text:
+      zh-CN: 新 attach 的 host root 在该 view epoch 的首次 runtime commit 与 view-effect projection 达到一致前不得被视觉暴露；平台为 detached instance 保留的 owner shell 在不存在 host view epoch 时也必须保持隐藏。
+      en: A newly attached host root must not be visually exposed before the view epoch's first runtime commit and view-effect projection are coherent; any owner shell retained by the platform for a detached instance must also remain hidden while no host view epoch exists.
 dependsOn:
   contracts:
     - C-LIFECYCLE-0005
@@ -62,6 +66,9 @@ revisions:
   - version: 0.1.1
     change: implemented
     summary: RuntimeSession and the React, Vue, and Web Component owners now implement initial and repeatable L1 ViewIntent reconciliation.
+  - version: 0.1.2
+    change: refined
+    summary: Required a reveal barrier for newly attached roots and visual hiding for retained detached owner shells.
 tags:
   - lifecycle
   - view-intent

--- a/spec/tests/T-LIFECYCLE-0006.yaml
+++ b/spec/tests/T-LIFECYCLE-0006.yaml
@@ -44,6 +44,11 @@ cases:
     covers:
       - C-LIFECYCLE-0008-G
     expectation: run-lifecycle-surface-only-exposes-set-present
+  - id: T-LIFECYCLE-0006-CASE-REVEAL-BARRIER
+    title: View epochs remain hidden until initial commit and view effects are coherent
+    covers:
+      - C-LIFECYCLE-0008-J
+    expectation: materializing-and-detached-host-shells-are-not-partially-visible
 implementations:
   - id: runtime-view-intent-contract
     kind: runtime-test
@@ -64,6 +69,13 @@ implementations:
       - T-LIFECYCLE-0006-CASE-FIRST-MATERIALIZATION
       - T-LIFECYCLE-0006-CASE-REPEATABLE-DETACH
       - T-LIFECYCLE-0006-CASE-TERMINAL-OWNER
+  - id: adapters-base-view-visibility
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/base/test/view-visibility.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0006-CASE-REVEAL-BARRIER
   - id: adapter-react-initial-view-intent
     kind: adapter-test
     status: passing
@@ -73,6 +85,7 @@ implementations:
       - T-LIFECYCLE-0006-CASE-INITIAL-DETACHED
       - T-LIFECYCLE-0006-CASE-REPEATABLE-DETACH
       - T-LIFECYCLE-0006-CASE-LATEST-INTENT
+      - T-LIFECYCLE-0006-CASE-REVEAL-BARRIER
   - id: adapter-vue-initial-view-intent
     kind: adapter-test
     status: passing
@@ -82,6 +95,7 @@ implementations:
       - T-LIFECYCLE-0006-CASE-INITIAL-DETACHED
       - T-LIFECYCLE-0006-CASE-REPEATABLE-DETACH
       - T-LIFECYCLE-0006-CASE-LATEST-INTENT
+      - T-LIFECYCLE-0006-CASE-REVEAL-BARRIER
   - id: adapter-web-component-view-intent
     kind: adapter-test
     status: passing
@@ -91,6 +105,7 @@ implementations:
       - T-LIFECYCLE-0006-CASE-INITIAL-DETACHED
       - T-LIFECYCLE-0006-CASE-REPEATABLE-DETACH
       - T-LIFECYCLE-0006-CASE-TERMINAL-OWNER
+      - T-LIFECYCLE-0006-CASE-REVEAL-BARRIER
 verifies:
   contracts:
     - id: C-LIFECYCLE-0008
@@ -110,6 +125,9 @@ revisions:
   - version: 0.1.4
     change: implemented
     summary: Web Component now retains its custom-element owner while releasing and rematerializing internal view epochs; all required L1 implementations pass.
+  - version: 0.1.5
+    change: refined
+    summary: Added cross-adapter coverage for materialization reveal barriers and hidden detached owner shells.
 tags:
   - lifecycle
   - view-intent

--- a/spec/tests/T-LIFECYCLE-0006.yaml
+++ b/spec/tests/T-LIFECYCLE-0006.yaml
@@ -76,6 +76,13 @@ implementations:
     required: true
     consumesCases:
       - T-LIFECYCLE-0006-CASE-REVEAL-BARRIER
+  - id: runtime-feedback-view-epoch-replay
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/lifecycle.module-resources.v1.contract.test.ts
+    required: true
+    consumesCases:
+      - T-LIFECYCLE-0006-CASE-REVEAL-BARRIER
   - id: adapter-react-initial-view-intent
     kind: adapter-test
     status: passing
@@ -128,6 +135,9 @@ revisions:
   - version: 0.1.5
     change: refined
     summary: Added cross-adapter coverage for materialization reveal barriers and hidden detached owner shells.
+  - version: 0.1.6
+    change: fixed
+    summary: Required retained Feedback style to replay into each fresh EffectsPort before the first host commit.
 tags:
   - lifecycle
   - view-intent


### PR DESCRIPTION
## Summary

- hide retained Web Component owners while their L1 view epoch is detached, preventing inactive light DOM from leaking below the active Tabs panel
- add a cross-adapter reveal barrier so React and Vue roots stay visually hidden during materialization
- replay retained Feedback style into each fresh view EffectsPort during `mounting`, before the first host commit, so the first visible frame already has baseline style tokens
- refine the L1 ViewIntent contract and Tabs documentation around this perceptual materialization boundary

## Root cause

Web Components intentionally retain the custom-element owner and consumer light DOM across L1 detach, but the owner shell itself was not hidden.

For React and Vue, the first fix revealed the root at host commit completion. Feedback style was still projected from `CommitSignal.done()` through a second framework update, so the barrier and `data-pui-style` were not guaranteed to land in the same browser frame. React often batched that follow-up update before paint, while Vue more readily exposed the timing gap.

Feedback is now replayed from Proto-instance state to the fresh EffectsPort as the view epoch enters `mounting`. Host children, baseline style tokens, and barrier release therefore converge in the first framework commit. The dedicated barrier attribute remains separate from user styles and expose-state CSS variables. StrictMode replay and Vue KeepAlive reactivation also re-establish the barrier before reattaching a view.

## Validation

- `pnpm test:runtime` — 214 files, 952 tests passed
- `pnpm check:types:workspace`
- `pnpm check:types:docs` — 0 errors/warnings/hints
- `pnpm --filter apps-workspace generate:spec`
- manual browser verification for WC, React, and Vue shadcn Tabs demos
- 30 consecutive post-click materialization samples for React and 30 for Vue, all with complete style tokens and computed panel styles