### PR TITLE
Harden lifecycle, hook, Tabs, and Dialog prototype contracts

### DIFF
--- a/internal/contracts/as-hook/as-hook.v0.md
+++ b/internal/contracts/as-hook/as-hook.v0.md
@@ -72,7 +72,9 @@ Parameterized authored asHooks remain future governed design space.
 
 ### 2.2 Naming Rule (v0, mandatory)
 
-- asHook `name` must match `/^as[A-Z]/`.
+- `defineAsHook({ name })` records a prototype spec name and follows prototype naming rules, such as `as-dialog-content`.
+- The author-facing caller binding should use the `asXxx` form, such as `asDialogContent`.
+- Runtime cannot observe a JavaScript/TypeScript binding name, so caller-binding validation belongs to lint, CLI, generator, or TypeScript tooling rather than `defineAsHook({ name })` runtime validation.
 - Violations must throw.
 
 ---
@@ -157,6 +159,7 @@ Only `state` is required to be projected as Borrowed view.
 - runtime records child asHook calls made directly inside the current asHook setup frame
 - child entries are exposed through `asHooks` and may also be mirrored in `artifacts.asHooks`
 - every child entry retains `result` as the runtime truth source and `handle` as the stable caller-facing projection; `getAsHookHandle(name)` retrieves the latter
+- an authored asHook contract may declare an `asHooks` handle map so literal-name lookups infer the child handle type without a free generic assertion
 - child state handles stay inside the child entry result; they are not flattened into the outer `stateHandles`
 - an outer `projectHandle` may deliberately re-export selected child handles under a named field; the runtime does not automatically flatten, alias, or expose every nested capability
 - prototype authors do not declare child entries through a `def` API

--- a/internal/contracts/as-hook/base-text/as-hook.v0.md
+++ b/internal/contracts/as-hook/base-text/as-hook.v0.md
@@ -61,8 +61,9 @@ asHook 在 v0 中提供：
 
 ### 2.2 命名规范（v0 强制）
 
-- asHook 的 `name` 必须满足：`/^as[A-Z]/`。
-- 不满足命名规范必须抛错。
+- `defineAsHook({ name })` 记录的是 prototype spec name，应遵守 prototype 命名规则，例如 `as-dialog-content`。
+- 面向作者的 caller binding 应采用 `asXxx` 形式，例如 `asDialogContent`。
+- runtime 无法观察 JavaScript / TypeScript binding name，因此 caller binding 校验属于 lint、CLI、generator 或 TypeScript tooling，不应通过检查 `defineAsHook({ name })` 实现。
 
 ---
 

--- a/internal/contracts/types/as-hook.contract.v0.type-test.ts
+++ b/internal/contracts/types/as-hook.contract.v0.type-test.ts
@@ -1,4 +1,5 @@
 import { defineAsHook, type AsHookResult, type State } from '@proto.ui/core';
+import { asBoundary } from '@proto.ui/hooks';
 
 type Props = { disabled?: boolean };
 
@@ -45,6 +46,11 @@ const asNoArgs = defineAsHook({
 asNoArgs();
 // @ts-expect-error authored asHook callers are no-arg in v0
 asNoArgs({ enabled: true });
+
+const boundary = asBoundary();
+boundary.configure({ debugLabel: 'typed-boundary' });
+// @ts-expect-error privileged Boundary configuration lives on the returned handle
+asBoundary({ debugLabel: 'legacy-parameterized-boundary' });
 
 const asCustomHandle = defineAsHook<
   Props,

--- a/internal/contracts/types/as-hook.contract.v0.type-test.ts
+++ b/internal/contracts/types/as-hook.contract.v0.type-test.ts
@@ -12,6 +12,9 @@ type ButtonContract = {
     click: void;
     submit: { source: 'keyboard' | 'pointer' };
   };
+  asHooks: {
+    asNested: { close(): void };
+  };
 };
 
 declare const buttonResult: AsHookResult<Props, ButtonContract>;
@@ -26,7 +29,7 @@ const submitKey = buttonResult.artifacts?.eventKeys?.submit;
 const exactClick: 'click' | undefined = clickKey;
 const exactSubmit: 'submit' | undefined = submitKey;
 
-const nestedHandle = buttonResult.getAsHookHandle?.<{ close(): void }>('asNested');
+const nestedHandle = buttonResult.getAsHookHandle?.('asNested');
 nestedHandle?.close();
 
 // Legacy third generic as raw state map should keep working.

--- a/internal/contracts/types/dialog-as-hook.contract.v0.type-test.ts
+++ b/internal/contracts/types/dialog-as-hook.contract.v0.type-test.ts
@@ -6,12 +6,14 @@ import {
 import type {
   ShadcnDialogContentExposes,
   ShadcnDialogContentProps,
+  ShadcnDialogRootProps,
 } from '@proto.ui/prototypes-shadcn';
 
 declare const baseProps: DialogContentProps;
 declare const baseExposes: DialogContentExposes;
 declare const shadcnProps: ShadcnDialogContentProps;
 declare const shadcnExposes: ShadcnDialogContentExposes;
+declare const shadcnRootProps: ShadcnDialogRootProps;
 
 // Base asHook types reflect capabilities injected by the nested Transition.
 baseProps.enterDuration;
@@ -28,8 +30,10 @@ dialog.asTransition.controls.complete();
 dialog.stateHandles.transitionState;
 
 // A design-language library maintains a narrower translated public API.
-shadcnProps.alert;
+shadcnRootProps.alert;
 shadcnExposes.open;
+// @ts-expect-error alert mode is owned by Dialog Root rather than Content
+shadcnProps.alert;
 // @ts-expect-error Shadcn motion policy is internal rather than a public prop
 shadcnProps.enterDuration;
 // @ts-expect-error Shadcn does not publish Transition controls in its final expose type

--- a/packages/adapters/react/test/dialog.test.ts
+++ b/packages/adapters/react/test/dialog.test.ts
@@ -18,6 +18,7 @@ function dialogContext(open: boolean): DialogContextValue {
     controlled: false,
     disabled: false,
     alert: false,
+    a11yLabel: '',
     requestedOpen: open,
     requestReason: null,
     requestFocusReason: null,

--- a/packages/adapters/react/test/dialog.test.ts
+++ b/packages/adapters/react/test/dialog.test.ts
@@ -1,22 +1,36 @@
 import { describe, expect, it } from 'vitest';
 import { definePrototype } from '@proto.ui/core';
 
-import { DIALOG_CONTEXT, dialogContent, dialogMask } from '../../../prototypes/base/src/dialog';
+import {
+  DIALOG_CONTEXT,
+  dialogContent,
+  dialogMask,
+  type DialogContextValue,
+} from '../../../prototypes/base/src/dialog';
 import { createMountedReactAdapter } from './utils/fake-react';
+
+function dialogContext(open: boolean): DialogContextValue {
+  return {
+    rootId: 'react-adapter-dialog',
+    open,
+    openFocusReason: null,
+    returnFocusReason: null,
+    controlled: false,
+    disabled: false,
+    alert: false,
+    requestedOpen: open,
+    requestReason: null,
+    requestFocusReason: null,
+    requestVersion: 0,
+  };
+}
 
 describe('adapter-react: dialog integration', () => {
   it('renders dialog content when open and hides it when closed', () => {
     const proto = definePrototype({
       name: 'react-dialog-content-open-close',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div', 'hello')];
       },
@@ -43,14 +57,7 @@ describe('adapter-react: dialog integration', () => {
     const proto = definePrototype({
       name: 'react-dialog-transition-attrs',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div')];
       },
@@ -75,14 +82,7 @@ describe('adapter-react: dialog integration', () => {
     const proto = definePrototype({
       name: 'react-dialog-mask-transition',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: false,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(false));
         dialogMask.setup(def);
         return (r) => [r.el('div')];
       },
@@ -112,14 +112,7 @@ describe('adapter-react: dialog integration', () => {
     const proto = definePrototype({
       name: 'react-dialog-layer-base',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div', 'hello')];
       },
@@ -148,14 +141,7 @@ describe('adapter-react: dialog integration', () => {
     const proto = definePrototype({
       name: 'react-dialog-renderer-owned-portal',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div', 'hello')];
       },
@@ -186,14 +172,7 @@ describe('adapter-react: dialog integration', () => {
     const proto = definePrototype({
       name: 'react-dialog-outside-pointerdown',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div', 'hello')];
       },
@@ -217,14 +196,7 @@ describe('adapter-react: dialog integration', () => {
     const proto = definePrototype({
       name: 'react-dialog-mask-passthrough',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogMask.setup(def);
         return (r) => [r.el('div')];
       },

--- a/packages/adapters/vue/test/dialog.test.ts
+++ b/packages/adapters/vue/test/dialog.test.ts
@@ -1,22 +1,36 @@
 import { describe, expect, it } from 'vitest';
 import { definePrototype } from '@proto.ui/core';
 
-import { DIALOG_CONTEXT, dialogContent, dialogMask } from '../../../prototypes/base/src/dialog';
+import {
+  DIALOG_CONTEXT,
+  dialogContent,
+  dialogMask,
+  type DialogContextValue,
+} from '../../../prototypes/base/src/dialog';
 import { createMountedVueAdapter, createMountedVueAdapterWithOptions, flushVue } from './utils/vue';
+
+function dialogContext(open: boolean): DialogContextValue {
+  return {
+    rootId: 'vue-adapter-dialog',
+    open,
+    openFocusReason: null,
+    returnFocusReason: null,
+    controlled: false,
+    disabled: false,
+    alert: false,
+    requestedOpen: open,
+    requestReason: null,
+    requestFocusReason: null,
+    requestVersion: 0,
+  };
+}
 
 describe('adapter-vue: dialog integration', () => {
   it('renders dialog content when open and hides it when closed', async () => {
     const proto = definePrototype({
       name: 'vue-dialog-content-open-close',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div', 'hello')];
       },
@@ -45,14 +59,7 @@ describe('adapter-vue: dialog integration', () => {
     const proto = definePrototype({
       name: 'vue-dialog-transition-attrs',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div')];
       },
@@ -78,14 +85,7 @@ describe('adapter-vue: dialog integration', () => {
     const proto = definePrototype({
       name: 'vue-dialog-mask-transition',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: false,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(false));
         dialogMask.setup(def);
         return (r) => [r.el('div')];
       },
@@ -109,14 +109,7 @@ describe('adapter-vue: dialog integration', () => {
     const proto = definePrototype({
       name: 'vue-dialog-portaled-rematerialization',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div', 'portaled dialog epoch')];
       },
@@ -160,14 +153,7 @@ describe('adapter-vue: dialog integration', () => {
     const proto = definePrototype({
       name: 'vue-dialog-layer-base',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div', 'hello')];
       },
@@ -198,14 +184,7 @@ describe('adapter-vue: dialog integration', () => {
     const proto = definePrototype({
       name: 'vue-dialog-outside-pointerdown',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogContent.setup(def);
         return (r) => [r.el('div', 'hello')];
       },
@@ -231,14 +210,7 @@ describe('adapter-vue: dialog integration', () => {
     const proto = definePrototype({
       name: 'vue-dialog-mask-passthrough',
       setup(def) {
-        def.context.provide(DIALOG_CONTEXT, {
-          open: true,
-          openFocusReason: null,
-          returnFocusReason: null,
-          controlled: false,
-          disabled: false,
-          alert: false,
-        });
+        def.context.provide(DIALOG_CONTEXT, dialogContext(true));
         dialogMask.setup(def);
         return (r) => [r.el('div')];
       },

--- a/packages/adapters/vue/test/dialog.test.ts
+++ b/packages/adapters/vue/test/dialog.test.ts
@@ -18,6 +18,7 @@ function dialogContext(open: boolean): DialogContextValue {
     controlled: false,
     disabled: false,
     alert: false,
+    a11yLabel: '',
     requestedOpen: open,
     requestReason: null,
     requestFocusReason: null,

--- a/packages/adapters/web-component/test/dialog-overlay.test.ts
+++ b/packages/adapters/web-component/test/dialog-overlay.test.ts
@@ -196,6 +196,13 @@ describe('adapter-web-component: dialog overlay', () => {
 
     expect(styleContains(content, 'hidden')).toBe(false);
     expect(document.activeElement).toBe(cancel);
+    expect(content.getAttribute('role')).toBe('dialog');
+    expect(content.getAttribute('aria-modal')).toBe('true');
+    expect(content.getAttribute('aria-labelledby')).toBe(title.id);
+    expect(content.getAttribute('aria-describedby')).toBe(description.id);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(trigger.getAttribute('aria-haspopup')).toBe('dialog');
+    expect(trigger.getAttribute('aria-controls')).toBe(content.id);
 
     cancel.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await Promise.resolve();
@@ -205,6 +212,7 @@ describe('adapter-web-component: dialog overlay', () => {
     await completeTransitions(mask, content);
     expect(content.hasAttribute('data-pui-view-detached')).toBe(true);
     expect(document.activeElement).toBe(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
 
     root.remove();
     document.body.style.overflow = '';

--- a/packages/core/src/a11y.ts
+++ b/packages/core/src/a11y.ts
@@ -1,6 +1,7 @@
 import type { State } from './state';
 
 export type A11yRole = string;
+export type A11yRoleTarget = A11yRole | State<A11yRole>;
 
 export type A11yTextTarget = string | State<string | null | undefined>;
 export type A11yTextAlternative = { kind: 'content' } | { kind: 'text'; value: A11yTextTarget };
@@ -43,7 +44,7 @@ export type A11ySemanticObjectSnapshot = {
 
 export type A11yDefAPI = {
   id(target: A11yIdentityTarget): void;
-  role(role: A11yRole): void;
+  role(role: A11yRoleTarget): void;
   name(value: A11yTextTarget): void;
   nameFromContent(): void;
   description(value: A11yTextTarget): void;

--- a/packages/core/src/focus.ts
+++ b/packages/core/src/focus.ts
@@ -137,6 +137,13 @@ export type FocusFacts = Readonly<{
   focusable: boolean;
   active: boolean;
   hasFocused: boolean;
+  rovingSelected: boolean;
+  rovingActive: boolean;
+}>;
+
+export type FocusRovingMemberStatus = Readonly<{
+  selected?: boolean;
+  active?: boolean;
 }>;
 
 export interface FocusableHandle<P extends PropsBaseType = PropsBaseType> {
@@ -150,6 +157,7 @@ export interface FocusableHandle<P extends PropsBaseType = PropsBaseType> {
   isFocused(): boolean;
   setDisabled(disabled: boolean): void;
   setNavParticipation(navParticipation: 'auto' | 'none'): void;
+  setRovingStatus(status: FocusRovingMemberStatus): void;
 
   configure(patch: FocusableConfigPatch): void;
 }

--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -272,6 +272,11 @@ export interface DefHandle<Props extends PropsBaseType, Exposes = Record<string,
 
   anatomy: {
     claim(family: AnatomyFamily, decl: AnatomyClaimDecl): void;
+    subscribeParts(
+      family: AnatomyFamily,
+      role: string,
+      onChange: (run: RunHandle<Props>, parts: readonly AnatomyPartView[]) => void
+    ): Unsubscribe;
   };
 
   a11y: A11yDefAPI;

--- a/packages/core/src/prototype.ts
+++ b/packages/core/src/prototype.ts
@@ -36,19 +36,29 @@ export type AsHookDisposer = () => void;
 export type AsHookContract = {
   state?: AsHookStateMap;
   event?: AsHookEventMap;
+  asHooks?: Record<string, unknown>;
 };
 
 type NormalizeAsHookContract<C> = C extends AsHookContract
   ? {
       state: C['state'] extends AsHookStateMap ? C['state'] : {};
       event: C['event'] extends AsHookEventMap ? C['event'] : {};
+      asHooks: C['asHooks'] extends Record<string, unknown> ? C['asHooks'] : {};
     }
   : C extends AsHookStateMap
-    ? { state: C; event: {} }
-    : { state: {}; event: {} };
+    ? { state: C; event: {}; asHooks: {} }
+    : { state: {}; event: {}; asHooks: {} };
 
 type AsHookStatesOf<C> = NormalizeAsHookContract<C>['state'];
 type AsHookEventsOf<C> = NormalizeAsHookContract<C>['event'];
+type AsHookHandlesOf<C> = NormalizeAsHookContract<C>['asHooks'];
+
+export type AsHookHandleLookup<ContractInput> = {
+  <K extends keyof AsHookHandlesOf<ContractInput> & string>(
+    name: K
+  ): AsHookHandlesOf<ContractInput>[K] | undefined;
+  <Handle = unknown>(name: string): Handle | undefined;
+};
 
 export type AsHookDisposers = Readonly<{
   all: readonly AsHookDisposer[];
@@ -102,7 +112,7 @@ export type AsHookResult<Props extends PropsBaseType = PropsBaseType, ContractIn
   getMethod?: <K extends string>(key: K) => unknown;
   asHooks?: readonly AsHookChildResult[];
   getAsHook?: (name: string) => AsHookChildResult | undefined;
-  getAsHookHandle?: <Handle = unknown>(name: string) => Handle | undefined;
+  getAsHookHandle?: AsHookHandleLookup<ContractInput>;
   artifacts?: AsHookArtifacts<Props, ContractInput>;
   disposers?: AsHookDisposers;
   context?: unknown;

--- a/packages/hooks/src/as-boundary.ts
+++ b/packages/hooks/src/as-boundary.ts
@@ -1,4 +1,4 @@
-import type { BoundaryConfigPatch, BoundaryHandle } from '@proto.ui/core';
+import type { BoundaryHandle } from '@proto.ui/core';
 import type { PropsBaseType } from '@proto.ui/types';
 import { definePrivilegedAsHook } from './privileged';
 
@@ -17,10 +17,6 @@ const getBoundary = definePrivilegedAsHook<PropsBaseType, BoundaryHandle<PropsBa
   },
 });
 
-export function asBoundary<P extends PropsBaseType = PropsBaseType>(
-  patch?: BoundaryConfigPatch
-): BoundaryHandle<P> {
-  const handle = getBoundary() as BoundaryHandle<P>;
-  if (patch) handle.configure(patch);
-  return handle;
+export function asBoundary<P extends PropsBaseType = PropsBaseType>(): BoundaryHandle<P> {
+  return getBoundary() as BoundaryHandle<P>;
 }

--- a/packages/hooks/src/as-overlay.ts
+++ b/packages/hooks/src/as-overlay.ts
@@ -13,7 +13,7 @@ type OverlayFacade = {
 
 type OverlayPort = {
   setViewActive(active: boolean): void;
-  reconcileViewResources(): void;
+  reconcileViewResourcesAfterCallback(): void;
 };
 
 const installOverlay = definePrivilegedAsHook<PropsBaseType, OverlayHandle<PropsBaseType>>({
@@ -31,17 +31,10 @@ const installOverlay = definePrivilegedAsHook<PropsBaseType, OverlayHandle<Props
     let retainedView = false;
     let offPresence: (() => void) | null = null;
     let disposed = false;
-    let viewActiveVersion = 0;
-
     const scheduleBoundViewActive = (active: boolean) => {
       port.setViewActive(active);
-      const version = ++viewActiveVersion;
       if (!active) return;
-      queueMicrotask(() => {
-        if (disposed || version !== viewActiveVersion || !presenceBinding) return;
-        if (presenceBinding.present.get() !== active) return;
-        port.reconcileViewResources();
-      });
+      port.reconcileViewResourcesAfterCallback();
     };
 
     const driveLogicalPresence = (open: boolean) => {

--- a/packages/modules/a11y/src/create.ts
+++ b/packages/modules/a11y/src/create.ts
@@ -146,6 +146,13 @@ class A11yModuleImpl extends ModuleBase {
       this.stateWatchOffs.push(off);
     }
 
+    if (isState(this.ir.role)) {
+      const off = this.statePort.watch(this.ir.role as any, () => {
+        this.applyProjection();
+      });
+      this.stateWatchOffs.push(off);
+    }
+
     if (this.ir.name?.kind === 'text' && isState(this.ir.name.value)) {
       const off = this.statePort.watch(this.ir.name.value as any, () => {
         this.applyProjection();
@@ -185,7 +192,7 @@ class A11yModuleImpl extends ModuleBase {
 
     return {
       id: isState(this.ir.id) ? (this.ir.id.get() as string | null | undefined) : this.ir.id,
-      role: this.ir.role,
+      role: isState(this.ir.role) ? (this.ir.role.get() as A11yRole) : this.ir.role,
       name: resolveTextAlternative(this.ir.name),
       description: resolveTextAlternative(this.ir.description),
       states,

--- a/packages/modules/a11y/src/types.ts
+++ b/packages/modules/a11y/src/types.ts
@@ -6,6 +6,7 @@ import type {
   A11yRelationKey,
   A11yRelationSpec,
   A11yRole,
+  A11yRoleTarget,
   A11ySemanticObjectSnapshot,
   A11yStateKey,
   A11yTextAlternative,
@@ -29,7 +30,7 @@ export type A11yRelationBinding = {
 
 export type A11ySemanticObjectIR = {
   id?: A11yIdentityTarget;
-  role?: A11yRole;
+  role?: A11yRoleTarget;
   name?: A11yTextAlternative;
   description?: A11yTextAlternative;
   states: Map<A11yStateKey, A11yStateBinding>;

--- a/packages/modules/a11y/src/web.ts
+++ b/packages/modules/a11y/src/web.ts
@@ -6,10 +6,12 @@ const ARIA_STATE_ATTRS: Record<string, string> = {
   checked: 'aria-checked',
   disabled: 'aria-disabled',
   expanded: 'aria-expanded',
+  hasPopup: 'aria-haspopup',
   invalid: 'aria-invalid',
   orientation: 'aria-orientation',
   pressed: 'aria-pressed',
   selected: 'aria-selected',
+  modal: 'aria-modal',
 };
 
 const ARIA_RELATION_ATTRS: Record<string, string> = {

--- a/packages/modules/anatomy/src/create.ts
+++ b/packages/modules/anatomy/src/create.ts
@@ -20,6 +20,7 @@ export function createAnatomyModule(ctx: ModuleFactoryArgs): AnatomyModule {
       return {
         facade: {
           claim: (family, decl) => impl.claim(family, decl),
+          subscribeParts: (family, role, cb) => impl.subscribeParts(family, role, cb),
           has: (family, role) => impl.has(family, role),
           parts: ((family, options) =>
             impl.parts(family, options as any)) as AnatomyFacade['parts'],

--- a/packages/modules/anatomy/src/impl.ts
+++ b/packages/modules/anatomy/src/impl.ts
@@ -211,6 +211,7 @@ function getHookNames(proto: Prototype<any> | null): Set<string> {
 }
 
 export class AnatomyModuleImpl extends ModuleBase {
+  private static readonly liveInstances = new Set<AnatomyModuleImpl>();
   private static readonly sharedOrderObservers = new Map<
     AnatomyFamily,
     Map<AnatomyInstanceToken, { off: Unsubscribe; listeners: Set<AnatomyModuleImpl> }>
@@ -233,6 +234,7 @@ export class AnatomyModuleImpl extends ModuleBase {
     super(caps);
     this.prototypeName = prototypeName;
     this.exposePort = exposePort;
+    AnatomyModuleImpl.liveInstances.add(this);
   }
 
   private ensureFamilyRegistered(family: AnatomyFamily): NormalizedFamily {
@@ -297,7 +299,11 @@ export class AnatomyModuleImpl extends ModuleBase {
     cb: (ctx: AnatomyOrderCallbackCtx, parts: readonly AnatomyPartView[]) => void
   ): Unsubscribe {
     this.ensureSetup('def.anatomy.subscribeParts');
+    let previousSignature = this.computeRoleOrderSignature(family, role);
     return this.subscribeOrder(family, (ctx) => {
+      const nextSignature = this.computeRoleOrderSignature(family, role);
+      if (nextSignature === previousSignature) return;
+      previousSignature = nextSignature;
       const parts = this.tryOrderedPartsOf(family, role) ?? [];
       cb(ctx, parts);
     });
@@ -527,6 +533,11 @@ export class AnatomyModuleImpl extends ModuleBase {
 
   override onProtoPhase(phase: ProtoPhase): void {
     super.onProtoPhase(phase);
+    if (phase === 'mounted') {
+      for (const family of this.claimFamilies) {
+        AnatomyModuleImpl.notifyStructuralChange(family);
+      }
+    }
     if (phase === 'unmounted') this.dispose();
   }
 
@@ -554,6 +565,7 @@ export class AnatomyModuleImpl extends ModuleBase {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    AnatomyModuleImpl.liveInstances.delete(this);
     for (const family of this.observedOrderRoots.keys()) {
       this.teardownOrderObserver(family);
     }
@@ -565,6 +577,7 @@ export class AnatomyModuleImpl extends ModuleBase {
     const instance = this.caps.get(ANATOMY_INSTANCE_TOKEN_CAP) as AnatomyInstanceToken;
     for (const family of this.claimFamilies) {
       CENTER.deleteClaim(instance, family);
+      AnatomyModuleImpl.notifyStructuralChange(family);
     }
     this.claimFamilies.clear();
   }
@@ -621,6 +634,13 @@ export class AnatomyModuleImpl extends ModuleBase {
       this.orderListeners.delete(family);
       this.teardownOrderObserver(family);
     };
+  }
+
+  private static notifyStructuralChange(family: AnatomyFamily): void {
+    for (const impl of AnatomyModuleImpl.liveInstances) {
+      if (!impl.orderListeners.has(family)) continue;
+      impl.emitOrderChangeIfNeeded(family);
+    }
   }
 
   private ensureOrderObserver(family: AnatomyFamily): void {
@@ -708,6 +728,13 @@ export class AnatomyModuleImpl extends ModuleBase {
     if (!domain.rootInstance) return 'missing-domain';
     const ordered = this.sortClaims(domain.claims);
     return ordered.map((claim) => `${claim.role}:${this.getIdentityId(claim.instance)}`).join('|');
+  }
+
+  private computeRoleOrderSignature(family: AnatomyFamily, role: string): string {
+    const domain = this.resolveCurrentDomain(family, false);
+    if (!domain.rootInstance) return 'missing-domain';
+    const ordered = this.sortClaims(domain.claims.filter((claim) => claim.role === role));
+    return ordered.map((claim) => this.getIdentityId(claim.instance)).join('|');
   }
 
   private getIdentityId(value: unknown): number {

--- a/packages/modules/anatomy/src/impl.ts
+++ b/packages/modules/anatomy/src/impl.ts
@@ -33,6 +33,7 @@ import type {
   AnatomyDiagnostic,
   AnatomyOrderCallbackDispatcher,
   AnatomyOrderChangeCb,
+  AnatomyOrderCallbackCtx,
 } from './types';
 
 type HookTraceEntry = { name?: string };
@@ -288,6 +289,18 @@ export class AnatomyModuleImpl extends ModuleBase {
   has(family: AnatomyFamily, role: string): boolean {
     this.ensureRuntime('run.anatomy.has');
     return (this.partsOf(family, role) ?? []).length > 0;
+  }
+
+  subscribeParts(
+    family: AnatomyFamily,
+    role: string,
+    cb: (ctx: AnatomyOrderCallbackCtx, parts: readonly AnatomyPartView[]) => void
+  ): Unsubscribe {
+    this.ensureSetup('def.anatomy.subscribeParts');
+    return this.subscribeOrder(family, (ctx) => {
+      const parts = this.tryOrderedPartsOf(family, role) ?? [];
+      cb(ctx, parts);
+    });
   }
 
   parts(family: AnatomyFamily, options?: AnatomyQueryOptions): readonly AnatomyPartView[] | null {

--- a/packages/modules/anatomy/src/types.ts
+++ b/packages/modules/anatomy/src/types.ts
@@ -24,6 +24,11 @@ export type AnatomyOrderChangeCb = (ctx: AnatomyOrderCallbackCtx) => void;
 
 export type AnatomyFacade = {
   claim(family: AnatomyFamily, decl: AnatomyClaimDecl): void;
+  subscribeParts(
+    family: AnatomyFamily,
+    role: string,
+    cb: (ctx: AnatomyOrderCallbackCtx, parts: readonly AnatomyPartView[]) => void
+  ): Unsubscribe;
 
   has(family: AnatomyFamily, role: string): boolean;
   parts: AnatomyQueryOrderView['parts'];

--- a/packages/modules/base/src/system-caps.ts
+++ b/packages/modules/base/src/system-caps.ts
@@ -45,6 +45,13 @@ export interface SystemCaps {
    * - State/event modules MUST treat it as unknown and not depend on its shape.
    */
   getCallbackCtx(): unknown;
+
+  /**
+   * Queue work until the outermost runtime callback chain has completed.
+   * Module implementations may use this to avoid mutating host resources in
+   * the middle of lifecycle/event/state callback delivery.
+   */
+  deferAfterCallback?(task: () => void): void;
 }
 
 export const SYS_CAP = cap<SystemCaps>('@proto.ui/__sys');

--- a/packages/modules/focus/src/center.ts
+++ b/packages/modules/focus/src/center.ts
@@ -322,8 +322,8 @@ export class FocusCenter {
 
     const focusedIndex = members.findIndex((entry) => entry.getFacts().focused);
     const activeIndex = members.findIndex((entry) => entry.getFacts().rovingActive);
+    if (options?.requireFocusedMember && focusedIndex < 0) return false;
     const currentIndex = focusedIndex >= 0 ? focusedIndex : activeIndex;
-    if (options?.requireFocusedMember && currentIndex < 0) return false;
 
     const loop = provider.getRovingConfig().loop;
 

--- a/packages/modules/focus/src/center.ts
+++ b/packages/modules/focus/src/center.ts
@@ -320,14 +320,24 @@ export class FocusCenter {
     const members = this.getRovingMembers(provider);
     if (members.length === 0) return false;
 
-    const currentIndex = members.findIndex((entry) => entry.getFacts().focused);
+    const focusedIndex = members.findIndex((entry) => entry.getFacts().focused);
+    const activeIndex = members.findIndex((entry) => entry.getFacts().rovingActive);
+    const currentIndex = focusedIndex >= 0 ? focusedIndex : activeIndex;
     if (options?.requireFocusedMember && currentIndex < 0) return false;
 
     const loop = provider.getRovingConfig().loop;
 
     let target: FocusCenterEntry | null = null;
-    if (op === 'first' || op === 'selected') {
+    if (op === 'first') {
       target = members[0] ?? null;
+    } else if (op === 'selected') {
+      const selected = members.filter((entry) => entry.getFacts().rovingSelected);
+      if (selected.length > 1) {
+        provider.pushWarning(
+          `[Focus] roving set has multiple selected members; focusSelected uses the first member in host order.`
+        );
+      }
+      target = selected[0] ?? members[0] ?? null;
     } else if (op === 'last') {
       target = members[members.length - 1] ?? null;
     } else if (currentIndex >= 0) {

--- a/packages/modules/focus/src/create.ts
+++ b/packages/modules/focus/src/create.ts
@@ -7,6 +7,7 @@ import {
   FocusRovingConfigPatch,
   FocusRovingHandle,
   FocusRovingKey,
+  type FocusRovingMemberStatus,
   type FocusScopeConfig,
   illegalPhase,
   FocusRequestOptions,
@@ -120,6 +121,8 @@ class FocusModuleImpl extends ModuleBase {
   private readonly focusableState: ObservedStateHandle<boolean, any>;
   private readonly activeState: ObservedStateHandle<boolean, any>;
   private readonly hasFocusedState: ObservedStateHandle<boolean, any>;
+  private rovingSelected = false;
+  private rovingActive = false;
 
   private readonly focusableHandle: FocusableHandle<any>;
   private readonly entryHandle: FocusEntryHandle<any>;
@@ -164,6 +167,7 @@ class FocusModuleImpl extends ModuleBase {
       setDisabled: (disabled: boolean) => this.setDisabled(disabled),
       setNavParticipation: (navParticipation: 'auto' | 'none') =>
         this.setNavParticipation(navParticipation),
+      setRovingStatus: (status: FocusRovingMemberStatus) => this.setRovingStatus(status),
       configure: (patch: FocusableConfigPatch) => this.configureFocusable(patch),
     };
 
@@ -922,6 +926,11 @@ class FocusModuleImpl extends ModuleBase {
     this.syncCenter();
   }
 
+  setRovingStatus(status: FocusRovingMemberStatus): void {
+    if (typeof status.selected !== 'undefined') this.rovingSelected = status.selected;
+    if (typeof status.active !== 'undefined') this.rovingActive = status.active;
+  }
+
   setEntryDisabled(disabled: boolean): void {
     this.entryConfig = Object.freeze({
       ...this.entryConfig,
@@ -976,6 +985,8 @@ class FocusModuleImpl extends ModuleBase {
       focusable: this.focusableState.get(),
       active: this.activeState.get(),
       hasFocused: this.hasFocusedState.get(),
+      rovingSelected: this.rovingSelected,
+      rovingActive: this.rovingActive,
     });
   }
 
@@ -1023,6 +1034,7 @@ export function createFocusModule(ctx: ModuleFactoryArgs): FocusModule {
         configureScope: (patch) => impl.configureScope(patch),
         setDisabled: (disabled) => impl.setDisabled(disabled),
         setNavParticipation: (navParticipation) => impl.setNavParticipation(navParticipation),
+        setRovingStatus: (status) => impl.setRovingStatus(status),
         setEntryDisabled: (disabled) => impl.setEntryDisabled(disabled),
         requestFocus: (options) => impl.requestFocus(options),
         requestEntryFocus: (options) => impl.requestEntryFocus(options),

--- a/packages/modules/focus/src/types.ts
+++ b/packages/modules/focus/src/types.ts
@@ -7,6 +7,7 @@ import type {
   FocusRovingConfigPatch,
   FocusRovingHandle,
   FocusRovingKey,
+  FocusRovingMemberStatus,
   FocusScopeConfig,
   FocusRequestOptions,
   FocusScopeConfigPatch,
@@ -36,6 +37,7 @@ export type FocusPort = {
   configureScope(patch: FocusScopeConfigPatch): void;
   setDisabled(disabled: boolean): void;
   setNavParticipation(navParticipation: 'auto' | 'none'): void;
+  setRovingStatus(status: FocusRovingMemberStatus): void;
   setEntryDisabled(disabled: boolean): void;
   requestFocus(options?: FocusRequestOptions): void;
   requestEntryFocus(options?: FocusRequestOptions): void;

--- a/packages/modules/overlay/src/create.ts
+++ b/packages/modules/overlay/src/create.ts
@@ -48,7 +48,7 @@ export function createOverlayModule(ctx: ModuleFactoryArgs): OverlayModule {
           registerAnchor: (target) => impl.registerAnchor(target),
           registerContent: (target) => impl.registerContent(target),
           setViewActive: (active) => impl.setViewActive(active),
-          reconcileViewResources: () => impl.reconcileViewResources(),
+          reconcileViewResourcesAfterCallback: () => impl.reconcileViewResourcesAfterCallback(),
         },
       };
     },

--- a/packages/modules/overlay/src/impl.ts
+++ b/packages/modules/overlay/src/impl.ts
@@ -94,6 +94,7 @@ export class OverlayModuleImpl extends ModuleBase {
   private readonly warnings: string[] = [];
   private readonly boundary: BoundaryHandle<any>;
   private lastReason: OverlayReason | undefined = undefined;
+  private viewReconciliationVersion = 0;
   private registration: OverlayRegistration = Object.freeze({
     trigger: null,
     anchor: null,
@@ -314,6 +315,7 @@ export class OverlayModuleImpl extends ModuleBase {
     }
 
     this.viewActive = active;
+    this.viewReconciliationVersion += 1;
     if (active) {
       if (this.mountPhase === 'mounted') this.lockModalIfNeeded();
       return;
@@ -321,9 +323,18 @@ export class OverlayModuleImpl extends ModuleBase {
     this.deactivateViewSideEffects();
   }
 
-  reconcileViewResources(): void {
+  reconcileViewResourcesAfterCallback(): void {
     if (!this.viewActive) return;
-    this.syncViewSideEffects();
+    const version = this.viewReconciliationVersion;
+    const reconcile = () => {
+      if (!this.viewActive || version !== this.viewReconciliationVersion) return;
+      this.syncViewSideEffects();
+    };
+    if (this.sys.deferAfterCallback) {
+      this.sys.deferAfterCallback(reconcile);
+      return;
+    }
+    reconcile();
   }
 
   private replaceRegistration(next: Partial<OverlayRegistration>) {

--- a/packages/modules/overlay/src/types.ts
+++ b/packages/modules/overlay/src/types.ts
@@ -33,7 +33,7 @@ export type OverlayPort = {
   registerAnchor(target: unknown): void;
   registerContent(target: unknown): void;
   setViewActive(active: boolean): void;
-  reconcileViewResources(): void;
+  reconcileViewResourcesAfterCallback(): void;
 };
 
 export type OverlayModule = ModuleInstance<OverlayFacade> & {

--- a/packages/prototypes/base/src/dialog/close.ts
+++ b/packages/prototypes/base/src/dialog/close.ts
@@ -9,10 +9,12 @@ import {
 import type { DialogCloseAsHookContract, DialogCloseExposes, DialogCloseProps } from './types';
 
 function setupDialogClose(def: DefHandle<DialogCloseProps, DialogCloseExposes>): void {
+  // P-BASE-DIALOG-CLOSE-COMMAND, P-BASE-DIALOG-CLOSE-NO-BUTTON-DEPENDENCY
   def.anatomy.claim(DIALOG_FAMILY, { role: 'close' });
   const command = setupDialogCommand(def, 'dialog close');
 
   def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
+    // P-BASE-DIALOG-CLOSE-DISABLED
     command.syncDisabled(!!run.props.get().disabled || next.disabled);
   });
 
@@ -25,12 +27,14 @@ function setupDialogClose(def: DefHandle<DialogCloseProps, DialogCloseExposes>):
   });
 
   def.event.on('press.commit', (run, ev) => {
+    // P-BASE-DIALOG-CLOSE-REQUEST, P-BASE-DIALOG-CLOSE-DISABLED
     if (command.disabled.get()) return;
     const returnFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
     requestDialogOpen(run, false, 'close.press', returnFocusReason);
   });
 }
 
+// P-BASE-DIALOG-CLOSE-AUTHORING-ENTRIES
 export const asDialogClose = defineAsHook<
   DialogCloseProps,
   DialogCloseExposes,

--- a/packages/prototypes/base/src/dialog/close.ts
+++ b/packages/prototypes/base/src/dialog/close.ts
@@ -1,25 +1,27 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asButton } from '../button';
+import { setupDialogCommand } from './command';
 import { DIALOG_CONTEXT, DIALOG_FAMILY, type DialogOpenFocusReason } from './shared';
 import type { DialogCloseAsHookContract, DialogCloseExposes, DialogCloseProps } from './types';
 
 function setupDialogClose(def: DefHandle<DialogCloseProps, DialogCloseExposes>): void {
   def.anatomy.claim(DIALOG_FAMILY, { role: 'close' });
-  asButton();
+  const command = setupDialogCommand(def, 'dialog close');
 
-  def.props.define({
-    disabled: { type: 'boolean', empty: 'fallback' },
-  });
-  def.props.setDefaults({
-    disabled: false,
+  def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
+    command.syncDisabled(!!run.props.get().disabled || next.disabled);
   });
 
-  def.context.subscribe(DIALOG_CONTEXT);
+  def.lifecycle.onCreated((run) => {
+    command.syncDisabled(!!run.props.get().disabled || run.context.read(DIALOG_CONTEXT).disabled);
+  });
+
+  def.props.watch(['disabled'], (run, next) => {
+    command.syncDisabled(!!next.disabled || run.context.read(DIALOG_CONTEXT).disabled);
+  });
 
   def.event.on('press.commit', (run, ev) => {
-    const ownDisabled = !!run.props.get().disabled;
     const ctx = run.context.read(DIALOG_CONTEXT);
-    if (ownDisabled || ctx.disabled) return;
+    if (command.disabled.get()) return;
     if (ctx.controlled) return;
     const returnFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
     run.context.update(DIALOG_CONTEXT, (prev) => ({

--- a/packages/prototypes/base/src/dialog/close.ts
+++ b/packages/prototypes/base/src/dialog/close.ts
@@ -1,6 +1,11 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { setupDialogCommand } from './command';
-import { DIALOG_CONTEXT, DIALOG_FAMILY, type DialogOpenFocusReason } from './shared';
+import {
+  DIALOG_CONTEXT,
+  DIALOG_FAMILY,
+  requestDialogOpen,
+  type DialogOpenFocusReason,
+} from './shared';
 import type { DialogCloseAsHookContract, DialogCloseExposes, DialogCloseProps } from './types';
 
 function setupDialogClose(def: DefHandle<DialogCloseProps, DialogCloseExposes>): void {
@@ -20,16 +25,9 @@ function setupDialogClose(def: DefHandle<DialogCloseProps, DialogCloseExposes>):
   });
 
   def.event.on('press.commit', (run, ev) => {
-    const ctx = run.context.read(DIALOG_CONTEXT);
     if (command.disabled.get()) return;
-    if (ctx.controlled) return;
     const returnFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
-    run.context.update(DIALOG_CONTEXT, (prev) => ({
-      ...prev,
-      open: false,
-      openFocusReason: null,
-      returnFocusReason,
-    }));
+    requestDialogOpen(run, false, 'close.press', returnFocusReason);
   });
 }
 

--- a/packages/prototypes/base/src/dialog/command.ts
+++ b/packages/prototypes/base/src/dialog/command.ts
@@ -1,0 +1,81 @@
+import type { DefHandle, State } from '@proto.ui/core';
+import { asFocusable, asTrigger } from '@proto.ui/hooks';
+
+type DialogCommandProps = { disabled?: boolean };
+
+export type DialogCommand = {
+  disabled: State<boolean>;
+  syncDisabled(disabled: boolean): void;
+};
+
+/**
+ * Dialog-owned command substrate shared by Trigger and Close. It deliberately
+ * consumes core/privileged capabilities rather than the Button prototype
+ * protocol, preserving independent Base prototype ownership.
+ */
+export function setupDialogCommand(
+  def: DefHandle<DialogCommandProps, any>,
+  reasonPrefix: string
+): DialogCommand {
+  asTrigger();
+
+  def.props.define({
+    disabled: { type: 'boolean', empty: 'fallback' },
+  });
+  def.props.setDefaults({ disabled: false });
+
+  const disabled = def.state.bool('disabled', false);
+  const hovered = def.state.bool('hovered', false);
+  const pressed = def.state.bool('pressed', false);
+  const focusable = asFocusable<DialogCommandProps>();
+  focusable.configure({ disabled: false });
+  const focused = focusable.focused;
+  const focusVisible = focusable.focusVisible;
+
+  def.expose.state('disabled', disabled);
+  def.expose.state('hovered', hovered);
+  def.expose.state('focused', focused);
+  def.expose.state('focusVisible', focusVisible);
+  def.expose.state('pressed', pressed);
+  def.expose.method('focusSelf', (options: any) => {
+    if (disabled.get()) return;
+    focusable.focusSelf(options);
+  });
+  def.expose.event('click', { payload: 'void' });
+
+  def.a11y.role('button');
+  def.a11y.nameFromContent();
+  def.a11y.state('disabled', disabled);
+  def.a11y.action('activate', { event: 'click' });
+
+  const clearTransient = (reason: string) => {
+    hovered.set(false, reason);
+    pressed.set(false, reason);
+  };
+  const syncDisabled = (nextDisabled: boolean) => {
+    disabled.set(nextDisabled, `reason: ${reasonPrefix} disabled sync`);
+    focusable.setDisabled(nextDisabled);
+    if (nextDisabled) clearTransient(`reason: ${reasonPrefix} disabled => reset interaction`);
+  };
+
+  def.event.onGlobal('key.down', (_run, ev) => {
+    const detail = ev?.detail;
+    if (disabled.get() || !focused.get() || detail?.key !== ' ') return;
+    detail?.preventDefault?.();
+  });
+  def.event.on('pointer.enter', () => {
+    if (!disabled.get()) hovered.set(true, `reason: ${reasonPrefix} pointer.enter`);
+  });
+  def.event.on('pointer.leave', () => clearTransient(`reason: ${reasonPrefix} pointer.leave`));
+  def.event.on('pointer.cancel', () => clearTransient(`reason: ${reasonPrefix} pointer.cancel`));
+  def.event.on('pointer.down', () => {
+    if (!disabled.get()) pressed.set(true, `reason: ${reasonPrefix} pointer.down`);
+  });
+  def.event.on('pointer.up', () => pressed.set(false, `reason: ${reasonPrefix} pointer.up`));
+  def.event.on('press.commit', (run) => {
+    pressed.set(false, `reason: ${reasonPrefix} press.commit`);
+    if (!disabled.get()) run.expose.emit('click');
+  });
+
+  return { disabled, syncDisabled };
+}

--- a/packages/prototypes/base/src/dialog/command.ts
+++ b/packages/prototypes/base/src/dialog/command.ts
@@ -17,6 +17,8 @@ export function setupDialogCommand(
   def: DefHandle<DialogCommandProps, any>,
   reasonPrefix: string
 ): DialogCommand {
+  // P-BASE-DIALOG-TRIGGER-NO-BUTTON-DEPENDENCY, P-BASE-DIALOG-CLOSE-NO-BUTTON-DEPENDENCY
+  // P-BASE-DIALOG-TRIGGER-COMMAND, P-BASE-DIALOG-CLOSE-COMMAND
   asTrigger();
 
   def.props.define({
@@ -51,17 +53,20 @@ export function setupDialogCommand(
     pressed.set(false, reason);
   };
   const syncDisabled = (nextDisabled: boolean) => {
+    // P-BASE-DIALOG-TRIGGER-DISABLED, P-BASE-DIALOG-CLOSE-DISABLED
     disabled.set(nextDisabled, `reason: ${reasonPrefix} disabled sync`);
     focusable.setDisabled(nextDisabled);
     if (nextDisabled) clearTransient(`reason: ${reasonPrefix} disabled => reset interaction`);
   };
 
   def.event.onGlobal('key.down', (_run, ev) => {
+    // P-BASE-DIALOG-TRIGGER-COMMAND, P-BASE-DIALOG-CLOSE-COMMAND
     const detail = ev?.detail;
     if (disabled.get() || !focused.get() || detail?.key !== ' ') return;
     detail?.preventDefault?.();
   });
   def.event.on('pointer.enter', () => {
+    // P-BASE-DIALOG-TRIGGER-COMMAND, P-BASE-DIALOG-CLOSE-COMMAND
     if (!disabled.get()) hovered.set(true, `reason: ${reasonPrefix} pointer.enter`);
   });
   def.event.on('pointer.leave', () => clearTransient(`reason: ${reasonPrefix} pointer.leave`));

--- a/packages/prototypes/base/src/dialog/command.ts
+++ b/packages/prototypes/base/src/dialog/command.ts
@@ -41,8 +41,6 @@ export function setupDialogCommand(
     if (disabled.get()) return;
     focusable.focusSelf(options);
   });
-  def.expose.event('click', { payload: 'void' });
-
   def.a11y.role('button');
   def.a11y.nameFromContent();
   def.a11y.state('disabled', disabled);
@@ -72,9 +70,8 @@ export function setupDialogCommand(
     if (!disabled.get()) pressed.set(true, `reason: ${reasonPrefix} pointer.down`);
   });
   def.event.on('pointer.up', () => pressed.set(false, `reason: ${reasonPrefix} pointer.up`));
-  def.event.on('press.commit', (run) => {
+  def.event.on('press.commit', () => {
     pressed.set(false, `reason: ${reasonPrefix} press.commit`);
-    if (!disabled.get()) run.expose.emit('click');
   });
 
   return { disabled, syncDisabled };

--- a/packages/prototypes/base/src/dialog/content.ts
+++ b/packages/prototypes/base/src/dialog/content.ts
@@ -8,13 +8,12 @@ import type {
   DialogContentHandles,
   DialogContentProps,
 } from './types';
-import type { TransitionHandles } from '../transition/types';
 
 function projectDialogContentHandle(
   result: import('@proto.ui/core').AsHookResult<DialogContentProps, DialogContentAsHookContract>
 ): DialogContentHandles {
   const open = result.getState?.('open');
-  const asTransition = result.getAsHookHandle?.<TransitionHandles>('asTransition');
+  const asTransition = result.getAsHookHandle?.('asTransition');
   if (!open || !asTransition) {
     throw new Error('[as-dialog-content] missing captured Dialog or Transition handles.');
   }

--- a/packages/prototypes/base/src/dialog/content.ts
+++ b/packages/prototypes/base/src/dialog/content.ts
@@ -1,7 +1,13 @@
 import { defineAsHook, definePrototype, tw, type DefHandle } from '@proto.ui/core';
 import { asBoundary, asFocusScope, asOverlay } from '@proto.ui/hooks';
 import { asTransition } from '../tools';
-import { DIALOG_CONTEXT, DIALOG_FAMILY, type DialogOpenFocusReason } from './shared';
+import {
+  DIALOG_CONTEXT,
+  DIALOG_FAMILY,
+  requestDialogOpen,
+  type DialogContextValue,
+  type DialogOpenFocusReason,
+} from './shared';
 import type {
   DialogContentAsHookContract,
   DialogContentExposes,
@@ -61,6 +67,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   def.expose.state('open', open);
 
   let mountedRun: any = null;
+  let currentContext: DialogContextValue | null = null;
 
   const updateOpen = (
     nextOpen: boolean,
@@ -93,6 +100,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   };
 
   def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
+    currentContext = next;
     syncAlert(run);
     updateOpen(next.open, 'reason: dialog context sync => content', {
       focusReason: next.open ? next.openFocusReason : next.returnFocusReason,
@@ -102,6 +110,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   def.lifecycle.onCreated((run) => {
     syncAlert(run);
     const ctx = run.context.read(DIALOG_CONTEXT);
+    currentContext = ctx;
     updateOpen(ctx.open, 'reason: lifecycle.onCreated => dialog content open sync', {
       focusReason: ctx.open ? ctx.openFocusReason : ctx.returnFocusReason,
     });
@@ -111,6 +120,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     mountedRun = run;
     syncAlert(run);
     const ctx = run.context.read(DIALOG_CONTEXT);
+    currentContext = ctx;
     updateOpen(ctx.open, 'reason: lifecycle.onMounted => dialog content open sync', {
       focusReason: ctx.open ? ctx.openFocusReason : ctx.returnFocusReason,
     });
@@ -118,25 +128,18 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
 
   def.lifecycle.onUnmounted(() => {
     mountedRun = null;
+    currentContext = null;
   });
 
   overlay.open.watch((_ctx, event) => {
-    if (event.type !== 'next') return;
-    if (!event.next) {
-      const run = mountedRun;
-      if (!run) return;
-      const ctx = run.context.read(DIALOG_CONTEXT);
-      const returnFocusReason: DialogOpenFocusReason | null =
-        event.reason === 'escape' ? 'keyboard' : null;
-      if (returnFocusReason) focusScope.deactivate({ reason: returnFocusReason });
-      if (ctx.controlled) return;
-      run.context.update(DIALOG_CONTEXT, (prev: any) => ({
-        ...prev,
-        open: false,
-        openFocusReason: null,
-        returnFocusReason,
-      }));
-    }
+    if (event.type !== 'next' || event.next || event.reason !== 'escape') return;
+    const run = mountedRun;
+    if (!run) return;
+    const ctx = currentContext;
+    if (!ctx) return;
+    if (!ctx.open) return;
+    requestDialogOpen(run, false, 'escape', 'keyboard');
+    if (ctx.controlled) overlay.openOverlay('controlled.sync');
   });
 
   boundary.subscribeOutside(() => {
@@ -144,21 +147,12 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     const returnFocusReason: DialogOpenFocusReason = 'pointer';
     const run = mountedRun;
     if (!run) return;
-    const ctx = run.context.read(DIALOG_CONTEXT);
+    const ctx = currentContext;
+    if (!ctx) return;
     if (!ctx.open) return;
     if (alertProp.get()) return;
 
-    if (ctx.controlled) {
-      focusScope.deactivate({ reason: returnFocusReason });
-      overlay.close('outside.press');
-      return;
-    }
-    run.context.update(DIALOG_CONTEXT, (prev: any) => ({
-      ...prev,
-      open: false,
-      openFocusReason: null,
-      returnFocusReason,
-    }));
+    requestDialogOpen(run, false, 'outside.press', returnFocusReason);
   });
 
   def.rule({

--- a/packages/prototypes/base/src/dialog/content.ts
+++ b/packages/prototypes/base/src/dialog/content.ts
@@ -30,13 +30,6 @@ function projectDialogContentHandle(
 function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExposes>): void {
   def.anatomy.claim(DIALOG_FAMILY, { role: 'content' });
 
-  def.props.define({
-    alert: { type: 'boolean', empty: 'fallback' },
-  });
-  def.props.setDefaults({
-    alert: false,
-  });
-
   const alertProp = def.state.bool('alert', false);
   const role = def.state.string('dialogRole', 'dialog', {
     options: ['dialog', 'alertdialog'],
@@ -116,8 +109,8 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     );
   };
 
-  const syncAlert = (run: any, ctx: DialogContextValue) => {
-    const alert = !!run.props.get().alert || ctx.alert;
+  const syncAlert = (ctx: DialogContextValue) => {
+    const alert = ctx.alert;
     alertProp.set(alert, 'reason: dialog alert sync');
     role.set(alert ? 'alertdialog' : 'dialog', 'reason: dialog semantic role sync');
   };
@@ -125,7 +118,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
     currentContext = next;
     syncIdentity(next);
-    syncAlert(run, next);
+    syncAlert(next);
     updateOpen(next.open, 'reason: dialog context sync => content', {
       focusReason: next.open ? next.openFocusReason : next.returnFocusReason,
     });
@@ -135,7 +128,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     const ctx = run.context.read(DIALOG_CONTEXT);
     currentContext = ctx;
     syncIdentity(ctx);
-    syncAlert(run, ctx);
+    syncAlert(ctx);
     updateOpen(ctx.open, 'reason: lifecycle.onCreated => dialog content open sync', {
       focusReason: ctx.open ? ctx.openFocusReason : ctx.returnFocusReason,
     });
@@ -146,7 +139,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     const ctx = run.context.read(DIALOG_CONTEXT);
     currentContext = ctx;
     syncIdentity(ctx);
-    syncAlert(run, ctx);
+    syncAlert(ctx);
     updateOpen(ctx.open, 'reason: lifecycle.onMounted => dialog content open sync', {
       focusReason: ctx.open ? ctx.openFocusReason : ctx.returnFocusReason,
     });
@@ -155,10 +148,6 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   def.lifecycle.onUnmounted(() => {
     mountedRun = null;
     currentContext = null;
-  });
-
-  def.props.watch(['alert'], (run) => {
-    if (currentContext) syncAlert(run, currentContext);
   });
 
   overlay.open.watch((_ctx, event) => {

--- a/packages/prototypes/base/src/dialog/content.ts
+++ b/packages/prototypes/base/src/dialog/content.ts
@@ -4,6 +4,7 @@ import { asTransition } from '../tools';
 import {
   DIALOG_CONTEXT,
   DIALOG_FAMILY,
+  createDialogPartId,
   requestDialogOpen,
   type DialogContextValue,
   type DialogOpenFocusReason,
@@ -37,6 +38,18 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   });
 
   const alertProp = def.state.bool('alert', false);
+  const role = def.state.string('dialogRole', 'dialog', {
+    options: ['dialog', 'alertdialog'],
+  });
+  const modal = def.state.bool('dialogModal', true);
+  const contentId = def.state.string('dialogContentId', '');
+  const titleId = def.state.string('dialogTitleId', '');
+  const descriptionId = def.state.string('dialogDescriptionId', '');
+  def.a11y.id(contentId);
+  def.a11y.role(role);
+  def.a11y.state('modal', modal);
+  def.a11y.relation('labelledBy', { target: titleId });
+  def.a11y.relation('describedBy', { target: descriptionId });
 
   const overlay = asOverlay<DialogContentProps>();
   overlay.configure({
@@ -94,23 +107,35 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     }
   };
 
-  const syncAlert = (run: any) => {
-    const alert = !!run.props.get().alert;
+  const syncIdentity = (ctx: DialogContextValue) => {
+    contentId.set(createDialogPartId(ctx.rootId, 'content'), 'reason: dialog content id sync');
+    titleId.set(createDialogPartId(ctx.rootId, 'title'), 'reason: dialog title relation sync');
+    descriptionId.set(
+      createDialogPartId(ctx.rootId, 'description'),
+      'reason: dialog description relation sync'
+    );
+  };
+
+  const syncAlert = (run: any, ctx: DialogContextValue) => {
+    const alert = !!run.props.get().alert || ctx.alert;
     alertProp.set(alert, 'reason: dialog alert sync');
+    role.set(alert ? 'alertdialog' : 'dialog', 'reason: dialog semantic role sync');
   };
 
   def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
     currentContext = next;
-    syncAlert(run);
+    syncIdentity(next);
+    syncAlert(run, next);
     updateOpen(next.open, 'reason: dialog context sync => content', {
       focusReason: next.open ? next.openFocusReason : next.returnFocusReason,
     });
   });
 
   def.lifecycle.onCreated((run) => {
-    syncAlert(run);
     const ctx = run.context.read(DIALOG_CONTEXT);
     currentContext = ctx;
+    syncIdentity(ctx);
+    syncAlert(run, ctx);
     updateOpen(ctx.open, 'reason: lifecycle.onCreated => dialog content open sync', {
       focusReason: ctx.open ? ctx.openFocusReason : ctx.returnFocusReason,
     });
@@ -118,9 +143,10 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
 
   def.lifecycle.onMounted((run) => {
     mountedRun = run;
-    syncAlert(run);
     const ctx = run.context.read(DIALOG_CONTEXT);
     currentContext = ctx;
+    syncIdentity(ctx);
+    syncAlert(run, ctx);
     updateOpen(ctx.open, 'reason: lifecycle.onMounted => dialog content open sync', {
       focusReason: ctx.open ? ctx.openFocusReason : ctx.returnFocusReason,
     });
@@ -129,6 +155,10 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   def.lifecycle.onUnmounted(() => {
     mountedRun = null;
     currentContext = null;
+  });
+
+  def.props.watch(['alert'], (run) => {
+    if (currentContext) syncAlert(run, currentContext);
   });
 
   overlay.open.watch((_ctx, event) => {

--- a/packages/prototypes/base/src/dialog/content.ts
+++ b/packages/prototypes/base/src/dialog/content.ts
@@ -39,18 +39,16 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   });
   const modal = def.state.bool('dialogModal', true);
   const contentId = def.state.string('dialogContentId', '');
-  const titleId = def.state.string('dialogTitleId', '');
-  const descriptionId = def.state.string('dialogDescriptionId', '');
+  const accessibleLabel = def.state.string('dialogAccessibleLabel', '');
+  const labelledBy = def.state.string('dialogLabelledBy', '');
+  const describedBy = def.state.string('dialogDescribedBy', '');
   // P-BASE-DIALOG-CONTENT-A11Y-ROLE, P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
-  // TODO(P-BASE-DIALOG-CONTENT-A11Y-RELATIONS): make labelledBy/describedBy
-  // conditional on live Title/Description membership once anatomy exposes
-  // part-presence notifications; stable target IDs currently may dangle when
-  // those optional parts are absent.
   def.a11y.id(contentId);
   def.a11y.role(role);
+  def.a11y.name(accessibleLabel);
   def.a11y.state('modal', modal);
-  def.a11y.relation('labelledBy', { target: titleId });
-  def.a11y.relation('describedBy', { target: descriptionId });
+  def.a11y.relation('labelledBy', { target: labelledBy });
+  def.a11y.relation('describedBy', { target: describedBy });
 
   // P-BASE-DIALOG-CONTENT-DISMISS, P-BASE-DIALOG-CONTENT-FOCUS
   const overlay = asOverlay<DialogContentProps>();
@@ -86,6 +84,52 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
 
   let mountedRun: any = null;
   let currentContext: DialogContextValue | null = null;
+  let warnedMissingAlertDescription = false;
+
+  const hasLivePart = (run: any, role: 'title' | 'description'): boolean => {
+    try {
+      return run.anatomy.has(DIALOG_FAMILY, role);
+    } catch (error) {
+      if ((error as { code?: string })?.code === 'ANATOMY_CLAIM_INVALID') return false;
+      throw error;
+    }
+  };
+
+  const syncA11yRelations = (run: any, ctx: DialogContextValue) => {
+    // P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
+    // P-BASE-DIALOG-DESCRIPTION-ALERT
+    const hasTitle = hasLivePart(run, 'title');
+    const hasDescription = hasLivePart(run, 'description');
+    labelledBy.set(
+      hasTitle ? createDialogPartId(ctx.rootId, 'title') : '',
+      'reason: dialog live title relation sync'
+    );
+    accessibleLabel.set(
+      hasTitle ? '' : ctx.a11yLabel,
+      'reason: dialog accessible label fallback sync'
+    );
+    describedBy.set(
+      hasDescription ? createDialogPartId(ctx.rootId, 'description') : '',
+      'reason: dialog live description relation sync'
+    );
+
+    if (!mountedRun || !ctx.alert || hasDescription) {
+      warnedMissingAlertDescription = false;
+      return;
+    }
+    if (warnedMissingAlertDescription) return;
+    warnedMissingAlertDescription = true;
+    console.warn(
+      '[base-dialog-content] Alert Dialog requires a Dialog Description containing its primary message.'
+    );
+  };
+
+  def.anatomy.subscribeParts(DIALOG_FAMILY, 'title', (run) => {
+    if (currentContext) syncA11yRelations(run, currentContext);
+  });
+  def.anatomy.subscribeParts(DIALOG_FAMILY, 'description', (run) => {
+    if (currentContext) syncA11yRelations(run, currentContext);
+  });
 
   const updateOpen = (
     nextOpen: boolean,
@@ -116,11 +160,6 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   const syncIdentity = (ctx: DialogContextValue) => {
     // P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
     contentId.set(createDialogPartId(ctx.rootId, 'content'), 'reason: dialog content id sync');
-    titleId.set(createDialogPartId(ctx.rootId, 'title'), 'reason: dialog title relation sync');
-    descriptionId.set(
-      createDialogPartId(ctx.rootId, 'description'),
-      'reason: dialog description relation sync'
-    );
   };
 
   const syncAlert = (ctx: DialogContextValue) => {
@@ -134,6 +173,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     currentContext = next;
     syncIdentity(next);
     syncAlert(next);
+    syncA11yRelations(run, next);
     updateOpen(next.open, 'reason: dialog context sync => content', {
       focusReason: next.open ? next.openFocusReason : next.returnFocusReason,
     });
@@ -144,6 +184,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     currentContext = ctx;
     syncIdentity(ctx);
     syncAlert(ctx);
+    syncA11yRelations(run, ctx);
     updateOpen(ctx.open, 'reason: lifecycle.onCreated => dialog content open sync', {
       focusReason: ctx.open ? ctx.openFocusReason : ctx.returnFocusReason,
     });
@@ -155,6 +196,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     currentContext = ctx;
     syncIdentity(ctx);
     syncAlert(ctx);
+    syncA11yRelations(run, ctx);
     updateOpen(ctx.open, 'reason: lifecycle.onMounted => dialog content open sync', {
       focusReason: ctx.open ? ctx.openFocusReason : ctx.returnFocusReason,
     });

--- a/packages/prototypes/base/src/dialog/content.ts
+++ b/packages/prototypes/base/src/dialog/content.ts
@@ -19,6 +19,8 @@ import type {
 function projectDialogContentHandle(
   result: import('@proto.ui/core').AsHookResult<DialogContentProps, DialogContentAsHookContract>
 ): DialogContentHandles {
+  // C-AS-HOOK-0009-E, C-AS-HOOK-0009-F: selectively re-export Transition's
+  // stable child handle without flattening its state into Dialog Content.
   const open = result.getState?.('open');
   const asTransition = result.getAsHookHandle?.('asTransition');
   if (!open || !asTransition) {
@@ -28,6 +30,7 @@ function projectDialogContentHandle(
 }
 
 function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExposes>): void {
+  // P-BASE-DIALOG-CONTENT-PRESENCE, P-BASE-DIALOG-CONTENT-A11Y-ROLE
   def.anatomy.claim(DIALOG_FAMILY, { role: 'content' });
 
   const alertProp = def.state.bool('alert', false);
@@ -38,12 +41,18 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   const contentId = def.state.string('dialogContentId', '');
   const titleId = def.state.string('dialogTitleId', '');
   const descriptionId = def.state.string('dialogDescriptionId', '');
+  // P-BASE-DIALOG-CONTENT-A11Y-ROLE, P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
+  // TODO(P-BASE-DIALOG-CONTENT-A11Y-RELATIONS): make labelledBy/describedBy
+  // conditional on live Title/Description membership once anatomy exposes
+  // part-presence notifications; stable target IDs currently may dangle when
+  // those optional parts are absent.
   def.a11y.id(contentId);
   def.a11y.role(role);
   def.a11y.state('modal', modal);
   def.a11y.relation('labelledBy', { target: titleId });
   def.a11y.relation('describedBy', { target: descriptionId });
 
+  // P-BASE-DIALOG-CONTENT-DISMISS, P-BASE-DIALOG-CONTENT-FOCUS
   const overlay = asOverlay<DialogContentProps>();
   overlay.configure({
     closeOnEscape: true,
@@ -56,12 +65,15 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     modal: false,
     layerRole: 'dialog-content',
   });
+  // P-BASE-DIALOG-CONTENT-DISMISS
   const boundary = asBoundary();
   boundary.observe('pointer.press');
 
+  // P-BASE-DIALOG-CONTENT-FOCUS
   const focusScope = asFocusScope<DialogContentProps>();
   focusScope.configure({ trap: true, loop: true });
 
+  // P-BASE-DIALOG-CONTENT-PRESENCE
   const transition = asTransition();
   overlay.bindPresence({
     enter: transition.controls.enter,
@@ -80,6 +92,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
     reason?: string,
     options?: { focusReason?: DialogOpenFocusReason | null }
   ) => {
+    // P-BASE-DIALOG-CONTENT-PRESENCE, P-BASE-DIALOG-CONTENT-FOCUS
     const prevOpen = open.get();
     open.set(nextOpen, reason ?? 'reason: dialog content sync => open');
     if (nextOpen) {
@@ -101,6 +114,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   };
 
   const syncIdentity = (ctx: DialogContextValue) => {
+    // P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
     contentId.set(createDialogPartId(ctx.rootId, 'content'), 'reason: dialog content id sync');
     titleId.set(createDialogPartId(ctx.rootId, 'title'), 'reason: dialog title relation sync');
     descriptionId.set(
@@ -110,6 +124,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   };
 
   const syncAlert = (ctx: DialogContextValue) => {
+    // P-BASE-DIALOG-CONTENT-A11Y-ROLE
     const alert = ctx.alert;
     alertProp.set(alert, 'reason: dialog alert sync');
     role.set(alert ? 'alertdialog' : 'dialog', 'reason: dialog semantic role sync');
@@ -151,6 +166,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   });
 
   overlay.open.watch((_ctx, event) => {
+    // P-BASE-DIALOG-CONTENT-DISMISS, P-BASE-DIALOG-CONTENT-CONTROLLED
     if (event.type !== 'next' || event.next || event.reason !== 'escape') return;
     const run = mountedRun;
     if (!run) return;
@@ -162,6 +178,7 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   });
 
   boundary.subscribeOutside(() => {
+    // P-BASE-DIALOG-CONTENT-DISMISS, P-BASE-DIALOG-CONTENT-CONTROLLED
     if (!overlay.isOpen()) return;
     const returnFocusReason: DialogOpenFocusReason = 'pointer';
     const run = mountedRun;
@@ -175,11 +192,13 @@ function setupDialogContent(def: DefHandle<DialogContentProps, DialogContentExpo
   });
 
   def.rule({
+    // P-BASE-DIALOG-CONTENT-PRESENCE
     when: (w) => w.state(transition.isPresent).eq(false),
     intent: (i) => i.feedback.style.use(tw('hidden')),
   });
 }
 
+// P-BASE-DIALOG-CONTENT-AUTHORING-ENTRIES
 export const asDialogContent = defineAsHook<
   DialogContentProps,
   DialogContentExposes,

--- a/packages/prototypes/base/src/dialog/description.ts
+++ b/packages/prototypes/base/src/dialog/description.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { DIALOG_FAMILY } from './shared';
+import { createDialogPartId, DIALOG_CONTEXT, DIALOG_FAMILY } from './shared';
 import type {
   DialogDescriptionAsHookContract,
   DialogDescriptionExposes,
@@ -10,6 +10,17 @@ function setupDialogDescription(
   def: DefHandle<DialogDescriptionProps, DialogDescriptionExposes>
 ): void {
   def.anatomy.claim(DIALOG_FAMILY, { role: 'description' });
+  const id = def.state.string('dialogDescriptionId', '');
+  def.a11y.id(id);
+  def.context.subscribe(DIALOG_CONTEXT, (_run, next) => {
+    id.set(createDialogPartId(next.rootId, 'description'), 'reason: dialog description id sync');
+  });
+  def.lifecycle.onCreated((run) => {
+    id.set(
+      createDialogPartId(run.context.read(DIALOG_CONTEXT).rootId, 'description'),
+      'reason: dialog description created id sync'
+    );
+  });
 }
 
 export const asDialogDescription = defineAsHook<

--- a/packages/prototypes/base/src/dialog/description.ts
+++ b/packages/prototypes/base/src/dialog/description.ts
@@ -9,6 +9,7 @@ import type {
 function setupDialogDescription(
   def: DefHandle<DialogDescriptionProps, DialogDescriptionExposes>
 ): void {
+  // P-BASE-DIALOG-DESCRIPTION-RELATION
   def.anatomy.claim(DIALOG_FAMILY, { role: 'description' });
   const id = def.state.string('dialogDescriptionId', '');
   def.a11y.id(id);
@@ -23,6 +24,13 @@ function setupDialogDescription(
   });
 }
 
+/*
+ * TODO(P-BASE-DIALOG-DESCRIPTION-ALERT): enforce the alert-only Description
+ * requirement once anatomy can express conditional cardinality. Runtime
+ * identity projection cannot synthesize the alert's primary message.
+ */
+
+// P-BASE-DIALOG-DESCRIPTION-AUTHORING-ENTRIES
 export const asDialogDescription = defineAsHook<
   DialogDescriptionProps,
   DialogDescriptionExposes,

--- a/packages/prototypes/base/src/dialog/description.ts
+++ b/packages/prototypes/base/src/dialog/description.ts
@@ -24,12 +24,6 @@ function setupDialogDescription(
   });
 }
 
-/*
- * TODO(P-BASE-DIALOG-DESCRIPTION-ALERT): enforce the alert-only Description
- * requirement once anatomy can express conditional cardinality. Runtime
- * identity projection cannot synthesize the alert's primary message.
- */
-
 // P-BASE-DIALOG-DESCRIPTION-AUTHORING-ENTRIES
 export const asDialogDescription = defineAsHook<
   DialogDescriptionProps,

--- a/packages/prototypes/base/src/dialog/overlay.ts
+++ b/packages/prototypes/base/src/dialog/overlay.ts
@@ -12,6 +12,8 @@ import type {
 function projectDialogMaskHandle(
   result: import('@proto.ui/core').AsHookResult<DialogMaskProps, DialogMaskAsHookContract>
 ): DialogMaskHandles {
+  // C-AS-HOOK-0009-E, C-AS-HOOK-0009-F: selectively re-export Transition's
+  // stable child handle without flattening its state into Dialog Mask.
   const open = result.getState?.('open');
   const asTransition = result.getAsHookHandle?.('asTransition');
   if (!open || !asTransition) {
@@ -21,7 +23,9 @@ function projectDialogMaskHandle(
 }
 
 function setupDialogMask(def: DefHandle<DialogMaskProps, DialogMaskExposes>): void {
+  // P-BASE-DIALOG-MASK-MODAL
   def.anatomy.claim(DIALOG_FAMILY, { role: 'mask' });
+  // P-BASE-DIALOG-MASK-PASSTHROUGH
   def.props.define({
     passthrough: { type: 'boolean', empty: 'fallback' },
   });
@@ -29,6 +33,7 @@ function setupDialogMask(def: DefHandle<DialogMaskProps, DialogMaskExposes>): vo
     passthrough: false,
   });
 
+  // P-BASE-DIALOG-MASK-MODAL, P-BASE-DIALOG-MASK-NO-DISMISS
   const overlay = asOverlay<DialogMaskProps>();
   overlay.configure({
     closeOnEscape: false,
@@ -38,6 +43,7 @@ function setupDialogMask(def: DefHandle<DialogMaskProps, DialogMaskExposes>): vo
     modal: true,
     layerRole: 'dialog-mask',
   });
+  // P-BASE-DIALOG-MASK-PASSTHROUGH
   const hitParticipation = asHitParticipation({
     debugLabel: 'dialog-mask',
     meta: {
@@ -45,6 +51,7 @@ function setupDialogMask(def: DefHandle<DialogMaskProps, DialogMaskExposes>): vo
     },
   });
 
+  // P-BASE-DIALOG-MASK-PRESENCE
   const transition = asTransition();
   overlay.bindPresence({
     enter: transition.controls.enter,
@@ -56,6 +63,7 @@ function setupDialogMask(def: DefHandle<DialogMaskProps, DialogMaskExposes>): vo
   let hitSyncDisposed = false;
 
   const syncHitParticipation = (run: any) => {
+    // P-BASE-DIALOG-MASK-PASSTHROUGH
     if (hitSyncDisposed) return;
 
     const target = run.host?.get?.() ?? null;
@@ -75,6 +83,7 @@ function setupDialogMask(def: DefHandle<DialogMaskProps, DialogMaskExposes>): vo
   };
 
   const updateOpen = (nextOpen: boolean, reason?: string) => {
+    // P-BASE-DIALOG-MASK-PRESENCE
     open.set(nextOpen, reason ?? 'reason: dialog mask sync => open');
     if (nextOpen) {
       overlay.openOverlay(reason ?? 'dialog.open');
@@ -109,11 +118,13 @@ function setupDialogMask(def: DefHandle<DialogMaskProps, DialogMaskExposes>): vo
   });
 
   def.rule({
+    // P-BASE-DIALOG-MASK-PRESENCE
     when: (w) => w.state(transition.isPresent).eq(false),
     intent: (i) => i.feedback.style.use(tw('hidden')),
   });
 }
 
+// P-BASE-DIALOG-MASK-AUTHORING-ENTRIES
 export const asDialogMask = defineAsHook<
   DialogMaskProps,
   DialogMaskExposes,

--- a/packages/prototypes/base/src/dialog/overlay.ts
+++ b/packages/prototypes/base/src/dialog/overlay.ts
@@ -8,13 +8,12 @@ import type {
   DialogMaskHandles,
   DialogMaskProps,
 } from './types';
-import type { TransitionHandles } from '../transition/types';
 
 function projectDialogMaskHandle(
   result: import('@proto.ui/core').AsHookResult<DialogMaskProps, DialogMaskAsHookContract>
 ): DialogMaskHandles {
   const open = result.getState?.('open');
-  const asTransition = result.getAsHookHandle?.<TransitionHandles>('asTransition');
+  const asTransition = result.getAsHookHandle?.('asTransition');
   if (!open || !asTransition) {
     throw new Error('[as-dialog-mask] missing captured Dialog or Transition handles.');
   }

--- a/packages/prototypes/base/src/dialog/overlay.ts
+++ b/packages/prototypes/base/src/dialog/overlay.ts
@@ -99,10 +99,6 @@ function setupDialogMask(def: DefHandle<DialogMaskProps, DialogMaskExposes>): vo
   def.lifecycle.onMounted((run) => {
     hitSyncDisposed = false;
     syncHitParticipation(run);
-    queueMicrotask(() => {
-      if (hitSyncDisposed) return;
-      syncHitParticipation(run);
-    });
     updateOpen(open.get(), 'reason: lifecycle.onMounted => dialog mask open sync');
   });
 

--- a/packages/prototypes/base/src/dialog/root.ts
+++ b/packages/prototypes/base/src/dialog/root.ts
@@ -10,7 +10,11 @@ function sameContext(a: DialogContextValue, b: DialogContextValue): boolean {
     a.returnFocusReason === b.returnFocusReason &&
     a.controlled === b.controlled &&
     a.disabled === b.disabled &&
-    a.alert === b.alert
+    a.alert === b.alert &&
+    a.requestedOpen === b.requestedOpen &&
+    a.requestReason === b.requestReason &&
+    a.requestFocusReason === b.requestFocusReason &&
+    a.requestVersion === b.requestVersion
   );
 }
 
@@ -36,12 +40,17 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
     controlled: false,
     disabled: false,
     alert: false,
+    requestedOpen: false,
+    requestReason: null,
+    requestFocusReason: null,
+    requestVersion: 0,
   });
 
   const openState = useOpenState({
     exposeOpenMethodKey: 'openDialog',
   });
   const open = openState.getState?.('open');
+  def.expose.event('openChange', { payload: 'json' });
 
   const initialContext: DialogContextValue = {
     open: false,
@@ -50,9 +59,14 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
     controlled: false,
     disabled: false,
     alert: false,
+    requestedOpen: false,
+    requestReason: null,
+    requestFocusReason: null,
+    requestVersion: 0,
   };
   let snapshot: DialogContextValue = initialContext;
   let published: DialogContextValue = initialContext;
+  let lastRequestVersion = 0;
 
   const syncContext = (run: any) => {
     const next = {
@@ -65,9 +79,21 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
     run.context.update(DIALOG_CONTEXT, next);
   };
 
-  def.context.subscribe(DIALOG_CONTEXT, (_run, next) => {
+  def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
     snapshot = next;
     published = next;
+    if (next.requestVersion !== lastRequestVersion) {
+      lastRequestVersion = next.requestVersion;
+      if (!next.controlled) {
+        open?.set(next.requestedOpen, 'reason: dialog open request => uncontrolled sync');
+      }
+      run.expose.emit('openChange', {
+        open: next.requestedOpen,
+        reason: next.requestReason,
+        focusReason: next.requestFocusReason,
+      });
+      return;
+    }
     if (!snapshot.controlled) {
       open?.set(next.open, 'reason: dialog context sync => open');
     }

--- a/packages/prototypes/base/src/dialog/root.ts
+++ b/packages/prototypes/base/src/dialog/root.ts
@@ -26,9 +26,11 @@ function sameContext(a: DialogContextValue, b: DialogContextValue): boolean {
 }
 
 function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): void {
+  // P-BASE-DIALOG-ROLE-MODAL-WINDOW, P-BASE-DIALOG-ROOT-OWNER
   def.anatomy.claim(DIALOG_FAMILY, { role: 'root' });
   const rootId = createDialogRootId();
 
+  // P-BASE-DIALOG-PROPS
   def.props.define({
     open: { type: 'boolean', empty: 'fallback' },
     defaultOpen: { type: 'boolean', empty: 'fallback' },
@@ -41,6 +43,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
     alert: false,
   });
 
+  // P-BASE-DIALOG-CONTEXT
   def.context.provide(DIALOG_CONTEXT, {
     rootId,
     open: false,
@@ -55,6 +58,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
     requestVersion: 0,
   });
 
+  // P-BASE-DIALOG-OPEN-EXPOSE, P-BASE-DIALOG-CONTROLLED-OWNER
   const openState = useOpenState({
     exposeOpenMethodKey: 'openDialog',
     requestOpen(run, nextOpen, reason) {
@@ -64,6 +68,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
     },
   });
   const open = openState.getState?.('open');
+  // P-BASE-DIALOG-OPEN-CHANGE
   def.expose.event('openChange', { payload: 'json' });
 
   const initialContext: DialogContextValue = {
@@ -84,6 +89,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
   let lastRequestVersion = 0;
 
   const syncContext = (run: any) => {
+    // P-BASE-DIALOG-CONTEXT
     const next = {
       ...snapshot,
       open: open?.get() ?? false,
@@ -95,6 +101,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
   };
 
   def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
+    // P-BASE-DIALOG-OPEN-CHANGE, P-BASE-DIALOG-CONTROLLED-OWNER
     snapshot = next;
     published = next;
     if (next.requestVersion !== lastRequestVersion) {
@@ -115,6 +122,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
   });
 
   def.lifecycle.onCreated((run) => {
+    // P-BASE-DIALOG-ROOT-OWNER, P-BASE-DIALOG-PROPS
     snapshot = {
       ...snapshot,
       controlled: run.props.isProvided('open'),
@@ -140,6 +148,12 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
   });
 }
 
+/*
+ * P-BASE-DIALOG-PROTOCOL-INDEPENDENCE: Root consumes a protocol-neutral useOpenState helper,
+ * not another Base prototype-specific authored asHook.
+ */
+
+// P-BASE-DIALOG-AUTHORING-ENTRIES
 export const asDialogRoot = defineAsHook<
   DialogRootProps,
   DialogRootExposes,

--- a/packages/prototypes/base/src/dialog/root.ts
+++ b/packages/prototypes/base/src/dialog/root.ts
@@ -18,6 +18,7 @@ function sameContext(a: DialogContextValue, b: DialogContextValue): boolean {
     a.controlled === b.controlled &&
     a.disabled === b.disabled &&
     a.alert === b.alert &&
+    a.a11yLabel === b.a11yLabel &&
     a.requestedOpen === b.requestedOpen &&
     a.requestReason === b.requestReason &&
     a.requestFocusReason === b.requestFocusReason &&
@@ -36,11 +37,13 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
     defaultOpen: { type: 'boolean', empty: 'fallback' },
     disabled: { type: 'boolean', empty: 'fallback' },
     alert: { type: 'boolean', empty: 'fallback' },
+    a11yLabel: { type: 'string', empty: 'fallback' },
   });
   def.props.setDefaults({
     defaultOpen: false,
     disabled: false,
     alert: false,
+    a11yLabel: '',
   });
 
   // P-BASE-DIALOG-CONTEXT
@@ -52,6 +55,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
     controlled: false,
     disabled: false,
     alert: false,
+    a11yLabel: '',
     requestedOpen: false,
     requestReason: null,
     requestFocusReason: null,
@@ -79,6 +83,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
     controlled: false,
     disabled: false,
     alert: false,
+    a11yLabel: '',
     requestedOpen: false,
     requestReason: null,
     requestFocusReason: null,
@@ -128,16 +133,18 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
       controlled: run.props.isProvided('open'),
       disabled: !!run.props.get().disabled,
       alert: !!run.props.get().alert,
+      a11yLabel: run.props.get().a11yLabel ?? '',
     };
     syncContext(run);
   });
 
-  def.props.watch(['open', 'disabled', 'alert'], (run, next) => {
+  def.props.watch(['open', 'disabled', 'alert', 'a11yLabel'], (run, next) => {
     snapshot = {
       ...snapshot,
       controlled: run.props.isProvided('open'),
       disabled: !!next.disabled,
       alert: !!next.alert,
+      a11yLabel: next.a11yLabel ?? '',
     };
     syncContext(run);
   });

--- a/packages/prototypes/base/src/dialog/root.ts
+++ b/packages/prototypes/base/src/dialog/root.ts
@@ -1,10 +1,16 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { useOpenState } from '../tools';
-import { DIALOG_CONTEXT, DIALOG_FAMILY, type DialogContextValue } from './shared';
+import {
+  createDialogRootId,
+  DIALOG_CONTEXT,
+  DIALOG_FAMILY,
+  type DialogContextValue,
+} from './shared';
 import type { DialogRootAsHookContract, DialogRootExposes, DialogRootProps } from './types';
 
 function sameContext(a: DialogContextValue, b: DialogContextValue): boolean {
   return (
+    a.rootId === b.rootId &&
     a.open === b.open &&
     a.openFocusReason === b.openFocusReason &&
     a.returnFocusReason === b.returnFocusReason &&
@@ -20,6 +26,7 @@ function sameContext(a: DialogContextValue, b: DialogContextValue): boolean {
 
 function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): void {
   def.anatomy.claim(DIALOG_FAMILY, { role: 'root' });
+  const rootId = createDialogRootId();
 
   def.props.define({
     open: { type: 'boolean', empty: 'fallback' },
@@ -34,6 +41,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
   });
 
   def.context.provide(DIALOG_CONTEXT, {
+    rootId,
     open: false,
     openFocusReason: null,
     returnFocusReason: null,
@@ -53,6 +61,7 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
   def.expose.event('openChange', { payload: 'json' });
 
   const initialContext: DialogContextValue = {
+    rootId,
     open: false,
     openFocusReason: null,
     returnFocusReason: null,

--- a/packages/prototypes/base/src/dialog/root.ts
+++ b/packages/prototypes/base/src/dialog/root.ts
@@ -4,6 +4,7 @@ import {
   createDialogRootId,
   DIALOG_CONTEXT,
   DIALOG_FAMILY,
+  requestDialogOpen,
   type DialogContextValue,
 } from './shared';
 import type { DialogRootAsHookContract, DialogRootExposes, DialogRootProps } from './types';
@@ -56,6 +57,11 @@ function setupDialogRoot(def: DefHandle<DialogRootProps, DialogRootExposes>): vo
 
   const openState = useOpenState({
     exposeOpenMethodKey: 'openDialog',
+    requestOpen(run, nextOpen, reason) {
+      const ctx = run.context.read(DIALOG_CONTEXT);
+      if (ctx.disabled) return;
+      requestDialogOpen(run, nextOpen, reason, 'programmatic');
+    },
   });
   const open = openState.getState?.('open');
   def.expose.event('openChange', { payload: 'json' });

--- a/packages/prototypes/base/src/dialog/shared.ts
+++ b/packages/prototypes/base/src/dialog/shared.ts
@@ -3,6 +3,7 @@ import { createAnatomyFamily, createContextKey } from '@proto.ui/core';
 export type DialogOpenFocusReason = 'programmatic' | 'keyboard' | 'pointer';
 
 export type DialogContextValue = {
+  // P-BASE-DIALOG-CONTEXT
   rootId: string;
   open: boolean;
   openFocusReason: DialogOpenFocusReason | null;
@@ -36,6 +37,7 @@ export function requestDialogOpen(
   reason: string,
   focusReason: DialogOpenFocusReason | null
 ): boolean {
+  // P-BASE-DIALOG-OPEN-CHANGE, P-BASE-DIALOG-CONTROLLED-OWNER
   try {
     run.context.update(DIALOG_CONTEXT, (prev: DialogContextValue) => ({
       ...prev,
@@ -54,6 +56,7 @@ export function requestDialogOpen(
   }
 }
 
+// P-BASE-DIALOG-ANATOMY
 export const DIALOG_FAMILY = createAnatomyFamily('base-dialog', {
   roles: {
     root: { cardinality: { min: 1, max: 1 } },
@@ -74,4 +77,5 @@ export const DIALOG_FAMILY = createAnatomyFamily('base-dialog', {
   ],
 });
 
+// P-BASE-DIALOG-CONTEXT
 export const DIALOG_CONTEXT = createContextKey<DialogContextValue>('base-dialog');

--- a/packages/prototypes/base/src/dialog/shared.ts
+++ b/packages/prototypes/base/src/dialog/shared.ts
@@ -11,6 +11,7 @@ export type DialogContextValue = {
   controlled: boolean;
   disabled: boolean;
   alert: boolean;
+  a11yLabel: string;
   requestedOpen: boolean;
   requestReason: string | null;
   requestFocusReason: DialogOpenFocusReason | null;

--- a/packages/prototypes/base/src/dialog/shared.ts
+++ b/packages/prototypes/base/src/dialog/shared.ts
@@ -9,7 +9,35 @@ export type DialogContextValue = {
   controlled: boolean;
   disabled: boolean;
   alert: boolean;
+  requestedOpen: boolean;
+  requestReason: string | null;
+  requestFocusReason: DialogOpenFocusReason | null;
+  requestVersion: number;
 };
+
+export function requestDialogOpen(
+  run: any,
+  nextOpen: boolean,
+  reason: string,
+  focusReason: DialogOpenFocusReason | null
+): boolean {
+  try {
+    run.context.update(DIALOG_CONTEXT, (prev: DialogContextValue) => ({
+      ...prev,
+      open: prev.controlled ? prev.open : nextOpen,
+      openFocusReason: nextOpen ? focusReason : null,
+      returnFocusReason: nextOpen ? null : focusReason,
+      requestedOpen: nextOpen,
+      requestReason: reason,
+      requestFocusReason: focusReason,
+      requestVersion: prev.requestVersion + 1,
+    }));
+    return true;
+  } catch (error) {
+    if ((error as { code?: string })?.code === 'CONTEXT_DISCONNECTED') return false;
+    throw error;
+  }
+}
 
 export const DIALOG_FAMILY = createAnatomyFamily('base-dialog', {
   roles: {

--- a/packages/prototypes/base/src/dialog/shared.ts
+++ b/packages/prototypes/base/src/dialog/shared.ts
@@ -3,6 +3,7 @@ import { createAnatomyFamily, createContextKey } from '@proto.ui/core';
 export type DialogOpenFocusReason = 'programmatic' | 'keyboard' | 'pointer';
 
 export type DialogContextValue = {
+  rootId: string;
   open: boolean;
   openFocusReason: DialogOpenFocusReason | null;
   returnFocusReason: DialogOpenFocusReason | null;
@@ -14,6 +15,20 @@ export type DialogContextValue = {
   requestFocusReason: DialogOpenFocusReason | null;
   requestVersion: number;
 };
+
+let nextDialogRootId = 0;
+
+export function createDialogRootId(): string {
+  nextDialogRootId += 1;
+  return `pui-dialog-${nextDialogRootId}`;
+}
+
+export function createDialogPartId(
+  rootId: string,
+  role: 'content' | 'title' | 'description'
+): string {
+  return `${rootId || 'pui-dialog'}-${role}`;
+}
 
 export function requestDialogOpen(
   run: any,
@@ -46,7 +61,7 @@ export const DIALOG_FAMILY = createAnatomyFamily('base-dialog', {
     mask: { cardinality: { min: 0, max: 1 } },
     content: { cardinality: { min: 0, max: 1 } },
     title: { cardinality: { min: 0, max: 1 } },
-    description: { cardinality: { min: 0, max: 100 } },
+    description: { cardinality: { min: 0, max: 1 } },
     close: { cardinality: { min: 0, max: 100 } },
   },
   relations: [

--- a/packages/prototypes/base/src/dialog/title.ts
+++ b/packages/prototypes/base/src/dialog/title.ts
@@ -3,6 +3,7 @@ import { createDialogPartId, DIALOG_CONTEXT, DIALOG_FAMILY } from './shared';
 import type { DialogTitleAsHookContract, DialogTitleExposes, DialogTitleProps } from './types';
 
 function setupDialogTitle(def: DefHandle<DialogTitleProps, DialogTitleExposes>): void {
+  // P-BASE-DIALOG-TITLE-LABEL
   def.anatomy.claim(DIALOG_FAMILY, { role: 'title' });
   const id = def.state.string('dialogTitleId', '');
   def.a11y.id(id);
@@ -18,6 +19,11 @@ function setupDialogTitle(def: DefHandle<DialogTitleProps, DialogTitleExposes>):
   });
 }
 
+/*
+ * P-BASE-DIALOG-TITLE-NO-BEHAVIOR: absence of event, open, and focus syntax is the implementation.
+ */
+
+// P-BASE-DIALOG-TITLE-AUTHORING-ENTRIES
 export const asDialogTitle = defineAsHook<
   DialogTitleProps,
   DialogTitleExposes,

--- a/packages/prototypes/base/src/dialog/title.ts
+++ b/packages/prototypes/base/src/dialog/title.ts
@@ -1,9 +1,21 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { DIALOG_FAMILY } from './shared';
+import { createDialogPartId, DIALOG_CONTEXT, DIALOG_FAMILY } from './shared';
 import type { DialogTitleAsHookContract, DialogTitleExposes, DialogTitleProps } from './types';
 
 function setupDialogTitle(def: DefHandle<DialogTitleProps, DialogTitleExposes>): void {
   def.anatomy.claim(DIALOG_FAMILY, { role: 'title' });
+  const id = def.state.string('dialogTitleId', '');
+  def.a11y.id(id);
+  def.a11y.nameFromContent();
+  def.context.subscribe(DIALOG_CONTEXT, (_run, next) => {
+    id.set(createDialogPartId(next.rootId, 'title'), 'reason: dialog title id sync');
+  });
+  def.lifecycle.onCreated((run) => {
+    id.set(
+      createDialogPartId(run.context.read(DIALOG_CONTEXT).rootId, 'title'),
+      'reason: dialog title created id sync'
+    );
+  });
 }
 
 export const asDialogTitle = defineAsHook<

--- a/packages/prototypes/base/src/dialog/trigger.ts
+++ b/packages/prototypes/base/src/dialog/trigger.ts
@@ -1,6 +1,11 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { setupDialogCommand } from './command';
-import { DIALOG_CONTEXT, DIALOG_FAMILY, type DialogOpenFocusReason } from './shared';
+import {
+  DIALOG_CONTEXT,
+  DIALOG_FAMILY,
+  requestDialogOpen,
+  type DialogOpenFocusReason,
+} from './shared';
 import type {
   DialogTriggerAsHookContract,
   DialogTriggerExposes,
@@ -26,14 +31,8 @@ function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExpo
   def.event.on('press.commit', (run, ev) => {
     const ctx = run.context.read(DIALOG_CONTEXT);
     if (command.disabled.get()) return;
-    if (ctx.controlled) return;
     const openFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
-    run.context.update(DIALOG_CONTEXT, (prev) => ({
-      ...prev,
-      open: !prev.open,
-      openFocusReason: prev.open ? null : openFocusReason,
-      returnFocusReason: prev.open ? openFocusReason : null,
-    }));
+    requestDialogOpen(run, !ctx.open, 'trigger.press', openFocusReason);
   });
 }
 

--- a/packages/prototypes/base/src/dialog/trigger.ts
+++ b/packages/prototypes/base/src/dialog/trigger.ts
@@ -1,5 +1,5 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
-import { asButton } from '../button';
+import { setupDialogCommand } from './command';
 import { DIALOG_CONTEXT, DIALOG_FAMILY, type DialogOpenFocusReason } from './shared';
 import type {
   DialogTriggerAsHookContract,
@@ -9,21 +9,23 @@ import type {
 
 function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExposes>): void {
   def.anatomy.claim(DIALOG_FAMILY, { role: 'trigger' });
-  asButton();
+  const command = setupDialogCommand(def, 'dialog trigger');
 
-  def.props.define({
-    disabled: { type: 'boolean', empty: 'fallback' },
-  });
-  def.props.setDefaults({
-    disabled: false,
+  def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
+    command.syncDisabled(!!run.props.get().disabled || next.disabled);
   });
 
-  def.context.subscribe(DIALOG_CONTEXT);
+  def.lifecycle.onCreated((run) => {
+    command.syncDisabled(!!run.props.get().disabled || run.context.read(DIALOG_CONTEXT).disabled);
+  });
+
+  def.props.watch(['disabled'], (run, next) => {
+    command.syncDisabled(!!next.disabled || run.context.read(DIALOG_CONTEXT).disabled);
+  });
 
   def.event.on('press.commit', (run, ev) => {
-    const ownDisabled = !!run.props.get().disabled;
     const ctx = run.context.read(DIALOG_CONTEXT);
-    if (ownDisabled || ctx.disabled) return;
+    if (command.disabled.get()) return;
     if (ctx.controlled) return;
     const openFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
     run.context.update(DIALOG_CONTEXT, (prev) => ({

--- a/packages/prototypes/base/src/dialog/trigger.ts
+++ b/packages/prototypes/base/src/dialog/trigger.ts
@@ -15,11 +15,13 @@ import type {
 } from './types';
 
 function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExposes>): void {
+  // P-BASE-DIALOG-TRIGGER-COMMAND, P-BASE-DIALOG-TRIGGER-NO-BUTTON-DEPENDENCY
   def.anatomy.claim(DIALOG_FAMILY, { role: 'trigger' });
   const command = setupDialogCommand(def, 'dialog trigger');
   const expanded = def.state.bool('dialogExpanded', false);
   const hasPopup = def.state.string('dialogHasPopup', 'dialog');
   const controls = def.state.string('dialogContentId', '');
+  // P-BASE-DIALOG-TRIGGER-A11Y
   def.a11y.state('expanded', expanded);
   def.a11y.state('hasPopup', hasPopup);
   def.a11y.relation('controls', { target: controls });
@@ -30,6 +32,7 @@ function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExpo
   };
 
   def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
+    // P-BASE-DIALOG-TRIGGER-DISABLED, P-BASE-DIALOG-TRIGGER-A11Y
     command.syncDisabled(!!run.props.get().disabled || next.disabled);
     syncDialogFacts(next);
   });
@@ -45,6 +48,7 @@ function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExpo
   });
 
   def.event.on('press.commit', (run, ev) => {
+    // P-BASE-DIALOG-TRIGGER-REQUEST, P-BASE-DIALOG-TRIGGER-DISABLED
     const ctx = run.context.read(DIALOG_CONTEXT);
     if (command.disabled.get()) return;
     const openFocusReason: DialogOpenFocusReason = ev?.detail?.key ? 'keyboard' : 'pointer';
@@ -52,6 +56,7 @@ function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExpo
   });
 }
 
+// P-BASE-DIALOG-TRIGGER-AUTHORING-ENTRIES
 export const asDialogTrigger = defineAsHook<
   DialogTriggerProps,
   DialogTriggerExposes,

--- a/packages/prototypes/base/src/dialog/trigger.ts
+++ b/packages/prototypes/base/src/dialog/trigger.ts
@@ -1,9 +1,11 @@
 import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { setupDialogCommand } from './command';
 import {
+  createDialogPartId,
   DIALOG_CONTEXT,
   DIALOG_FAMILY,
   requestDialogOpen,
+  type DialogContextValue,
   type DialogOpenFocusReason,
 } from './shared';
 import type {
@@ -15,13 +17,27 @@ import type {
 function setupDialogTrigger(def: DefHandle<DialogTriggerProps, DialogTriggerExposes>): void {
   def.anatomy.claim(DIALOG_FAMILY, { role: 'trigger' });
   const command = setupDialogCommand(def, 'dialog trigger');
+  const expanded = def.state.bool('dialogExpanded', false);
+  const hasPopup = def.state.string('dialogHasPopup', 'dialog');
+  const controls = def.state.string('dialogContentId', '');
+  def.a11y.state('expanded', expanded);
+  def.a11y.state('hasPopup', hasPopup);
+  def.a11y.relation('controls', { target: controls });
+
+  const syncDialogFacts = (ctx: DialogContextValue) => {
+    expanded.set(ctx.open, 'reason: dialog trigger expanded sync');
+    controls.set(createDialogPartId(ctx.rootId, 'content'), 'reason: dialog trigger controls sync');
+  };
 
   def.context.subscribe(DIALOG_CONTEXT, (run, next) => {
     command.syncDisabled(!!run.props.get().disabled || next.disabled);
+    syncDialogFacts(next);
   });
 
   def.lifecycle.onCreated((run) => {
-    command.syncDisabled(!!run.props.get().disabled || run.context.read(DIALOG_CONTEXT).disabled);
+    const ctx = run.context.read(DIALOG_CONTEXT);
+    command.syncDisabled(!!run.props.get().disabled || ctx.disabled);
+    syncDialogFacts(ctx);
   });
 
   def.props.watch(['disabled'], (run, next) => {

--- a/packages/prototypes/base/src/dialog/types.ts
+++ b/packages/prototypes/base/src/dialog/types.ts
@@ -38,9 +38,18 @@ export type DialogTriggerExposes = {
 };
 
 export type DialogTriggerAsHookContract = {
+  state: DialogCommandStateHandles;
   event: {
     click: void;
   };
+};
+
+export type DialogCommandStateHandles = {
+  disabled: State<boolean>;
+  hovered: State<boolean>;
+  focused: State<boolean>;
+  focusVisible: State<boolean>;
+  pressed: State<boolean>;
 };
 
 export type DialogMaskProps = TransitionProps & {
@@ -120,6 +129,7 @@ export type DialogCloseExposes = {
 };
 
 export type DialogCloseAsHookContract = {
+  state: DialogCommandStateHandles;
   event: {
     click: void;
   };

--- a/packages/prototypes/base/src/dialog/types.ts
+++ b/packages/prototypes/base/src/dialog/types.ts
@@ -46,14 +46,10 @@ export type DialogTriggerExposes = {
   focusVisible: ExposeState<boolean>;
   pressed: ExposeState<boolean>;
   focusSelf: ExposeMethod<(options?: { reason?: 'programmatic' | 'keyboard' | 'pointer' }) => void>;
-  click: import('@proto.ui/core').ExposeEvent<void>;
 };
 
 export type DialogTriggerAsHookContract = {
   state: DialogCommandStateHandles;
-  event: {
-    click: void;
-  };
 };
 
 export type DialogCommandStateHandles = {
@@ -88,9 +84,7 @@ export type DialogMaskHandles = {
   asTransition: TransitionHandles;
 };
 
-export type DialogContentProps = TransitionProps & {
-  alert?: boolean;
-};
+export type DialogContentProps = TransitionProps;
 
 export type DialogContentExposes = TransitionExposes & {
   open: ExposeState<boolean>;
@@ -137,12 +131,8 @@ export type DialogCloseExposes = {
   focusVisible: ExposeState<boolean>;
   pressed: ExposeState<boolean>;
   focusSelf: ExposeMethod<(options?: { reason?: 'programmatic' | 'keyboard' | 'pointer' }) => void>;
-  click: import('@proto.ui/core').ExposeEvent<void>;
 };
 
 export type DialogCloseAsHookContract = {
   state: DialogCommandStateHandles;
-  event: {
-    click: void;
-  };
 };

--- a/packages/prototypes/base/src/dialog/types.ts
+++ b/packages/prototypes/base/src/dialog/types.ts
@@ -1,4 +1,11 @@
-import type { BorrowedStateHandle, ExposeMethod, ExposeState, State } from '@proto.ui/core';
+import type {
+  BorrowedStateHandle,
+  ExposeEvent,
+  ExposeMethod,
+  ExposeState,
+  State,
+} from '@proto.ui/core';
+import type { DialogOpenFocusReason } from './shared';
 import type { TransitionExposes, TransitionHandles, TransitionProps } from '../transition/types';
 
 export interface DialogRootProps {
@@ -13,6 +20,11 @@ export type DialogRootExposes = {
   openDialog: ExposeMethod<(reason?: string) => void>;
   close: ExposeMethod<(reason?: string) => void>;
   toggle: ExposeMethod<(reason?: string) => void>;
+  openChange: ExposeEvent<{
+    open: boolean;
+    reason: string | null;
+    focusReason: DialogOpenFocusReason | null;
+  }>;
 };
 
 export type DialogRootStateHandles = {

--- a/packages/prototypes/base/src/dialog/types.ts
+++ b/packages/prototypes/base/src/dialog/types.ts
@@ -14,6 +14,7 @@ export interface DialogRootProps {
   defaultOpen?: boolean;
   disabled?: boolean;
   alert?: boolean;
+  a11yLabel?: string;
 }
 
 export type DialogRootExposes = {

--- a/packages/prototypes/base/src/dialog/types.ts
+++ b/packages/prototypes/base/src/dialog/types.ts
@@ -9,6 +9,7 @@ import type { DialogOpenFocusReason } from './shared';
 import type { TransitionExposes, TransitionHandles, TransitionProps } from '../transition/types';
 
 export interface DialogRootProps {
+  // P-BASE-DIALOG-PROPS
   open?: boolean;
   defaultOpen?: boolean;
   disabled?: boolean;
@@ -16,10 +17,12 @@ export interface DialogRootProps {
 }
 
 export type DialogRootExposes = {
+  // P-BASE-DIALOG-OPEN-EXPOSE
   open: ExposeState<boolean>;
   openDialog: ExposeMethod<(reason?: string) => void>;
   close: ExposeMethod<(reason?: string) => void>;
   toggle: ExposeMethod<(reason?: string) => void>;
+  // P-BASE-DIALOG-OPEN-CHANGE
   openChange: ExposeEvent<{
     open: boolean;
     reason: string | null;
@@ -36,10 +39,12 @@ export type DialogRootAsHookContract = {
 };
 
 export interface DialogTriggerProps {
+  // P-BASE-DIALOG-TRIGGER-DISABLED
   disabled?: boolean;
 }
 
 export type DialogTriggerExposes = {
+  // P-BASE-DIALOG-TRIGGER-COMMAND, P-BASE-DIALOG-TRIGGER-DISABLED
   disabled: ExposeState<boolean>;
   hovered: ExposeState<boolean>;
   focused: ExposeState<boolean>;
@@ -61,6 +66,7 @@ export type DialogCommandStateHandles = {
 };
 
 export type DialogMaskProps = TransitionProps & {
+  // P-BASE-DIALOG-MASK-PASSTHROUGH
   passthrough?: boolean;
 };
 
@@ -87,6 +93,7 @@ export type DialogMaskHandles = {
 export type DialogContentProps = TransitionProps;
 
 export type DialogContentExposes = TransitionExposes & {
+  // P-BASE-DIALOG-CONTENT-PRESENCE
   open: ExposeState<boolean>;
 };
 
@@ -121,10 +128,12 @@ export type DialogDescriptionExposes = {};
 export type DialogDescriptionAsHookContract = {};
 
 export interface DialogCloseProps {
+  // P-BASE-DIALOG-CLOSE-DISABLED
   disabled?: boolean;
 }
 
 export type DialogCloseExposes = {
+  // P-BASE-DIALOG-CLOSE-COMMAND, P-BASE-DIALOG-CLOSE-DISABLED
   disabled: ExposeState<boolean>;
   hovered: ExposeState<boolean>;
   focused: ExposeState<boolean>;

--- a/packages/prototypes/base/src/dialog/types.ts
+++ b/packages/prototypes/base/src/dialog/types.ts
@@ -55,6 +55,9 @@ export type DialogMaskStateHandles = {
 
 export type DialogMaskAsHookContract = {
   state: DialogMaskStateHandles;
+  asHooks: {
+    asTransition: TransitionHandles;
+  };
 };
 
 export type DialogMaskHandles = {
@@ -78,6 +81,9 @@ export type DialogContentStateHandles = {
 
 export type DialogContentAsHookContract = {
   state: DialogContentStateHandles;
+  asHooks: {
+    asTransition: TransitionHandles;
+  };
 };
 
 export type DialogContentHandles = {

--- a/packages/prototypes/base/src/tabs/content.ts
+++ b/packages/prototypes/base/src/tabs/content.ts
@@ -17,6 +17,7 @@ function syncCurrentFromContext(
 }
 
 function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>): void {
+  // P-BASE-TABS-CONTENT-ROLE-PANEL, P-BASE-TABS-CONTENT-PROTOCOL-DEPENDENCY
   // P-BASE-TABS-CONTENT-CLAIM-ROLE, P-BASE-TABS-CONTENT-SAME-DOMAIN
   def.anatomy.claim(TABS_FAMILY, { role: 'content' });
   // P-BASE-TABS-CONTENT-CURRENT-DERIVED
@@ -32,6 +33,7 @@ function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>):
     disabled: true,
   });
 
+  // P-BASE-TABS-CONTENT-PROP-VALUE, P-BASE-TABS-CONTENT-PRESENCE-POLICY
   def.props.define({
     value: { type: 'string', empty: 'fallback' },
     keepMounted: { type: 'boolean', empty: 'fallback' },
@@ -44,17 +46,19 @@ function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>):
   let ownValue = '';
   let rootId = '';
   let keepMounted = false;
+  // P-BASE-TABS-CONTENT-CURRENT-EXPOSE
   def.expose.state('current', current);
   def.expose.state('hidden', hidden);
 
   // P-BASE-TABS-CONTENT-A11Y-ROLE, P-BASE-TABS-CONTENT-A11Y-LABELLEDBY-TARGET
-  // P-BASE-TABS-CONTENT-HIDDEN-WHEN-INACTIVE
+  // P-BASE-TABS-CONTENT-A11Y-HIDDEN, P-BASE-TABS-CONTENT-HIDDEN-WHEN-INACTIVE
   def.a11y.id(contentId);
   def.a11y.role('tabpanel');
   def.a11y.state('hidden', hidden);
   def.a11y.relation('labelledBy', { target: triggerId });
 
   const syncIds = () => {
+    // P-BASE-TABS-A11Y-RELATIONSHIP-TARGET
     contentId.set(createTabsPartId(rootId, 'content', ownValue), 'reason: tabs content id sync');
     triggerId.set(
       createTabsPartId(rootId, 'trigger', ownValue),
@@ -66,10 +70,12 @@ function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>):
     next: TabsContextValue,
     lifecycle: { setPresent(present: boolean): void }
   ) => {
+    // P-BASE-TABS-CONTENT-CONTEXT-CONSUME, P-BASE-TABS-CONTENT-CURRENT-DERIVED
     rootId = next.rootId;
     syncIds();
     syncCurrentFromContext(next.value, ownValue, current, hidden, focusEntry);
     const nextCurrent = next.value === ownValue;
+    // P-BASE-TABS-CONTENT-DEFAULT-L1-DETACH, P-BASE-TABS-CONTENT-PRESENCE-POLICY
     lifecycle.setPresent(keepMounted || nextCurrent);
   };
 
@@ -106,6 +112,11 @@ function setupTabsContent(def: DefHandle<TabsContentProps, TabsContentExposes>):
   });
 }
 
+/*
+ * P-BASE-TABS-CONTENT-TABINDEX-DEFERRED is deprecated and intentionally has no implementation.
+ */
+
+// P-BASE-TABS-CONTENT-AUTHORING-ENTRIES
 export const asTabsContent = defineAsHook<
   TabsContentProps,
   TabsContentExposes,

--- a/packages/prototypes/base/src/tabs/indicator.ts
+++ b/packages/prototypes/base/src/tabs/indicator.ts
@@ -7,11 +7,13 @@ import type {
 } from './types';
 
 function setupTabsIndicator(def: DefHandle<TabsIndicatorProps, TabsIndicatorExposes>): void {
+  // P-BASE-TABS-INDICATOR-PROTOCOL-DEPENDENCY
   // P-BASE-TABS-INDICATOR-ROLE-INDICATOR, P-BASE-TABS-INDICATOR-CLAIM-ROLE
   // P-BASE-TABS-INDICATOR-SAME-DOMAIN
   def.anatomy.claim(TABS_FAMILY, { role: 'indicator' });
 
   // P-BASE-TABS-INDICATOR-DERIVED-VALUE, P-BASE-TABS-INDICATOR-DERIVED-ACTIVE-VALUE
+  // P-BASE-TABS-INDICATOR-DERIVED-ORIENTATION
   const value = def.state.string('value', '');
   const activeValue = def.state.string('activeValue', '');
   const orientation = def.state.string('orientation', 'horizontal', {

--- a/packages/prototypes/base/src/tabs/list.ts
+++ b/packages/prototypes/base/src/tabs/list.ts
@@ -1,14 +1,13 @@
-import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
+import { defineAsHook, definePrototype, type DefHandle, type RunHandle } from '@proto.ui/core';
 import { asFocusRoving } from '@proto.ui/hooks';
-import { useFocusRoving } from '../behaviors';
 import { TABS_CONTEXT, TABS_FAMILY } from './shared';
 import type { TabsListAsHookContract, TabsListExposes, TabsListProps } from './types';
 
 function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   // P-BASE-TABS-LIST-CLAIM-ROLE, P-BASE-TABS-LIST-SAME-DOMAIN
   def.anatomy.claim(TABS_FAMILY, { role: 'list' });
-  let activeValue = '';
   let selectedValue = '';
+  let mountedRun: RunHandle<TabsListProps> | null = null;
 
   def.props.define({
     orientation: { type: 'enum', empty: 'fallback', options: ['horizontal', 'vertical'] },
@@ -30,28 +29,37 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   def.a11y.name(a11yLabel);
   def.a11y.state('orientation', orientation);
 
+  // P-BASE-TABS-LIST-FOCUS-ROVING, P-BASE-TABS-LIST-SKIP-DISABLED
+  // P-BASE-TABS-LIST-ORIENTATION-KEYS, P-BASE-TABS-LIST-HOME-END
   const focusRoving = asFocusRoving<TabsListProps>();
   focusRoving.configure({
     navigation: 'arrow',
     orientation: 'horizontal',
     entry: 'manual',
   });
-  useFocusRoving({
-    family: TABS_FAMILY,
-    itemRole: 'trigger',
-    loop: false,
-    skipDisabled: true,
-    getId: (snapshot) => {
-      const value = snapshot.value;
-      return typeof value === 'string' && value ? value : null;
-    },
-    getActiveId: () => activeValue,
-    getCurrentId: () => selectedValue,
-    exposeFocusCurrentMethodKey: 'focusSelected',
+
+  // P-BASE-TABS-LIST-FOCUS-METHODS
+  def.expose.method('focusFirst', () => focusRoving.focusFirst());
+  def.expose.method('focusLast', () => focusRoving.focusLast());
+  def.expose.method('focusNext', () => focusRoving.focusNext());
+  def.expose.method('focusPrev', () => focusRoving.focusPrev());
+  def.expose.method('focusSelected', () => {
+    if (!mountedRun || !selectedValue) return;
+    const selected = mountedRun.anatomy.order.partsOf(TABS_FAMILY, 'trigger').find((part) => {
+      const read = part.getExpose('__collectionItem');
+      const snapshot = typeof read === 'function' ? read() : read;
+      return (snapshot as { value?: unknown } | null)?.value === selectedValue;
+    });
+    const focusSelf = selected?.getExpose('focusSelf');
+    if (typeof focusSelf === 'function') focusSelf({ reason: 'keyboard' });
   });
 
+  // TODO(C-AS-FOCUS-ROVING-0001-B): route focusSelected directly through the
+  // roving handle after Focus models semantic selected membership. Its current
+  // generic implementation resolves "selected" to the first eligible member,
+  // which is incorrect for manual-activation Tabs after focus has roved.
+
   def.context.subscribe(TABS_CONTEXT, (_run, next) => {
-    activeValue = next.activeValue ?? '';
     selectedValue = next.value ?? '';
     const nextOrientation = next.orientation ?? 'horizontal';
     orientation.set(nextOrientation, 'reason: tabs list context orientation sync');
@@ -59,8 +67,8 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   });
 
   def.lifecycle.onMounted((run) => {
+    mountedRun = run;
     const ctx = run.context.read(TABS_CONTEXT);
-    activeValue = ctx.activeValue ?? '';
     selectedValue = ctx.value ?? '';
     const nextOrientation = ctx.orientation ?? 'horizontal';
     orientation.set(nextOrientation, 'reason: tabs list mounted orientation sync');
@@ -75,7 +83,7 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   });
 
   def.lifecycle.onUnmounted(() => {
-    activeValue = '';
+    mountedRun = null;
     selectedValue = '';
   });
 }

--- a/packages/prototypes/base/src/tabs/list.ts
+++ b/packages/prototypes/base/src/tabs/list.ts
@@ -4,11 +4,13 @@ import { TABS_CONTEXT, TABS_FAMILY } from './shared';
 import type { TabsListAsHookContract, TabsListExposes, TabsListProps } from './types';
 
 function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
+  // P-BASE-TABS-LIST-ROLE-COLLECTION, P-BASE-TABS-LIST-PROTOCOL-DEPENDENCY
   // P-BASE-TABS-LIST-CLAIM-ROLE, P-BASE-TABS-LIST-SAME-DOMAIN
   def.anatomy.claim(TABS_FAMILY, { role: 'list' });
   let selectedValue = '';
   let mountedRun: RunHandle<TabsListProps> | null = null;
 
+  // P-BASE-TABS-LIST-PROP-LOOP, P-BASE-TABS-LIST-PROP-A11Y-LABEL
   def.props.define({
     orientation: { type: 'enum', empty: 'fallback', options: ['horizontal', 'vertical'] },
     loop: { type: 'boolean', empty: 'fallback' },
@@ -25,6 +27,7 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   });
   const a11yLabel = def.state.string('a11yLabel', '');
   // P-BASE-TABS-LIST-A11Y-ROLE, P-BASE-TABS-LIST-A11Y-ORIENTATION
+  // P-BASE-TABS-LIST-A11Y-LABEL
   def.a11y.role('tablist');
   def.a11y.name(a11yLabel);
   def.a11y.state('orientation', orientation);
@@ -60,6 +63,7 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   // which is incorrect for manual-activation Tabs after focus has roved.
 
   def.context.subscribe(TABS_CONTEXT, (_run, next) => {
+    // P-BASE-TABS-LIST-CONTEXT-CONSUME
     selectedValue = next.value ?? '';
     const nextOrientation = next.orientation ?? 'horizontal';
     orientation.set(nextOrientation, 'reason: tabs list context orientation sync');
@@ -88,6 +92,7 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   });
 }
 
+// P-BASE-TABS-LIST-AUTHORING-ENTRIES
 export const asTabsList = defineAsHook<TabsListProps, TabsListExposes, TabsListAsHookContract>({
   name: 'as-tabs-list',
   setup: setupTabsList,

--- a/packages/prototypes/base/src/tabs/list.ts
+++ b/packages/prototypes/base/src/tabs/list.ts
@@ -1,4 +1,4 @@
-import { defineAsHook, definePrototype, type DefHandle, type RunHandle } from '@proto.ui/core';
+import { defineAsHook, definePrototype, type DefHandle } from '@proto.ui/core';
 import { asFocusRoving } from '@proto.ui/hooks';
 import { TABS_CONTEXT, TABS_FAMILY } from './shared';
 import type { TabsListAsHookContract, TabsListExposes, TabsListProps } from './types';
@@ -7,9 +7,6 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   // P-BASE-TABS-LIST-ROLE-COLLECTION, P-BASE-TABS-LIST-PROTOCOL-DEPENDENCY
   // P-BASE-TABS-LIST-CLAIM-ROLE, P-BASE-TABS-LIST-SAME-DOMAIN
   def.anatomy.claim(TABS_FAMILY, { role: 'list' });
-  let selectedValue = '';
-  let mountedRun: RunHandle<TabsListProps> | null = null;
-
   // P-BASE-TABS-LIST-PROP-LOOP, P-BASE-TABS-LIST-PROP-A11Y-LABEL
   def.props.define({
     orientation: { type: 'enum', empty: 'fallback', options: ['horizontal', 'vertical'] },
@@ -46,34 +43,17 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   def.expose.method('focusLast', () => focusRoving.focusLast());
   def.expose.method('focusNext', () => focusRoving.focusNext());
   def.expose.method('focusPrev', () => focusRoving.focusPrev());
-  def.expose.method('focusSelected', () => {
-    if (!mountedRun || !selectedValue) return;
-    const selected = mountedRun.anatomy.order.partsOf(TABS_FAMILY, 'trigger').find((part) => {
-      const read = part.getExpose('__collectionItem');
-      const snapshot = typeof read === 'function' ? read() : read;
-      return (snapshot as { value?: unknown } | null)?.value === selectedValue;
-    });
-    const focusSelf = selected?.getExpose('focusSelf');
-    if (typeof focusSelf === 'function') focusSelf({ reason: 'keyboard' });
-  });
-
-  // TODO(C-AS-FOCUS-ROVING-0001-B): route focusSelected directly through the
-  // roving handle after Focus models semantic selected membership. Its current
-  // generic implementation resolves "selected" to the first eligible member,
-  // which is incorrect for manual-activation Tabs after focus has roved.
+  def.expose.method('focusSelected', () => focusRoving.focusSelected());
 
   def.context.subscribe(TABS_CONTEXT, (_run, next) => {
     // P-BASE-TABS-LIST-CONTEXT-CONSUME
-    selectedValue = next.value ?? '';
     const nextOrientation = next.orientation ?? 'horizontal';
     orientation.set(nextOrientation, 'reason: tabs list context orientation sync');
     focusRoving.setOrientation(nextOrientation);
   });
 
   def.lifecycle.onMounted((run) => {
-    mountedRun = run;
     const ctx = run.context.read(TABS_CONTEXT);
-    selectedValue = ctx.value ?? '';
     const nextOrientation = ctx.orientation ?? 'horizontal';
     orientation.set(nextOrientation, 'reason: tabs list mounted orientation sync');
     focusRoving.setOrientation(nextOrientation);
@@ -84,11 +64,6 @@ function setupTabsList(def: DefHandle<TabsListProps, TabsListExposes>): void {
   def.props.watch(['loop', 'a11yLabel'], (_run, next) => {
     focusRoving.setLoop(!!next.loop);
     a11yLabel.set(next.a11yLabel ?? '', 'reason: tabs list props a11y label sync');
-  });
-
-  def.lifecycle.onUnmounted(() => {
-    mountedRun = null;
-    selectedValue = '';
   });
 }
 

--- a/packages/prototypes/base/src/tabs/root.ts
+++ b/packages/prototypes/base/src/tabs/root.ts
@@ -9,6 +9,7 @@ type TriggerSnapshot = {
 };
 
 function readTriggerSnapshot(part: { getExpose(key: string): unknown | null }): TriggerSnapshot {
+  // P-BASE-TABS-SELECTION-FALLBACK
   const exposed = part.getExpose('__collectionItem');
   const disabledExpose = part.getExpose('disabled');
   const disabled =
@@ -40,11 +41,14 @@ function hasEnabledTriggerValue(run: RunHandle<TabsRootProps>, target: string): 
 }
 
 function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
-  // P-BASE-TABS-ANATOMY-FAMILY, P-BASE-TABS-ROOT-SEMANTIC-OWNER
+  // P-BASE-TABS-ROLE-SINGLE-SELECTION, P-BASE-TABS-ROOT-SEMANTIC-OWNER
   def.anatomy.claim(TABS_FAMILY, { role: 'root' });
+  // P-BASE-TABS-PROTOCOL-INDEPENDENCE
   const collection = asCollection();
   collection.configure({ family: TABS_FAMILY, itemRole: 'trigger' });
 
+  // P-BASE-TABS-PROP-VALUE, P-BASE-TABS-PROP-DEFAULT-VALUE
+  // P-BASE-TABS-PROP-ORIENTATION, P-BASE-TABS-PROP-ACTIVATION-MODE
   def.props.define({
     value: { type: 'string', empty: 'fallback' },
     defaultValue: { type: 'string', empty: 'fallback' },
@@ -57,7 +61,7 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
     activationMode: 'automatic',
   });
 
-  // P-BASE-TABS-VALUE-EXPOSE, P-BASE-TABS-CONTEXT-VALUE
+  // P-BASE-TABS-CONTEXT-VALUE
   def.context.provide(TABS_CONTEXT, {
     rootId: '',
     value: '',
@@ -78,16 +82,19 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
   let lastRequestVersion = 0;
   let lastValidationVersion = 0;
 
+  // P-BASE-TABS-VALUE-EXPOSE, P-BASE-TABS-VALUE-CHANGE-SIGNAL
   def.expose.state('value', value);
   def.expose.event('valueChange', { payload: 'json' });
 
   const resolveSelection = (run: RunHandle<TabsRootProps>, candidate: string): string => {
+    // P-BASE-TABS-VALID-VALUE-REQUIRED, P-BASE-TABS-SELECTION-FALLBACK
     if (candidate && hasEnabledTriggerValue(run, candidate)) return candidate;
     const fallback = getEnabledTriggerValues(run)[0];
     return fallback ?? candidate ?? '';
   };
 
   const publishContext = (run: RunHandle<TabsRootProps>) => {
+    // P-BASE-TABS-CONTEXT-SYNC, P-BASE-TABS-ACTIVE-VALUE
     const next = {
       rootId,
       value: value.get(),
@@ -117,6 +124,7 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
   };
 
   const validateSelection = (run: RunHandle<TabsRootProps>, reason: string) => {
+    // P-BASE-TABS-SELECTION-FALLBACK, P-BASE-TABS-CONTROLLED-VALUE
     const currentValue = value.get();
     const nextValue = controlled ? currentValue : resolveSelection(run, currentValue);
     if (!controlled && nextValue !== currentValue) {
@@ -129,6 +137,7 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
   };
 
   def.context.subscribe(TABS_CONTEXT, (run, next) => {
+    // P-BASE-TABS-UNCONTROLLED-UPDATES-VALUE, P-BASE-TABS-CONTROLLED-EMITS-NEXT
     activeValue = next.activeValue ?? '';
     if (next.requestVersion !== lastRequestVersion) {
       lastRequestVersion = next.requestVersion;
@@ -155,6 +164,7 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
   });
 
   def.lifecycle.onCreated((run) => {
+    // P-BASE-TABS-CONTROLLED-VALUE, P-BASE-TABS-PROP-DEFAULT-VALUE
     controlled = run.props.isProvided('value');
     const initialValue = controlled
       ? (run.props.get().value ?? '')
@@ -172,6 +182,7 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
   });
 
   def.props.watch(['value', 'orientation', 'activationMode'], (run, next) => {
+    // P-BASE-TABS-CONTROLLED-VALUE, P-BASE-TABS-CONTEXT-SYNC
     controlled = run.props.isProvided('value');
     if (controlled) {
       value.set(next.value ?? '', 'reason: props.watch(value) => controlled tabs sync');
@@ -182,6 +193,17 @@ function setupTabsRoot(def: DefHandle<TabsRootProps, TabsRootExposes>): void {
   });
 }
 
+/*
+ * P-BASE-TABS criteria outside Tabs-root-internal prototype syntax:
+ * - P-BASE-TABS-PROP-NO-EVENT-CALLBACK: absence of event callback props is the implementation.
+ * - P-BASE-TABS-VALUE-MATCHING: implemented by Trigger and Content equality checks.
+ * - P-BASE-TABS-A11Y-ROLE-TARGETS, P-BASE-TABS-A11Y-RELATIONSHIP-TARGET: implemented by parts.
+ * - P-BASE-TABS-DEFAULT-L1-DETACH, P-BASE-TABS-PRESENCE-POLICY: implemented by Content.
+ * - P-BASE-TABS-INDICATOR-MEASUREMENT-DEFERRED: Indicator remains a context-only consumer.
+ * - P-BASE-TABS-DUPLICATE-VALUE-FALLBACK-DEFERRED: no duplicate-value policy is implemented.
+ */
+
+// P-BASE-TABS-AUTHORING-ENTRIES
 export const asTabsRoot = defineAsHook<TabsRootProps, TabsRootExposes, TabsRootAsHookContract>({
   name: 'as-tabs-root',
   setup: setupTabsRoot,

--- a/packages/prototypes/base/src/tabs/shared.ts
+++ b/packages/prototypes/base/src/tabs/shared.ts
@@ -4,7 +4,9 @@ export type TabsOrientation = 'horizontal' | 'vertical';
 export type TabsActivationMode = 'automatic' | 'manual';
 
 export type TabsContextValue = {
+  // P-BASE-TABS-A11Y-RELATIONSHIP-TARGET
   rootId: string;
+  // P-BASE-TABS-CONTEXT-VALUE, P-BASE-TABS-ACTIVE-VALUE
   value: string;
   activeValue: string;
   orientation: TabsOrientation;
@@ -32,6 +34,12 @@ export function createTabsPartId(
   return `${rootId || 'pui-tabs'}-${role}-${safeValue}`;
 }
 
+// P-BASE-TABS-ANATOMY-FAMILY, P-BASE-TABS-FAMILY-ROLES
+// P-BASE-TABS-ROOT-CARDINALITY, P-BASE-TABS-LIST-CARDINALITY
+// P-BASE-TABS-TRIGGER-CARDINALITY, P-BASE-TABS-CONTENT-CARDINALITY
+// P-BASE-TABS-INDICATOR-CARDINALITY
+// P-BASE-TABS-ROOT-CONTAINS-LIST, P-BASE-TABS-LIST-CONTAINS-TRIGGER
+// P-BASE-TABS-ROOT-CONTAINS-CONTENT, P-BASE-TABS-ROOT-CONTAINS-INDICATOR
 export const TABS_FAMILY = createAnatomyFamily('base-tabs', {
   roles: {
     root: { cardinality: { min: 1, max: 1 } },
@@ -47,4 +55,5 @@ export const TABS_FAMILY = createAnatomyFamily('base-tabs', {
     { kind: 'contains', parent: 'root', child: 'indicator' },
   ],
 });
+// P-BASE-TABS-CONTEXT-KEY
 export const TABS_CONTEXT = createContextKey<TabsContextValue>('base-tabs');

--- a/packages/prototypes/base/src/tabs/trigger.ts
+++ b/packages/prototypes/base/src/tabs/trigger.ts
@@ -15,12 +15,20 @@ function syncNavParticipationFromContext(
   ctx: TabsContextValue,
   ownValue: string,
   disabled: { get(): boolean },
-  focusable: { setNavParticipation(value: 'auto' | 'none'): void }
+  focusable: {
+    setNavParticipation(value: 'auto' | 'none'): void;
+    setRovingStatus(status: { selected?: boolean; active?: boolean }): void;
+  }
 ): void {
   // P-BASE-TABS-ACTIVE-VALUE, P-BASE-TABS-LIST-FOCUS-ROVING
+  // P-BASE-TABS-TRIGGER-SELECTED-DERIVED
   const activeValue = ctx.activeValue || ctx.value;
   const participates = !!ownValue && ownValue === activeValue && !disabled.get();
   focusable.setNavParticipation(participates ? 'auto' : 'none');
+  focusable.setRovingStatus({
+    selected: !!ownValue && ownValue === ctx.value,
+    active: participates,
+  });
 }
 
 function readTriggerSnapshot(part: { getExpose(key: string): unknown | null }) {

--- a/packages/prototypes/base/src/tabs/trigger.ts
+++ b/packages/prototypes/base/src/tabs/trigger.ts
@@ -17,6 +17,7 @@ function syncNavParticipationFromContext(
   disabled: { get(): boolean },
   focusable: { setNavParticipation(value: 'auto' | 'none'): void }
 ): void {
+  // P-BASE-TABS-ACTIVE-VALUE, P-BASE-TABS-LIST-FOCUS-ROVING
   const activeValue = ctx.activeValue || ctx.value;
   const participates = !!ownValue && ownValue === activeValue && !disabled.get();
   focusable.setNavParticipation(participates ? 'auto' : 'none');
@@ -57,8 +58,10 @@ function resolveEnabledTriggerValue(run: any, candidate: string): string {
 }
 
 function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>): void {
+  // P-BASE-TABS-TRIGGER-ROLE-TAB, P-BASE-TABS-TRIGGER-PROTOCOL-DEPENDENCY
   // P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY
   // P-BASE-TABS-TRIGGER-ACTIVATION-REQUESTS-SELECTION
+  // P-BASE-TABS-TRIGGER-KEYBOARD-ACTIVATION
   asTrigger();
   // P-BASE-TABS-TRIGGER-FOCUSABLE
   const focusable = asFocusable<TabsTriggerProps>();
@@ -67,6 +70,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   const focusVisible = focusable.focusVisible;
   // P-BASE-TABS-TRIGGER-SELECTED-DERIVED, P-BASE-TABS-TRIGGER-SELECTED-EXPOSE
   const selected = def.state.bool('selected', false);
+  // P-BASE-TABS-TRIGGER-DISABLED-EXPOSE, P-BASE-TABS-TRIGGER-INTERACTION-STATES
   const disabled = def.state.bool('disabled', false);
   const hovered = def.state.bool('hovered', false);
   const pressed = def.state.bool('pressed', false);
@@ -74,6 +78,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   const contentId = def.state.string('contentId', '');
 
   // P-BASE-TABS-TRIGGER-CLAIM-ROLE, P-BASE-TABS-TRIGGER-SAME-DOMAIN
+  // P-BASE-TABS-TRIGGER-COLLECTION-ITEM
   const collectionItem = asCollectionItem();
   collectionItem.configure({
     family: TABS_FAMILY,
@@ -87,6 +92,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
     },
   });
 
+  // P-BASE-TABS-TRIGGER-PROP-VALUE, P-BASE-TABS-TRIGGER-PROP-DISABLED
   def.props.define({
     value: { type: 'string', empty: 'fallback' },
     disabled: { type: 'boolean', empty: 'fallback' },
@@ -99,6 +105,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   let ownValue = '';
   let rootId = '';
 
+  // P-BASE-TABS-TRIGGER-INTERACTION-STATES, P-BASE-TABS-TRIGGER-CLICK-SIGNAL
   def.expose.state('disabled', disabled);
   def.expose.state('hovered', hovered);
   def.expose.state('focused', focused);
@@ -112,7 +119,8 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   def.expose.event('click', { payload: 'void' });
 
   // P-BASE-TABS-TRIGGER-A11Y-ROLE, P-BASE-TABS-TRIGGER-A11Y-SELECTED
-  // P-BASE-TABS-TRIGGER-A11Y-CONTROLS-TARGET
+  // P-BASE-TABS-TRIGGER-A11Y-DISABLED, P-BASE-TABS-TRIGGER-A11Y-CONTROLS-TARGET
+  // P-BASE-TABS-TRIGGER-ACCESSIBLE-NAME
   def.a11y.id(triggerId);
   def.a11y.role('tab');
   def.a11y.nameFromContent();
@@ -122,6 +130,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   def.a11y.action('activate', { event: 'click' });
 
   const syncIds = () => {
+    // P-BASE-TABS-A11Y-RELATIONSHIP-TARGET
     triggerId.set(createTabsPartId(rootId, 'trigger', ownValue), 'reason: tabs trigger id sync');
     contentId.set(
       createTabsPartId(rootId, 'content', ownValue),
@@ -130,6 +139,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   };
 
   const syncDisabled = (nextDisabled: boolean) => {
+    // P-BASE-TABS-TRIGGER-DISABLED-SUPPRESS-ACTIVATION
     disabled.set(nextDisabled, 'reason: tabs trigger sync disabled');
     focusable.setDisabled(nextDisabled);
     if (nextDisabled) {
@@ -139,6 +149,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   };
 
   const requestSelection = (run: any, ctx: TabsContextValue) => {
+    // P-BASE-TABS-TRIGGER-ACTIVATION-REQUESTS-SELECTION
     const nextValue = run.props.get().value ?? '';
     run.context.update(TABS_CONTEXT, {
       ...ctx,
@@ -156,6 +167,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   };
 
   def.context.subscribe(TABS_CONTEXT, (_run, next) => {
+    // P-BASE-TABS-TRIGGER-CONTEXT-CONSUME, P-BASE-TABS-TRIGGER-SELECTED-DERIVED
     rootId = next.rootId;
     syncIds();
     syncSelectedFromContext(next.value, ownValue, selected);
@@ -193,6 +205,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   });
 
   const updateActiveValue = (run: any) => {
+    // P-BASE-TABS-ACTIVE-VALUE
     const nextValue = run.props.get().value ?? '';
     run.context.update(TABS_CONTEXT, (prev: any) => {
       if (prev.activeValue === nextValue) return prev;
@@ -201,6 +214,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   };
 
   const notifyRootToValidateSelection = (run: any) => {
+    // P-BASE-TABS-SELECTION-FALLBACK
     run.context.update(TABS_CONTEXT, (prev: TabsContextValue) => ({
       ...prev,
       value: prev.controlled ? prev.value : resolveEnabledTriggerValue(run, prev.value ?? ''),
@@ -210,6 +224,8 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   };
 
   def.event.on('press.commit', (run) => {
+    // P-BASE-TABS-TRIGGER-DISABLED-SUPPRESS-ACTIVATION
+    // P-BASE-TABS-TRIGGER-ACTIVATION-REQUESTS-SELECTION, P-BASE-TABS-TRIGGER-CLICK-SIGNAL
     pressed.set(false, 'reason: tabs trigger press.commit => pressed');
     if (disabled.get()) return;
     const ctx = run.context.read(TABS_CONTEXT);
@@ -218,6 +234,8 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   });
 
   focused.watch((run, event) => {
+    // P-BASE-TABS-TRIGGER-AUTOMATIC-FOCUS-SELECTION
+    // P-BASE-TABS-TRIGGER-MANUAL-FOCUS-STABLE
     if (event.type !== 'next' || !event.next) return;
     if (disabled.get()) return;
     const nextValue = run.props.get().value ?? '';
@@ -229,6 +247,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   });
 
   def.event.onGlobal('key.down', (_run, ev) => {
+    // P-BASE-TABS-TRIGGER-KEYBOARD-ACTIVATION
     const detail = ev?.detail;
     if (disabled.get()) return;
     if (!focused.get()) return;
@@ -237,6 +256,7 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   });
 
   def.event.on('pointer.enter', () => {
+    // P-BASE-TABS-TRIGGER-INTERACTION-STATES
     if (disabled.get()) return;
     hovered.set(true, 'reason: tabs trigger pointer.enter => hovered');
   });
@@ -257,6 +277,13 @@ function setupTabsTrigger(def: DefHandle<TabsTriggerProps, TabsTriggerExposes>):
   });
 }
 
+/*
+ * P-BASE-TABS-TRIGGER criteria represented by absence or delegated ownership:
+ * - P-BASE-TABS-TRIGGER-NO-ACTIVE-EXPOSE-FIRST-PASS: no active expose is declared.
+ * - P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY: command semantics use core asTrigger/asFocusable.
+ */
+
+// P-BASE-TABS-TRIGGER-AUTHORING-ENTRIES
 export const asTabsTrigger = defineAsHook<
   TabsTriggerProps,
   TabsTriggerExposes,

--- a/packages/prototypes/base/src/tabs/types.ts
+++ b/packages/prototypes/base/src/tabs/types.ts
@@ -35,6 +35,7 @@ export type TabsListExposes = {
   focusLast: ExposeMethod<() => void>;
   focusNext: ExposeMethod<() => void>;
   focusPrev: ExposeMethod<() => void>;
+  focusSelected: ExposeMethod<() => void>;
 };
 export type TabsListAsHookContract = {};
 

--- a/packages/prototypes/base/src/tabs/types.ts
+++ b/packages/prototypes/base/src/tabs/types.ts
@@ -2,14 +2,21 @@ import { ExposeEvent, ExposeMethod, ExposeState, FocusRequestOptions, State } fr
 import type { TabsActivationMode, TabsOrientation } from './shared';
 
 export interface TabsRootProps {
+  // P-BASE-TABS-PROP-VALUE
   value?: string;
+  // P-BASE-TABS-PROP-DEFAULT-VALUE
   defaultValue?: string;
+  // P-BASE-TABS-PROP-ORIENTATION
   orientation?: TabsOrientation;
+  // P-BASE-TABS-PROP-ACTIVATION-MODE
   activationMode?: TabsActivationMode;
+  // P-BASE-TABS-PROP-NO-EVENT-CALLBACK: valueChange is an expose signal, not a prop.
 }
 
 export type TabsRootExposes = {
+  // P-BASE-TABS-VALUE-EXPOSE
   value: ExposeState<string>;
+  // P-BASE-TABS-VALUE-CHANGE-SIGNAL
   valueChange: ExposeEvent<{ value: string }>;
 };
 
@@ -26,11 +33,14 @@ export type TabsRootAsHookContract = {
 
 export interface TabsListProps {
   orientation?: TabsOrientation;
+  // P-BASE-TABS-LIST-PROP-LOOP
   loop?: boolean;
+  // P-BASE-TABS-LIST-PROP-A11Y-LABEL
   a11yLabel?: string;
 }
 
 export type TabsListExposes = {
+  // P-BASE-TABS-LIST-FOCUS-METHODS
   focusFirst: ExposeMethod<() => void>;
   focusLast: ExposeMethod<() => void>;
   focusNext: ExposeMethod<() => void>;
@@ -40,18 +50,25 @@ export type TabsListExposes = {
 export type TabsListAsHookContract = {};
 
 export interface TabsTriggerProps {
+  // P-BASE-TABS-TRIGGER-PROP-VALUE
   value?: string;
+  // P-BASE-TABS-TRIGGER-PROP-DISABLED
   disabled?: boolean;
 }
 
 export type TabsTriggerExposes = {
+  // P-BASE-TABS-TRIGGER-DISABLED-EXPOSE
   disabled: ExposeState<boolean>;
+  // P-BASE-TABS-TRIGGER-INTERACTION-STATES
   hovered: ExposeState<boolean>;
   focused: ExposeState<boolean>;
   focusVisible: ExposeState<boolean>;
   pressed: ExposeState<boolean>;
+  // P-BASE-TABS-TRIGGER-SELECTED-EXPOSE
   selected: ExposeState<boolean>;
+  // P-BASE-TABS-TRIGGER-FOCUSABLE
   focusSelf: ExposeMethod<(options?: FocusRequestOptions) => void>;
+  // P-BASE-TABS-TRIGGER-CLICK-SIGNAL
   click: ExposeEvent<void>;
 };
 
@@ -72,12 +89,15 @@ export type TabsTriggerAsHookContract = {
 };
 
 export interface TabsContentProps {
+  // P-BASE-TABS-CONTENT-PROP-VALUE
   value?: string;
+  // P-BASE-TABS-CONTENT-PRESENCE-POLICY
   /** Retain the complete host view while this panel is inactive. Defaults to false. */
   keepMounted?: boolean;
 }
 
 export type TabsContentExposes = {
+  // P-BASE-TABS-CONTENT-CURRENT-EXPOSE
   current: ExposeState<boolean>;
   hidden: ExposeState<boolean>;
 };

--- a/packages/prototypes/base/src/tools/use-open-state.ts
+++ b/packages/prototypes/base/src/tools/use-open-state.ts
@@ -10,6 +10,7 @@ export type OpenStateOptions = {
   exposeOpenMethodKey?: string;
   exposeCloseMethodKey?: string;
   exposeToggleMethodKey?: string;
+  requestOpen?: (run: RunHandle<any>, nextOpen: boolean, reason: string) => void;
 };
 
 export type OpenStateExposes = {
@@ -80,29 +81,47 @@ export const useOpenState = defineHook<
       open.set(next, reason ?? 'reason: useOpenState.setOpen');
     };
 
+    const requestOpen = (next: boolean, reason: string) => {
+      const run = api.store.run as RunHandle<any> | undefined;
+      if (options?.requestOpen && run) {
+        options.requestOpen(run, next, reason);
+        return;
+      }
+      setOpen(next, reason);
+    };
+
     api.store.syncFromProps = syncFromProps;
     api.store.syncControlled = syncControlled;
     api.store.setOpen = setOpen;
 
     def.expose.state(exposeStateKey as keyof OpenStateExposes & string, open);
     def.expose.method(exposeOpenMethodKey as keyof OpenStateExposes & string, (reason?: string) => {
-      setOpen(true, reason ?? 'reason: useOpenState.openNow');
+      requestOpen(true, reason ?? 'reason: useOpenState.openNow');
     });
     def.expose.method(
       exposeCloseMethodKey as keyof OpenStateExposes & string,
       (reason?: string) => {
-        setOpen(false, reason ?? 'reason: useOpenState.close');
+        requestOpen(false, reason ?? 'reason: useOpenState.close');
       }
     );
     def.expose.method(
       exposeToggleMethodKey as keyof OpenStateExposes & string,
       (reason?: string) => {
-        setOpen(!open.get(), reason ?? 'reason: useOpenState.toggle');
+        requestOpen(!open.get(), reason ?? 'reason: useOpenState.toggle');
       }
     );
 
     def.lifecycle.onCreated((run) => {
+      api.store.run = run;
       syncFromProps(run);
+    });
+
+    def.lifecycle.onMounted((run) => {
+      api.store.run = run;
+    });
+
+    def.lifecycle.onUnmounted(() => {
+      api.store.run = undefined;
     });
 
     def.props.watch([prop as any, disabledProp as any], (run, next) => {

--- a/packages/prototypes/base/test/dialog.test.ts
+++ b/packages/prototypes/base/test/dialog.test.ts
@@ -229,8 +229,7 @@ describe('prototypes/base: dialog', () => {
     const mask = document.createElement('base-dialog-mask') as any;
     const content = document.createElement('base-dialog-content') as any;
 
-    setElementProps(root, { defaultOpen: true });
-    setElementProps(content, { alert: true });
+    setElementProps(root, { defaultOpen: true, alert: true });
     root.appendChild(trigger);
     root.appendChild(mask);
     root.appendChild(content);

--- a/packages/prototypes/base/test/dialog.test.ts
+++ b/packages/prototypes/base/test/dialog.test.ts
@@ -162,6 +162,7 @@ describe('prototypes/base: dialog', () => {
   });
 
   it('controlled root methods emit requests without replacing the owner open fact', async () => {
+    // T-BASE-DIALOG-0001-CASE-CONTROLLED-METHODS
     const root = document.createElement('base-dialog-root') as any;
     const requests: any[] = [];
     root.addEventListener('openChange', (event: Event) => {
@@ -194,6 +195,35 @@ describe('prototypes/base: dialog', () => {
         focusReason: 'programmatic',
       })
     );
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('Trigger and Close command surfaces prevent focused Space default actions', async () => {
+    // T-BASE-DIALOG-TRIGGER-0001-CASE-COMMAND
+    // T-BASE-DIALOG-CLOSE-0001-CASE-COMMAND
+    const root = document.createElement('base-dialog-root') as any;
+    const trigger = document.createElement('base-dialog-trigger') as any;
+    const content = document.createElement('base-dialog-content') as any;
+    const close = document.createElement('base-dialog-close') as any;
+    setElementProps(root, { defaultOpen: true });
+    content.appendChild(close);
+    root.append(trigger, content);
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    trigger.focus();
+    const triggerSpace = new KeyboardEvent('keydown', { key: ' ', cancelable: true });
+    window.dispatchEvent(triggerSpace);
+    expect(triggerSpace.defaultPrevented).toBe(true);
+
+    close.focus();
+    const closeSpace = new KeyboardEvent('keydown', { key: ' ', cancelable: true });
+    window.dispatchEvent(closeSpace);
+    expect(closeSpace.defaultPrevented).toBe(true);
 
     root.remove();
     await Promise.resolve();

--- a/packages/prototypes/base/test/dialog.test.ts
+++ b/packages/prototypes/base/test/dialog.test.ts
@@ -208,6 +208,8 @@ describe('prototypes/base: dialog', () => {
     await Promise.resolve();
 
     expect(root.getExposes().open.get()).toBe(true);
+    expect(content.getAttribute('role')).toBe('dialog');
+    expect(content.getAttribute('aria-modal')).toBe('true');
 
     document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
     await Promise.resolve();
@@ -238,6 +240,8 @@ describe('prototypes/base: dialog', () => {
     await Promise.resolve();
 
     expect(root.getExposes().open.get()).toBe(true);
+    expect(content.getAttribute('role')).toBe('alertdialog');
+    expect(content.getAttribute('aria-modal')).toBe('true');
 
     document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
     await Promise.resolve();

--- a/packages/prototypes/base/test/dialog.test.ts
+++ b/packages/prototypes/base/test/dialog.test.ts
@@ -64,12 +64,16 @@ describe('prototypes/base: dialog', () => {
     await Promise.resolve();
   });
 
-  it('controlled root synchronizes open from props and ignores trigger/close clicks', async () => {
+  it('controlled root keeps prop state while trigger and close emit openChange requests', async () => {
     const root = document.createElement('base-dialog-root') as any;
     const trigger = document.createElement('base-dialog-trigger') as any;
     const mask = document.createElement('base-dialog-mask') as any;
     const content = document.createElement('base-dialog-content') as any;
     const close = document.createElement('base-dialog-close') as any;
+    const requests: any[] = [];
+    root.addEventListener('openChange', (event: Event) => {
+      requests.push((event as CustomEvent).detail);
+    });
 
     setElementProps(root, { open: false });
     root.appendChild(trigger);
@@ -83,17 +87,22 @@ describe('prototypes/base: dialog', () => {
 
     expect(root.getExposes().open.get()).toBe(false);
     expect(content.hasAttribute('data-pui-view-detached')).toBe(true);
+    expect(requests).toEqual([]);
 
     trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await flushViewReconciliation();
 
     expect(root.getExposes().open.get()).toBe(false);
     expect(content.hasAttribute('data-pui-view-detached')).toBe(true);
+    expect(requests).toEqual([
+      expect.objectContaining({ open: true, reason: 'trigger.press', focusReason: 'pointer' }),
+    ]);
 
     setElementProps(root, { open: true });
     await Promise.resolve();
 
     expect(root.getExposes().open.get()).toBe(true);
+    expect(requests).toEqual([expect.objectContaining({ open: true, reason: 'trigger.press' })]);
     expect(styleContains(content, 'hidden')).toBe(false);
     expect(styleContains(mask, 'hidden')).toBe(false);
 
@@ -101,6 +110,10 @@ describe('prototypes/base: dialog', () => {
     await Promise.resolve();
 
     expect(root.getExposes().open.get()).toBe(true);
+    expect(requests).toEqual([
+      expect.objectContaining({ open: true, reason: 'trigger.press' }),
+      expect.objectContaining({ open: false, reason: 'close.press', focusReason: 'pointer' }),
+    ]);
 
     setElementProps(root, { open: false });
     await Promise.resolve();
@@ -109,6 +122,40 @@ describe('prototypes/base: dialog', () => {
     expect(root.getExposes().open.get()).toBe(false);
     expect(content.hasAttribute('data-pui-view-detached')).toBe(true);
     expect(mask.hasAttribute('data-pui-view-detached')).toBe(true);
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('controlled dismissal emits requests without closing before the owner updates open', async () => {
+    const root = document.createElement('base-dialog-root') as any;
+    const trigger = document.createElement('base-dialog-trigger') as any;
+    const mask = document.createElement('base-dialog-mask') as any;
+    const content = document.createElement('base-dialog-content') as any;
+    const requests: any[] = [];
+    root.addEventListener('openChange', (event: Event) => {
+      requests.push((event as CustomEvent).detail);
+    });
+
+    setElementProps(root, { open: true });
+    root.appendChild(trigger);
+    root.appendChild(mask);
+    root.appendChild(content);
+    document.body.appendChild(root);
+    await flushViewReconciliation();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await flushViewReconciliation();
+    expect(root.getExposes().open.get()).toBe(true);
+    expect(content.getExposes().transitionState.get()).not.toBe('leaving');
+
+    document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+    await flushViewReconciliation();
+    expect(root.getExposes().open.get()).toBe(true);
+    expect(requests).toEqual([
+      expect.objectContaining({ open: false, reason: 'escape', focusReason: 'keyboard' }),
+      expect.objectContaining({ open: false, reason: 'outside.press', focusReason: 'pointer' }),
+    ]);
 
     root.remove();
     await Promise.resolve();

--- a/packages/prototypes/base/test/dialog.test.ts
+++ b/packages/prototypes/base/test/dialog.test.ts
@@ -161,6 +161,44 @@ describe('prototypes/base: dialog', () => {
     await Promise.resolve();
   });
 
+  it('controlled root methods emit requests without replacing the owner open fact', async () => {
+    const root = document.createElement('base-dialog-root') as any;
+    const requests: any[] = [];
+    root.addEventListener('openChange', (event: Event) => {
+      requests.push((event as CustomEvent).detail);
+    });
+    setElementProps(root, { open: false });
+    document.body.appendChild(root);
+
+    await Promise.resolve();
+
+    root.getExposes().openDialog('root.method.open');
+    expect(root.getExposes().open.get()).toBe(false);
+    expect(requests).toEqual([
+      expect.objectContaining({
+        open: true,
+        reason: 'root.method.open',
+        focusReason: 'programmatic',
+      }),
+    ]);
+
+    setElementProps(root, { open: true });
+    await Promise.resolve();
+    root.getExposes().toggle('root.method.toggle');
+
+    expect(root.getExposes().open.get()).toBe(true);
+    expect(requests.at(-1)).toEqual(
+      expect.objectContaining({
+        open: false,
+        reason: 'root.method.toggle',
+        focusReason: 'programmatic',
+      })
+    );
+
+    root.remove();
+    await Promise.resolve();
+  });
+
   it('ESC closes dialog content', async () => {
     const root = document.createElement('base-dialog-root') as any;
     const trigger = document.createElement('base-dialog-trigger') as any;

--- a/packages/prototypes/base/test/dialog.test.ts
+++ b/packages/prototypes/base/test/dialog.test.ts
@@ -1,12 +1,22 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { styleContains } from '../../test-utils/style';
 import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
-import { dialogClose, dialogContent, dialogMask, dialogRoot, dialogTrigger } from '../src/dialog';
+import {
+  dialogClose,
+  dialogContent,
+  dialogDescription,
+  dialogMask,
+  dialogRoot,
+  dialogTitle,
+  dialogTrigger,
+} from '../src/dialog';
 
 AdaptToWebComponent(dialogRoot as any);
 AdaptToWebComponent(dialogTrigger as any);
 AdaptToWebComponent(dialogMask as any);
 AdaptToWebComponent(dialogContent as any);
+AdaptToWebComponent(dialogTitle as any);
+AdaptToWebComponent(dialogDescription as any);
 AdaptToWebComponent(dialogClose as any);
 
 async function flushViewReconciliation(): Promise<void> {
@@ -291,13 +301,85 @@ describe('prototypes/base: dialog', () => {
     await Promise.resolve();
   });
 
+  it('projects only live Title and Description relationships and falls back to Root a11yLabel', async () => {
+    // T-BASE-DIALOG-CONTENT-0001-CASE-A11Y
+    const root = document.createElement('base-dialog-root') as any;
+    const content = document.createElement('base-dialog-content') as any;
+    const title = document.createElement('base-dialog-title') as any;
+    const description = document.createElement('base-dialog-description') as any;
+
+    setElementProps(root, { defaultOpen: true, a11yLabel: 'Settings' });
+    root.appendChild(content);
+    document.body.appendChild(root);
+    await flushViewReconciliation();
+
+    expect(content.getAttribute('aria-label')).toBe('Settings');
+    expect(content.hasAttribute('aria-labelledby')).toBe(false);
+    expect(content.hasAttribute('aria-describedby')).toBe(false);
+
+    content.append(title, description);
+    await flushViewReconciliation();
+
+    expect({
+      label: content.getAttribute('aria-label'),
+      labelledBy: content.getAttribute('aria-labelledby'),
+      describedBy: content.getAttribute('aria-describedby'),
+    }).toEqual({
+      label: null,
+      labelledBy: title.id,
+      describedBy: description.id,
+    });
+
+    title.remove();
+    description.remove();
+    await flushViewReconciliation();
+
+    expect(content.getAttribute('aria-label')).toBe('Settings');
+    expect(content.hasAttribute('aria-labelledby')).toBe(false);
+    expect(content.hasAttribute('aria-describedby')).toBe(false);
+
+    root.remove();
+    await Promise.resolve();
+  });
+
+  it('diagnoses an Alert Dialog whose live anatomy has no Description', async () => {
+    // T-BASE-DIALOG-DESCRIPTION-0001-CASE-ALERT
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const root = document.createElement('base-dialog-root') as any;
+      const content = document.createElement('base-dialog-content') as any;
+      const description = document.createElement('base-dialog-description') as any;
+      setElementProps(root, { defaultOpen: true, alert: true, a11yLabel: 'Confirm action' });
+      content.appendChild(description);
+      root.appendChild(content);
+      document.body.appendChild(root);
+      await flushViewReconciliation();
+
+      expect(warn).not.toHaveBeenCalled();
+
+      description.remove();
+      await flushViewReconciliation();
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Alert Dialog requires a Dialog Description')
+      );
+
+      root.remove();
+      await Promise.resolve();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('alert=true prevents outside press from closing but ESC still closes', async () => {
     const root = document.createElement('base-dialog-root') as any;
     const trigger = document.createElement('base-dialog-trigger') as any;
     const mask = document.createElement('base-dialog-mask') as any;
     const content = document.createElement('base-dialog-content') as any;
+    const description = document.createElement('base-dialog-description') as any;
 
     setElementProps(root, { defaultOpen: true, alert: true });
+    content.appendChild(description);
     root.appendChild(trigger);
     root.appendChild(mask);
     root.appendChild(content);

--- a/packages/prototypes/base/test/tabs.test.ts
+++ b/packages/prototypes/base/test/tabs.test.ts
@@ -261,6 +261,14 @@ describe('prototypes/base: tabs', () => {
     expect(triggerB.tabIndex).toBe(-1);
 
     triggerA.focus();
+    // T-BASE-TABS-TRIGGER-0001-CASE-KEYBOARD
+    const spaceEvent = new KeyboardEvent('keydown', { key: ' ', cancelable: true });
+    window.dispatchEvent(spaceEvent);
+    await Promise.resolve();
+    expect(spaceEvent.defaultPrevented).toBe(true);
+    window.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
+    await Promise.resolve();
+
     const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true });
     window.dispatchEvent(tabEvent);
     await Promise.resolve();

--- a/packages/prototypes/base/test/tabs.test.ts
+++ b/packages/prototypes/base/test/tabs.test.ts
@@ -354,6 +354,13 @@ describe('prototypes/base: tabs', () => {
     expect(triggerB.tabIndex).toBe(-1);
     expect(triggerC.tabIndex).toBe(0);
 
+    list.getExposes().focusSelected();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(triggerA);
+    expect(root.getExposes().value.get()).toBe('a');
+
     triggerC.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await Promise.resolve();
     await Promise.resolve();

--- a/packages/prototypes/shadcn/src/dialog/close.ts
+++ b/packages/prototypes/shadcn/src/dialog/close.ts
@@ -1,5 +1,5 @@
 import { definePrototype, tw } from '@proto.ui/core';
-import { asButton, asDialogClose } from '@proto.ui/prototypes-base';
+import { asDialogClose } from '@proto.ui/prototypes-base';
 import type { ShadcnDialogCloseExposes, ShadcnDialogCloseProps } from './types';
 
 type ShadcnDialogCloseVariant =
@@ -55,10 +55,9 @@ const dialogClose = definePrototype<ShadcnDialogCloseProps, ShadcnDialogCloseExp
       disabled: false,
     });
 
-    asDialogClose();
-    const buttonState = asButton().stateHandles;
+    const buttonState = asDialogClose().stateHandles;
     if (!buttonState) {
-      throw new Error('[shadcn-dialog-close] asButton must project Button state handles.');
+      throw new Error('[shadcn-dialog-close] Dialog Close must project command states.');
     }
     const { disabled, hovered, focusVisible, pressed } = buttonState;
 

--- a/packages/prototypes/shadcn/src/dialog/trigger.ts
+++ b/packages/prototypes/shadcn/src/dialog/trigger.ts
@@ -1,5 +1,5 @@
 import { definePrototype, tw } from '@proto.ui/core';
-import { asButton, asDialogTrigger } from '@proto.ui/prototypes-base';
+import { asDialogTrigger } from '@proto.ui/prototypes-base';
 import type { ShadcnDialogTriggerExposes, ShadcnDialogTriggerProps } from './types';
 
 type ShadcnDialogTriggerVariant =
@@ -55,10 +55,9 @@ const dialogTrigger = definePrototype<ShadcnDialogTriggerProps, ShadcnDialogTrig
       disabled: false,
     });
 
-    asDialogTrigger();
-    const buttonState = asButton().stateHandles;
+    const buttonState = asDialogTrigger().stateHandles;
     if (!buttonState) {
-      throw new Error('[shadcn-dialog-trigger] asButton must project Button state handles.');
+      throw new Error('[shadcn-dialog-trigger] Dialog Trigger must project command states.');
     }
     const { disabled, hovered, focusVisible, pressed } = buttonState;
     const expanded = def.state.fromAccessibility('expanded');

--- a/packages/prototypes/shadcn/src/dialog/types.ts
+++ b/packages/prototypes/shadcn/src/dialog/types.ts
@@ -4,7 +4,6 @@ import type {
   DialogCloseProps,
   DialogContentAsHookContract,
   DialogContentExposes,
-  DialogContentProps,
   DialogDescriptionAsHookContract,
   DialogDescriptionExposes,
   DialogDescriptionProps,
@@ -38,7 +37,7 @@ export type ShadcnDialogMaskProps = Pick<DialogMaskProps, 'passthrough'>;
 export type ShadcnDialogMaskExposes = Pick<DialogMaskExposes, 'transitionState' | 'isPresent'>;
 export type ShadcnDialogMaskAsHookContract = DialogMaskAsHookContract;
 
-export type ShadcnDialogContentProps = Pick<DialogContentProps, 'alert'>;
+export interface ShadcnDialogContentProps {}
 export type ShadcnDialogContentExposes = Pick<
   DialogContentExposes,
   'open' | 'transitionState' | 'isPresent'

--- a/packages/runtime/src/instance/execute/callback-scope.ts
+++ b/packages/runtime/src/instance/execute/callback-scope.ts
@@ -22,6 +22,7 @@ import type { PropsPort, PropsWatchTask } from '@proto.ui/module-props';
  */
 export class CallbackScope<P extends PropsBaseType> {
   private delayContext: ActiveRuntimeDelayContext | undefined;
+  private depth = 0;
 
   constructor(
     private readonly getPhase: () => ExecPhase,
@@ -56,6 +57,7 @@ export class CallbackScope<P extends PropsBaseType> {
     const prevCtx = (this.moduleHub as any).__getCallbackCtx?.();
 
     this.setPhase('callback');
+    this.depth += 1;
 
     // Provide callback ctx for modules via SYS_CAP.getCallbackCtx()
     (this.moduleHub as any).__setCallbackCtx?.(ctx);
@@ -69,6 +71,8 @@ export class CallbackScope<P extends PropsBaseType> {
       if (this.delayContext) exitActiveRuntimeDelayContext();
       (this.moduleHub as any).__setCallbackCtx?.(prevCtx);
       this.setPhase(prevPhase);
+      this.depth -= 1;
+      if (this.depth === 0) (this.moduleHub as any).__flushAfterCallbackTasks?.();
     }
   }
 
@@ -82,6 +86,7 @@ export class CallbackScope<P extends PropsBaseType> {
     const prevCtx = (this.moduleHub as any).__getCallbackCtx?.();
 
     this.setPhase('callback');
+    this.depth += 1;
     (this.moduleHub as any).__setCallbackCtx?.(ctx);
     if (this.delayContext) enterActiveRuntimeDelayContext(this.delayContext);
 
@@ -92,6 +97,8 @@ export class CallbackScope<P extends PropsBaseType> {
       if (this.delayContext) exitActiveRuntimeDelayContext();
       (this.moduleHub as any).__setCallbackCtx?.(prevCtx);
       this.setPhase(prevPhase);
+      this.depth -= 1;
+      if (this.depth === 0) (this.moduleHub as any).__flushAfterCallbackTasks?.();
     }
   }
 

--- a/packages/runtime/src/kernel/handles/def.ts
+++ b/packages/runtime/src/kernel/handles/def.ts
@@ -349,6 +349,13 @@ export const createDefHandle = <P extends PropsBaseType, E = Record<string, unkn
         if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
         anatomy.claim(family, decl);
       },
+      subscribeParts(family, role, onChange) {
+        ensureSetup('def.anatomy.subscribeParts');
+        if (!anatomy) throw new Error(`[Anatomy] module unavailable`);
+        return anatomy.subscribeParts(family, role, (ctx, parts) =>
+          onChange(ctx as RunHandle<P>, parts)
+        );
+      },
     },
 
     a11y: {

--- a/packages/runtime/src/orchestrator/module-orchestrator/runtime-module-orchestrator.ts
+++ b/packages/runtime/src/orchestrator/module-orchestrator/runtime-module-orchestrator.ts
@@ -41,6 +41,7 @@ export class RuntimeModuleOrchestrator implements ModuleOrchestrator {
 
   // runtime-owned callback ctx (opaque)
   private callbackCtx: unknown = undefined;
+  private afterCallbackTasks: Array<() => void> = [];
 
   constructor(init: { prototypeName: string; getPhase: () => ExecPhase }, modules: ModuleDecl[]) {
     this.prototypeName = init.prototypeName;
@@ -96,6 +97,10 @@ export class RuntimeModuleOrchestrator implements ModuleOrchestrator {
 
       getCallbackCtx: () => {
         return this.getExecPhase() === 'callback' ? this.callbackCtx : undefined;
+      },
+
+      deferAfterCallback: (task) => {
+        this.afterCallbackTasks.push(task);
       },
     };
 
@@ -318,6 +323,14 @@ export class RuntimeModuleOrchestrator implements ModuleOrchestrator {
     return this.callbackCtx;
   }
 
+  __flushAfterCallbackTasks(): void {
+    while (this.afterCallbackTasks.length > 0) {
+      const tasks = this.afterCallbackTasks;
+      this.afterCallbackTasks = [];
+      for (const task of tasks) task();
+    }
+  }
+
   // -------------------------
   // lifecycle
   // -------------------------
@@ -328,6 +341,7 @@ export class RuntimeModuleOrchestrator implements ModuleOrchestrator {
 
     // best-effort clear callback ctx
     this.callbackCtx = undefined;
+    this.afterCallbackTasks = [];
 
     // dispose hooks first so modules can teardown while caps still readable
     for (const r of this.records) {

--- a/packages/runtime/test/contract/a11y.v0.contract.test.ts
+++ b/packages/runtime/test/contract/a11y.v0.contract.test.ts
@@ -39,6 +39,27 @@ function createHost(initialRaw: Record<string, unknown> = {}) {
 }
 
 describe('runtime contract: a11y (v0)', () => {
+  it('A11Y-0050: role may follow a state-backed semantic fact', () => {
+    let role!: { set(value: string, reason?: string): void };
+    const P = definePrototype({
+      name: 'x-a11y-dynamic-role',
+      setup(def) {
+        role = def.state.string('role', 'dialog', { options: ['dialog', 'alertdialog'] });
+        def.a11y.role(role as any);
+        return (r) => r.el('div', 'dialog');
+      },
+    });
+
+    const ctx = createHost();
+    const result = executeWithHost(P as any, ctx.host as any);
+    const port = result.caps.getPort<A11yPort>('a11y');
+    expect(port?.getSnapshot().role).toBe('dialog');
+
+    result.invokeInCallbackScope(() => role.set('alertdialog', 'reason: alert mode'));
+    expect(port?.getSnapshot().role).toBe('alertdialog');
+    expect(ctx.snapshots.at(-1)?.role).toBe('alertdialog');
+  });
+
   it('A11Y-0100: def.a11y records semantic object IR and projects state snapshots', () => {
     // T-A11Y-0001-CASE-IR
     const P: Prototype<{ disabled?: boolean }> = definePrototype({

--- a/packages/runtime/test/contract/anatomy.order.v0.contract.test.ts
+++ b/packages/runtime/test/contract/anatomy.order.v0.contract.test.ts
@@ -409,17 +409,21 @@ describe('runtime contract: anatomy.order (v0)', () => {
       roles: {
         root: { cardinality: { min: 1, max: 1 } },
         item: { cardinality: { min: 0, max: 10 } },
+        other: { cardinality: { min: 0, max: 10 } },
       },
     });
     const orderMap = new Map<string, number>([
       ['root', 0],
       ['item', 1],
+      ['other', 2],
     ]);
     const rootTarget = createTarget('root', orderMap);
     const itemTarget = createTarget('item', orderMap);
+    const otherTarget = createTarget('other', orderMap);
     const parents = new Map<unknown, unknown | null>([
       [rootTarget, null],
       [itemTarget, rootTarget],
+      [otherTarget, rootTarget],
     ]);
 
     let notifyOrder: (() => void) | null = null;
@@ -440,9 +444,16 @@ describe('runtime contract: anatomy.order (v0)', () => {
         def.expose.value('id' as any, 'item');
       },
     });
+    const Other = definePrototype({
+      name: 'x-rt-anatomy-parts-subscription-other',
+      setup(def) {
+        def.anatomy.claim(family, { role: 'other' });
+      },
+    });
     const getPrototype = (instance: unknown) => {
       if (instance === rootTarget) return Root;
       if (instance === itemTarget) return Item;
+      if (instance === otherTarget) return Other;
       return null;
     };
 
@@ -460,6 +471,19 @@ describe('runtime contract: anatomy.order (v0)', () => {
         },
       }).host as any
     );
+    executeWithHost(
+      Other as any,
+      createHost({
+        instance: otherTarget,
+        getParent: (instance) => parents.get(instance) ?? null,
+        getPrototype,
+      }).host as any
+    );
+    expect(notifyOrder).not.toBeNull();
+    const notify = notifyOrder as unknown as () => void;
+    notify();
+    expect(seen).toEqual([]);
+
     const itemExec = executeWithHost(
       Item as any,
       createHost({
@@ -469,14 +493,14 @@ describe('runtime contract: anatomy.order (v0)', () => {
       }).host as any
     );
 
-    expect(notifyOrder).not.toBeNull();
-    const notify = notifyOrder as unknown as () => void;
+    expect(seen).toEqual([['item']]);
     notify();
     expect(seen).toEqual([['item']]);
     notify();
     expect(seen).toHaveLength(1);
 
     await itemExec.invokeUnmounted();
+    expect(seen).toEqual([['item'], []]);
     notify();
     expect(seen).toEqual([['item'], []]);
   });

--- a/packages/runtime/test/contract/anatomy.order.v0.contract.test.ts
+++ b/packages/runtime/test/contract/anatomy.order.v0.contract.test.ts
@@ -5,8 +5,10 @@ import { executeWithHost } from '../../src';
 import {
   ANATOMY_GET_PROTO_CAP,
   ANATOMY_INSTANCE_TOKEN_CAP,
+  ANATOMY_ORDER_OBSERVER_CAP,
   ANATOMY_PARENT_CAP,
   ANATOMY_ROOT_TARGET_CAP,
+  type AnatomyOrderObserver,
 } from '@proto.ui/module-anatomy';
 
 type Target = {
@@ -31,6 +33,7 @@ function createHost(args: {
   instance: Target;
   getParent: (instance: unknown) => unknown | null;
   getPrototype: (instance: unknown) => Prototype<any> | null;
+  observeOrder?: AnatomyOrderObserver;
 }) {
   const host: RuntimeHost<any> = {
     prototypeName: `host-${args.instance.id}`,
@@ -47,6 +50,7 @@ function createHost(args: {
         [ANATOMY_PARENT_CAP, args.getParent],
         [ANATOMY_GET_PROTO_CAP, args.getPrototype],
         [ANATOMY_ROOT_TARGET_CAP, (instance: unknown) => instance as Target],
+        ...(args.observeOrder ? ([[ANATOMY_ORDER_OBSERVER_CAP, args.observeOrder]] as const) : []),
       ]);
     },
   };
@@ -397,5 +401,83 @@ describe('runtime contract: anatomy.order (v0)', () => {
     const read = readOrderedIds as unknown as () => unknown[];
     expect(() => read()).not.toThrow();
     expect(read()).toEqual(['a', 'b']);
+  });
+
+  /** T-ANATOMY-ORDER-0001-CASE-PARTS-SUBSCRIPTION */
+  it('ANATOMY-ORDER-RT-0500: def.anatomy.subscribeParts reports live role membership changes', async () => {
+    const family = createAnatomyFamily('rt-anatomy-parts-subscription', {
+      roles: {
+        root: { cardinality: { min: 1, max: 1 } },
+        item: { cardinality: { min: 0, max: 10 } },
+      },
+    });
+    const orderMap = new Map<string, number>([
+      ['root', 0],
+      ['item', 1],
+    ]);
+    const rootTarget = createTarget('root', orderMap);
+    const itemTarget = createTarget('item', orderMap);
+    const parents = new Map<unknown, unknown | null>([
+      [rootTarget, null],
+      [itemTarget, rootTarget],
+    ]);
+
+    let notifyOrder: (() => void) | null = null;
+    const seen: unknown[][] = [];
+    const Root = definePrototype({
+      name: 'x-rt-anatomy-parts-subscription-root',
+      setup(def) {
+        def.anatomy.claim(family, { role: 'root' });
+        def.anatomy.subscribeParts(family, 'item', (_run, parts) => {
+          seen.push(parts.map((part) => part.getExpose('id')));
+        });
+      },
+    });
+    const Item = definePrototype({
+      name: 'x-rt-anatomy-parts-subscription-item',
+      setup(def) {
+        def.anatomy.claim(family, { role: 'item' });
+        def.expose.value('id' as any, 'item');
+      },
+    });
+    const getPrototype = (instance: unknown) => {
+      if (instance === rootTarget) return Root;
+      if (instance === itemTarget) return Item;
+      return null;
+    };
+
+    executeWithHost(
+      Root as any,
+      createHost({
+        instance: rootTarget,
+        getParent: (instance) => parents.get(instance) ?? null,
+        getPrototype,
+        observeOrder: (_target, notify) => {
+          notifyOrder = notify;
+          return () => {
+            notifyOrder = null;
+          };
+        },
+      }).host as any
+    );
+    const itemExec = executeWithHost(
+      Item as any,
+      createHost({
+        instance: itemTarget,
+        getParent: (instance) => parents.get(instance) ?? null,
+        getPrototype,
+      }).host as any
+    );
+
+    expect(notifyOrder).not.toBeNull();
+    const notify = notifyOrder as unknown as () => void;
+    notify();
+    expect(seen).toEqual([['item']]);
+    notify();
+    expect(seen).toHaveLength(1);
+
+    await itemExec.invokeUnmounted();
+    notify();
+    expect(seen).toEqual([['item'], []]);
   });
 });

--- a/packages/runtime/test/contract/boundary.v0.contract.test.ts
+++ b/packages/runtime/test/contract/boundary.v0.contract.test.ts
@@ -31,18 +31,20 @@ const createHost = <P extends PropsBaseType>(
 };
 
 describe('runtime contract: interaction boundary (v0)', () => {
-  it('BOUNDARY-0100: repeated asBoundary(...) calls on one instance reuse one underlying boundary and merge setup-time configuration deterministically', () => {
+  it('BOUNDARY-0100: repeated no-arg asBoundary calls reuse one configurable handle', () => {
     let a!: BoundaryHandle<PropsBaseType>;
     let b!: BoundaryHandle<PropsBaseType>;
 
     const P = definePrototype({
       name: 'x-boundary-0100',
       setup() {
-        a = asBoundary<PropsBaseType>({
+        a = asBoundary<PropsBaseType>();
+        a.configure({
           debugLabel: 'alpha',
           meta: { origin: 'first' },
         });
-        b = asBoundary<PropsBaseType>({
+        b = asBoundary<PropsBaseType>();
+        b.configure({
           debugLabel: 'beta',
           meta: { step: 2 },
         });

--- a/packages/runtime/test/contract/focus-roving.v0.contract.test.ts
+++ b/packages/runtime/test/contract/focus-roving.v0.contract.test.ts
@@ -206,6 +206,76 @@ describe('runtime contract: focus-roving (v0)', () => {
     expect(focused).toEqual(['item-a']);
   });
 
+  it('FOCUS-ROVING-0320: focusSelected uses semantic member status instead of host order', () => {
+    // T-FOCUS-ROVING-0001-CASE-MEMBER-STATUS
+    let roving!: FocusRovingHandle<PropsBaseType>;
+    const Roving = definePrototype({
+      name: 'x-focus-roving-0320-owner',
+      setup() {
+        roving = asFocusRoving<PropsBaseType>();
+        return (r) => r.el('div', 'roving');
+      },
+    });
+    const Item = definePrototype<{ selected?: boolean; active?: boolean }>({
+      name: 'x-focus-roving-0320-item',
+      setup(def) {
+        def.props.define({
+          selected: { type: 'boolean', empty: 'fallback' },
+          active: { type: 'boolean', empty: 'fallback' },
+        });
+        const focusable = asFocusable<{ selected?: boolean; active?: boolean }>();
+        def.lifecycle.onCreated((run) => {
+          focusable.setRovingStatus({
+            selected: !!run.props.get().selected,
+            active: !!run.props.get().active,
+          });
+        });
+        return (r) => r.el('button', 'item');
+      },
+    });
+
+    const order = new Map<string, number>([
+      ['roving', 0],
+      ['item-a', 1],
+      ['item-b', 2],
+    ]);
+    const globalTarget = new FocusTarget('global', new Map());
+    const targets = {
+      roving: new FocusTarget('roving', order),
+      itemA: new FocusTarget('item-a', order),
+      itemB: new FocusTarget('item-b', order),
+    };
+    const parents = new Map<unknown, unknown | null>([
+      [targets.roving, null],
+      [targets.itemA, targets.roving],
+      [targets.itemB, targets.roving],
+    ]);
+    const focused: string[] = [];
+    const hostOptions = { globalTarget, parents, focused };
+
+    executeWithHost(Roving as any, createTreeHost(Roving.name, targets.roving, hostOptions) as any);
+    executeWithHost(
+      Item as any,
+      {
+        ...createTreeHost(Item.name, targets.itemA, hostOptions),
+        getRawProps: () => ({ active: true }),
+      } as any
+    );
+    executeWithHost(
+      Item as any,
+      {
+        ...createTreeHost(Item.name, targets.itemB, hostOptions),
+        getRawProps: () => ({ selected: true }),
+      } as any
+    );
+
+    roving.focusSelected();
+    expect(focused).toEqual(['item-b']);
+
+    roving.focusNext();
+    expect(focused).toEqual(['item-b', 'item-b']);
+  });
+
   it('FOCUS-ROVING-0350: arrow navigation requests default-action cancellation through event host cap', () => {
     const Roving = definePrototype({
       name: 'x-focus-roving-0350-owner',

--- a/packages/runtime/test/contract/focus-roving.v0.contract.test.ts
+++ b/packages/runtime/test/contract/focus-roving.v0.contract.test.ts
@@ -453,6 +453,91 @@ describe('runtime contract: focus-roving (v0)', () => {
     expect(focused).toEqual(['item-a', 'item-b', 'item-a']);
   });
 
+  it('FOCUS-ROVING-0370: a shared global key event only moves the roving set that contains focus', () => {
+    // T-FOCUS-ROVING-0001-CASE-MULTI-INSTANCE-ISOLATION
+    const Roving = definePrototype({
+      name: 'x-focus-roving-0370-owner',
+      setup() {
+        const roving = asFocusRoving<PropsBaseType>();
+        roving.configure({ navigation: 'arrow', orientation: 'horizontal' });
+        return (r) => r.el('div', 'roving');
+      },
+    });
+    const Item = definePrototype<{ active?: boolean }>({
+      name: 'x-focus-roving-0370-item',
+      setup(def) {
+        def.props.define({ active: { type: 'boolean', empty: 'fallback' } });
+        const focusable = asFocusable<{ active?: boolean }>();
+        def.lifecycle.onCreated((run) => {
+          focusable.setRovingStatus({ active: !!run.props.get().active });
+        });
+        return (r) => r.el('button', 'item');
+      },
+    });
+
+    const order = new Map<string, number>([
+      ['roving-a', 0],
+      ['item-a1', 1],
+      ['item-a2', 2],
+      ['roving-b', 3],
+      ['item-b1', 4],
+      ['item-b2', 5],
+    ]);
+    const globalTarget = new FocusTarget('global', new Map());
+    const targets = {
+      rovingA: new FocusTarget('roving-a', order),
+      itemA1: new FocusTarget('item-a1', order),
+      itemA2: new FocusTarget('item-a2', order),
+      rovingB: new FocusTarget('roving-b', order),
+      itemB1: new FocusTarget('item-b1', order),
+      itemB2: new FocusTarget('item-b2', order),
+    };
+    const parents = new Map<unknown, unknown | null>([
+      [targets.rovingA, null],
+      [targets.itemA1, targets.rovingA],
+      [targets.itemA2, targets.rovingA],
+      [targets.rovingB, null],
+      [targets.itemB1, targets.rovingB],
+      [targets.itemB2, targets.rovingB],
+    ]);
+    const focused: string[] = [];
+    const hostOptions = { globalTarget, parents, focused };
+
+    executeWithHost(
+      Roving as any,
+      createTreeHost(Roving.name, targets.rovingA, hostOptions) as any
+    );
+    const itemA1 = executeWithHost(
+      Item as any,
+      {
+        ...createTreeHost(Item.name, targets.itemA1, hostOptions),
+        getRawProps: () => ({ active: true }),
+      } as any
+    );
+    executeWithHost(Item as any, createTreeHost(Item.name, targets.itemA2, hostOptions) as any);
+    executeWithHost(
+      Roving as any,
+      createTreeHost(Roving.name, targets.rovingB, hostOptions) as any
+    );
+    executeWithHost(
+      Item as any,
+      {
+        ...createTreeHost(Item.name, targets.itemB1, hostOptions),
+        getRawProps: () => ({ active: true }),
+      } as any
+    );
+    executeWithHost(Item as any, createTreeHost(Item.name, targets.itemB2, hostOptions) as any);
+
+    itemA1.caps.getPort<FocusPort>('focus')?.requestFocus({ reason: 'keyboard' });
+    globalTarget.dispatchEvent(
+      new CustomEvent('key.down', {
+        detail: { key: 'ArrowRight', nativeEvent: { type: 'keydown' } },
+      })
+    );
+
+    expect(focused).toEqual(['item-a1', 'item-a2']);
+  });
+
   it('FOCUS-ROVING-0310: scope getRoving handle declares logical roving ownership', () => {
     const Scope = definePrototype({
       name: 'x-focus-roving-0310-scope',

--- a/packages/runtime/test/contract/focus.v0.contract.test.ts
+++ b/packages/runtime/test/contract/focus.v0.contract.test.ts
@@ -320,6 +320,8 @@ describe('runtime contract: focus (v0)', () => {
       focusable: true,
       active: true,
       hasFocused: true,
+      rovingSelected: false,
+      rovingActive: false,
     });
   });
 
@@ -462,6 +464,8 @@ describe('runtime contract: focus (v0)', () => {
       focusable: false,
       active: false,
       hasFocused: false,
+      rovingSelected: false,
+      rovingActive: false,
     });
   });
 
@@ -548,6 +552,8 @@ describe('runtime contract: focus (v0)', () => {
       focusable: true,
       active: true,
       hasFocused: true,
+      rovingSelected: false,
+      rovingActive: false,
     });
   });
 
@@ -576,6 +582,8 @@ describe('runtime contract: focus (v0)', () => {
       focusable: false,
       active: true,
       hasFocused: false,
+      rovingSelected: false,
+      rovingActive: false,
     });
   });
 

--- a/packages/runtime/test/contract/overlay.v0.contract.test.ts
+++ b/packages/runtime/test/contract/overlay.v0.contract.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { definePrototype, type OverlayHandle } from '@proto.ui/core';
+import {
+  definePrototype,
+  HOST_ELEMENT_CAP,
+  type ObservedStateHandle,
+  type OverlayHandle,
+} from '@proto.ui/core';
 import { asOverlay } from '@proto.ui/hooks';
 import type { RuntimeHost } from '../../src';
 import { executeWithHost } from '../../src';
 import { BOUNDARY_HOST_BRIDGE_CAP } from '@proto.ui/module-boundary';
 import { EVENT_GLOBAL_TARGET_CAP } from '@proto.ui/module-event';
-import type { OverlayPort } from '@proto.ui/module-overlay';
+import { OVERLAY_GLOBAL_MOUNT_CAP, type OverlayPort } from '@proto.ui/module-overlay';
 import type { PropsBaseType } from '@proto.ui/types';
 
 const createHost = <P extends PropsBaseType>(
@@ -254,5 +259,65 @@ describe('runtime contract: overlay (v0)', () => {
     result.invokeInCallbackScope(() => overlay.close('programmatic'));
     expect(overlay.isOpen()).toBe(false);
     expect(result.session.viewIntent.getSnapshot().present).toBe(true);
+  });
+
+  it('OVERLAY-0800: bound host resources reconcile after the outer callback chain', () => {
+    let overlay!: OverlayHandle<PropsBaseType>;
+    let present = false;
+    const watchers = new Set<(run: unknown, event: any) => void>();
+    const presentHandle: ObservedStateHandle<boolean, PropsBaseType> = {
+      get: () => present,
+      watch(cb) {
+        watchers.add(cb as any);
+        return () => watchers.delete(cb as any);
+      },
+    };
+    const setPresent = (next: boolean) => {
+      if (next === present) return;
+      const prev = present;
+      present = next;
+      for (const watcher of [...watchers]) {
+        watcher(undefined, { type: 'next', next, prev });
+      }
+    };
+    const hostElement = document.createElement('div');
+    const mounted: HTMLElement[] = [];
+
+    const P = definePrototype({
+      name: 'x-overlay-0800',
+      setup() {
+        overlay = asOverlay<PropsBaseType>();
+        overlay.configure({ portal: true });
+        overlay.bindPresence({
+          enter: () => setPresent(true),
+          leave: () => setPresent(false),
+          present: presentHandle,
+        });
+        return (r) => r.el('div', 'ok');
+      },
+    });
+
+    const { host } = createHost(P.name, {
+      onRuntimeReady(wiring) {
+        wiring.attach('overlay', [
+          [HOST_ELEMENT_CAP, hostElement],
+          [
+            OVERLAY_GLOBAL_MOUNT_CAP,
+            {
+              mount: (element: HTMLElement) => mounted.push(element),
+              unmount: () => {},
+            },
+          ],
+        ]);
+      },
+    });
+    const result = executeWithHost(P as any, host as any);
+
+    result.invokeInCallbackScope(() => {
+      overlay.openOverlay('programmatic');
+      expect(mounted).toEqual([]);
+    });
+
+    expect(mounted).toEqual([hostElement]);
   });
 });

--- a/spec/contracts/C-A11Y-0001.yaml
+++ b/spec/contracts/C-A11Y-0001.yaml
@@ -50,6 +50,10 @@ criteria:
     text:
       zh-CN: a11y name 与 description 可以引用字符串或 state handle；当引用 state handle 时，adapter 投射必须随 state 值变化更新。
       en: A11y name and description may reference a string or a state handle; when they reference a state handle, adapter projection must update as the state value changes.
+  - id: C-A11Y-0001-J
+    text:
+      zh-CN: a11y role 可以引用静态字符串或 state handle；当交互对象的 role 由受治理状态切换时，adapter 投射必须随 state 更新。
+      en: A11y role may reference a static string or a state handle; when an interaction object's role changes through governed state, adapter projection must update with that state.
 sources:
   - path: internal/records/2026-06-30-a11y-module-planning-for-button.zh-CN.md
   - path: packages/modules/a11y/src/types.ts
@@ -80,6 +84,9 @@ revisions:
   - version: 0.1.1
     change: refined
     summary: Allowed a11y name and description text facts to reference state handles for dynamic host-neutral labels.
+  - version: 0.1.2
+    change: refined
+    summary: Allowed semantic roles to reference state handles for governed dynamic role projection.
 tags:
   - a11y
   - accessibility

--- a/spec/contracts/C-ANATOMY-ORDER-0003.yaml
+++ b/spec/contracts/C-ANATOMY-ORDER-0003.yaml
@@ -1,0 +1,50 @@
+id: C-ANATOMY-ORDER-0003
+type: contract
+title: Anatomy part subscriptions observe live structural membership
+status: draft
+since: 0.1.0
+summary: '`def.anatomy.subscribeParts` registers a setup-only callback for live changes to one role projection in the current anatomy domain.'
+statement:
+  zh-CN: >-
+    `def.anatomy.subscribeParts(family, role, callback)` 在 setup 期间注册对当前 anatomy domain 中指定 role part 投影的观察。回调在 runtime callback scope 中接收 `run` 与变化后的有序 part projection；它只表达结构成员或顺序签名变化，不表达 part 的业务数据变化。
+
+
+  en: >-
+    `def.anatomy.subscribeParts(family, role, callback)` registers during setup to observe the specified role projection in the current anatomy domain. The callback receives `run` and the updated ordered part projection in runtime callback scope; it represents structural membership or order-signature changes only, not changes to part business data.
+
+
+criteria:
+  - id: C-ANATOMY-ORDER-0003-A
+    text:
+      zh-CN: '`def.anatomy.subscribeParts` 只能在 setup 期间注册，并必须返回可取消订阅的函数。'
+      en: '`def.anatomy.subscribeParts` may only be registered during setup and must return an unsubscribe function.'
+  - id: C-ANATOMY-ORDER-0003-B
+    text:
+      zh-CN: 回调必须在 runtime callback scope 中运行，并接收当前 same-domain、指定 role 的变化后有序 part projection。
+      en: The callback must run in runtime callback scope and receive the updated ordered projection for the specified role in the current same-domain anatomy.
+  - id: C-ANATOMY-ORDER-0003-C
+    text:
+      zh-CN: 订阅只须在 host-observable order signature 变化后触发；不得将首次注册解释为 initial emission，消费者必须在适当 lifecycle callback 中完成初始同步。
+      en: The subscription only needs to fire after the host-observable order signature changes; registration must not be interpreted as an initial emission, and consumers must perform initial synchronization in an appropriate lifecycle callback.
+  - id: C-ANATOMY-ORDER-0003-D
+    text:
+      zh-CN: Expose、State、Feedback 或其他业务数据变化若未改变 part order signature，不得单独触发 parts subscription。
+      en: Expose, State, Feedback, or other business-data changes must not independently trigger a parts subscription when the part order signature is unchanged.
+sources:
+  - path: packages/core/src/handles.ts
+  - path: packages/modules/anatomy/src/impl.ts
+  - path: packages/runtime/test/contract/anatomy.order.v0.contract.test.ts
+dependsOn:
+  contracts:
+    - C-ANATOMY-0005
+    - C-ANATOMY-ORDER-0001
+    - C-ANATOMY-ORDER-0002
+revisions:
+  - version: 0.1.0
+    change: introduced
+    summary: Added the public setup-time subscription for live role membership and order changes.
+tags:
+  - anatomy
+  - order
+  - subscription
+  - membership

--- a/spec/contracts/C-ANATOMY-ORDER-0003.yaml
+++ b/spec/contracts/C-ANATOMY-ORDER-0003.yaml
@@ -30,6 +30,10 @@ criteria:
     text:
       zh-CN: Expose、State、Feedback 或其他业务数据变化若未改变 part order signature，不得单独触发 parts subscription。
       en: Expose, State, Feedback, or other business-data changes must not independently trigger a parts subscription when the part order signature is unchanged.
+  - id: C-ANATOMY-ORDER-0003-E
+    text:
+      zh-CN: Same-domain part 的 mounted/unmounted membership 变化必须直接可观察，即使 portal 等宿主投射使该 part 不位于 anatomy root 的物理 DOM subtree 中。
+      en: Mounted/unmounted membership changes of same-domain parts must be directly observable even when host projection such as a portal places the part outside the anatomy root's physical DOM subtree.
 sources:
   - path: packages/core/src/handles.ts
   - path: packages/modules/anatomy/src/impl.ts
@@ -43,6 +47,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added the public setup-time subscription for live role membership and order changes.
+  - version: 0.1.1
+    change: refined
+    summary: Required role-scoped logical membership notifications independently from physical root-subtree observation.
 tags:
   - anatomy
   - order

--- a/spec/contracts/C-AS-FOCUS-ROVING-0001.yaml
+++ b/spec/contracts/C-AS-FOCUS-ROVING-0001.yaml
@@ -52,6 +52,13 @@ criteria:
     dependsOn:
       decisions:
         - D-FOCUS-ROVING-NAVIGATION-OWNERSHIP-0001
+  - id: C-AS-FOCUS-ROVING-0001-I
+    text:
+      zh-CN: Focusable member 必须可以在运行期发布独立的 `selected` 与 `active` roving facts；`focusSelected()` 必须优先聚焦 selected eligible member，next/prev 在无 focused member 时可以 active member 作为起点。语义 selection 不得由 host order 或自然 Tab participation 猜测。
+      en: A focusable member must be able to publish independent runtime `selected` and `active` roving facts; `focusSelected()` must prefer the selected eligible member, and next/previous may use the active member as their starting point when no member is focused. Semantic selection must not be inferred from host order or natural Tab participation.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
 sources:
   - path: internal/contracts/focus/base-text/focus-roving.v0.md
   - path: internal/contracts/focus/base-text/focus-model.v0.md
@@ -89,6 +96,9 @@ revisions:
   - version: 0.1.4
     change: refined
     summary: Added runtime strategy synchronization methods for orientation and loop updates after setup.
+  - version: 0.1.5
+    change: refined
+    summary: Added runtime selected and active membership facts for semantic roving requests.
 tags:
   - focus
   - as-hook

--- a/spec/contracts/C-AS-FOCUS-ROVING-0001.yaml
+++ b/spec/contracts/C-AS-FOCUS-ROVING-0001.yaml
@@ -59,6 +59,13 @@ criteria:
     dependsOn:
       contracts:
         - C-AS-FOCUSABLE-0001
+  - id: C-AS-FOCUS-ROVING-0001-J
+    text:
+      zh-CN: 共享 global keyboard target 上的 roving key event 只能由包含实际 focused member 的 roving set 消费；`active` fact 可以作为显式 next/prev request 在无焦点时的起点，但不得让未聚焦的并列实例响应同一键盘事件。
+      en: A roving key event on a shared global keyboard target may only be consumed by the roving set containing the actually focused member; the `active` fact may seed an explicit next/previous request when no member is focused, but must not make unfocused sibling instances respond to the same keyboard event.
+    dependsOn:
+      contracts:
+        - C-AS-FOCUSABLE-0001
 sources:
   - path: internal/contracts/focus/base-text/focus-roving.v0.md
   - path: internal/contracts/focus/base-text/focus-model.v0.md
@@ -99,6 +106,9 @@ revisions:
   - version: 0.1.5
     change: refined
     summary: Added runtime selected and active membership facts for semantic roving requests.
+  - version: 0.1.6
+    change: refined
+    summary: Restricted shared global keyboard events to the roving set that contains actual focus.
 tags:
   - focus
   - as-hook

--- a/spec/contracts/C-AS-HOOK-0009.yaml
+++ b/spec/contracts/C-AS-HOOK-0009.yaml
@@ -34,6 +34,10 @@ criteria:
     text:
       zh-CN: 嵌套 child entry 必须同时保留原始 `result` 与稳定 `handle`；外层可显式投射选中的 child handle，但 runtime 不得自动摊平全部嵌套能力。
       en: A nested child entry must retain both its raw `result` and stable `handle`; an outer hook may explicitly project selected child handles, but the runtime must not automatically flatten every nested capability.
+  - id: C-AS-HOOK-0009-F
+    text:
+      zh-CN: authored asHook contract 可以声明 `asHooks` child-handle map；对已声明 literal name 的 `getAsHookHandle(name)` 查询必须推导对应 handle 类型，同时不得改变 runtime 的选择性重新导出与非 flatten 边界。
+      en: An authored asHook contract may declare an `asHooks` child-handle map; `getAsHookHandle(name)` lookups for declared literal names must infer the corresponding handle type without changing the runtime boundary of selective re-export and no automatic flattening.
 sources:
   - path: internal/contracts/as-hook/as-hook.v0.md
     sections:
@@ -62,6 +66,9 @@ revisions:
   - version: 0.1.1
     change: revised
     summary: Preserved both raw artifacts and projected handles on nested child entries for selective parent projection.
+  - version: 0.1.2
+    change: refined
+    summary: Added typed child-handle maps for literal getAsHookHandle lookups without flattening nested capabilities.
 tags:
   - as-hook
   - handle

--- a/spec/contracts/C-AS-OVERLAY-0001.yaml
+++ b/spec/contracts/C-AS-OVERLAY-0001.yaml
@@ -58,6 +58,10 @@ criteria:
     text:
       zh-CN: portal view epoch detach 只能撤销临时 host projection；被保留 Proto instance 的 logical parent、context/anatomy topology 与重新进入能力必须继续有效。
       en: Detaching a portal view epoch may revoke only the temporary host projection; the retained Proto instance's logical parent, context/anatomy topology, and ability to re-enter must remain valid.
+  - id: C-AS-OVERLAY-0001-L
+    text:
+      zh-CN: Presence signal 在 runtime callback chain 内变为 active 时，Overlay host resource reconciliation 必须由 runtime/module 边界推迟到最外层 callback 完成后；author-facing hook 不得直接选择 `queueMicrotask` 或其它宿主线程调度机制。
+      en: When a Presence signal becomes active within a runtime callback chain, Overlay host-resource reconciliation must be deferred by the runtime/module boundary until the outermost callback completes; the author-facing hook must not directly choose `queueMicrotask` or another host-thread scheduling mechanism.
 sources:
   - path: internal/contracts/overlay/as-overlay.v0.md
   - path: packages/hooks/src/as-overlay.ts
@@ -96,6 +100,9 @@ revisions:
   - version: 0.1.3
     change: refined
     summary: Required portal host-projection teardown to preserve retained Proto logical ownership across view epochs.
+  - version: 0.1.4
+    change: refined
+    summary: Moved post-callback host-resource reconciliation from hook-selected microtasks into the runtime and Overlay module boundary.
 tags:
   - overlay
   - as-hook

--- a/spec/contracts/C-BOUNDARY-0001.yaml
+++ b/spec/contracts/C-BOUNDARY-0001.yaml
@@ -8,8 +8,10 @@ statement:
   zh-CN: >-
     Boundary 必须将宿主采样的传输与交互域分类分开：Event 负责监听、路由、生命周期 gating 与 callback scope，Boundary 负责将当前多 region 交互域分类为 `inside | outside | unknown`。`boundary.observe('pointer.press')` 是 setup-only 且幂等的采样请求；outside 通知只能由该共享分类结果产生，并且 stacked boundary 只允许最上层 active boundary 发布 outside。Overlay、dismiss 与 focus 是 Boundary 的消费者，Hit Participation 仍是独立能力。
 
+
   en: >-
     Boundary must separate host-sample transport from interaction-domain classification: Event owns listening, routing, lifecycle gating, and callback scope, while Boundary classifies the current multi-region interaction domain as `inside | outside | unknown`. `boundary.observe('pointer.press')` is a setup-only idempotent observation request; outside notifications may only derive from that shared classification, and stacked boundaries permit only the top-most active boundary to publish outside. Overlay, dismiss, and focus are Boundary consumers, while Hit Participation remains independent.
+
 
 criteria:
   - id: C-BOUNDARY-0001-A
@@ -36,6 +38,10 @@ criteria:
     text:
       zh-CN: view detach 时 Boundary 必须暂停 sample 消费，Proto instance 终止时必须清理 region 与 subscriber。
       en: Boundary must suspend sample consumption while the view is detached and clean up regions and subscribers when the Proto instance terminates.
+  - id: C-BOUNDARY-0001-G
+    text:
+      zh-CN: '`asBoundary()` 必须是 no-arg privileged once caller；同一 setup chain 重复调用必须返回严格相同的 handle，setup-time 配置通过 `handle.configure(patch)` 表达。'
+      en: '`asBoundary()` must be a no-argument privileged once caller; repeated calls in one setup chain must return the exact same handle, and setup-time configuration is expressed through `handle.configure(patch)`.'
 sources:
   - path: internal/contracts/interaction-boundary/interaction-boundary.v0.md
   - path: packages/core/src/boundary.ts
@@ -54,6 +60,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Defined Event-transported Boundary observation, ternary classification, weak stacking, and cleanup.
+  - version: 0.1.1
+    change: refined
+    summary: Migrated Boundary to a no-argument once caller with configuration through the returned handle.
 tags:
   - boundary
   - event

--- a/spec/decisions/D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001.yaml
+++ b/spec/decisions/D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001.yaml
@@ -6,11 +6,11 @@ since: 0.1.0
 summary: Privileged asHooks that still accept patch/options parameters are an open migration fracture; the intended direction is no-arg callers with setup-time configuration exposed through returned handles or explicit configuration APIs.
 statement:
   zh-CN: >-
-    v0 的 asHook 语义收口不只影响普通 `defineAsHook(...)` 产物，也暴露了既有特权 asHook 的迁移断口。`asFocusable()`、`asFocusScope()`、`asFocusRoving()` 与 `asOverlay()` 已迁移为 no-arg once caller；其中需要 setup 配置的能力通过返回 handle 提供配置入口。`asTransition()` 经权限复核后已经退出特权体系：它只消费公开 lifecycle、`run.lifecycle.setPresent()` 与 Core `delay()`，现由普通 `defineAsHook(...)` 加定制 handle 投射实现。现存 `asBoundary(patch)`、`asHitParticipation(...)` 等 API 仍带有参数化或 configurable 重复调用语义。这些能力暂按各自既有实现维持，但不应继续作为长期 asHook caller 形态扩散。后续迁移方向是：特权 asHook caller 本身也应尽可能无参数；需要配置时，通过第一次调用返回的 handle/API 提供 setup 期配置入口，并由对应特权 asHook 契约定义合并、冲突诊断和返回值复用规则。
+    v0 的 asHook 语义收口不只影响普通 `defineAsHook(...)` 产物，也暴露了既有特权 asHook 的迁移断口。`asFocusable()`、`asFocusScope()`、`asFocusRoving()`、`asOverlay()` 与 `asBoundary()` 已迁移为 no-arg once caller；其中需要 setup 配置的能力通过返回 handle 提供配置入口。`asTransition()` 经权限复核后已经退出特权体系：它只消费公开 lifecycle、`run.lifecycle.setPresent()` 与 Core `delay()`，现由普通 `defineAsHook(...)` 加定制 handle 投射实现。现存 `asHitParticipation(...)` 等 API 仍带有参数化或 configurable 重复调用语义。这些能力暂按各自既有实现维持，但不应继续作为长期 asHook caller 形态扩散。后续迁移方向是：特权 asHook caller 本身也应尽可能无参数；需要配置时，通过第一次调用返回的 handle/API 提供 setup 期配置入口，并由对应特权 asHook 契约定义合并、冲突诊断和返回值复用规则。
 
 
   en: >-
-    The v0 asHook semantic narrowing affects more than ordinary `defineAsHook(...)` products: it exposes an open migration fracture in existing privileged asHooks. `asFocusable()`, `asFocusScope()`, `asFocusRoving()`, and `asOverlay()` have now migrated to no-arg once callers, with setup configuration exposed through returned handles. After an authority review, `asTransition()` has left the privileged system: it consumes only public lifecycle APIs, `run.lifecycle.setPresent()`, and Core `delay()`, and is now implemented through ordinary `defineAsHook(...)` plus custom handle projection. Current APIs such as `asBoundary(patch)` and `asHitParticipation(...)` still carry parameterized or configurable repeat-call semantics. These capabilities remain governed by their existing implementations for now, but should not continue to spread as the long-term asHook caller shape. The migration direction is that privileged asHook callers should also be no-arg where possible; configuration should be exposed through setup-time handles/APIs returned by the first call, with merge, conflict diagnostics, and return-value reuse defined by each privileged asHook contract.
+    The v0 asHook semantic narrowing affects more than ordinary `defineAsHook(...)` products: it exposes an open migration fracture in existing privileged asHooks. `asFocusable()`, `asFocusScope()`, `asFocusRoving()`, `asOverlay()`, and `asBoundary()` have now migrated to no-arg once callers, with setup configuration exposed through returned handles. After an authority review, `asTransition()` has left the privileged system: it consumes only public lifecycle APIs, `run.lifecycle.setPresent()`, and Core `delay()`, and is now implemented through ordinary `defineAsHook(...)` plus custom handle projection. Current APIs such as `asHitParticipation(...)` still carry parameterized or configurable repeat-call semantics. These capabilities remain governed by their existing implementations for now, but should not continue to spread as the long-term asHook caller shape. The migration direction is that privileged asHook callers should also be no-arg where possible; configuration should be exposed through setup-time handles/APIs returned by the first call, with merge, conflict diagnostics, and return-value reuse defined by each privileged asHook contract.
 
 
 openQuestions:
@@ -103,6 +103,9 @@ revisions:
   - version: 0.1.6
     change: partially-implemented
     summary: Migrated asOverlay to a no-argument once caller with returned configuration and Presence-binding APIs.
+  - version: 0.1.7
+    change: partially-implemented
+    summary: Migrated asBoundary to a no-argument once caller with setup-time configuration through the returned handle.
 tags:
   - as-hook
   - privileged

--- a/spec/prototypes/P-BASE-DIALOG-CLOSE.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-CLOSE.yaml
@@ -1,0 +1,56 @@
+id: P-BASE-DIALOG-CLOSE
+type: prototype
+title: Base Dialog Close requests dismissal
+status: draft
+since: 0.2.0
+summary: Dialog Close is a repeatable button-semantic command that requests close without owning the controlled open fact.
+statement:
+  zh-CN: Dialog Close 是 Content 内可重复的 button-semantic command。它拥有自身交互状态，activation 向 Root 请求 open=false，并携带 focus restore reason；受控模式下不得自行关闭 Dialog。
+  en: Dialog Close is a repeatable button-semantic command inside Content. It owns its interaction states, requests open=false from Root with a focus-restoration reason on activation, and must not close a controlled Dialog by itself.
+criteria:
+  - id: P-BASE-DIALOG-CLOSE-AUTHORING-ENTRIES
+    text:
+      {
+        zh-CN: '`base-dialog-close` 与 `asDialogClose` 是同一 protocol 的 authoring entries。',
+        en: '`base-dialog-close` and `asDialogClose` are authoring entries for the same protocol.',
+      }
+  - id: P-BASE-DIALOG-CLOSE-NO-BUTTON-DEPENDENCY
+    text:
+      {
+        zh-CN: Close 必须直接消费 core/privileged command 能力，不得消费 `asButton`。',
+        en: Close must consume core/privileged command capabilities directly and must not consume `asButton`.,
+      }
+  - id: P-BASE-DIALOG-CLOSE-COMMAND
+    text:
+      {
+        zh-CN: Close 必须投射 button semantics、content-derived name 与 focus/press 行为。',
+        en: Close must project button semantics,
+        a content-derived name,
+        and focus/press behavior.,
+      }
+  - id: P-BASE-DIALOG-CLOSE-REQUEST
+    text:
+      {
+        zh-CN: activation 必须请求 open=false，并区分 pointer/keyboard return-focus reason。',
+        en: Activation must request open=false and distinguish pointer/keyboard return-focus reason.,
+      }
+  - id: P-BASE-DIALOG-CLOSE-DISABLED
+    text:
+      {
+        zh-CN: own 或 Root disabled 必须禁止 Close activation 与 focus request。',
+        en: Own or Root disabled state must suppress Close activation and focus requests.,
+      }
+sources:
+  - path: packages/prototypes/base/src/dialog/close.ts
+  - path: packages/prototypes/base/src/dialog/command.ts
+dependsOn:
+  prototypes: [P-BASE-DIALOG, P-BASE-DIALOG-CONTENT]
+  contracts: [C-A11Y-0001, C-AS-TRIGGER-0001, C-AS-FOCUSABLE-0001]
+verifies: { tests: [T-BASE-DIALOG-CLOSE-0001] }
+revisions:
+  - {
+      version: 0.2.0,
+      change: introduced,
+      summary: Cataloged Dialog Close request and command semantics.,
+    }
+tags: [prototype, base, dialog, close]

--- a/spec/prototypes/P-BASE-DIALOG-CLOSE.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-CLOSE.yaml
@@ -10,36 +10,24 @@ statement:
 criteria:
   - id: P-BASE-DIALOG-CLOSE-AUTHORING-ENTRIES
     text:
-      {
-        zh-CN: '`base-dialog-close` 与 `asDialogClose` 是同一 protocol 的 authoring entries。',
-        en: '`base-dialog-close` and `asDialogClose` are authoring entries for the same protocol.',
-      }
+      zh-CN: '`base-dialog-close` 与 `asDialogClose` 是同一 protocol 的 authoring entries。'
+      en: '`base-dialog-close` and `asDialogClose` are authoring entries for the same protocol.'
   - id: P-BASE-DIALOG-CLOSE-NO-BUTTON-DEPENDENCY
     text:
-      {
-        zh-CN: Close 必须直接消费 core/privileged command 能力，不得消费 `asButton`。',
-        en: Close must consume core/privileged command capabilities directly and must not consume `asButton`.,
-      }
+      zh-CN: Close 必须直接消费 core/privileged command 能力，不得消费 `asButton`。
+      en: Close must consume core/privileged command capabilities directly and must not consume `asButton`.
   - id: P-BASE-DIALOG-CLOSE-COMMAND
     text:
-      {
-        zh-CN: Close 必须投射 button semantics、content-derived name 与 focus/press 行为。',
-        en: Close must project button semantics,
-        a content-derived name,
-        and focus/press behavior.,
-      }
+      zh-CN: Close 必须投射 button semantics、content-derived name、keyboard/pointer press activation，并 expose disabled、hovered、focused、focusVisible、pressed 与 focusSelf command surfaces；focused Space keydown 必须阻止宿主默认滚动动作。
+      en: Close must project button semantics, a content-derived name, keyboard/pointer press activation, and expose disabled, hovered, focused, focusVisible, pressed, and focusSelf command surfaces; focused Space keydown must prevent the host's default scrolling action.
   - id: P-BASE-DIALOG-CLOSE-REQUEST
     text:
-      {
-        zh-CN: activation 必须请求 open=false，并区分 pointer/keyboard return-focus reason。',
-        en: Activation must request open=false and distinguish pointer/keyboard return-focus reason.,
-      }
+      zh-CN: activation 必须请求 open=false，并区分 pointer/keyboard return-focus reason。
+      en: Activation must request open=false and distinguish pointer/keyboard return-focus reason.
   - id: P-BASE-DIALOG-CLOSE-DISABLED
     text:
-      {
-        zh-CN: own 或 Root disabled 必须禁止 Close activation 与 focus request。',
-        en: Own or Root disabled state must suppress Close activation and focus requests.,
-      }
+      zh-CN: own 或 Root disabled 必须禁止 Close activation 与 focus request。
+      en: Own or Root disabled state must suppress Close activation and focus requests.
 sources:
   - path: packages/prototypes/base/src/dialog/close.ts
   - path: packages/prototypes/base/src/dialog/command.ts
@@ -48,9 +36,10 @@ dependsOn:
   contracts: [C-A11Y-0001, C-AS-TRIGGER-0001, C-AS-FOCUSABLE-0001]
 verifies: { tests: [T-BASE-DIALOG-CLOSE-0001] }
 revisions:
-  - {
-      version: 0.2.0,
-      change: introduced,
-      summary: Cataloged Dialog Close request and command semantics.,
-    }
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged Dialog Close request and command semantics.
+  - version: 0.2.1
+    change: refined
+    summary: Made the shared command state, focus, and keyboard surfaces explicit.
 tags: [prototype, base, dialog, close]

--- a/spec/prototypes/P-BASE-DIALOG-CONTENT.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-CONTENT.yaml
@@ -1,0 +1,71 @@
+id: P-BASE-DIALOG-CONTENT
+type: prototype
+title: Base Dialog Content owns the active dialog surface
+status: draft
+since: 0.2.0
+summary: Dialog Content is the modal surface that owns dialog semantics, focus containment, dismissal requests, transition presence, and title/description relationships.
+statement:
+  zh-CN: Dialog Content 是至多一个的 active modal surface。它从 Root open 派生 Overlay/Transition presence，active 时包含 focus，并把 Escape/outside 转换为 Root request。普通模式投射 dialog；alert 模式投射 alertdialog 且不允许 outside dismiss。
+  en: Dialog Content is an optional, at-most-one active modal surface. It derives Overlay/Transition presence from Root open, contains focus while active, and converts Escape/outside interactions into Root requests. Normal mode projects dialog; alert mode projects alertdialog and disallows outside dismissal.
+criteria:
+  - id: P-BASE-DIALOG-CONTENT-AUTHORING-ENTRIES
+    text:
+      {
+        zh-CN: '`base-dialog-content` 与 `asDialogContent` 是同一 protocol 的 authoring entries。',
+        en: '`base-dialog-content` and `asDialogContent` are authoring entries for the same protocol.',
+      }
+  - id: P-BASE-DIALOG-CONTENT-PRESENCE
+    text:
+      {
+        zh-CN: Content 必须经 Transition 保留 leave view，并在 closed 后执行 L1 detach。',
+        en: Content must retain the leaving view through Transition and perform L1 detach after closed.,
+      }
+  - id: P-BASE-DIALOG-CONTENT-FOCUS
+    text:
+      {
+        zh-CN: active Content 必须 trap/loop focus，关闭后按 request focus reason 恢复 Trigger。',
+        en: Active Content must trap and loop focus and restore Trigger after close according to request focus reason.,
+      }
+  - id: P-BASE-DIALOG-CONTENT-DISMISS
+    text:
+      {
+        zh-CN: Escape 必须请求关闭；普通 Dialog 的 outside press 必须请求关闭；alert Dialog 必须拒绝 outside request。',
+        en: Escape must request close; outside press must request close for normal Dialog and be rejected for alert Dialog.,
+      }
+  - id: P-BASE-DIALOG-CONTENT-CONTROLLED
+    text:
+      {
+        zh-CN: 受控 dismissal 只能发出 request，不得在 owner input 更新前完成 logical close。',
+        en: Controlled dismissal may only emit a request and must not complete logical close before owner input updates.,
+      }
+  - id: P-BASE-DIALOG-CONTENT-A11Y-ROLE
+    text:
+      {
+        zh-CN: Content 必须按 alert fact 投射 `dialog` 或 `alertdialog`，并投射 modal=true。',
+        en: Content must project `dialog` or `alertdialog` according to the alert fact and project modal=true.,
+      }
+  - id: P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
+    text:
+      {
+        zh-CN: Content 必须通过稳定同域 identity 被 Title labelled，并在 Description 存在时由其描述。',
+        en: Content must be labelled by Title through stable same-domain identity and described by Description when present.,
+      }
+sources:
+  - path: packages/prototypes/base/src/dialog/content.ts
+  - path: packages/adapters/web-component/test/dialog-overlay.test.ts
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
+    label: WAI-ARIA APG Dialog Modal Pattern
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
+    label: WAI-ARIA APG Alert Dialog Pattern
+dependsOn:
+  prototypes: [P-BASE-DIALOG]
+  contracts:
+    [C-A11Y-0001, C-AS-FOCUS-SCOPE-0001, C-AS-OVERLAY-0001, C-AS-TRANSITION-0001, C-BOUNDARY-0001]
+verifies: { tests: [T-BASE-DIALOG-CONTENT-0001] }
+revisions:
+  - {
+      version: 0.2.0,
+      change: introduced,
+      summary: Cataloged Dialog Content semantics and lifecycle.,
+    }
+tags: [prototype, base, dialog, content, accessibility]

--- a/spec/prototypes/P-BASE-DIALOG-CONTENT.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-CONTENT.yaml
@@ -34,8 +34,8 @@ criteria:
       en: Content must project `dialog` or `alertdialog` according to the Root alert fact and project modal=true.
   - id: P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
     text:
-      zh-CN: Content 必须通过稳定同域 identity 被 Title labelled，并在 Description 存在时由其描述。
-      en: Content must be labelled by Title through stable same-domain identity and described by Description when present.
+      zh-CN: Title 存在时，Content 必须通过稳定同域 identity 被其 labelled，并忽略 Root a11yLabel；Title 不存在时必须移除 labelledBy，并在 Root a11yLabel 非空时将其投射为 accessible name。Description 存在时必须投射 describedBy，不存在时必须移除该关系，任何关系都不得指向缺失 part。
+      en: When Title exists, Content must be labelled by its stable same-domain identity and ignore Root a11yLabel; when Title is absent, it must remove labelledBy and project Root a11yLabel as the accessible name when non-empty. It must project describedBy when Description exists and remove the relation when absent; no relation may target a missing part.
 sources:
   - path: packages/prototypes/base/src/dialog/content.ts
   - path: packages/adapters/web-component/test/dialog-overlay.test.ts
@@ -46,7 +46,14 @@ sources:
 dependsOn:
   prototypes: [P-BASE-DIALOG]
   contracts:
-    [C-A11Y-0001, C-AS-FOCUS-SCOPE-0001, C-AS-OVERLAY-0001, C-AS-TRANSITION-0001, C-BOUNDARY-0001]
+    [
+      C-A11Y-0001,
+      C-ANATOMY-ORDER-0003,
+      C-AS-FOCUS-SCOPE-0001,
+      C-AS-OVERLAY-0001,
+      C-AS-TRANSITION-0001,
+      C-BOUNDARY-0001,
+    ]
 verifies: { tests: [T-BASE-DIALOG-CONTENT-0001] }
 revisions:
   - version: 0.2.0
@@ -55,4 +62,7 @@ revisions:
   - version: 0.2.1
     change: refined
     summary: Clarified that alert mode is owned by Root context.
+  - version: 0.2.2
+    change: refined
+    summary: Made title and description relations conditional on live anatomy and added the Root a11yLabel fallback.
 tags: [prototype, base, dialog, content, accessibility]

--- a/spec/prototypes/P-BASE-DIALOG-CONTENT.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-CONTENT.yaml
@@ -10,46 +10,32 @@ statement:
 criteria:
   - id: P-BASE-DIALOG-CONTENT-AUTHORING-ENTRIES
     text:
-      {
-        zh-CN: '`base-dialog-content` 与 `asDialogContent` 是同一 protocol 的 authoring entries。',
-        en: '`base-dialog-content` and `asDialogContent` are authoring entries for the same protocol.',
-      }
+      zh-CN: '`base-dialog-content` 与 `asDialogContent` 是同一 protocol 的 authoring entries。'
+      en: '`base-dialog-content` and `asDialogContent` are authoring entries for the same protocol.'
   - id: P-BASE-DIALOG-CONTENT-PRESENCE
     text:
-      {
-        zh-CN: Content 必须经 Transition 保留 leave view，并在 closed 后执行 L1 detach。',
-        en: Content must retain the leaving view through Transition and perform L1 detach after closed.,
-      }
+      zh-CN: Content 必须经 Transition 保留 leave view，并在 closed 后执行 L1 detach。
+      en: Content must retain the leaving view through Transition and perform L1 detach after closed.
   - id: P-BASE-DIALOG-CONTENT-FOCUS
     text:
-      {
-        zh-CN: active Content 必须 trap/loop focus，关闭后按 request focus reason 恢复 Trigger。',
-        en: Active Content must trap and loop focus and restore Trigger after close according to request focus reason.,
-      }
+      zh-CN: active Content 必须 trap/loop focus，关闭后按 request focus reason 恢复 Trigger。
+      en: Active Content must trap and loop focus and restore Trigger after close according to request focus reason.
   - id: P-BASE-DIALOG-CONTENT-DISMISS
     text:
-      {
-        zh-CN: Escape 必须请求关闭；普通 Dialog 的 outside press 必须请求关闭；alert Dialog 必须拒绝 outside request。',
-        en: Escape must request close; outside press must request close for normal Dialog and be rejected for alert Dialog.,
-      }
+      zh-CN: Escape 必须请求关闭；普通 Dialog 的 outside press 必须请求关闭；alert Dialog 必须拒绝 outside request。
+      en: Escape must request close; outside press must request close for normal Dialog and be rejected for alert Dialog.
   - id: P-BASE-DIALOG-CONTENT-CONTROLLED
     text:
-      {
-        zh-CN: 受控 dismissal 只能发出 request，不得在 owner input 更新前完成 logical close。',
-        en: Controlled dismissal may only emit a request and must not complete logical close before owner input updates.,
-      }
+      zh-CN: 受控 dismissal 只能发出 request，不得在 owner input 更新前完成 logical close。
+      en: Controlled dismissal may only emit a request and must not complete logical close before owner input updates.
   - id: P-BASE-DIALOG-CONTENT-A11Y-ROLE
     text:
-      {
-        zh-CN: Content 必须按 alert fact 投射 `dialog` 或 `alertdialog`，并投射 modal=true。',
-        en: Content must project `dialog` or `alertdialog` according to the alert fact and project modal=true.,
-      }
+      zh-CN: Content 必须按 Root alert fact 投射 `dialog` 或 `alertdialog`，并投射 modal=true。
+      en: Content must project `dialog` or `alertdialog` according to the Root alert fact and project modal=true.
   - id: P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
     text:
-      {
-        zh-CN: Content 必须通过稳定同域 identity 被 Title labelled，并在 Description 存在时由其描述。',
-        en: Content must be labelled by Title through stable same-domain identity and described by Description when present.,
-      }
+      zh-CN: Content 必须通过稳定同域 identity 被 Title labelled，并在 Description 存在时由其描述。
+      en: Content must be labelled by Title through stable same-domain identity and described by Description when present.
 sources:
   - path: packages/prototypes/base/src/dialog/content.ts
   - path: packages/adapters/web-component/test/dialog-overlay.test.ts
@@ -63,9 +49,10 @@ dependsOn:
     [C-A11Y-0001, C-AS-FOCUS-SCOPE-0001, C-AS-OVERLAY-0001, C-AS-TRANSITION-0001, C-BOUNDARY-0001]
 verifies: { tests: [T-BASE-DIALOG-CONTENT-0001] }
 revisions:
-  - {
-      version: 0.2.0,
-      change: introduced,
-      summary: Cataloged Dialog Content semantics and lifecycle.,
-    }
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged Dialog Content semantics and lifecycle.
+  - version: 0.2.1
+    change: refined
+    summary: Clarified that alert mode is owned by Root context.
 tags: [prototype, base, dialog, content, accessibility]

--- a/spec/prototypes/P-BASE-DIALOG-DESCRIPTION.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-DESCRIPTION.yaml
@@ -10,22 +10,16 @@ statement:
 criteria:
   - id: P-BASE-DIALOG-DESCRIPTION-AUTHORING-ENTRIES
     text:
-      {
-        zh-CN: '`base-dialog-description` 与 `asDialogDescription` 是同一 protocol 的 authoring entries。',
-        en: '`base-dialog-description` and `asDialogDescription` are authoring entries for the same protocol.',
-      }
+      zh-CN: '`base-dialog-description` 与 `asDialogDescription` 是同一 protocol 的 authoring entries。'
+      en: '`base-dialog-description` and `asDialogDescription` are authoring entries for the same protocol.'
   - id: P-BASE-DIALOG-DESCRIPTION-RELATION
     text:
-      {
-        zh-CN: Description 必须获得同域稳定 identity，Content 必须通过 describedBy 引用它。',
-        en: Description must receive stable same-domain identity and Content must reference it through describedBy.,
-      }
+      zh-CN: Description 必须获得同域稳定 identity，Content 必须通过 describedBy 引用它。
+      en: Description must receive stable same-domain identity and Content must reference it through describedBy.
   - id: P-BASE-DIALOG-DESCRIPTION-ALERT
     text:
-      {
-        zh-CN: alertdialog authoring 必须包含描述主要消息的 Description。',
-        en: Alert-dialog authoring must include a Description containing the primary message.,
-      }
+      zh-CN: alertdialog authoring 必须包含描述主要消息的 Description。
+      en: Alert-dialog authoring must include a Description containing the primary message.
 sources:
   - path: packages/prototypes/base/src/dialog/description.ts
   - path: https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
@@ -33,9 +27,7 @@ sources:
 dependsOn: { prototypes: [P-BASE-DIALOG, P-BASE-DIALOG-CONTENT], contracts: [C-A11Y-0001] }
 verifies: { tests: [T-BASE-DIALOG-DESCRIPTION-0001] }
 revisions:
-  - {
-      version: 0.2.0,
-      change: introduced,
-      summary: Cataloged Dialog Description relationship and alert requirement.,
-    }
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged Dialog Description relationship and alert requirement.
 tags: [prototype, base, dialog, description]

--- a/spec/prototypes/P-BASE-DIALOG-DESCRIPTION.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-DESCRIPTION.yaml
@@ -1,0 +1,41 @@
+id: P-BASE-DIALOG-DESCRIPTION
+type: prototype
+title: Base Dialog Description describes Dialog Content
+status: draft
+since: 0.2.0
+summary: Dialog Description is the optional single primary-message part referenced by Content, and is required by valid alert-dialog authoring.
+statement:
+  zh-CN: Dialog Description 是 Content 内至多一个的 primary-message part。它通过稳定同域 identity 成为 Content describedBy target；alertdialog 的有效 authoring 必须提供 Description。
+  en: Dialog Description is an optional, at-most-one primary-message part inside Content. Stable same-domain identity makes it the Content describedBy target; valid alertdialog authoring must provide Description.
+criteria:
+  - id: P-BASE-DIALOG-DESCRIPTION-AUTHORING-ENTRIES
+    text:
+      {
+        zh-CN: '`base-dialog-description` 与 `asDialogDescription` 是同一 protocol 的 authoring entries。',
+        en: '`base-dialog-description` and `asDialogDescription` are authoring entries for the same protocol.',
+      }
+  - id: P-BASE-DIALOG-DESCRIPTION-RELATION
+    text:
+      {
+        zh-CN: Description 必须获得同域稳定 identity，Content 必须通过 describedBy 引用它。',
+        en: Description must receive stable same-domain identity and Content must reference it through describedBy.,
+      }
+  - id: P-BASE-DIALOG-DESCRIPTION-ALERT
+    text:
+      {
+        zh-CN: alertdialog authoring 必须包含描述主要消息的 Description。',
+        en: Alert-dialog authoring must include a Description containing the primary message.,
+      }
+sources:
+  - path: packages/prototypes/base/src/dialog/description.ts
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
+    label: WAI-ARIA APG Alert Dialog Pattern
+dependsOn: { prototypes: [P-BASE-DIALOG, P-BASE-DIALOG-CONTENT], contracts: [C-A11Y-0001] }
+verifies: { tests: [T-BASE-DIALOG-DESCRIPTION-0001] }
+revisions:
+  - {
+      version: 0.2.0,
+      change: introduced,
+      summary: Cataloged Dialog Description relationship and alert requirement.,
+    }
+tags: [prototype, base, dialog, description]

--- a/spec/prototypes/P-BASE-DIALOG-DESCRIPTION.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-DESCRIPTION.yaml
@@ -18,8 +18,8 @@ criteria:
       en: Description must receive stable same-domain identity and Content must reference it through describedBy.
   - id: P-BASE-DIALOG-DESCRIPTION-ALERT
     text:
-      zh-CN: alertdialog authoring 必须包含描述主要消息的 Description。
-      en: Alert-dialog authoring must include a Description containing the primary message.
+      zh-CN: alertdialog authoring 必须包含描述主要消息的 Description；Content 在 live anatomy 中检测到 alert mode 缺少 Description 时必须发出诊断。
+      en: Alert-dialog authoring must include a Description containing the primary message; Content must emit a diagnostic when live anatomy detects alert mode without Description.
 sources:
   - path: packages/prototypes/base/src/dialog/description.ts
   - path: https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
@@ -30,4 +30,7 @@ revisions:
   - version: 0.2.0
     change: introduced
     summary: Cataloged Dialog Description relationship and alert requirement.
+  - version: 0.2.1
+    change: refined
+    summary: Required a live-anatomy diagnostic when Alert Dialog lacks Description.
 tags: [prototype, base, dialog, description]

--- a/spec/prototypes/P-BASE-DIALOG-MASK.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-MASK.yaml
@@ -1,0 +1,54 @@
+id: P-BASE-DIALOG-MASK
+type: prototype
+title: Base Dialog Mask projects modal occlusion and hit participation
+status: draft
+since: 0.2.0
+summary: Dialog Mask is the optional modal backdrop whose presence follows Dialog open through Transition while hit participation remains independently configurable.
+statement:
+  zh-CN: Dialog Mask 是至多一个的 modal backdrop part。它消费 Overlay、Transition 与 Hit Participation，但不拥有 open 或 dismissal；logical close 后必须保留到 leave 完成。
+  en: Dialog Mask is an optional, at-most-one modal-backdrop part. It consumes Overlay, Transition, and Hit Participation but owns neither open nor dismissal; after logical close it remains present until leave completes.
+criteria:
+  - id: P-BASE-DIALOG-MASK-AUTHORING-ENTRIES
+    text:
+      {
+        zh-CN: '`base-dialog-mask` 与 `asDialogMask` 是同一 protocol 的 authoring entries。',
+        en: '`base-dialog-mask` and `asDialogMask` are authoring entries for the same protocol.',
+      }
+  - id: P-BASE-DIALOG-MASK-MODAL
+    text:
+      {
+        zh-CN: Mask active presence 必须持有 modal lock 与 backdrop layer。',
+        en: Active Mask presence must retain the modal lock and backdrop layer.,
+      }
+  - id: P-BASE-DIALOG-MASK-PRESENCE
+    text:
+      {
+        zh-CN: Mask 必须由 Transition 绑定 Overlay presence，并在 closed 后才执行 L1 detach。',
+        en: Mask must bind Overlay presence through Transition and request L1 detach only after closed.,
+      }
+  - id: P-BASE-DIALOG-MASK-PASSTHROUGH
+    text:
+      {
+        zh-CN: '`passthrough=true` 只改变 Hit Participation，不得改变 Dialog open。',
+        en: '`passthrough=true` changes only Hit Participation and must not change Dialog open.',
+      }
+  - id: P-BASE-DIALOG-MASK-NO-DISMISS
+    text:
+      {
+        zh-CN: Mask 不得自行拥有 Escape 或 outside dismissal policy。',
+        en: Mask must not independently own Escape or outside-dismissal policy.,
+      }
+sources:
+  - path: packages/prototypes/base/src/dialog/overlay.ts
+  - path: packages/prototypes/base/test/dialog.test.ts
+dependsOn:
+  prototypes: [P-BASE-DIALOG]
+  contracts: [C-AS-OVERLAY-0001, C-AS-TRANSITION-0001]
+verifies: { tests: [T-BASE-DIALOG-MASK-0001] }
+revisions:
+  - {
+      version: 0.2.0,
+      change: introduced,
+      summary: Cataloged Dialog Mask presence and hit participation.,
+    }
+tags: [prototype, base, dialog, mask, overlay]

--- a/spec/prototypes/P-BASE-DIALOG-MASK.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-MASK.yaml
@@ -10,34 +10,24 @@ statement:
 criteria:
   - id: P-BASE-DIALOG-MASK-AUTHORING-ENTRIES
     text:
-      {
-        zh-CN: '`base-dialog-mask` 与 `asDialogMask` 是同一 protocol 的 authoring entries。',
-        en: '`base-dialog-mask` and `asDialogMask` are authoring entries for the same protocol.',
-      }
+      zh-CN: '`base-dialog-mask` 与 `asDialogMask` 是同一 protocol 的 authoring entries。'
+      en: '`base-dialog-mask` and `asDialogMask` are authoring entries for the same protocol.'
   - id: P-BASE-DIALOG-MASK-MODAL
     text:
-      {
-        zh-CN: Mask active presence 必须持有 modal lock 与 backdrop layer。',
-        en: Active Mask presence must retain the modal lock and backdrop layer.,
-      }
+      zh-CN: Mask active presence 必须持有 modal lock 与 backdrop layer。
+      en: Active Mask presence must retain the modal lock and backdrop layer.
   - id: P-BASE-DIALOG-MASK-PRESENCE
     text:
-      {
-        zh-CN: Mask 必须由 Transition 绑定 Overlay presence，并在 closed 后才执行 L1 detach。',
-        en: Mask must bind Overlay presence through Transition and request L1 detach only after closed.,
-      }
+      zh-CN: Mask 必须由 Transition 绑定 Overlay presence，并在 closed 后才执行 L1 detach。
+      en: Mask must bind Overlay presence through Transition and request L1 detach only after closed.
   - id: P-BASE-DIALOG-MASK-PASSTHROUGH
     text:
-      {
-        zh-CN: '`passthrough=true` 只改变 Hit Participation，不得改变 Dialog open。',
-        en: '`passthrough=true` changes only Hit Participation and must not change Dialog open.',
-      }
+      zh-CN: '`passthrough=true` 只改变 Hit Participation，不得改变 Dialog open。'
+      en: '`passthrough=true` changes only Hit Participation and must not change Dialog open.'
   - id: P-BASE-DIALOG-MASK-NO-DISMISS
     text:
-      {
-        zh-CN: Mask 不得自行拥有 Escape 或 outside dismissal policy。',
-        en: Mask must not independently own Escape or outside-dismissal policy.,
-      }
+      zh-CN: Mask 不得自行拥有 Escape 或 outside dismissal policy。
+      en: Mask must not independently own Escape or outside-dismissal policy.
 sources:
   - path: packages/prototypes/base/src/dialog/overlay.ts
   - path: packages/prototypes/base/test/dialog.test.ts
@@ -46,9 +36,7 @@ dependsOn:
   contracts: [C-AS-OVERLAY-0001, C-AS-TRANSITION-0001]
 verifies: { tests: [T-BASE-DIALOG-MASK-0001] }
 revisions:
-  - {
-      version: 0.2.0,
-      change: introduced,
-      summary: Cataloged Dialog Mask presence and hit participation.,
-    }
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged Dialog Mask presence and hit participation.
 tags: [prototype, base, dialog, mask, overlay]

--- a/spec/prototypes/P-BASE-DIALOG-TITLE.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-TITLE.yaml
@@ -1,0 +1,40 @@
+id: P-BASE-DIALOG-TITLE
+type: prototype
+title: Base Dialog Title labels Dialog Content
+status: draft
+since: 0.2.0
+summary: Dialog Title is the optional single visible label part referenced by Content through stable same-domain identity.
+statement:
+  zh-CN: Dialog Title 是 Content 内至多一个的 visible label part。它不拥有 open、focus 或 command 行为，只提供稳定 a11y identity 与 content-derived name source。
+  en: Dialog Title is an optional, at-most-one visible label part inside Content. It owns no open, focus, or command behavior and provides only stable a11y identity and a content-derived name source.
+criteria:
+  - id: P-BASE-DIALOG-TITLE-AUTHORING-ENTRIES
+    text:
+      {
+        zh-CN: '`base-dialog-title` 与 `asDialogTitle` 是同一 protocol 的 authoring entries。',
+        en: '`base-dialog-title` and `asDialogTitle` are authoring entries for the same protocol.',
+      }
+  - id: P-BASE-DIALOG-TITLE-LABEL
+    text:
+      {
+        zh-CN: Title 必须获得同域稳定 identity，Content 必须通过 labelledBy 引用它。',
+        en: Title must receive stable same-domain identity and Content must reference it through labelledBy.,
+      }
+  - id: P-BASE-DIALOG-TITLE-NO-BEHAVIOR
+    text:
+      {
+        zh-CN: Title 不得拥有 activation、open 或 focus containment。',
+        en: Title must not own activation,
+        open state,
+        or focus containment.,
+      }
+sources: [{ path: packages/prototypes/base/src/dialog/title.ts }]
+dependsOn: { prototypes: [P-BASE-DIALOG, P-BASE-DIALOG-CONTENT], contracts: [C-A11Y-0001] }
+verifies: { tests: [T-BASE-DIALOG-TITLE-0001] }
+revisions:
+  - {
+      version: 0.2.0,
+      change: introduced,
+      summary: Cataloged Dialog Title labelling responsibility.,
+    }
+tags: [prototype, base, dialog, title]

--- a/spec/prototypes/P-BASE-DIALOG-TITLE.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-TITLE.yaml
@@ -10,31 +10,21 @@ statement:
 criteria:
   - id: P-BASE-DIALOG-TITLE-AUTHORING-ENTRIES
     text:
-      {
-        zh-CN: '`base-dialog-title` 与 `asDialogTitle` 是同一 protocol 的 authoring entries。',
-        en: '`base-dialog-title` and `asDialogTitle` are authoring entries for the same protocol.',
-      }
+      zh-CN: '`base-dialog-title` 与 `asDialogTitle` 是同一 protocol 的 authoring entries。'
+      en: '`base-dialog-title` and `asDialogTitle` are authoring entries for the same protocol.'
   - id: P-BASE-DIALOG-TITLE-LABEL
     text:
-      {
-        zh-CN: Title 必须获得同域稳定 identity，Content 必须通过 labelledBy 引用它。',
-        en: Title must receive stable same-domain identity and Content must reference it through labelledBy.,
-      }
+      zh-CN: Title 必须获得同域稳定 identity，Content 必须通过 labelledBy 引用它。
+      en: Title must receive stable same-domain identity and Content must reference it through labelledBy.
   - id: P-BASE-DIALOG-TITLE-NO-BEHAVIOR
     text:
-      {
-        zh-CN: Title 不得拥有 activation、open 或 focus containment。',
-        en: Title must not own activation,
-        open state,
-        or focus containment.,
-      }
+      zh-CN: Title 不得拥有 activation、open 或 focus containment。
+      en: Title must not own activation, open state, or focus containment.
 sources: [{ path: packages/prototypes/base/src/dialog/title.ts }]
 dependsOn: { prototypes: [P-BASE-DIALOG, P-BASE-DIALOG-CONTENT], contracts: [C-A11Y-0001] }
 verifies: { tests: [T-BASE-DIALOG-TITLE-0001] }
 revisions:
-  - {
-      version: 0.2.0,
-      change: introduced,
-      summary: Cataloged Dialog Title labelling responsibility.,
-    }
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged Dialog Title labelling responsibility.
 tags: [prototype, base, dialog, title]

--- a/spec/prototypes/P-BASE-DIALOG-TRIGGER.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-TRIGGER.yaml
@@ -1,0 +1,51 @@
+id: P-BASE-DIALOG-TRIGGER
+type: prototype
+title: Base Dialog Trigger requests modal visibility
+status: draft
+since: 0.2.0
+summary: Dialog Trigger is a button-semantic command that requests open-state changes from its owning Dialog root.
+statement:
+  zh-CN: Dialog Trigger 是 Dialog domain 内可重复的 button-semantic command part。它拥有自身 focus/hover/press 与有效 disabled 状态，但不拥有 Dialog open；activation 只能向 Root 请求下一 open 值。
+  en: Dialog Trigger is a repeatable button-semantic command part in a Dialog domain. It owns its focus, hover, press, and effective disabled states but does not own Dialog open; activation may only request the next open value from Root.
+criteria:
+  - id: P-BASE-DIALOG-TRIGGER-AUTHORING-ENTRIES
+    text:
+      {
+        zh-CN: '`base-dialog-trigger` 与 `asDialogTrigger` 是同一 protocol 的 authoring entries。',
+        en: '`base-dialog-trigger` and `asDialogTrigger` are authoring entries for the same protocol.',
+      }
+  - id: P-BASE-DIALOG-TRIGGER-NO-BUTTON-DEPENDENCY
+    text:
+      zh-CN: Trigger 必须直接消费 core/privileged command 能力，不得消费 `asButton`。
+      en: Trigger must consume core/privileged command capabilities directly and must not consume `asButton`.
+  - id: P-BASE-DIALOG-TRIGGER-COMMAND
+    text:
+      zh-CN: Trigger 必须具备 button role、content-derived name、focus 与 press activation。
+      en: Trigger must provide button role, a content-derived name, focus, and press activation.
+  - id: P-BASE-DIALOG-TRIGGER-DISABLED
+    text:
+      zh-CN: own 或 Root disabled 为 true 时必须禁止 activation 与 focus request。
+      en: Own or Root disabled state must suppress activation and focus requests.
+  - id: P-BASE-DIALOG-TRIGGER-REQUEST
+    text:
+      zh-CN: activation 必须请求 `!root.open`，并区分 pointer 与 keyboard focus reason。
+      en: Activation must request `!root.open` and distinguish pointer from keyboard focus reason.
+  - id: P-BASE-DIALOG-TRIGGER-A11Y
+    text:
+      zh-CN: Trigger 必须投射 expanded、`hasPopup=dialog` 与 controls Content identity。
+      en: Trigger must project expanded, `hasPopup=dialog`, and controls relation to Content identity.
+sources:
+  - path: packages/prototypes/base/src/dialog/trigger.ts
+  - path: packages/prototypes/base/src/dialog/command.ts
+  - path: packages/adapters/web-component/test/dialog-overlay.test.ts
+dependsOn:
+  prototypes: [P-BASE-DIALOG]
+  contracts: [C-A11Y-0001, C-AS-TRIGGER-0001, C-AS-FOCUSABLE-0001]
+verifies: { tests: [T-BASE-DIALOG-TRIGGER-0001] }
+revisions:
+  - {
+      version: 0.2.0,
+      change: introduced,
+      summary: Cataloged Dialog Trigger ownership and accessibility.,
+    }
+tags: [prototype, base, dialog, trigger]

--- a/spec/prototypes/P-BASE-DIALOG-TRIGGER.yaml
+++ b/spec/prototypes/P-BASE-DIALOG-TRIGGER.yaml
@@ -10,18 +10,16 @@ statement:
 criteria:
   - id: P-BASE-DIALOG-TRIGGER-AUTHORING-ENTRIES
     text:
-      {
-        zh-CN: '`base-dialog-trigger` 与 `asDialogTrigger` 是同一 protocol 的 authoring entries。',
-        en: '`base-dialog-trigger` and `asDialogTrigger` are authoring entries for the same protocol.',
-      }
+      zh-CN: '`base-dialog-trigger` 与 `asDialogTrigger` 是同一 protocol 的 authoring entries。'
+      en: '`base-dialog-trigger` and `asDialogTrigger` are authoring entries for the same protocol.'
   - id: P-BASE-DIALOG-TRIGGER-NO-BUTTON-DEPENDENCY
     text:
       zh-CN: Trigger 必须直接消费 core/privileged command 能力，不得消费 `asButton`。
       en: Trigger must consume core/privileged command capabilities directly and must not consume `asButton`.
   - id: P-BASE-DIALOG-TRIGGER-COMMAND
     text:
-      zh-CN: Trigger 必须具备 button role、content-derived name、focus 与 press activation。
-      en: Trigger must provide button role, a content-derived name, focus, and press activation.
+      zh-CN: Trigger 必须具备 button role、content-derived name、keyboard/pointer press activation，并 expose disabled、hovered、focused、focusVisible、pressed 与 focusSelf command surfaces；focused Space keydown 必须阻止宿主默认滚动动作。
+      en: Trigger must provide button role, a content-derived name, keyboard/pointer press activation, and expose disabled, hovered, focused, focusVisible, pressed, and focusSelf command surfaces; focused Space keydown must prevent the host's default scrolling action.
   - id: P-BASE-DIALOG-TRIGGER-DISABLED
     text:
       zh-CN: own 或 Root disabled 为 true 时必须禁止 activation 与 focus request。
@@ -43,9 +41,10 @@ dependsOn:
   contracts: [C-A11Y-0001, C-AS-TRIGGER-0001, C-AS-FOCUSABLE-0001]
 verifies: { tests: [T-BASE-DIALOG-TRIGGER-0001] }
 revisions:
-  - {
-      version: 0.2.0,
-      change: introduced,
-      summary: Cataloged Dialog Trigger ownership and accessibility.,
-    }
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged Dialog Trigger ownership and accessibility.
+  - version: 0.2.1
+    change: refined
+    summary: Made the shared command state, focus, and keyboard surfaces explicit.
 tags: [prototype, base, dialog, trigger]

--- a/spec/prototypes/P-BASE-DIALOG.yaml
+++ b/spec/prototypes/P-BASE-DIALOG.yaml
@@ -53,8 +53,8 @@ criteria:
       en: Root must accept `open`, `defaultOpen`, `disabled`, and `alert`; providing `open` selects controlled mode.
   - id: P-BASE-DIALOG-OPEN-EXPOSE
     text:
-      zh-CN: Root 必须 expose `open` state，以及 `openDialog`、`close`、`toggle` methods。
-      en: Root must expose open state and the `openDialog`, `close`, and `toggle` methods.
+      zh-CN: Root 必须 expose `open` state，以及 `openDialog`、`close`、`toggle` methods；这些 method 必须进入与交互相同的 request channel，不得绕过 controlled owner。
+      en: Root must expose open state and the `openDialog`, `close`, and `toggle` methods; these methods must enter the same request channel as interactions and must not bypass the controlled owner.
   - id: P-BASE-DIALOG-OPEN-CHANGE
     text:
       zh-CN: Trigger、Close、Escape 与 outside press 的 open request 必须通过 Root `openChange` signal 发出，并携带 requested open、reason 与 focus reason。
@@ -94,4 +94,7 @@ revisions:
   - version: 0.2.0
     change: introduced
     summary: Cataloged the Base Dialog root and compound protocol.
+  - version: 0.2.1
+    change: refined
+    summary: Required Root methods to preserve controlled ownership through the open request channel.
 tags: [prototype, base, dialog, modal, compound]

--- a/spec/prototypes/P-BASE-DIALOG.yaml
+++ b/spec/prototypes/P-BASE-DIALOG.yaml
@@ -45,12 +45,12 @@ criteria:
       en: Dialog parts must not obtain core Dialog semantics by consuming Button or another Base prototype-specific authored asHook.
   - id: P-BASE-DIALOG-ROOT-OWNER
     text:
-      zh-CN: Root 必须是 open、controlled ownership、disabled、alert mode、part identity 与 request sequencing 的 semantic owner。
-      en: Root must be the semantic owner of open state, controlled ownership, disabled state, alert mode, part identity, and request sequencing.
+      zh-CN: Root 必须是 open、controlled ownership、disabled、alert mode、accessible-label fallback、part identity 与 request sequencing 的 semantic owner。
+      en: Root must be the semantic owner of open state, controlled ownership, disabled state, alert mode, the accessible-label fallback, part identity, and request sequencing.
   - id: P-BASE-DIALOG-PROPS
     text:
-      zh-CN: Root 必须接受 `open`、`defaultOpen`、`disabled` 与 `alert`；`open` 被提供时进入受控模式。
-      en: Root must accept `open`, `defaultOpen`, `disabled`, and `alert`; providing `open` selects controlled mode.
+      zh-CN: Root 必须接受 `open`、`defaultOpen`、`disabled`、`alert` 与 host-neutral `a11yLabel`；`open` 被提供时进入受控模式。
+      en: Root must accept `open`, `defaultOpen`, `disabled`, `alert`, and the host-neutral `a11yLabel`; providing `open` selects controlled mode.
   - id: P-BASE-DIALOG-OPEN-EXPOSE
     text:
       zh-CN: Root 必须 expose `open` state，以及 `openDialog`、`close`、`toggle` methods；这些 method 必须进入与交互相同的 request channel，不得绕过 controlled owner。
@@ -65,8 +65,8 @@ criteria:
       en: After a request, a controlled Dialog must retain the owner-provided open fact until a new `open` input arrives.
   - id: P-BASE-DIALOG-CONTEXT
     text:
-      zh-CN: Root 必须通过同域 Context 向 parts 发布 open、disabled、alert、focus reason、identity 与 request facts。
-      en: Root must publish open, disabled, alert, focus-reason, identity, and request facts to same-domain parts through Context.
+      zh-CN: Root 必须通过同域 Context 向 parts 发布 open、disabled、alert、a11yLabel、focus reason、identity 与 request facts。
+      en: Root must publish open, disabled, alert, a11yLabel, focus-reason, identity, and request facts to same-domain parts through Context.
   - id: P-BASE-DIALOG-ANATOMY
     text:
       zh-CN: canonical anatomy roles、cardinality 与 contains relations 必须由顶层 anatomy 字段定义。
@@ -97,4 +97,7 @@ revisions:
   - version: 0.2.1
     change: refined
     summary: Required Root methods to preserve controlled ownership through the open request channel.
+  - version: 0.2.2
+    change: refined
+    summary: Added the host-neutral a11yLabel fallback published to Content through Dialog context.
 tags: [prototype, base, dialog, modal, compound]

--- a/spec/prototypes/P-BASE-DIALOG.yaml
+++ b/spec/prototypes/P-BASE-DIALOG.yaml
@@ -1,0 +1,97 @@
+id: P-BASE-DIALOG
+type: prototype
+title: Base Dialog is a root-owned modal dialog protocol
+status: draft
+since: 0.2.0
+summary: Base Dialog is a compound modal-window protocol whose root owns open state, controlled requests, shared context, and the Dialog anatomy domain.
+statement:
+  zh-CN: >-
+    Base Dialog 是 compound modal-window protocol。Root 持有 open state 与 Dialog context；Trigger、Mask、Content、Title、Description、Close 作为同域 parts 协作。受控与非受控交互都必须产生 `openChange` request，只有 owner input 或非受控 root 可以改变最终 open fact。Content 与 Mask 的感知 transition 和 L1 view materialization 不得成为第二套 open truth。
+
+
+  en: >-
+    Base Dialog is a compound modal-window protocol. Root owns open state and Dialog context while Trigger, Mask, Content, Title, Description, and Close cooperate as parts in the same domain. Controlled and uncontrolled interactions both produce `openChange` requests, while only owner input or an uncontrolled root may change the final open fact. Content and Mask perceptual transitions and L1 view materialization must not become a second open truth.
+
+
+anatomy:
+  family: base-dialog
+  roles:
+    root: { cardinality: { min: 1, max: 1 } }
+    trigger: { cardinality: { min: 0, max: '*' } }
+    mask: { cardinality: { min: 0, max: 1 } }
+    content: { cardinality: { min: 0, max: 1 } }
+    title: { cardinality: { min: 0, max: 1 } }
+    description: { cardinality: { min: 0, max: 1 } }
+    close: { cardinality: { min: 0, max: '*' } }
+  relations:
+    - { kind: contains, parent: root, child: trigger }
+    - { kind: contains, parent: root, child: mask }
+    - { kind: contains, parent: root, child: content }
+    - { kind: contains, parent: content, child: title }
+    - { kind: contains, parent: content, child: description }
+    - { kind: contains, parent: content, child: close }
+criteria:
+  - id: P-BASE-DIALOG-ROLE-MODAL-WINDOW
+    text:
+      zh-CN: Dialog 必须表示覆盖当前工作流并在 active 期间限制 outside interaction 的 modal window protocol。
+      en: Dialog must represent a modal-window protocol that overlays the current workflow and restricts outside interaction while active.
+  - id: P-BASE-DIALOG-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-dialog-root` 与 `asDialogRoot` 是同一 root protocol 的 direct 与 authored-asHook entries。'
+      en: '`base-dialog-root` and `asDialogRoot` are direct and authored-asHook entries for the same root protocol.'
+  - id: P-BASE-DIALOG-PROTOCOL-INDEPENDENCE
+    text:
+      zh-CN: Dialog parts 不得通过消费 Button 或其它 Base prototype-specific authored asHook 获得 Dialog 自身核心语义。
+      en: Dialog parts must not obtain core Dialog semantics by consuming Button or another Base prototype-specific authored asHook.
+  - id: P-BASE-DIALOG-ROOT-OWNER
+    text:
+      zh-CN: Root 必须是 open、controlled ownership、disabled、alert mode、part identity 与 request sequencing 的 semantic owner。
+      en: Root must be the semantic owner of open state, controlled ownership, disabled state, alert mode, part identity, and request sequencing.
+  - id: P-BASE-DIALOG-PROPS
+    text:
+      zh-CN: Root 必须接受 `open`、`defaultOpen`、`disabled` 与 `alert`；`open` 被提供时进入受控模式。
+      en: Root must accept `open`, `defaultOpen`, `disabled`, and `alert`; providing `open` selects controlled mode.
+  - id: P-BASE-DIALOG-OPEN-EXPOSE
+    text:
+      zh-CN: Root 必须 expose `open` state，以及 `openDialog`、`close`、`toggle` methods。
+      en: Root must expose open state and the `openDialog`, `close`, and `toggle` methods.
+  - id: P-BASE-DIALOG-OPEN-CHANGE
+    text:
+      zh-CN: Trigger、Close、Escape 与 outside press 的 open request 必须通过 Root `openChange` signal 发出，并携带 requested open、reason 与 focus reason。
+      en: Open requests from Trigger, Close, Escape, and outside press must emit through Root `openChange` with requested open, reason, and focus reason.
+  - id: P-BASE-DIALOG-CONTROLLED-OWNER
+    text:
+      zh-CN: 受控 Dialog 在 request 后必须保持 owner 提供的 open fact，直到新的 `open` input 到达。
+      en: After a request, a controlled Dialog must retain the owner-provided open fact until a new `open` input arrives.
+  - id: P-BASE-DIALOG-CONTEXT
+    text:
+      zh-CN: Root 必须通过同域 Context 向 parts 发布 open、disabled、alert、focus reason、identity 与 request facts。
+      en: Root must publish open, disabled, alert, focus-reason, identity, and request facts to same-domain parts through Context.
+  - id: P-BASE-DIALOG-ANATOMY
+    text:
+      zh-CN: canonical anatomy roles、cardinality 与 contains relations 必须由顶层 anatomy 字段定义。
+      en: Canonical anatomy roles, cardinalities, and contains relations must be defined by the top-level anatomy field.
+sources:
+  - path: packages/prototypes/base/src/dialog/root.ts
+  - path: packages/prototypes/base/src/dialog/shared.ts
+  - path: packages/prototypes/base/test/dialog.test.ts
+  - path: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
+    label: WAI-ARIA APG Dialog Modal Pattern
+dependsOn:
+  contracts:
+    - C-ANATOMY-0002
+    - C-CONTEXT-0001
+    - C-EXPOSE-STATE-0001
+    - C-EXPOSE-EVENT-0001
+    - C-LIFECYCLE-0008
+  decisions:
+    - D-PROTOTYPE-ENTITY-NAMING-0001
+    - D-BASE-PROTOTYPE-INDEPENDENCE-0001
+verifies:
+  tests:
+    - T-BASE-DIALOG-0001
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged the Base Dialog root and compound protocol.
+tags: [prototype, base, dialog, modal, compound]

--- a/spec/prototypes/P-BASE-TABS-LIST.yaml
+++ b/spec/prototypes/P-BASE-TABS-LIST.yaml
@@ -3,14 +3,14 @@ type: prototype
 title: Base Tabs List is the tab trigger collection and roving focus container
 status: draft
 since: 0.1.0
-summary: Base Tabs List is the optional at-most-one Tabs anatomy part that owns the trigger collection surface and roving focus methods while consuming Tabs context for orientation and the selected value used by focusSelected.
+summary: Base Tabs List is the optional at-most-one Tabs anatomy part that owns the trigger collection surface and roving focus methods while consuming Tabs context for orientation.
 statement:
   zh-CN: >-
-    Base Tabs List 是 Base Tabs anatomy family 中可选且至多一个的 list part。它承载 trigger collection 与 roving focus 方法，消费 Tabs context 中的 orientation，以及 `focusSelected` 所需的 selected value，但不拥有 selected value，也不处理 tabpanel visibility。`base-tabs-list` direct prototype 与 `asTabsList` authored asHook 是同一 Tabs list protocol 的两个 authoring entries。
+    Base Tabs List 是 Base Tabs anatomy family 中可选且至多一个的 list part。它承载 trigger collection 与 roving focus 方法，并消费 Tabs context 中的 orientation；Trigger 将 selected 与 active 成员事实发布给 Focus，因此 List 不直接读取 selected value，也不处理 tabpanel visibility。`base-tabs-list` direct prototype 与 `asTabsList` authored asHook 是同一 Tabs list protocol 的两个 authoring entries。
 
 
   en: >-
-    Base Tabs List is the optional and at-most-one list part in the Base Tabs anatomy family. It hosts the trigger collection and roving focus methods and consumes orientation plus the selected value needed by `focusSelected` from Tabs context, but does not own selected value or handle tabpanel visibility. The `base-tabs-list` direct prototype and the `asTabsList` authored asHook are two authoring entries of the same Tabs list protocol.
+    Base Tabs List is the optional and at-most-one list part in the Base Tabs anatomy family. It hosts the trigger collection and roving focus methods and consumes orientation from Tabs context; Trigger publishes selected and active member facts to Focus, so List does not read selected value directly or handle tabpanel visibility. The `base-tabs-list` direct prototype and the `asTabsList` authored asHook are two authoring entries of the same Tabs list protocol.
 
 
 criteria:
@@ -56,8 +56,8 @@ criteria:
         - C-CONTEXT-0002
   - id: P-BASE-TABS-LIST-CONTEXT-CONSUME
     text:
-      zh-CN: Tabs List 必须读取或订阅 Tabs context，以获得 orientation 与 `focusSelected` 所需的 selected value；roving movement 的 active member 由 Focus module 从实际 focus facts 解析。
-      en: Tabs List must read or subscribe to Tabs context to obtain orientation and the selected value needed by `focusSelected`; the Focus module resolves the active roving member from actual focus facts.
+      zh-CN: Tabs List 必须读取或订阅 Tabs context 以获得 orientation；Trigger 必须向 Focus module 发布 selected 与 active roving member facts，List 的 `focusSelected` 与 movement 不得自行重建成员语义。
+      en: Tabs List must read or subscribe to Tabs context to obtain orientation; Trigger must publish selected and active roving-member facts to the Focus module, and List must not reconstruct member semantics for `focusSelected` or movement.
     dependsOn:
       contracts:
         - C-CONTEXT-0006
@@ -169,6 +169,9 @@ revisions:
   - version: 0.2.0
     change: refined
     summary: Removed the deprecated useFocusRoving dependency and assigned active-member movement to asFocusRoving.
+  - version: 0.2.1
+    change: refined
+    summary: Removed the temporary Tabs-specific focusSelected bridge after Focus gained semantic selected and active member facts.
 tags:
   - prototype
   - base

--- a/spec/prototypes/P-BASE-TABS-LIST.yaml
+++ b/spec/prototypes/P-BASE-TABS-LIST.yaml
@@ -3,14 +3,14 @@ type: prototype
 title: Base Tabs List is the tab trigger collection and roving focus container
 status: draft
 since: 0.1.0
-summary: Base Tabs List is the optional at-most-one Tabs anatomy part that owns the trigger collection surface and roving focus methods while consuming Tabs context for orientation, selected value, and active value.
+summary: Base Tabs List is the optional at-most-one Tabs anatomy part that owns the trigger collection surface and roving focus methods while consuming Tabs context for orientation and the selected value used by focusSelected.
 statement:
   zh-CN: >-
-    Base Tabs List 是 Base Tabs anatomy family 中可选且至多一个的 list part。它承载 trigger collection 与 roving focus 方法，消费 Tabs context 中的 orientation、selected value 与 activeValue，但不拥有 selected value，也不处理 tabpanel visibility。`base-tabs-list` direct prototype 与 `asTabsList` authored asHook 是同一 Tabs list protocol 的两个 authoring entries。
+    Base Tabs List 是 Base Tabs anatomy family 中可选且至多一个的 list part。它承载 trigger collection 与 roving focus 方法，消费 Tabs context 中的 orientation，以及 `focusSelected` 所需的 selected value，但不拥有 selected value，也不处理 tabpanel visibility。`base-tabs-list` direct prototype 与 `asTabsList` authored asHook 是同一 Tabs list protocol 的两个 authoring entries。
 
 
   en: >-
-    Base Tabs List is the optional and at-most-one list part in the Base Tabs anatomy family. It hosts the trigger collection and roving focus methods, consumes orientation, selected value, and activeValue from Tabs context, but does not own selected value or handle tabpanel visibility. The `base-tabs-list` direct prototype and the `asTabsList` authored asHook are two authoring entries of the same Tabs list protocol.
+    Base Tabs List is the optional and at-most-one list part in the Base Tabs anatomy family. It hosts the trigger collection and roving focus methods and consumes orientation plus the selected value needed by `focusSelected` from Tabs context, but does not own selected value or handle tabpanel visibility. The `base-tabs-list` direct prototype and the `asTabsList` authored asHook are two authoring entries of the same Tabs list protocol.
 
 
 criteria:
@@ -56,8 +56,8 @@ criteria:
         - C-CONTEXT-0002
   - id: P-BASE-TABS-LIST-CONTEXT-CONSUME
     text:
-      zh-CN: Tabs List 必须读取或订阅 Tabs context，以获得 orientation、selected value 与 activeValue。
-      en: Tabs List must read or subscribe to Tabs context to obtain orientation, selected value, and activeValue.
+      zh-CN: Tabs List 必须读取或订阅 Tabs context，以获得 orientation 与 `focusSelected` 所需的 selected value；roving movement 的 active member 由 Focus module 从实际 focus facts 解析。
+      en: Tabs List must read or subscribe to Tabs context to obtain orientation and the selected value needed by `focusSelected`; the Focus module resolves the active roving member from actual focus facts.
     dependsOn:
       contracts:
         - C-CONTEXT-0006
@@ -166,6 +166,9 @@ revisions:
   - version: 0.1.1
     change: refined
     summary: Added host-neutral a11yLabel as the Tabs List accessible name input.
+  - version: 0.2.0
+    change: refined
+    summary: Removed the deprecated useFocusRoving dependency and assigned active-member movement to asFocusRoving.
 tags:
   - prototype
   - base

--- a/spec/prototypes/P-BASE-TABS-TRIGGER.yaml
+++ b/spec/prototypes/P-BASE-TABS-TRIGGER.yaml
@@ -153,6 +153,14 @@ criteria:
       contracts:
         - C-AS-TRIGGER-0001
         - C-EVENT-TYPE-0001
+  - id: P-BASE-TABS-TRIGGER-KEYBOARD-ACTIVATION
+    text:
+      zh-CN: Tabs Trigger 必须通过 Trigger semantics 支持键盘 activation；focused trigger 的 Space keydown 必须阻止页面滚动等宿主默认动作。
+      en: Tabs Trigger must support keyboard activation through Trigger semantics; Space keydown on a focused trigger must prevent host default actions such as page scrolling.
+    dependsOn:
+      contracts:
+        - C-AS-TRIGGER-0001
+        - C-EVENT-TYPE-0001
   - id: P-BASE-TABS-TRIGGER-DISABLED-SUPPRESS-ACTIVATION
     text:
       zh-CN: Disabled Tabs Trigger 不得请求 root selection，也不得更新 Tabs context activeValue。
@@ -250,6 +258,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added the first Base Tabs Trigger protocol catalog.
+  - version: 0.2.0
+    change: refined
+    summary: Made keyboard activation and Space default-action control explicit.
 tags:
   - prototype
   - base

--- a/spec/tests/T-A11Y-0001.yaml
+++ b/spec/tests/T-A11Y-0001.yaml
@@ -5,6 +5,12 @@ status: draft
 since: 0.1.0
 summary: Contract tests for a11y semantic object IR, Button consumption, identity/relation projection, and Web adapter projection.
 cases:
+  - id: T-A11Y-0001-CASE-DYNAMIC-ROLE
+    title: A semantic role may follow a state-backed fact
+    covers:
+      - C-A11Y-0001-C
+      - C-A11Y-0001-J
+    expectation: state-backed-role-projection
   - id: T-A11Y-0001-CASE-IR
     title: A prototype can declare identity, role, name, state, action, and relation into a stable a11y IR
     covers:
@@ -42,6 +48,7 @@ implementations:
     path: packages/runtime/test/contract/a11y.v0.contract.test.ts
     required: true
     consumesCases:
+      - T-A11Y-0001-CASE-DYNAMIC-ROLE
       - T-A11Y-0001-CASE-IR
   - id: base-button-a11y-contract
     kind: module-test
@@ -70,6 +77,7 @@ verifies:
         - C-A11Y-0001-G
         - C-A11Y-0001-H
         - C-A11Y-0001-I
+        - C-A11Y-0001-J
   hostCaps:
     - id: HC-A11Y-0001
       anchors:
@@ -82,6 +90,9 @@ revisions:
   - version: 0.1.1
     change: refined
     summary: Added coverage for dynamic a11y name projection from state-backed text facts.
+  - version: 0.1.2
+    change: refined
+    summary: Added runtime coverage for state-backed semantic role projection.
 tags:
   - a11y
   - accessibility

--- a/spec/tests/T-ANATOMY-ORDER-0001.yaml
+++ b/spec/tests/T-ANATOMY-ORDER-0001.yaml
@@ -38,6 +38,7 @@ cases:
       - C-ANATOMY-ORDER-0003-B
       - C-ANATOMY-ORDER-0003-C
       - C-ANATOMY-ORDER-0003-D
+      - C-ANATOMY-ORDER-0003-E
     expectation: live-role-projection-subscription
 implementations:
   - id: module-anatomy-impl-spec
@@ -88,6 +89,7 @@ verifies:
         - C-ANATOMY-ORDER-0003-B
         - C-ANATOMY-ORDER-0003-C
         - C-ANATOMY-ORDER-0003-D
+        - C-ANATOMY-ORDER-0003-E
 exercises:
   contracts:
     - id: C-ANATOMY-0005
@@ -103,6 +105,9 @@ revisions:
   - version: 0.2.0
     change: refined
     summary: Added runtime coverage for setup-time live role projection subscriptions.
+  - version: 0.2.1
+    change: refined
+    summary: Added role filtering and direct logical mount/unmount membership coverage.
 tags:
   - anatomy
   - order

--- a/spec/tests/T-ANATOMY-ORDER-0001.yaml
+++ b/spec/tests/T-ANATOMY-ORDER-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Anatomy order view tests
 status: draft
 since: 0.1.0
-summary: Module and runtime tests for host-ordered part projections, self adjacency, order version, and privileged missing query policy.
+summary: Module and runtime tests for host-ordered part projections, self adjacency, order version, live role subscriptions, and privileged missing query policy.
 cases:
   - id: T-ANATOMY-ORDER-0001-CASE-HOST-ORDER
     title: Anatomy order reflects the host-observable order of same-domain parts
@@ -31,6 +31,14 @@ cases:
       - C-ANATOMY-0005-D
       - C-ANATOMY-ORDER-0001-B
     expectation: privileged-missing-domain-policy
+  - id: T-ANATOMY-ORDER-0001-CASE-PARTS-SUBSCRIPTION
+    title: Anatomy parts subscriptions report changed same-domain role projections without duplicate emissions
+    covers:
+      - C-ANATOMY-ORDER-0003-A
+      - C-ANATOMY-ORDER-0003-B
+      - C-ANATOMY-ORDER-0003-C
+      - C-ANATOMY-ORDER-0003-D
+    expectation: live-role-projection-subscription
 implementations:
   - id: module-anatomy-impl-spec
     kind: module-test
@@ -59,6 +67,7 @@ implementations:
       - T-ANATOMY-ORDER-0001-CASE-SELF-ADJACENCY
       - T-ANATOMY-ORDER-0001-CASE-VERSION
       - T-ANATOMY-ORDER-0001-CASE-MISSING-POLICY
+      - T-ANATOMY-ORDER-0001-CASE-PARTS-SUBSCRIPTION
 verifies:
   contracts:
     - id: C-ANATOMY-ORDER-0001
@@ -73,6 +82,12 @@ verifies:
         - C-ANATOMY-ORDER-0002-B
         - C-ANATOMY-ORDER-0002-C
         - C-ANATOMY-ORDER-0002-D
+    - id: C-ANATOMY-ORDER-0003
+      anchors:
+        - C-ANATOMY-ORDER-0003-A
+        - C-ANATOMY-ORDER-0003-B
+        - C-ANATOMY-ORDER-0003-C
+        - C-ANATOMY-ORDER-0003-D
 exercises:
   contracts:
     - id: C-ANATOMY-0005
@@ -85,6 +100,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added anatomy.order host-order, self-adjacency, version, and missing-policy test mapping.
+  - version: 0.2.0
+    change: refined
+    summary: Added runtime coverage for setup-time live role projection subscriptions.
 tags:
   - anatomy
   - order

--- a/spec/tests/T-AS-HOOK-0001.yaml
+++ b/spec/tests/T-AS-HOOK-0001.yaml
@@ -45,6 +45,7 @@ cases:
       - C-AS-HOOK-0009-C
       - C-AS-HOOK-0009-D
       - C-AS-HOOK-0009-E
+      - C-AS-HOOK-0009-F
     expectation: stable-custom-caller-handle-projection
   - id: T-AS-HOOK-0001-CASE-TRACE
     title: applied asHooks leave readonly diagnostic trace metadata
@@ -115,6 +116,7 @@ verifies:
         - C-AS-HOOK-0009-C
         - C-AS-HOOK-0009-D
         - C-AS-HOOK-0009-E
+        - C-AS-HOOK-0009-F
 exercises:
   decisions:
     - id: D-AS-HOOK-CALLER-NAME-0001
@@ -129,6 +131,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added asHook core behavior test mapping.
+  - version: 0.1.1
+    change: refined
+    summary: Added type coverage for contract-declared child handle lookup inference.
 tags:
   - as-hook
   - setup

--- a/spec/tests/T-AS-OVERLAY-0001.yaml
+++ b/spec/tests/T-AS-OVERLAY-0001.yaml
@@ -53,6 +53,11 @@ cases:
       - C-AS-OVERLAY-0001-K
       - C-LIFECYCLE-0008-E
     expectation: portaled-overlay-logical-owner-survives-detach
+  - id: T-AS-OVERLAY-0001-CASE-POST-CALLBACK-RECONCILE
+    title: bound host resources reconcile only after the outer runtime callback chain
+    covers:
+      - C-AS-OVERLAY-0001-L
+    expectation: runtime-owned-post-callback-overlay-reconciliation
 implementations:
   - id: runtime-overlay-contract
     kind: runtime-test
@@ -65,6 +70,7 @@ implementations:
       - T-AS-OVERLAY-0001-CASE-KEEP-MOUNTED
       - T-AS-OVERLAY-0001-CASE-BOUNDARY-HIT
       - T-AS-OVERLAY-0001-CASE-DISMISS
+      - T-AS-OVERLAY-0001-CASE-POST-CALLBACK-RECONCILE
   - id: base-overlay-transition-contract
     kind: runtime-test
     status: passing
@@ -116,6 +122,7 @@ verifies:
         - C-AS-OVERLAY-0001-I
         - C-AS-OVERLAY-0001-J
         - C-AS-OVERLAY-0001-K
+        - C-AS-OVERLAY-0001-L
     - id: C-LIFECYCLE-0008
       anchors:
         - C-LIFECYCLE-0008-E
@@ -138,6 +145,9 @@ revisions:
   - version: 0.1.3
     change: updated
     summary: Added Vue Dialog portal re-entry coverage for retained logical ownership.
+  - version: 0.1.4
+    change: refined
+    summary: Added runtime coverage for post-callback Overlay host-resource reconciliation.
 tags:
   - overlay
   - presence

--- a/spec/tests/T-BASE-DIALOG-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-0001.yaml
@@ -1,0 +1,63 @@
+id: T-BASE-DIALOG-0001
+type: test
+title: Base Dialog root and compound protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers root ownership, authoring parity, controlled requests, context propagation, anatomy, and independence from sibling Base prototypes.
+cases:
+  - id: T-BASE-DIALOG-0001-CASE-ROOT-OWNERSHIP
+    title: Root owns Dialog facts and publishes the compound context
+    covers:
+      - P-BASE-DIALOG-ROLE-MODAL-WINDOW
+      - P-BASE-DIALOG-ROOT-OWNER
+      - P-BASE-DIALOG-PROPS
+      - P-BASE-DIALOG-OPEN-EXPOSE
+      - P-BASE-DIALOG-CONTEXT
+      - P-BASE-DIALOG-ANATOMY
+    expectation: dialog-root-owns-open-and-publishes-shared-facts
+  - id: T-BASE-DIALOG-0001-CASE-CONTROLLED-REQUESTS
+    title: Controlled interactions emit requests without replacing the owner fact
+    covers:
+      - P-BASE-DIALOG-OPEN-CHANGE
+      - P-BASE-DIALOG-CONTROLLED-OWNER
+    expectation: controlled-dialog-emits-open-change-and-retains-owner-open
+  - id: T-BASE-DIALOG-0001-CASE-AUTHORING-INDEPENDENCE
+    title: Direct and authored entries share the Dialog protocol without consuming Base Button
+    covers:
+      - P-BASE-DIALOG-AUTHORING-ENTRIES
+      - P-BASE-DIALOG-PROTOCOL-INDEPENDENCE
+    expectation: dialog-authoring-entries-share-an-independent-protocol
+implementations:
+  - id: prototypes-base-dialog-root-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/dialog.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-DIALOG-0001-CASE-ROOT-OWNERSHIP
+      - T-BASE-DIALOG-0001-CASE-CONTROLLED-REQUESTS
+      - T-BASE-DIALOG-0001-CASE-AUTHORING-INDEPENDENCE
+    exercises: [P-BASE-DIALOG]
+  - id: prototypes-shadcn-dialog-root-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/shadcn/test/dialog.test.ts
+    required: true
+    consumesCases: [T-BASE-DIALOG-0001-CASE-AUTHORING-INDEPENDENCE]
+    exercises: [P-BASE-DIALOG]
+verifies:
+  prototypes:
+    - id: P-BASE-DIALOG
+      anchors:
+        - P-BASE-DIALOG-ROOT-OWNER
+        - P-BASE-DIALOG-OPEN-CHANGE
+        - P-BASE-DIALOG-CONTROLLED-OWNER
+        - P-BASE-DIALOG-PROTOCOL-INDEPENDENCE
+exercises: { prototypes: [P-BASE-DIALOG] }
+revisions:
+  - {
+      version: 0.2.0,
+      change: introduced,
+      summary: Added Base Dialog root and compound protocol coverage.,
+    }
+tags: [prototype, base, dialog, test]

--- a/spec/tests/T-BASE-DIALOG-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-0001.yaml
@@ -21,6 +21,13 @@ cases:
       - P-BASE-DIALOG-OPEN-CHANGE
       - P-BASE-DIALOG-CONTROLLED-OWNER
     expectation: controlled-dialog-emits-open-change-and-retains-owner-open
+  - id: T-BASE-DIALOG-0001-CASE-CONTROLLED-METHODS
+    title: Controlled Root methods enter the request channel without replacing the owner fact
+    covers:
+      - P-BASE-DIALOG-OPEN-EXPOSE
+      - P-BASE-DIALOG-OPEN-CHANGE
+      - P-BASE-DIALOG-CONTROLLED-OWNER
+    expectation: controlled-dialog-methods-request-open-without-mutating-owner-fact
   - id: T-BASE-DIALOG-0001-CASE-AUTHORING-INDEPENDENCE
     title: Direct and authored entries share the Dialog protocol without consuming Base Button
     covers:
@@ -36,6 +43,7 @@ implementations:
     consumesCases:
       - T-BASE-DIALOG-0001-CASE-ROOT-OWNERSHIP
       - T-BASE-DIALOG-0001-CASE-CONTROLLED-REQUESTS
+      - T-BASE-DIALOG-0001-CASE-CONTROLLED-METHODS
       - T-BASE-DIALOG-0001-CASE-AUTHORING-INDEPENDENCE
     exercises: [P-BASE-DIALOG]
   - id: prototypes-shadcn-dialog-root-contract
@@ -55,9 +63,10 @@ verifies:
         - P-BASE-DIALOG-PROTOCOL-INDEPENDENCE
 exercises: { prototypes: [P-BASE-DIALOG] }
 revisions:
-  - {
-      version: 0.2.0,
-      change: introduced,
-      summary: Added Base Dialog root and compound protocol coverage.,
-    }
+  - version: 0.2.0
+    change: introduced
+    summary: Added Base Dialog root and compound protocol coverage.
+  - version: 0.2.1
+    change: refined
+    summary: Added controlled Root method request coverage.
 tags: [prototype, base, dialog, test]

--- a/spec/tests/T-BASE-DIALOG-CLOSE-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-CLOSE-0001.yaml
@@ -1,0 +1,42 @@
+id: T-BASE-DIALOG-CLOSE-0001
+type: test
+title: Base Dialog Close protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers Close command ownership, disabled gating, focus reason, controlled requests, and authoring parity.
+cases:
+  - id: T-BASE-DIALOG-CLOSE-0001-CASE-COMMAND
+    title: Close requests dismissal through Dialog-owned command capabilities
+    covers:
+      - P-BASE-DIALOG-CLOSE-AUTHORING-ENTRIES
+      - P-BASE-DIALOG-CLOSE-NO-BUTTON-DEPENDENCY
+      - P-BASE-DIALOG-CLOSE-COMMAND
+      - P-BASE-DIALOG-CLOSE-REQUEST
+      - P-BASE-DIALOG-CLOSE-DISABLED
+    expectation: dialog-close-requests-false-without-consuming-button
+implementations:
+  - id: prototypes-base-dialog-close-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/dialog.test.ts
+    required: true
+    consumesCases: [T-BASE-DIALOG-CLOSE-0001-CASE-COMMAND]
+    exercises: [P-BASE-DIALOG-CLOSE]
+  - id: prototypes-shadcn-dialog-close-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/shadcn/test/dialog.test.ts
+    required: true
+    consumesCases: [T-BASE-DIALOG-CLOSE-0001-CASE-COMMAND]
+    exercises: [P-BASE-DIALOG-CLOSE]
+verifies:
+  prototypes:
+    - id: P-BASE-DIALOG-CLOSE
+      anchors:
+        - P-BASE-DIALOG-CLOSE-NO-BUTTON-DEPENDENCY
+        - P-BASE-DIALOG-CLOSE-REQUEST
+        - P-BASE-DIALOG-CLOSE-DISABLED
+exercises: { prototypes: [P-BASE-DIALOG-CLOSE] }
+revisions:
+  - { version: 0.2.0, change: introduced, summary: Added Dialog Close protocol coverage. }
+tags: [prototype, base, dialog, close, test]

--- a/spec/tests/T-BASE-DIALOG-CONTENT-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-CONTENT-0001.yaml
@@ -26,7 +26,9 @@ implementations:
     status: passing
     path: packages/prototypes/base/test/dialog.test.ts
     required: true
-    consumesCases: [T-BASE-DIALOG-CONTENT-0001-CASE-SURFACE]
+    consumesCases:
+      - T-BASE-DIALOG-CONTENT-0001-CASE-SURFACE
+      - T-BASE-DIALOG-CONTENT-0001-CASE-A11Y
     exercises: [P-BASE-DIALOG-CONTENT]
   - id: adapter-web-component-dialog-content-contract
     kind: adapter-test
@@ -47,4 +49,7 @@ verifies:
 exercises: { prototypes: [P-BASE-DIALOG-CONTENT] }
 revisions:
   - { version: 0.2.0, change: introduced, summary: Added Dialog Content protocol coverage. }
+  - version: 0.2.1
+    change: refined
+    summary: Added live add/remove coverage for conditional Title and Description relationships and a11yLabel fallback.
 tags: [prototype, base, dialog, content, test]

--- a/spec/tests/T-BASE-DIALOG-CONTENT-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-CONTENT-0001.yaml
@@ -1,0 +1,50 @@
+id: T-BASE-DIALOG-CONTENT-0001
+type: test
+title: Base Dialog Content protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers Content transition presence, focus containment, dismissal requests, controlled ownership, and accessible modal semantics.
+cases:
+  - id: T-BASE-DIALOG-CONTENT-0001-CASE-SURFACE
+    title: Content coordinates presence, focus, and dismissal through Root
+    covers:
+      - P-BASE-DIALOG-CONTENT-AUTHORING-ENTRIES
+      - P-BASE-DIALOG-CONTENT-PRESENCE
+      - P-BASE-DIALOG-CONTENT-FOCUS
+      - P-BASE-DIALOG-CONTENT-DISMISS
+      - P-BASE-DIALOG-CONTENT-CONTROLLED
+    expectation: dialog-content-contains-focus-and-requests-dismissal-through-root
+  - id: T-BASE-DIALOG-CONTENT-0001-CASE-A11Y
+    title: Content projects modal role and stable title and description relationships
+    covers:
+      - P-BASE-DIALOG-CONTENT-A11Y-ROLE
+      - P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
+    expectation: dialog-content-projects-role-modal-and-naming-relations
+implementations:
+  - id: prototypes-base-dialog-content-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/dialog.test.ts
+    required: true
+    consumesCases: [T-BASE-DIALOG-CONTENT-0001-CASE-SURFACE]
+    exercises: [P-BASE-DIALOG-CONTENT]
+  - id: adapter-web-component-dialog-content-contract
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/dialog-overlay.test.ts
+    required: true
+    consumesCases: [T-BASE-DIALOG-CONTENT-0001-CASE-A11Y]
+    exercises: [P-BASE-DIALOG-CONTENT]
+verifies:
+  prototypes:
+    - id: P-BASE-DIALOG-CONTENT
+      anchors:
+        - P-BASE-DIALOG-CONTENT-PRESENCE
+        - P-BASE-DIALOG-CONTENT-DISMISS
+        - P-BASE-DIALOG-CONTENT-CONTROLLED
+        - P-BASE-DIALOG-CONTENT-A11Y-ROLE
+        - P-BASE-DIALOG-CONTENT-A11Y-RELATIONS
+exercises: { prototypes: [P-BASE-DIALOG-CONTENT] }
+revisions:
+  - { version: 0.2.0, change: introduced, summary: Added Dialog Content protocol coverage. }
+tags: [prototype, base, dialog, content, test]

--- a/spec/tests/T-BASE-DIALOG-DESCRIPTION-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-DESCRIPTION-0001.yaml
@@ -1,0 +1,37 @@
+id: T-BASE-DIALOG-DESCRIPTION-0001
+type: test
+title: Base Dialog Description protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers Description authoring parity, stable descriptive identity, and alert-dialog primary-message requirements.
+cases:
+  - id: T-BASE-DIALOG-DESCRIPTION-0001-CASE-RELATION
+    title: Description supplies the stable Content description relationship
+    covers:
+      - P-BASE-DIALOG-DESCRIPTION-AUTHORING-ENTRIES
+      - P-BASE-DIALOG-DESCRIPTION-RELATION
+    expectation: dialog-description-provides-stable-content-description
+  - id: T-BASE-DIALOG-DESCRIPTION-0001-CASE-ALERT
+    title: Alert Dialog includes its primary message as Description
+    covers: [P-BASE-DIALOG-DESCRIPTION-ALERT]
+    expectation: alert-dialog-description-carries-primary-message
+implementations:
+  - id: adapter-web-component-dialog-description-contract
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/dialog-overlay.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-DIALOG-DESCRIPTION-0001-CASE-RELATION
+      - T-BASE-DIALOG-DESCRIPTION-0001-CASE-ALERT
+    exercises: [P-BASE-DIALOG-DESCRIPTION]
+verifies:
+  prototypes:
+    - id: P-BASE-DIALOG-DESCRIPTION
+      anchors:
+        - P-BASE-DIALOG-DESCRIPTION-RELATION
+        - P-BASE-DIALOG-DESCRIPTION-ALERT
+exercises: { prototypes: [P-BASE-DIALOG-DESCRIPTION] }
+revisions:
+  - { version: 0.2.0, change: introduced, summary: Added Dialog Description protocol coverage. }
+tags: [prototype, base, dialog, description, test]

--- a/spec/tests/T-BASE-DIALOG-DESCRIPTION-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-DESCRIPTION-0001.yaml
@@ -16,6 +16,13 @@ cases:
     covers: [P-BASE-DIALOG-DESCRIPTION-ALERT]
     expectation: alert-dialog-description-carries-primary-message
 implementations:
+  - id: prototypes-base-dialog-description-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/dialog.test.ts
+    required: true
+    consumesCases: [T-BASE-DIALOG-DESCRIPTION-0001-CASE-ALERT]
+    exercises: [P-BASE-DIALOG-DESCRIPTION]
   - id: adapter-web-component-dialog-description-contract
     kind: adapter-test
     status: passing
@@ -23,7 +30,6 @@ implementations:
     required: true
     consumesCases:
       - T-BASE-DIALOG-DESCRIPTION-0001-CASE-RELATION
-      - T-BASE-DIALOG-DESCRIPTION-0001-CASE-ALERT
     exercises: [P-BASE-DIALOG-DESCRIPTION]
 verifies:
   prototypes:
@@ -34,4 +40,7 @@ verifies:
 exercises: { prototypes: [P-BASE-DIALOG-DESCRIPTION] }
 revisions:
   - { version: 0.2.0, change: introduced, summary: Added Dialog Description protocol coverage. }
+  - version: 0.2.1
+    change: refined
+    summary: Added runtime diagnostic coverage for Alert Dialog without Description.
 tags: [prototype, base, dialog, description, test]

--- a/spec/tests/T-BASE-DIALOG-MASK-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-MASK-0001.yaml
@@ -1,0 +1,41 @@
+id: T-BASE-DIALOG-MASK-0001
+type: test
+title: Base Dialog Mask protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers modal backdrop ownership, Transition-backed presence, passthrough, and the absence of independent dismissal policy.
+cases:
+  - id: T-BASE-DIALOG-MASK-0001-CASE-PRESENCE
+    title: Mask retains modal resources and its view through leave
+    covers:
+      - P-BASE-DIALOG-MASK-AUTHORING-ENTRIES
+      - P-BASE-DIALOG-MASK-MODAL
+      - P-BASE-DIALOG-MASK-PRESENCE
+    expectation: dialog-mask-releases-modal-resources-and-detaches-after-leave
+  - id: T-BASE-DIALOG-MASK-0001-CASE-PARTICIPATION
+    title: Mask passthrough changes hit participation without owning dismissal
+    covers:
+      - P-BASE-DIALOG-MASK-PASSTHROUGH
+      - P-BASE-DIALOG-MASK-NO-DISMISS
+    expectation: dialog-mask-passthrough-does-not-change-dialog-open
+implementations:
+  - id: prototypes-base-dialog-mask-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/dialog.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-DIALOG-MASK-0001-CASE-PRESENCE
+      - T-BASE-DIALOG-MASK-0001-CASE-PARTICIPATION
+    exercises: [P-BASE-DIALOG-MASK]
+verifies:
+  prototypes:
+    - id: P-BASE-DIALOG-MASK
+      anchors:
+        - P-BASE-DIALOG-MASK-PRESENCE
+        - P-BASE-DIALOG-MASK-PASSTHROUGH
+        - P-BASE-DIALOG-MASK-NO-DISMISS
+exercises: { prototypes: [P-BASE-DIALOG-MASK] }
+revisions:
+  - { version: 0.2.0, change: introduced, summary: Added Dialog Mask protocol coverage. }
+tags: [prototype, base, dialog, mask, test]

--- a/spec/tests/T-BASE-DIALOG-TITLE-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-TITLE-0001.yaml
@@ -1,0 +1,32 @@
+id: T-BASE-DIALOG-TITLE-0001
+type: test
+title: Base Dialog Title protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers Title authoring parity, stable labelling identity, and presentation-only ownership.
+cases:
+  - id: T-BASE-DIALOG-TITLE-0001-CASE-LABEL
+    title: Title labels Content without owning interaction behavior
+    covers:
+      - P-BASE-DIALOG-TITLE-AUTHORING-ENTRIES
+      - P-BASE-DIALOG-TITLE-LABEL
+      - P-BASE-DIALOG-TITLE-NO-BEHAVIOR
+    expectation: dialog-title-provides-stable-content-label-only
+implementations:
+  - id: adapter-web-component-dialog-title-contract
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/dialog-overlay.test.ts
+    required: true
+    consumesCases: [T-BASE-DIALOG-TITLE-0001-CASE-LABEL]
+    exercises: [P-BASE-DIALOG-TITLE]
+verifies:
+  prototypes:
+    - id: P-BASE-DIALOG-TITLE
+      anchors:
+        - P-BASE-DIALOG-TITLE-LABEL
+        - P-BASE-DIALOG-TITLE-NO-BEHAVIOR
+exercises: { prototypes: [P-BASE-DIALOG-TITLE] }
+revisions:
+  - { version: 0.2.0, change: introduced, summary: Added Dialog Title protocol coverage. }
+tags: [prototype, base, dialog, title, test]

--- a/spec/tests/T-BASE-DIALOG-TRIGGER-0001.yaml
+++ b/spec/tests/T-BASE-DIALOG-TRIGGER-0001.yaml
@@ -1,0 +1,46 @@
+id: T-BASE-DIALOG-TRIGGER-0001
+type: test
+title: Base Dialog Trigger protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers Trigger command ownership, request behavior, disabled gating, accessibility relationships, and authoring parity.
+cases:
+  - id: T-BASE-DIALOG-TRIGGER-0001-CASE-COMMAND
+    title: Trigger activates through Dialog-owned command capabilities
+    covers:
+      - P-BASE-DIALOG-TRIGGER-AUTHORING-ENTRIES
+      - P-BASE-DIALOG-TRIGGER-NO-BUTTON-DEPENDENCY
+      - P-BASE-DIALOG-TRIGGER-COMMAND
+      - P-BASE-DIALOG-TRIGGER-DISABLED
+      - P-BASE-DIALOG-TRIGGER-REQUEST
+    expectation: dialog-trigger-requests-open-without-consuming-button
+  - id: T-BASE-DIALOG-TRIGGER-0001-CASE-A11Y
+    title: Trigger projects popup state and the Content relationship
+    covers: [P-BASE-DIALOG-TRIGGER-A11Y]
+    expectation: dialog-trigger-projects-expanded-haspopup-and-controls
+implementations:
+  - id: prototypes-base-dialog-trigger-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/dialog.test.ts
+    required: true
+    consumesCases: [T-BASE-DIALOG-TRIGGER-0001-CASE-COMMAND]
+    exercises: [P-BASE-DIALOG-TRIGGER]
+  - id: adapter-web-component-dialog-trigger-contract
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/dialog-overlay.test.ts
+    required: true
+    consumesCases: [T-BASE-DIALOG-TRIGGER-0001-CASE-A11Y]
+    exercises: [P-BASE-DIALOG-TRIGGER]
+verifies:
+  prototypes:
+    - id: P-BASE-DIALOG-TRIGGER
+      anchors:
+        - P-BASE-DIALOG-TRIGGER-NO-BUTTON-DEPENDENCY
+        - P-BASE-DIALOG-TRIGGER-REQUEST
+        - P-BASE-DIALOG-TRIGGER-A11Y
+exercises: { prototypes: [P-BASE-DIALOG-TRIGGER] }
+revisions:
+  - { version: 0.2.0, change: introduced, summary: Added Dialog Trigger protocol coverage. }
+tags: [prototype, base, dialog, trigger, test]

--- a/spec/tests/T-BASE-TABS-TRIGGER-0001.yaml
+++ b/spec/tests/T-BASE-TABS-TRIGGER-0001.yaml
@@ -33,6 +33,11 @@ cases:
       - P-BASE-TABS-TRIGGER-DISABLED-SUPPRESS-ACTIVATION
       - P-BASE-TABS-TRIGGER-A11Y-DISABLED
     expectation: disabled-tabs-trigger-suppresses-selection
+  - id: T-BASE-TABS-TRIGGER-0001-CASE-KEYBOARD
+    title: focused Tabs Trigger suppresses the Space default action
+    covers:
+      - P-BASE-TABS-TRIGGER-KEYBOARD-ACTIVATION
+    expectation: focused-tabs-trigger-prevents-space-default-action
 implementations:
   - id: prototypes-base-tabs-trigger-contract
     kind: module-test
@@ -42,6 +47,7 @@ implementations:
     consumesCases:
       - T-BASE-TABS-TRIGGER-0001-CASE-SELECTION
       - T-BASE-TABS-TRIGGER-0001-CASE-DISABLED-GATING
+      - T-BASE-TABS-TRIGGER-0001-CASE-KEYBOARD
     exercises:
       - P-BASE-TABS-TRIGGER
 verifies:
@@ -50,6 +56,7 @@ verifies:
       anchors:
         - P-BASE-TABS-TRIGGER-NO-BUTTON-DEPENDENCY
         - P-BASE-TABS-TRIGGER-SELECTED-DERIVED
+        - P-BASE-TABS-TRIGGER-KEYBOARD-ACTIVATION
         - P-BASE-TABS-TRIGGER-A11Y-CONTROLS-TARGET
 exercises:
   prototypes:
@@ -58,6 +65,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Introduced Base Tabs Trigger protocol test entity aligned to P-BASE-TABS-TRIGGER criteria.
+  - version: 0.2.0
+    change: refined
+    summary: Added focused Space default-action coverage.
 tags:
   - prototype
   - base

--- a/spec/tests/T-BOUNDARY-0001.yaml
+++ b/spec/tests/T-BOUNDARY-0001.yaml
@@ -5,6 +5,11 @@ status: draft
 since: 0.1.0
 summary: Runtime tests for multi-region ternary classification, Event-transported observation, shared outside notification, weak stacking, Hit Participation independence, and lifecycle cleanup.
 cases:
+  - id: T-BOUNDARY-0001-CASE-NO-ARG-ONCE
+    title: repeated no-argument asBoundary calls reuse one configurable handle
+    covers:
+      - C-BOUNDARY-0001-G
+    expectation: no-argument-once-boundary-handle
   - id: T-BOUNDARY-0001-CASE-CLASSIFICATION
     title: disjoint regions preserve ternary classification
     covers:
@@ -42,6 +47,7 @@ implementations:
     path: packages/runtime/test/contract/boundary.v0.contract.test.ts
     required: true
     consumesCases:
+      - T-BOUNDARY-0001-CASE-NO-ARG-ONCE
       - T-BOUNDARY-0001-CASE-CLASSIFICATION
       - T-BOUNDARY-0001-CASE-OBSERVATION
       - T-BOUNDARY-0001-CASE-OUTSIDE
@@ -64,10 +70,14 @@ verifies:
         - C-BOUNDARY-0001-D
         - C-BOUNDARY-0001-E
         - C-BOUNDARY-0001-F
+        - C-BOUNDARY-0001-G
 revisions:
   - version: 0.1.0
     change: introduced
     summary: Added executable coverage for Boundary observation and classification ownership.
+  - version: 0.1.1
+    change: refined
+    summary: Added no-argument once-caller and returned configuration-handle coverage.
 tags:
   - boundary
   - event

--- a/spec/tests/T-FOCUS-ROVING-0001.yaml
+++ b/spec/tests/T-FOCUS-ROVING-0001.yaml
@@ -54,6 +54,11 @@ cases:
     covers:
       - C-AS-FOCUS-ROVING-0001-I
     expectation: roving-selected-and-active-status-drive-semantic-focus-requests
+  - id: T-FOCUS-ROVING-0001-CASE-MULTI-INSTANCE-ISOLATION
+    title: Shared global arrow events only move the roving instance that contains actual focus
+    covers:
+      - C-AS-FOCUS-ROVING-0001-J
+    expectation: unfocused-roving-instances-ignore-shared-global-key-events
 implementations:
   - id: runtime-focus-roving-contract
     kind: runtime-test
@@ -68,6 +73,7 @@ implementations:
       - T-FOCUS-ROVING-0001-CASE-NAV-PARTICIPATION
       - T-FOCUS-ROVING-0001-CASE-RUNTIME-STRATEGY
       - T-FOCUS-ROVING-0001-CASE-MEMBER-STATUS
+      - T-FOCUS-ROVING-0001-CASE-MULTI-INSTANCE-ISOLATION
   - id: prototypes-base-tabs-roving-tab-boundary
     kind: module-test
     status: passing
@@ -93,6 +99,7 @@ verifies:
         - C-AS-FOCUS-ROVING-0001-G
         - C-AS-FOCUS-ROVING-0001-H
         - C-AS-FOCUS-ROVING-0001-I
+        - C-AS-FOCUS-ROVING-0001-J
   decisions:
     - id: D-FOCUS-ROVING-NAVIGATION-OWNERSHIP-0001
       anchors:
@@ -124,6 +131,9 @@ revisions:
   - version: 0.1.5
     change: refined
     summary: Added semantic selected and active member status coverage.
+  - version: 0.1.6
+    change: refined
+    summary: Added multi-instance isolation coverage for shared global roving key events.
 tags:
   - focus
   - focus-roving

--- a/spec/tests/T-FOCUS-ROVING-0001.yaml
+++ b/spec/tests/T-FOCUS-ROVING-0001.yaml
@@ -49,6 +49,11 @@ cases:
     covers:
       - C-AS-FOCUS-ROVING-0001-H
     expectation: roving-runtime-strategy-updates-change-key-interpretation
+  - id: T-FOCUS-ROVING-0001-CASE-MEMBER-STATUS
+    title: focusSelected and unfocused movement consume semantic member status
+    covers:
+      - C-AS-FOCUS-ROVING-0001-I
+    expectation: roving-selected-and-active-status-drive-semantic-focus-requests
 implementations:
   - id: runtime-focus-roving-contract
     kind: runtime-test
@@ -62,6 +67,7 @@ implementations:
       - T-FOCUS-ROVING-0001-CASE-DEFAULT-ACTION-CONTROL
       - T-FOCUS-ROVING-0001-CASE-NAV-PARTICIPATION
       - T-FOCUS-ROVING-0001-CASE-RUNTIME-STRATEGY
+      - T-FOCUS-ROVING-0001-CASE-MEMBER-STATUS
   - id: prototypes-base-tabs-roving-tab-boundary
     kind: module-test
     status: passing
@@ -86,6 +92,7 @@ verifies:
         - C-AS-FOCUS-ROVING-0001-F
         - C-AS-FOCUS-ROVING-0001-G
         - C-AS-FOCUS-ROVING-0001-H
+        - C-AS-FOCUS-ROVING-0001-I
   decisions:
     - id: D-FOCUS-ROVING-NAVIGATION-OWNERSHIP-0001
       anchors:
@@ -114,6 +121,9 @@ revisions:
   - version: 0.1.4
     change: refined
     summary: Added coverage for runtime roving strategy updates after setup.
+  - version: 0.1.5
+    change: refined
+    summary: Added semantic selected and active member status coverage.
 tags:
   - focus
   - focus-roving


### PR DESCRIPTION
## Summary

- harden callback-phase lifecycle support used by Overlay and migrate privileged Boundary/Overlay hooks to their no-argument authoring model
- catalog the Base Dialog P entities and align Dialog commands, controlled open requests, nested asHook handles, accessibility semantics, and transition-backed presence with root ownership
- add live Anatomy part subscriptions, including role-scoped logical mount/unmount notifications that remain correct for portaled parts
- model semantic selected/active roving-member facts, remove the legacy Tabs focus helper, and connect Tabs code to its P-entity criteria
- condition Dialog Title/Description relationships on live membership, add the Root `a11yLabel` fallback, and diagnose Alert Dialogs without a Description
- isolate roving keyboard handling so a shared global Arrow event is consumed only by the Tabs instance that actually contains focus

## Why

The Proto UI 0.2 component prototype work moved quickly across lifecycle, asHook, Tabs, Overlay, and Dialog behavior. Several implementation details had outpaced their contracts and P-entity mappings.

The final Tabs regression exposed a concrete isolation issue: every demo has an active roving member, and the keyboard gate incorrectly treated that semantic active fact as proof that the instance contained focus. A single global Arrow event was therefore consumed by every demo, with the final handler moving focus into the React preview. The keyboard path now requires an actually focused member while imperative next/previous requests retain the active-member fallback.

## Impact

- lifecycle and hook ownership are documented and covered by runtime contracts
- Tabs instances remain isolated when multiple adapters share a page and global keyboard target
- Dialog accessibility relationships no longer point at missing optional parts
- portaled Dialog parts participate in live Anatomy membership observation
- controlled Dialog requests and root-owned state remain consistent across WC, React, and Vue adapters

## Validation

- `pnpm test`
  - 219 test files passed
  - 989 tests passed
  - 34 existing todo tests
- focused Focus/Tabs, Anatomy, Dialog, shadcn, React, Vue, Web Component, and spec-workspace contract suites
- workspace TypeScript check
