### PR TITLE
feat: add anchored overlay positioning

### DIFF
--- a/internal/contracts/overlay/as-overlay.v0.md
+++ b/internal/contracts/overlay/as-overlay.v0.md
@@ -270,21 +270,30 @@ Routine policies such as "restore to trigger on close" should not require manual
 
 ## 9. Placement
 
-`asOverlay()` may expose host-mediated placement configuration.
+`asOverlay()` exposes an opt-in anchored policy and delegates geometry to the Positioning module and its host capability. Overlay owns orchestration and lifetime, not measurement.
 
-v0 should only require a minimal anchored model, such as:
+The anchored model includes:
 
 - `placement`
 - `align`
 - `sideOffset`
 - `alignOffset`
+- `strategy: absolute | fixed`
+- `avoidCollisions`
+- `collisionBoundary: clippingAncestors | viewport`
+- `collisionPadding`
+
+The default collision boundary is the floating target's clipping ancestors and the root boundary is the visual viewport. Collision avoidance performs flip and shift. Resolved side and alignment are host projection facts and may differ from the authored request.
+
+An author-facing `AnatomyPartView` may be submitted as an anchor identity. Resolving that identity to a host target is an internal Anatomy-to-Overlay operation and must not reveal the raw target to prototype authors.
 
 The following are explicitly non-required in v0:
 
 - arrow middleware
-- collision avoidance guarantees
 - cursor-follow placement
 - top-layer guarantees
+- custom Element collision boundaries
+- sticky and hide-when-detached policy
 
 Adapters may provide stronger behavior, but the base contract should remain conservative.
 
@@ -310,13 +319,13 @@ The contract does not require a public arbitrary overlay-query API.
 
 ---
 
-## 11. No Portal Requirement in v0
+## 11. Portal Is Independent From Collision Detection
 
-`asOverlay()` must not require portal support in v0.
+Anchored positioning must not require Portal. Inline placement uses the floating target's real containing and clipping ancestors.
 
-Inline DOM placement is the default portable model.
+Portal is a separate opt-in capability used when a floating view must escape ancestor clipping or stacking context. Moving to a Portal changes host geometry and therefore the effective clipping ancestors; it does not change logical ownership.
 
-If a host later supports portal/teleport-like mounting, that capability should be defined at the adapter/runtime level rather than as a private overlay trick.
+Portal capability is defined at the adapter/runtime level rather than as a private positioning trick.
 
 For renderer-owned hosts, portal projection must remain renderer-owned. React adapters must use `createPortal`, Vue adapters must use an equivalent renderer primitive when available, and an Overlay host bridge must not imperatively reparent a node that the renderer still owns. Logical parent links remain adapter metadata and do not authorize DOM mutation behind the renderer.
 
@@ -337,10 +346,14 @@ type OverlayHandle = {
   toggle(reason?: string): void;
 
   configure(patch: OverlayConfigPatch): void;
+  updatePosition(patch: OverlayPositionPatch): void;
 
   registerContent(target: unknown): void;
   registerAnchor(target: unknown): void;
+  registerAnchorPart(part: AnatomyPartView): void;
   registerTrigger(target: unknown): void;
+
+  getPositionSnapshot(): AnchoredPositionSnapshot | null;
 };
 ```
 
@@ -348,7 +361,9 @@ Notes:
 
 - naming may later be normalized to `open/close/toggle`
 - `configure(...)` must be setup-only
+- `updatePosition(...)` updates only runtime geometry policy and does not redefine dismiss, focus, modal, or Portal policy
 - registration targets are adapter-facing and need not be public author primitives
+- `registerAnchorPart(...)` preserves the author-facing Anatomy target-safety boundary
 
 ---
 

--- a/packages/adapters/react/package.json
+++ b/packages/adapters/react/package.json
@@ -21,6 +21,7 @@
     "@proto.ui/module-focus": "workspace:*",
     "@proto.ui/module-hit-participation": "workspace:*",
     "@proto.ui/module-overlay": "workspace:*",
+    "@proto.ui/module-positioning": "workspace:*",
     "@proto.ui/module-props": "workspace:*",
     "@proto.ui/module-rule-expose-state-web": "workspace:*",
     "@proto.ui/module-rule-meta": "workspace:*"

--- a/packages/adapters/react/src/runtime/modules.ts
+++ b/packages/adapters/react/src/runtime/modules.ts
@@ -54,6 +54,10 @@ import {
   type OverlayGlobalMount,
   type OverlayLayerScheduler,
 } from '@proto.ui/module-overlay';
+import {
+  ANCHORED_POSITION_HOST_CAP,
+  createFloatingUiAnchoredPositionHost,
+} from '@proto.ui/module-positioning';
 import { RAW_PROPS_SOURCE_CAP } from '@proto.ui/module-props';
 import { RULE_EXPOSE_STATE_WEB_NATIVE_VARIANT_POLICY_CAP } from '@proto.ui/module-rule-expose-state-web';
 import { RULE_META_GET_CAP } from '@proto.ui/module-rule-meta';
@@ -259,6 +263,7 @@ export function createReactModules<Props extends PropsBaseType>(args: {
       [HOST_ELEMENT_CAP, el],
       [BOUNDARY_HOST_BRIDGE_CAP, createWebBoundaryHostBridge()],
     ])
+    .use('positioning', [[ANCHORED_POSITION_HOST_CAP, createFloatingUiAnchoredPositionHost()]])
     .use('overlay', () => [
       [HOST_ELEMENT_CAP, el],
       [OVERLAY_GLOBAL_MOUNT_CAP, createReactOverlayGlobalMount(instanceToken)],

--- a/packages/adapters/vue/package.json
+++ b/packages/adapters/vue/package.json
@@ -21,6 +21,7 @@
     "@proto.ui/module-focus": "workspace:*",
     "@proto.ui/module-hit-participation": "workspace:*",
     "@proto.ui/module-overlay": "workspace:*",
+    "@proto.ui/module-positioning": "workspace:*",
     "@proto.ui/module-props": "workspace:*",
     "@proto.ui/module-rule-expose-state-web": "workspace:*",
     "@proto.ui/module-rule-meta": "workspace:*"

--- a/packages/adapters/vue/src/runtime/modules.ts
+++ b/packages/adapters/vue/src/runtime/modules.ts
@@ -46,6 +46,10 @@ import {
   type OverlayGlobalMount,
   type OverlayLayerScheduler,
 } from '@proto.ui/module-overlay';
+import {
+  ANCHORED_POSITION_HOST_CAP,
+  createFloatingUiAnchoredPositionHost,
+} from '@proto.ui/module-positioning';
 import { RAW_PROPS_SOURCE_CAP, type RawPropsSource } from '@proto.ui/module-props';
 import {
   createExposeStateWebNameMap,
@@ -259,6 +263,7 @@ export function createVueModules<Props extends PropsBaseType>(args: {
       [HOST_ELEMENT_CAP, el],
       [BOUNDARY_HOST_BRIDGE_CAP, createWebBoundaryHostBridge()],
     ])
+    .use('positioning', [[ANCHORED_POSITION_HOST_CAP, createFloatingUiAnchoredPositionHost()]])
     .use('overlay', () => [
       [HOST_ELEMENT_CAP, el],
       [OVERLAY_GLOBAL_MOUNT_CAP, createVueOverlayGlobalMount(instanceToken)],

--- a/packages/adapters/web-component/package.json
+++ b/packages/adapters/web-component/package.json
@@ -22,6 +22,7 @@
     "@proto.ui/module-focus": "workspace:*",
     "@proto.ui/module-hit-participation": "workspace:*",
     "@proto.ui/module-overlay": "workspace:*",
+    "@proto.ui/module-positioning": "workspace:*",
     "@proto.ui/module-rule-expose-state-web": "workspace:*",
     "@proto.ui/module-rule-meta": "workspace:*",
     "@proto.ui/module-test-sys": "workspace:*"

--- a/packages/adapters/web-component/src/runtime/modules.ts
+++ b/packages/adapters/web-component/src/runtime/modules.ts
@@ -53,6 +53,10 @@ import {
   OVERLAY_MODAL_CAP,
   type OverlayLayerScheduler,
 } from '@proto.ui/module-overlay';
+import {
+  ANCHORED_POSITION_HOST_CAP,
+  createFloatingUiAnchoredPositionHost,
+} from '@proto.ui/module-positioning';
 import { type RawPropsSource, RAW_PROPS_SOURCE_CAP } from '@proto.ui/module-props';
 import { RULE_EXPOSE_STATE_WEB_NATIVE_VARIANT_POLICY_CAP } from '@proto.ui/module-rule-expose-state-web';
 import { RULE_META_GET_CAP } from '@proto.ui/module-rule-meta';
@@ -300,6 +304,7 @@ export function createWebComponentModules<Props extends PropsBaseType>(args: {
       [HOST_ELEMENT_CAP, el],
       [BOUNDARY_HOST_BRIDGE_CAP, createWebBoundaryHostBridge()],
     ])
+    .use('positioning', [[ANCHORED_POSITION_HOST_CAP, createFloatingUiAnchoredPositionHost()]])
     .use('overlay', () => [
       [HOST_ELEMENT_CAP, el],
       [

--- a/packages/cli/src/legacy/type.ts
+++ b/packages/cli/src/legacy/type.ts
@@ -232,6 +232,7 @@ export const SHADCN_STYLE_TOKENS = [
   'tracking-tight',
   'transition-all',
   'transition-colors',
+  'transition-none',
   'translate-x-0',
   'translate-y-0',
   'translate-y-px',

--- a/packages/cli/src/services/proto-style-css.ts
+++ b/packages/cli/src/services/proto-style-css.ts
@@ -91,6 +91,7 @@ const staticUtilities: Record<string, string[]> = {
   'slide-in-from-right-2': ['--pui-translate-x: 0.5rem;'],
   'slide-in-from-top-2': ['--pui-translate-y: -0.5rem;'],
   'transition-all': ['transition-property: all;'],
+  'transition-none': ['transition-property: none;'],
   'transition-colors': [
     'transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;',
   ],

--- a/packages/cli/test/proto-style-css.test.ts
+++ b/packages/cli/test/proto-style-css.test.ts
@@ -21,6 +21,7 @@ describe('proto style css renderer', () => {
       'animate-out',
       'fade-out-0',
       'zoom-out-95',
+      'transition-none',
       'duration-200',
     ]);
 
@@ -40,6 +41,7 @@ describe('proto style css renderer', () => {
     );
     expect(css).not.toContain('scale: var(--pui-enter-scale');
     expect(css).toContain('--pui-animation-duration: 200ms;');
+    expect(css).toContain('transition-property: none;');
     expect(css).not.toContain('Unsupported Proto UI style tokens');
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export * from './focus';
 export * from './boundary';
 export * from './hit-participation';
 export * from './overlay';
+export * from './positioning';
 export * from './collection';
 export * from './delay';
 

--- a/packages/core/src/overlay.ts
+++ b/packages/core/src/overlay.ts
@@ -1,5 +1,11 @@
 import type { PropsBaseType } from '@proto.ui/types';
+import type { AnatomyPartView } from './anatomy';
 import type { ObservedStateHandle } from './state';
+import type {
+  AnchoredCollisionBoundary,
+  AnchoredPositionSnapshot,
+  AnchoredPositionStrategy,
+} from './positioning';
 
 export type OverlayPlacement = 'top' | 'right' | 'bottom' | 'left';
 export type OverlayAlign = 'start' | 'center' | 'end';
@@ -31,6 +37,11 @@ export type OverlayConfigPatch = Readonly<{
   align?: OverlayAlign;
   sideOffset?: number;
   alignOffset?: number;
+  anchored?: boolean;
+  strategy?: AnchoredPositionStrategy;
+  avoidCollisions?: boolean;
+  collisionBoundary?: AnchoredCollisionBoundary;
+  collisionPadding?: number;
   entry?: OverlayFocusEntry;
   restore?: OverlayFocusRestore;
   portal?: boolean;
@@ -51,6 +62,11 @@ export type OverlayConfig = Readonly<{
   align: OverlayAlign;
   sideOffset: number;
   alignOffset: number;
+  anchored: boolean;
+  strategy: AnchoredPositionStrategy;
+  avoidCollisions: boolean;
+  collisionBoundary: AnchoredCollisionBoundary;
+  collisionPadding: number;
   entry: OverlayFocusEntry;
   restore: OverlayFocusRestore;
   portal: boolean;
@@ -59,6 +75,20 @@ export type OverlayConfig = Readonly<{
   layerOffset: number;
   meta?: Readonly<Record<string, unknown>>;
 }>;
+
+export type OverlayPositionPatch = Readonly<
+  Pick<
+    OverlayConfigPatch,
+    | 'placement'
+    | 'align'
+    | 'sideOffset'
+    | 'alignOffset'
+    | 'strategy'
+    | 'avoidCollisions'
+    | 'collisionBoundary'
+    | 'collisionPadding'
+  >
+>;
 
 export type OverlayRegistration = Readonly<{
   trigger: unknown | null;
@@ -86,10 +116,13 @@ export interface OverlayModuleHandle<P extends PropsBaseType = PropsBaseType> {
   toggle(reason?: OverlayReason): void;
 
   configure(patch: OverlayConfigPatch): void;
+  updatePosition(patch: OverlayPositionPatch): void;
 
   registerTrigger(target: unknown): void;
   registerAnchor(target: unknown): void;
+  registerAnchorPart(part: AnatomyPartView): void;
   registerContent(target: unknown): void;
+  getPositionSnapshot(): AnchoredPositionSnapshot | null;
 }
 
 export interface OverlayHandle<

--- a/packages/core/src/positioning.ts
+++ b/packages/core/src/positioning.ts
@@ -1,0 +1,36 @@
+export type AnchoredPositionSide = 'top' | 'right' | 'bottom' | 'left';
+export type AnchoredPositionAlign = 'start' | 'center' | 'end';
+export type AnchoredPositionStrategy = 'absolute' | 'fixed';
+export type AnchoredCollisionBoundary = 'clippingAncestors' | 'viewport';
+
+export type AnchoredPositionConfig = Readonly<{
+  side: AnchoredPositionSide;
+  align: AnchoredPositionAlign;
+  sideOffset: number;
+  alignOffset: number;
+  strategy: AnchoredPositionStrategy;
+  avoidCollisions: boolean;
+  collisionBoundary: AnchoredCollisionBoundary;
+  collisionPadding: number;
+}>;
+
+export type AnchoredPositionSnapshot = Readonly<{
+  side: AnchoredPositionSide;
+  align: AnchoredPositionAlign;
+  strategy: AnchoredPositionStrategy;
+}>;
+
+export type AnchoredPositionConnection = Readonly<{
+  anchor: unknown;
+  floating: unknown;
+  config: AnchoredPositionConfig;
+  onResolved?(snapshot: AnchoredPositionSnapshot): void;
+}>;
+
+export interface AnchoredPositionHandle {
+  connect(connection: AnchoredPositionConnection): void;
+  update(config: AnchoredPositionConfig): void;
+  requestUpdate(): void;
+  disconnect(): void;
+  getSnapshot(): AnchoredPositionSnapshot | null;
+}

--- a/packages/hooks/src/as-overlay.ts
+++ b/packages/hooks/src/as-overlay.ts
@@ -88,9 +88,12 @@ const installOverlay = definePrivilegedAsHook<PropsBaseType, OverlayHandle<Props
       close: (reason) => raw.close(reason),
       toggle: (reason) => raw.toggle(reason),
       configure: (patch) => raw.configure(patch),
+      updatePosition: (patch) => raw.updatePosition(patch),
       registerTrigger: (target) => raw.registerTrigger(target),
       registerAnchor: (target) => raw.registerAnchor(target),
+      registerAnchorPart: (part) => raw.registerAnchorPart(part),
       registerContent: (target) => raw.registerContent(target),
+      getPositionSnapshot: () => raw.getPositionSnapshot(),
       keepMounted() {
         rt.ensureSetup('overlay.keepMounted');
         if (presenceBinding) {

--- a/packages/modules/anatomy/src/impl.ts
+++ b/packages/modules/anatomy/src/impl.ts
@@ -65,6 +65,8 @@ type ClaimRecord = {
   getRootTarget: AnatomyRootTargetGetter;
 };
 
+const CLAIM_BY_PART_VIEW = new WeakMap<AnatomyPartView, ClaimRecord>();
+
 const ORDER_FOLLOWING = typeof Node !== 'undefined' ? Node.DOCUMENT_POSITION_FOLLOWING : 4;
 const ORDER_PRECEDING = typeof Node !== 'undefined' ? Node.DOCUMENT_POSITION_PRECEDING : 2;
 
@@ -446,6 +448,10 @@ export class AnatomyModuleImpl extends ModuleBase {
         out.push(...this.computeDiagnostics(family));
       }
       return out;
+    },
+    resolvePartTarget: (part: AnatomyPartView): unknown | null => {
+      const claim = CLAIM_BY_PART_VIEW.get(part);
+      return claim?.getRootTarget(claim.instance) ?? null;
     },
     parts: (family: AnatomyFamily, options?: AnatomyQueryOptions) => {
       if (options?.missing === 'null') return this.tryParts(family);
@@ -984,13 +990,15 @@ export class AnatomyModuleImpl extends ModuleBase {
   }
 
   private toPartView(claim: ClaimRecord): AnatomyPartView {
-    return {
+    const part: AnatomyPartView = {
       role: claim.role,
       hasExpose: (key: string) => claim.exposePort.has(key),
       getExpose: (key: string) =>
         claim.exposePort.has(key) ? (claim.exposePort.get(key) ?? null) : null,
       hasHook: (name: string) => getHookNames(claim.prototype).has(name),
     };
+    CLAIM_BY_PART_VIEW.set(part, claim);
+    return part;
   }
 
   private ensureSetup(op: string) {

--- a/packages/modules/anatomy/src/types.ts
+++ b/packages/modules/anatomy/src/types.ts
@@ -38,6 +38,8 @@ export type AnatomyFacade = {
 
 export type AnatomyPort = ModulePort & {
   getDiagnostics(): readonly AnatomyDiagnostic[];
+  /** Module-internal bridge. Never expose the returned host target to prototype authors. */
+  resolvePartTarget(part: AnatomyPartView): unknown | null;
   parts: AnatomyQueryOrderView['parts'];
   order: AnatomyQueryOrderView;
   setOrderCallbackDispatcher(dispatch: AnatomyOrderCallbackDispatcher): void;

--- a/packages/modules/overlay/src/create.ts
+++ b/packages/modules/overlay/src/create.ts
@@ -6,6 +6,8 @@ import { OverlayModuleImpl } from './impl';
 import type { BoundaryFacade } from '@proto.ui/module-boundary';
 import type { BoundaryPort } from '@proto.ui/module-boundary';
 import type { EventPort } from '@proto.ui/module-event';
+import type { AnatomyPort } from '@proto.ui/module-anatomy';
+import type { PositioningFacade } from '@proto.ui/module-positioning';
 
 export function createOverlayModule(ctx: ModuleFactoryArgs): OverlayModule {
   const { init, caps, deps } = ctx;
@@ -23,7 +25,9 @@ export function createOverlayModule(ctx: ModuleFactoryArgs): OverlayModule {
         init.prototypeName,
         boundaryFacade.getBoundary(),
         deps.requirePort<BoundaryPort>('boundary'),
-        deps.requirePort<EventPort>('event')
+        deps.requirePort<EventPort>('event'),
+        deps.requirePort<AnatomyPort>('anatomy'),
+        deps.requireFacade<PositioningFacade>('positioning').getAnchoredPosition()
       );
 
       return {
@@ -44,9 +48,12 @@ export function createOverlayModule(ctx: ModuleFactoryArgs): OverlayModule {
           getWarnings: () => impl.getWarnings(),
           getLastReason: () => impl.getLastReason(),
           getRegistration: () => impl.getRegistration(),
+          getPositionSnapshot: () => impl.getPositionSnapshot(),
           registerTrigger: (target) => impl.registerTrigger(target),
           registerAnchor: (target) => impl.registerAnchor(target),
+          registerAnchorPart: (part) => impl.registerAnchorPart(part),
           registerContent: (target) => impl.registerContent(target),
+          updatePosition: (patch) => impl.updatePosition(patch),
           setViewActive: (active) => impl.setViewActive(active),
           reconcileViewResourcesAfterCallback: () => impl.reconcileViewResourcesAfterCallback(),
         },
@@ -58,6 +65,6 @@ export function createOverlayModule(ctx: ModuleFactoryArgs): OverlayModule {
 export const OverlayModuleDef = defineModule({
   name: 'overlay',
   resourceOwnership: 'mixed',
-  deps: ['boundary', 'event'],
+  deps: ['boundary', 'event', 'anatomy', 'positioning'],
   create: createOverlayModule,
 });

--- a/packages/modules/overlay/src/impl.ts
+++ b/packages/modules/overlay/src/impl.ts
@@ -4,17 +4,22 @@ import type {
   ObservedStateHandle,
   OverlayConfig,
   OverlayConfigPatch,
+  OverlayPositionPatch,
   OverlayModuleHandle,
   MountPhase,
   ProtoPhase,
   OverlayReason,
   OverlayRegistration,
+  AnchoredPositionHandle,
+  AnchoredPositionSnapshot,
+  AnatomyPartView,
 } from '@proto.ui/core';
 import { illegalPhase } from '@proto.ui/core';
 import { ModuleBase } from '@proto.ui/module-base';
 import type { EventPort } from '@proto.ui/module-event';
 import type { BoundaryPort } from '@proto.ui/module-boundary';
 import type { StateEvent } from '@proto.ui/types';
+import type { AnatomyPort } from '@proto.ui/module-anatomy';
 import { HOST_ELEMENT_CAP } from '@proto.ui/core';
 import {
   OVERLAY_GLOBAL_MOUNT_CAP,
@@ -36,6 +41,11 @@ const DEFAULT_CONFIG: OverlayConfig = Object.freeze({
   align: 'start',
   sideOffset: 4,
   alignOffset: 0,
+  anchored: false,
+  strategy: 'absolute',
+  avoidCollisions: true,
+  collisionBoundary: 'clippingAncestors',
+  collisionPadding: 0,
   entry: 'content',
   restore: 'trigger',
   portal: false,
@@ -44,11 +54,11 @@ const DEFAULT_CONFIG: OverlayConfig = Object.freeze({
   layerOffset: 0,
 });
 
-function createObservedBoolHandle(initialValue = false) {
+function createObservedHandle<T>(initialValue: T) {
   let value = initialValue;
-  const watchers = new Set<(run: any, e: StateEvent<boolean>) => void>();
+  const watchers = new Set<(run: any, e: StateEvent<T>) => void>();
 
-  const handle: ObservedStateHandle<boolean, any> = {
+  const handle: ObservedStateHandle<T, any> = {
     get: () => value,
     watch: (cb) => {
       watchers.add(cb as any);
@@ -60,11 +70,11 @@ function createObservedBoolHandle(initialValue = false) {
 
   return {
     handle: Object.freeze(handle),
-    set(next: boolean, reason?: unknown) {
+    set(next: T, reason?: unknown) {
       if (Object.is(next, value)) return;
       const prev = value;
       value = next;
-      const event: StateEvent<boolean> = { type: 'next', next, prev, reason };
+      const event: StateEvent<T> = { type: 'next', next, prev, reason };
       for (const watcher of watchers) {
         watcher(undefined as any, event);
       }
@@ -101,12 +111,13 @@ export class OverlayModuleImpl extends ModuleBase {
     content: null,
   });
 
-  private readonly openState = createObservedBoolHandle(false);
+  private readonly openState = createObservedHandle(false);
   private viewActive = false;
   private globalMount: OverlayGlobalMount | null = null;
   private modalLock: OverlayModal | null = null;
   private layerScheduler: OverlayLayerScheduler | null = null;
   private mountedHost: HTMLElement | null = null;
+  private anchorPart: AnatomyPartView | null = null;
   private layerDetach: (() => void) | null = null;
   private layerHost: HTMLElement | null = null;
   private modalLocked = false;
@@ -126,7 +137,9 @@ export class OverlayModuleImpl extends ModuleBase {
     prototypeName: string,
     boundary: BoundaryHandle<any>,
     private readonly boundaryPort: BoundaryPort,
-    private readonly eventPort: EventPort
+    private readonly eventPort: EventPort,
+    private readonly anatomyPort: AnatomyPort,
+    private readonly anchoredPosition: AnchoredPositionHandle
   ) {
     super(caps);
     this.prototypeName = prototypeName;
@@ -272,15 +285,18 @@ export class OverlayModuleImpl extends ModuleBase {
       this.mountGlobalIfNeeded(hostEl);
       this.applyLayerIfNeeded(hostEl);
     }
+    this.syncAnchoredPosition();
     this.lockModalIfNeeded();
   }
 
   private deactivateViewSideEffects(): void {
+    this.anchoredPosition.disconnect();
     this.unlockModalIfNeeded();
   }
 
   private teardownMountedViewSideEffects(): void {
     this.clearLayer();
+    this.anchoredPosition.disconnect();
     this.unmountGlobalIfNeeded();
     this.unlockModalIfNeeded();
   }
@@ -392,6 +408,11 @@ export class OverlayModuleImpl extends ModuleBase {
     this.patchValue('align', patch.align);
     this.patchValue('sideOffset', patch.sideOffset);
     this.patchValue('alignOffset', patch.alignOffset);
+    this.patchValue('anchored', patch.anchored);
+    this.patchValue('strategy', patch.strategy);
+    this.patchValue('avoidCollisions', patch.avoidCollisions);
+    this.patchValue('collisionBoundary', patch.collisionBoundary);
+    this.patchValue('collisionPadding', patch.collisionPadding);
     this.patchValue('entry', patch.entry);
     this.patchValue('restore', patch.restore);
     this.patchValue('portal', patch.portal);
@@ -411,6 +432,22 @@ export class OverlayModuleImpl extends ModuleBase {
     if (this.config.defaultOpen) {
       this.setOpen(true, 'programmatic');
     }
+  }
+
+  updatePosition(patch: OverlayPositionPatch): void {
+    const assign = <K extends keyof OverlayConfig>(field: K, value: OverlayConfigPatch[K]) => {
+      if (typeof value === 'undefined') return;
+      this.config = Object.freeze({ ...this.config, [field]: value }) as OverlayConfig;
+    };
+    assign('placement', patch.placement);
+    assign('align', patch.align);
+    assign('sideOffset', patch.sideOffset);
+    assign('alignOffset', patch.alignOffset);
+    assign('strategy', patch.strategy);
+    assign('avoidCollisions', patch.avoidCollisions);
+    assign('collisionBoundary', patch.collisionBoundary);
+    assign('collisionPadding', patch.collisionPadding);
+    if (this.viewActive) this.syncAnchoredPosition();
   }
 
   open(reason?: OverlayReason): void {
@@ -445,12 +482,59 @@ export class OverlayModuleImpl extends ModuleBase {
     return this.registration;
   }
 
+  getPositionSnapshot(): AnchoredPositionSnapshot | null {
+    return this.anchoredPosition.getSnapshot();
+  }
+
+  private resolveAnchorTarget(): unknown | null {
+    if (this.anchorPart) {
+      const target = this.anatomyPort.resolvePartTarget(this.anchorPart);
+      if (target) return target;
+    }
+    return this.registration.anchor ?? this.registration.trigger;
+  }
+
+  private syncAnchoredPosition(): void {
+    if (!this.config.anchored || !this.viewActive || this.mountPhase !== 'mounted') {
+      this.anchoredPosition.disconnect();
+      return;
+    }
+    const anchor = this.resolveAnchorTarget();
+    const floating = this.registration.content ?? this.resolveHostElement();
+    if (!anchor || !floating) {
+      this.anchoredPosition.disconnect();
+      return;
+    }
+    this.anchoredPosition.connect({
+      anchor,
+      floating,
+      config: {
+        side: this.config.placement,
+        align: this.config.align,
+        sideOffset: this.config.sideOffset,
+        alignOffset: this.config.alignOffset,
+        strategy: this.config.strategy,
+        avoidCollisions: this.config.avoidCollisions,
+        collisionBoundary: this.config.collisionBoundary,
+        collisionPadding: this.config.collisionPadding,
+      },
+    });
+  }
+
   registerTrigger(target: unknown): void {
     this.replaceRegistration({ trigger: target });
+    if (this.viewActive) this.reconcileViewResourcesAfterCallback();
   }
 
   registerAnchor(target: unknown): void {
+    this.anchorPart = null;
     this.replaceRegistration({ anchor: target });
+    if (this.viewActive) this.reconcileViewResourcesAfterCallback();
+  }
+
+  registerAnchorPart(part: AnatomyPartView): void {
+    this.anchorPart = part;
+    if (this.viewActive) this.reconcileViewResourcesAfterCallback();
   }
 
   registerContent(target: unknown): void {
@@ -460,8 +544,7 @@ export class OverlayModuleImpl extends ModuleBase {
 
     const hostEl = this.resolveHostElement();
     if (!hostEl) return;
-    this.mountGlobalIfNeeded(hostEl);
-    this.applyLayerIfNeeded(hostEl);
+    this.reconcileViewResourcesAfterCallback();
   }
 
   readonly handle: OverlayModuleHandle<any> = {
@@ -471,8 +554,11 @@ export class OverlayModuleImpl extends ModuleBase {
     close: (reason?: OverlayReason) => this.close(reason),
     toggle: (reason?: OverlayReason) => this.toggle(reason),
     configure: (patch: OverlayConfigPatch) => this.configure(patch),
+    updatePosition: (patch: OverlayPositionPatch) => this.updatePosition(patch),
     registerTrigger: (target: unknown) => this.registerTrigger(target),
     registerAnchor: (target: unknown) => this.registerAnchor(target),
+    registerAnchorPart: (part: AnatomyPartView) => this.registerAnchorPart(part),
     registerContent: (target: unknown) => this.registerContent(target),
+    getPositionSnapshot: () => this.getPositionSnapshot(),
   };
 }

--- a/packages/modules/overlay/src/types.ts
+++ b/packages/modules/overlay/src/types.ts
@@ -3,6 +3,7 @@ import type {
   OverlayConfig,
   OverlayConfigPatch,
   OverlayModuleHandle,
+  OverlayPositionPatch,
   OverlayReason,
   OverlayRegistration,
 } from '@proto.ui/core';
@@ -29,9 +30,12 @@ export type OverlayPort = {
   getWarnings(): readonly string[];
   getLastReason(): OverlayReason | undefined;
   getRegistration(): OverlayRegistration;
+  getPositionSnapshot(): import('@proto.ui/core').AnchoredPositionSnapshot | null;
   registerTrigger(target: unknown): void;
   registerAnchor(target: unknown): void;
+  registerAnchorPart(part: import('@proto.ui/core').AnatomyPartView): void;
   registerContent(target: unknown): void;
+  updatePosition(patch: OverlayPositionPatch): void;
   setViewActive(active: boolean): void;
   reconcileViewResourcesAfterCallback(): void;
 };

--- a/packages/modules/positioning/README.md
+++ b/packages/modules/positioning/README.md
@@ -1,0 +1,39 @@
+# @proto.ui/module-positioning
+
+Proto UI module that provides host-mediated anchored positioning for overlays.
+
+## Purpose
+
+Provides collision-aware placement policy and host leases so prototypes can position floating content relative to an anchor without owning browser geometry APIs.
+
+## Package Role
+
+Adapter-facing module package used by the Proto UI runtime and adapter layer.
+
+## Install
+
+```bash
+npm install @proto.ui/module-positioning@0.1.0
+```
+
+## Internal Structure
+
+- `src/caps.ts`
+- `src/create.ts`
+- `src/impl.ts`
+- `src/index.ts`
+- `src/types.ts`
+- `src/web/floating-ui-host.ts`
+
+## Related Internal Packages
+
+- `@proto.ui/core`
+- `@proto.ui/module-base`
+
+## Runtime Dependency
+
+- `@floating-ui/dom`
+
+## License
+
+MIT

--- a/packages/modules/positioning/package.json
+++ b/packages/modules/positioning/package.json
@@ -1,16 +1,12 @@
 {
-  "name": "@proto.ui/module-overlay",
+  "name": "@proto.ui/module-positioning",
   "version": "0.1.0",
   "private": false,
   "type": "module",
   "dependencies": {
+    "@floating-ui/dom": "^1.7.4",
     "@proto.ui/core": "workspace:*",
-    "@proto.ui/module-base": "workspace:*",
-    "@proto.ui/module-boundary": "workspace:*",
-    "@proto.ui/module-event": "workspace:*",
-    "@proto.ui/module-anatomy": "workspace:*",
-    "@proto.ui/module-positioning": "workspace:*",
-    "@proto.ui/types": "workspace:*"
+    "@proto.ui/module-base": "workspace:*"
   },
   "exports": {
     ".": {
@@ -18,13 +14,13 @@
       "default": "./src/index.ts"
     }
   },
-  "description": "Proto UI module that provides overlay capability for adapters.",
+  "description": "Proto UI module for host-mediated anchored positioning.",
   "license": "MIT",
-  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/overlay",
+  "homepage": "https://github.com/Proto-UI/Proto-UI/tree/main/packages/modules/positioning",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Proto-UI/Proto-UI.git",
-    "directory": "packages/modules/overlay"
+    "directory": "packages/modules/positioning"
   },
   "bugs": {
     "url": "https://github.com/Proto-UI/Proto-UI/issues"
@@ -37,6 +33,6 @@
     "proto",
     "ui",
     "module",
-    "overlay"
+    "positioning"
   ]
 }

--- a/packages/modules/positioning/src/caps.ts
+++ b/packages/modules/positioning/src/caps.ts
@@ -1,0 +1,15 @@
+import { cap, type AnchoredPositionConnection } from '@proto.ui/core';
+
+export interface AnchoredPositionHostLease {
+  update(connection: AnchoredPositionConnection): void;
+  requestUpdate(): void;
+  dispose(): void;
+}
+
+export interface AnchoredPositionHost {
+  attach(connection: AnchoredPositionConnection): AnchoredPositionHostLease;
+}
+
+export const ANCHORED_POSITION_HOST_CAP = cap<AnchoredPositionHost>(
+  '@proto.ui/positioning/anchoredHost'
+);

--- a/packages/modules/positioning/src/create.ts
+++ b/packages/modules/positioning/src/create.ts
@@ -1,0 +1,30 @@
+import { createModule, defineModule, type ModuleFactoryArgs } from '@proto.ui/module-base';
+import { PositioningModuleImpl } from './impl';
+import type { PositioningFacade, PositioningModule, PositioningPort } from './types';
+
+export function createPositioningModule(ctx: ModuleFactoryArgs): PositioningModule {
+  const { init, caps, deps } = ctx;
+  const impl = new PositioningModuleImpl(caps);
+
+  return createModule<'positioning', 'instance', PositioningFacade, PositioningPort>({
+    name: 'positioning',
+    scope: 'instance',
+    init,
+    caps,
+    deps,
+    build: () => ({
+      facade: { getAnchoredPosition: () => impl.handle },
+      port: { getAnchoredPosition: () => impl.handle },
+      hooks: {
+        onProtoPhase: (phase) => impl.onProtoPhase(phase),
+      },
+    }),
+  }) as PositioningModule;
+}
+
+export const PositioningModuleDef = defineModule({
+  name: 'positioning',
+  resourceOwnership: 'mixed',
+  deps: [],
+  create: createPositioningModule,
+});

--- a/packages/modules/positioning/src/impl.ts
+++ b/packages/modules/positioning/src/impl.ts
@@ -1,0 +1,90 @@
+import type {
+  AnchoredPositionConfig,
+  AnchoredPositionConnection,
+  AnchoredPositionHandle,
+  AnchoredPositionSnapshot,
+  CapsVaultView,
+  ProtoPhase,
+} from '@proto.ui/core';
+import { ModuleBase } from '@proto.ui/module-base';
+import {
+  ANCHORED_POSITION_HOST_CAP,
+  type AnchoredPositionHost,
+  type AnchoredPositionHostLease,
+} from './caps';
+
+export class PositioningModuleImpl extends ModuleBase {
+  private connection: AnchoredPositionConnection | null = null;
+  private lease: AnchoredPositionHostLease | null = null;
+  private snapshot: AnchoredPositionSnapshot | null = null;
+
+  protected override onCapsEpoch(): void {
+    if (!this.connection) return;
+    this.attach(this.connection);
+  }
+
+  override onProtoPhase(phase: ProtoPhase): void {
+    super.onProtoPhase(phase);
+    if (phase === 'unmounted') this.disconnect();
+  }
+
+  private getHost(): AnchoredPositionHost | null {
+    return this.caps.has(ANCHORED_POSITION_HOST_CAP)
+      ? this.caps.get(ANCHORED_POSITION_HOST_CAP)
+      : null;
+  }
+
+  private bridge(connection: AnchoredPositionConnection): AnchoredPositionConnection {
+    const authoredResolved = connection.onResolved;
+    return {
+      ...connection,
+      onResolved: (snapshot) => {
+        this.snapshot = Object.freeze({ ...snapshot });
+        authoredResolved?.(this.snapshot);
+      },
+    };
+  }
+
+  private attach(connection: AnchoredPositionConnection): void {
+    this.lease?.dispose();
+    this.lease = null;
+    const host = this.getHost();
+    if (!host) return;
+    this.lease = host.attach(this.bridge(connection));
+  }
+
+  readonly handle: AnchoredPositionHandle = {
+    connect: (connection) => {
+      const sameTargets =
+        this.connection &&
+        Object.is(this.connection.anchor, connection.anchor) &&
+        Object.is(this.connection.floating, connection.floating);
+      this.connection = connection;
+      if (sameTargets && this.lease) {
+        this.lease.update(this.bridge(connection));
+        return;
+      }
+      this.snapshot = null;
+      this.attach(connection);
+    },
+    update: (config: AnchoredPositionConfig) => {
+      if (!this.connection) return;
+      this.connection = { ...this.connection, config };
+      if (this.lease) {
+        this.lease.update(this.bridge(this.connection));
+        return;
+      }
+      this.attach(this.connection);
+    },
+    requestUpdate: () => this.lease?.requestUpdate(),
+    disconnect: () => this.disconnect(),
+    getSnapshot: () => this.snapshot,
+  };
+
+  disconnect(): void {
+    this.lease?.dispose();
+    this.lease = null;
+    this.connection = null;
+    this.snapshot = null;
+  }
+}

--- a/packages/modules/positioning/src/index.ts
+++ b/packages/modules/positioning/src/index.ts
@@ -1,0 +1,5 @@
+export { PositioningModuleDef } from './create';
+export { ANCHORED_POSITION_HOST_CAP } from './caps';
+export type { AnchoredPositionHost, AnchoredPositionHostLease } from './caps';
+export type { PositioningFacade, PositioningModule, PositioningPort } from './types';
+export { createFloatingUiAnchoredPositionHost } from './web/floating-ui-host';

--- a/packages/modules/positioning/src/types.ts
+++ b/packages/modules/positioning/src/types.ts
@@ -1,0 +1,15 @@
+import type { AnchoredPositionHandle, ModuleInstance } from '@proto.ui/core';
+
+export type PositioningFacade = {
+  getAnchoredPosition(): AnchoredPositionHandle;
+};
+
+export type PositioningPort = {
+  getAnchoredPosition(): AnchoredPositionHandle;
+};
+
+export type PositioningModule = ModuleInstance<PositioningFacade> & {
+  name: 'positioning';
+  scope: 'instance';
+  port: PositioningPort;
+};

--- a/packages/modules/positioning/src/web/floating-ui-host.ts
+++ b/packages/modules/positioning/src/web/floating-ui-host.ts
@@ -1,0 +1,121 @@
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  shift,
+  size,
+  type Middleware,
+  type Placement,
+} from '@floating-ui/dom';
+import type {
+  AnchoredPositionAlign,
+  AnchoredPositionConfig,
+  AnchoredPositionConnection,
+  AnchoredPositionSide,
+} from '@proto.ui/core';
+import type { AnchoredPositionHost, AnchoredPositionHostLease } from '../caps';
+
+function toPlacement(config: AnchoredPositionConfig): Placement {
+  return config.align === 'center' ? config.side : `${config.side}-${config.align}`;
+}
+
+function fromPlacement(placement: Placement): {
+  side: AnchoredPositionSide;
+  align: AnchoredPositionAlign;
+} {
+  const [side, align] = placement.split('-') as [AnchoredPositionSide, AnchoredPositionAlign?];
+  return { side, align: align ?? 'center' };
+}
+
+function isElement(value: unknown): value is HTMLElement {
+  return typeof HTMLElement !== 'undefined' && value instanceof HTMLElement;
+}
+
+function middlewareFor(config: AnchoredPositionConfig): Middleware[] {
+  const middleware: Middleware[] = [
+    offset({ mainAxis: config.sideOffset, crossAxis: config.alignOffset }),
+  ];
+  const boundary = config.collisionBoundary === 'viewport' ? [] : 'clippingAncestors';
+  if (config.avoidCollisions) {
+    middleware.push(
+      flip({ boundary, rootBoundary: 'viewport', padding: config.collisionPadding }),
+      shift({ boundary, rootBoundary: 'viewport', padding: config.collisionPadding })
+    );
+  }
+  middleware.push(
+    size({
+      boundary,
+      rootBoundary: 'viewport',
+      padding: config.collisionPadding,
+      apply({ availableWidth, availableHeight, rects, elements }) {
+        Object.assign(elements.floating.style, {
+          '--proto-ui-anchor-width': `${rects.reference.width}px`,
+          '--proto-ui-anchor-height': `${rects.reference.height}px`,
+          '--proto-ui-available-width': `${availableWidth}px`,
+          '--proto-ui-available-height': `${availableHeight}px`,
+        });
+      },
+    })
+  );
+  return middleware;
+}
+
+export function createFloatingUiAnchoredPositionHost(): AnchoredPositionHost {
+  return {
+    attach(initial): AnchoredPositionHostLease {
+      let connection = initial;
+      let disposed = false;
+      let cleanup: (() => void) | null = null;
+
+      const position = async () => {
+        const { anchor, floating, config } = connection;
+        if (disposed || !isElement(anchor) || !isElement(floating)) return;
+        const result = await computePosition(anchor, floating, {
+          placement: toPlacement(config),
+          strategy: config.strategy,
+          middleware: middlewareFor(config),
+        });
+        if (disposed) return;
+        Object.assign(floating.style, {
+          position: result.strategy,
+          left: `${result.x}px`,
+          top: `${result.y}px`,
+        });
+        const resolved = fromPlacement(result.placement);
+        floating.dataset.side = resolved.side;
+        floating.dataset.align = resolved.align;
+        connection.onResolved?.({ ...resolved, strategy: result.strategy });
+      };
+
+      const restart = () => {
+        cleanup?.();
+        cleanup = null;
+        const { anchor, floating } = connection;
+        if (!isElement(anchor) || !isElement(floating)) return;
+        cleanup = autoUpdate(anchor, floating, position, { animationFrame: false });
+      };
+
+      restart();
+
+      return {
+        update(next) {
+          const targetsChanged =
+            !Object.is(connection.anchor, next.anchor) ||
+            !Object.is(connection.floating, next.floating);
+          connection = next;
+          if (targetsChanged) restart();
+          else void position();
+        },
+        requestUpdate() {
+          void position();
+        },
+        dispose() {
+          disposed = true;
+          cleanup?.();
+          cleanup = null;
+        },
+      };
+    },
+  };
+}

--- a/packages/modules/positioning/test/floating-ui-host.test.ts
+++ b/packages/modules/positioning/test/floating-ui-host.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AnchoredPositionConfig } from '@proto.ui/core';
+import { createFloatingUiAnchoredPositionHost } from '../src';
+
+const rect = (x: number, y: number, width: number, height: number): DOMRect =>
+  ({
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+function setRect(element: HTMLElement, value: DOMRect): void {
+  element.getBoundingClientRect = () => value;
+  Object.defineProperties(element, {
+    offsetWidth: { configurable: true, value: value.width },
+    offsetHeight: { configurable: true, value: value.height },
+  });
+}
+
+const baseConfig: AnchoredPositionConfig = {
+  side: 'bottom',
+  align: 'start',
+  sideOffset: 4,
+  alignOffset: 0,
+  strategy: 'fixed',
+  avoidCollisions: false,
+  collisionBoundary: 'clippingAncestors',
+  collisionPadding: 0,
+};
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe('module-positioning: Floating UI host', () => {
+  it('applies side, alignment, offsets, categorical data, and non-transform coordinates', async () => {
+    const anchor = document.createElement('button');
+    const floating = document.createElement('div');
+    document.body.append(anchor, floating);
+    setRect(anchor, rect(100, 100, 50, 20));
+    setRect(floating, rect(0, 0, 40, 10));
+
+    const snapshots: unknown[] = [];
+    const lease = createFloatingUiAnchoredPositionHost().attach({
+      anchor,
+      floating,
+      config: baseConfig,
+      onResolved: (snapshot) => snapshots.push(snapshot),
+    });
+    await flush();
+
+    expect(floating.style.position).toBe('fixed');
+    expect(floating.style.left).toBe('100px');
+    expect(floating.style.top).toBe('124px');
+    expect(floating.style.transform).toBe('');
+    expect(floating.dataset).toMatchObject({ side: 'bottom', align: 'start' });
+    expect(snapshots.at(-1)).toEqual({ side: 'bottom', align: 'start', strategy: 'fixed' });
+
+    lease.update({
+      anchor,
+      floating,
+      config: { ...baseConfig, side: 'top', align: 'end', sideOffset: 8 },
+    });
+    await flush();
+    expect(floating.style.left).toBe('110px');
+    expect(floating.style.top).toBe('82px');
+    expect(floating.dataset).toMatchObject({ side: 'top', align: 'end' });
+    lease.dispose();
+  });
+
+  it('reports collision-resolved side and alignment against the viewport', async () => {
+    const anchor = document.createElement('button');
+    const floating = document.createElement('div');
+    document.body.append(anchor, floating);
+    setRect(anchor, rect(100, 760, 50, 8));
+    setRect(floating, rect(0, 0, 80, 40));
+
+    const lease = createFloatingUiAnchoredPositionHost().attach({
+      anchor,
+      floating,
+      config: { ...baseConfig, avoidCollisions: true, collisionPadding: 4 },
+    });
+    await flush();
+
+    expect(floating.dataset.side).toBe('top');
+    expect(floating.dataset.align).toBe('end');
+    lease.dispose();
+  });
+});

--- a/packages/prototypes/base/src/hover-card/content.ts
+++ b/packages/prototypes/base/src/hover-card/content.ts
@@ -39,8 +39,19 @@ function setupHoverCardContent(
       empty: 'fallback',
       options: ['start', 'center', 'end'],
     },
+    sideOffset: { type: 'number', empty: 'fallback' },
+    alignOffset: { type: 'number', empty: 'fallback' },
+    avoidCollisions: { type: 'boolean', empty: 'fallback' },
+    collisionPadding: { type: 'number', empty: 'fallback' },
   });
-  def.props.setDefaults({ side: 'bottom', align: 'center' });
+  def.props.setDefaults({
+    side: 'bottom',
+    align: 'center',
+    sideOffset: 4,
+    alignOffset: 0,
+    avoidCollisions: true,
+    collisionPadding: 0,
+  });
 
   // P-BASE-HOVER-CARD-CONTENT-OVERLAY
   const overlay = asOverlay<HoverCardContentProps>();
@@ -53,6 +64,13 @@ function setupHoverCardContent(
     placement: 'bottom',
     align: 'center',
     sideOffset: 4,
+    alignOffset: 0,
+    anchored: true,
+    strategy: 'fixed',
+    avoidCollisions: true,
+    collisionBoundary: 'clippingAncestors',
+    collisionPadding: 0,
+    portal: true,
     modal: false,
     layerRole: 'hover-card-content',
     meta: { overlayKind: 'hover-card' },
@@ -76,14 +94,39 @@ function setupHoverCardContent(
     else overlay.close(reason);
   };
 
+  const syncPosition = (run: any) => {
+    // P-BASE-HOVER-CARD-CONTENT-POSITION, P-BASE-HOVER-CARD-CONTENT-COLLISION
+    const props = run.props.get();
+    overlay.updatePosition({
+      placement: props.side,
+      align: props.align,
+      sideOffset: props.sideOffset,
+      alignOffset: props.alignOffset,
+      avoidCollisions: props.avoidCollisions,
+      collisionPadding: props.collisionPadding,
+      strategy: 'fixed',
+      collisionBoundary: 'clippingAncestors',
+    });
+  };
+
+  def.props.watch(
+    ['side', 'align', 'sideOffset', 'alignOffset', 'avoidCollisions', 'collisionPadding'],
+    (run) => syncPosition(run)
+  );
+
   def.context.subscribe(HOVER_CARD_CONTEXT, (_run, next) => {
     updateOpen(next.open, 'reason: hover-card context sync => content open');
   });
   def.lifecycle.onCreated((run) => {
+    syncPosition(run);
     const ctx = run.context.read(HOVER_CARD_CONTEXT);
     updateOpen(ctx.open, 'reason: lifecycle.onCreated => hover-card content open sync');
   });
   def.lifecycle.onMounted((run) => {
+    // P-BASE-HOVER-CARD-CONTENT-ANCHOR, P-BASE-HOVER-CARD-CONTENT-PORTAL
+    const trigger = run.anatomy.partsOf(HOVER_CARD_FAMILY, 'trigger')[0] ?? null;
+    if (trigger) overlay.registerAnchorPart(trigger);
+    syncPosition(run);
     const ctx = run.context.read(HOVER_CARD_CONTEXT);
     updateOpen(ctx.open, 'reason: lifecycle.onMounted => hover-card content open sync');
   });
@@ -106,63 +149,13 @@ function setupHoverCardContent(
     when: (w) => w.state(transition.isPresent).eq(false),
     intent: (i) => i.feedback.style.use(tw('hidden')),
   });
-
-  // P-BASE-HOVER-CARD-CONTENT-POSITION
-  def.rule({
-    when: (w) => w.prop('side').eq('bottom'),
-    intent: (i) => i.feedback.style.use(tw('left-1/2 top-full mt-1 -translate-x-1/2')),
-  });
-  def.rule({
-    when: (w) => w.prop('side').eq('top'),
-    intent: (i) => i.feedback.style.use(tw('bottom-full left-1/2 mb-1 -translate-x-1/2')),
-  });
-  def.rule({
-    when: (w) => w.prop('side').eq('right'),
-    intent: (i) => i.feedback.style.use(tw('left-full top-1/2 ml-1 -translate-y-1/2')),
-  });
-  def.rule({
-    when: (w) => w.prop('side').eq('left'),
-    intent: (i) => i.feedback.style.use(tw('right-full top-1/2 mr-1 -translate-y-1/2')),
-  });
-  def.rule({
-    when: (w) => w.all(w.prop('align').eq('start'), w.prop('side').eq('bottom')),
-    intent: (i) => i.feedback.style.use(tw('left-0 translate-x-0')),
-  });
-  def.rule({
-    when: (w) => w.all(w.prop('align').eq('start'), w.prop('side').eq('top')),
-    intent: (i) => i.feedback.style.use(tw('left-0 translate-x-0')),
-  });
-  def.rule({
-    when: (w) => w.all(w.prop('align').eq('end'), w.prop('side').eq('bottom')),
-    intent: (i) => i.feedback.style.use(tw('left-auto right-0 translate-x-0')),
-  });
-  def.rule({
-    when: (w) => w.all(w.prop('align').eq('end'), w.prop('side').eq('top')),
-    intent: (i) => i.feedback.style.use(tw('left-auto right-0 translate-x-0')),
-  });
-  def.rule({
-    when: (w) => w.all(w.prop('align').eq('start'), w.prop('side').eq('left')),
-    intent: (i) => i.feedback.style.use(tw('top-0 translate-y-0')),
-  });
-  def.rule({
-    when: (w) => w.all(w.prop('align').eq('start'), w.prop('side').eq('right')),
-    intent: (i) => i.feedback.style.use(tw('top-0 translate-y-0')),
-  });
-  def.rule({
-    when: (w) => w.all(w.prop('align').eq('end'), w.prop('side').eq('left')),
-    intent: (i) => i.feedback.style.use(tw('bottom-0 top-auto translate-y-0')),
-  });
-  def.rule({
-    when: (w) => w.all(w.prop('align').eq('end'), w.prop('side').eq('right')),
-    intent: (i) => i.feedback.style.use(tw('bottom-0 top-auto translate-y-0')),
-  });
 }
 
 /*
  * P-BASE-HOVER-CARD-CONTENT-NON-MODAL: no focus scope, outside dismissal,
  * Escape dismissal, or dialog semantics are authored by Content.
- * P-BASE-HOVER-CARD-CONTENT-DEFERRED-EXTENSIONS: portal, collision geometry,
- * Arrow, forceMount, and numeric offsets remain downstream extensions.
+ * P-BASE-HOVER-CARD-CONTENT-DEFERRED-EXTENSIONS: Arrow, forceMount, custom
+ * collision boundary elements, sticky positioning, and detached-anchor hiding remain extensions.
  */
 
 // P-BASE-HOVER-CARD-CONTENT-AUTHORING-ENTRIES

--- a/packages/prototypes/base/src/hover-card/types.ts
+++ b/packages/prototypes/base/src/hover-card/types.ts
@@ -66,6 +66,10 @@ export type HoverCardContentProps = TransitionProps & {
   // P-BASE-HOVER-CARD-CONTENT-POSITION
   side?: HoverCardSide;
   align?: HoverCardAlign;
+  sideOffset?: number;
+  alignOffset?: number;
+  avoidCollisions?: boolean;
+  collisionPadding?: number;
 };
 
 export type HoverCardContentExposes = TransitionExposes & {

--- a/packages/prototypes/base/test/hover-card.test.ts
+++ b/packages/prototypes/base/test/hover-card.test.ts
@@ -194,17 +194,22 @@ describe('prototypes/base: hover-card', () => {
     expect(trigger.getExposes().disabled.get()).toBe(true);
   });
 
-  it('projects side and alignment props while exposing Transition controls', async () => {
+  it('positions from side and alignment props through the anchored host while exposing Transition controls', async () => {
     // T-BASE-HOVER-CARD-CONTENT-0001-CASE-POSITION
     vi.useFakeTimers();
     const { trigger, content } = createHoverCard({ openDelay: 0 });
-    setElementProps(content, { side: 'top', align: 'start' });
+    setElementProps(content, { side: 'top', align: 'start', avoidCollisions: false });
     await flushViewReconciliation();
 
     trigger.dispatchEvent(new Event('pointerenter'));
     await advance(0);
-    expect(styleContains(content, 'bottom-full')).toBe(true);
-    expect(styleContains(content, 'left-0')).toBe(true);
+    await flushViewReconciliation();
+    expect(content.style.position).toBe('fixed');
+    expect(content.dataset.side).toBe('top');
+    expect(content.dataset.align).toBe('start');
+    expect(content.style.left).toMatch(/px$/);
+    expect(content.style.top).toMatch(/px$/);
+    expect(styleContains(content, 'absolute')).toBe(true);
     expect(content.getExposes().transitionState.get()).toBe('entering');
     expect(typeof content.getExposes().controls.complete).toBe('function');
   });

--- a/packages/prototypes/shadcn/src/hover-card/content.ts
+++ b/packages/prototypes/shadcn/src/hover-card/content.ts
@@ -14,7 +14,7 @@ const hoverCardContent = definePrototype<
 
     def.feedback.style.use(
       tw(
-        'absolute z-50 w-64 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none duration-200'
+        'z-50 w-64 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-md outline-none transition-none duration-200'
       )
     );
 

--- a/packages/prototypes/shadcn/test/hover-card.test.ts
+++ b/packages/prototypes/shadcn/test/hover-card.test.ts
@@ -26,7 +26,7 @@ describe('prototypes/shadcn: hover-card', () => {
     const trigger = document.createElement('shadcn-hover-card-trigger') as any;
     const content = document.createElement('shadcn-hover-card-content') as any;
     setElementProps(root, { openDelay: 0, closeDelay: 0 });
-    setElementProps(content, { side: 'right', align: 'start' });
+    setElementProps(content, { side: 'right', align: 'start', avoidCollisions: false });
     root.append(trigger, content);
     document.body.appendChild(root);
     await flush();
@@ -44,12 +44,17 @@ describe('prototypes/shadcn: hover-card', () => {
     expect(styleContains(content, 'rounded-md')).toBe(true);
     expect(styleContains(content, 'bg-popover')).toBe(true);
     expect(styleContains(content, 'shadow-md')).toBe(true);
+    expect(styleContains(content, 'transition-none')).toBe(true);
+    expect(styleContains(content, 'duration-200')).toBe(true);
     expect(styleContains(content, 'data-[open]:animate-in')).toBe(true);
     expect(styleContains(content, 'data-[open]:fade-in-0')).toBe(true);
     expect(styleContains(content, 'data-[open]:zoom-in-95')).toBe(true);
     expect(styleContains(content, 'slide-in-from-left-2')).toBe(true);
-    expect(styleContains(content, 'left-full')).toBe(true);
-    expect(styleContains(content, 'top-0')).toBe(true);
+    expect(content.style.position).toBe('fixed');
+    expect(content.dataset.side).toBe('right');
+    expect(content.dataset.align).toBe('start');
+    expect(content.style.left).toMatch(/px$/);
+    expect(content.style.top).toMatch(/px$/);
 
     content.dispatchEvent(new Event('pointerenter'));
     trigger.dispatchEvent(new Event('pointerleave'));

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -29,6 +29,7 @@
     "@proto.ui/module-boundary": "workspace:*",
     "@proto.ui/module-hit-participation": "workspace:*",
     "@proto.ui/module-overlay": "workspace:*",
+    "@proto.ui/module-positioning": "workspace:*",
     "@proto.ui/module-presence": "workspace:*",
     "@proto.ui/module-test-sys": "workspace:*"
   },

--- a/packages/runtime/src/instance/instance.ts
+++ b/packages/runtime/src/instance/instance.ts
@@ -26,6 +26,7 @@ import { FocusModuleDef } from '@proto.ui/module-focus';
 import { BoundaryModuleDef } from '@proto.ui/module-boundary';
 import { HitParticipationModuleDef } from '@proto.ui/module-hit-participation';
 import { OverlayModuleDef } from '@proto.ui/module-overlay';
+import { PositioningModuleDef } from '@proto.ui/module-positioning';
 import { PresenceModuleDef } from '@proto.ui/module-presence';
 import { __RUN_TEST_SYS, TestSysModuleDef, type TestSysPort } from '@proto.ui/module-test-sys';
 
@@ -86,6 +87,7 @@ export function createRuntimeInstance<P extends PropsBaseType>(
     FocusModuleDef,
     BoundaryModuleDef,
     HitParticipationModuleDef,
+    PositioningModuleDef,
     OverlayModuleDef,
     PresenceModuleDef,
     TestSysModuleDef,

--- a/packages/runtime/test/contract/overlay.v0.contract.test.ts
+++ b/packages/runtime/test/contract/overlay.v0.contract.test.ts
@@ -11,6 +11,10 @@ import { executeWithHost } from '../../src';
 import { BOUNDARY_HOST_BRIDGE_CAP } from '@proto.ui/module-boundary';
 import { EVENT_GLOBAL_TARGET_CAP } from '@proto.ui/module-event';
 import { OVERLAY_GLOBAL_MOUNT_CAP, type OverlayPort } from '@proto.ui/module-overlay';
+import {
+  ANCHORED_POSITION_HOST_CAP,
+  type AnchoredPositionHostLease,
+} from '@proto.ui/module-positioning';
 import type { PropsBaseType } from '@proto.ui/types';
 
 const createHost = <P extends PropsBaseType>(
@@ -37,6 +41,86 @@ const createHost = <P extends PropsBaseType>(
 };
 
 describe('runtime contract: overlay (v0)', () => {
+  it('OVERLAY-0050: anchored positioning is host-mediated and active only with a live view', () => {
+    let overlay!: OverlayHandle<PropsBaseType>;
+    let connection: any = null;
+    let disposed = 0;
+    const anchor = document.createElement('button');
+    const content = document.createElement('div');
+
+    const lease: AnchoredPositionHostLease = {
+      update(next) {
+        connection = next;
+      },
+      requestUpdate() {},
+      dispose() {
+        disposed += 1;
+      },
+    };
+
+    const P = definePrototype({
+      name: 'x-overlay-0050',
+      setup(def) {
+        overlay = asOverlay<PropsBaseType>();
+        overlay.configure({
+          anchored: true,
+          defaultOpen: true,
+          placement: 'right',
+          align: 'end',
+          sideOffset: 8,
+          avoidCollisions: true,
+          collisionBoundary: 'clippingAncestors',
+          collisionPadding: 6,
+        });
+        def.lifecycle.onMounted(() => {
+          overlay.registerAnchor(anchor);
+          overlay.registerContent(content);
+        });
+        return (r) => r.el('div', 'ok');
+      },
+    });
+
+    const { host } = createHost(P.name, {
+      onRuntimeReady(wiring) {
+        wiring.attach('positioning', [
+          [
+            ANCHORED_POSITION_HOST_CAP,
+            {
+              attach(next: any) {
+                connection = next;
+                next.onResolved?.({ side: 'left', align: 'end', strategy: 'absolute' });
+                return lease;
+              },
+            },
+          ],
+        ]);
+      },
+    });
+    const result = executeWithHost(P as any, host as any);
+    const port = result.caps.getPort<OverlayPort>('overlay');
+
+    expect(connection).toMatchObject({
+      anchor,
+      floating: content,
+      config: {
+        side: 'right',
+        align: 'end',
+        sideOffset: 8,
+        avoidCollisions: true,
+        collisionBoundary: 'clippingAncestors',
+        collisionPadding: 6,
+      },
+    });
+    expect(port?.getPositionSnapshot()).toEqual({
+      side: 'left',
+      align: 'end',
+      strategy: 'absolute',
+    });
+
+    result.invokeInCallbackScope(() => overlay.close('programmatic'));
+    expect(disposed).toBeGreaterThan(0);
+  });
+
   it('OVERLAY-0100: repeated asOverlay calls reuse one handle and merge configuration', () => {
     let a!: OverlayHandle<PropsBaseType>;
     let b!: OverlayHandle<PropsBaseType>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       '@proto.ui/module-overlay':
         specifier: workspace:*
         version: link:../../modules/overlay
+      '@proto.ui/module-positioning':
+        specifier: workspace:*
+        version: link:../../modules/positioning
       '@proto.ui/module-props':
         specifier: workspace:*
         version: link:../../modules/props
@@ -290,6 +293,9 @@ importers:
       '@proto.ui/module-overlay':
         specifier: workspace:*
         version: link:../../modules/overlay
+      '@proto.ui/module-positioning':
+        specifier: workspace:*
+        version: link:../../modules/positioning
       '@proto.ui/module-props':
         specifier: workspace:*
         version: link:../../modules/props
@@ -357,6 +363,9 @@ importers:
       '@proto.ui/module-overlay':
         specifier: workspace:*
         version: link:../../modules/overlay
+      '@proto.ui/module-positioning':
+        specifier: workspace:*
+        version: link:../../modules/positioning
       '@proto.ui/module-props':
         specifier: workspace:*
         version: link:../../modules/props
@@ -595,6 +604,9 @@ importers:
       '@proto.ui/core':
         specifier: workspace:*
         version: link:../../core
+      '@proto.ui/module-anatomy':
+        specifier: workspace:*
+        version: link:../anatomy
       '@proto.ui/module-base':
         specifier: workspace:*
         version: link:../base
@@ -604,9 +616,24 @@ importers:
       '@proto.ui/module-event':
         specifier: workspace:*
         version: link:../event
+      '@proto.ui/module-positioning':
+        specifier: workspace:*
+        version: link:../positioning
       '@proto.ui/types':
         specifier: workspace:*
         version: link:../../types
+
+  packages/modules/positioning:
+    dependencies:
+      '@floating-ui/dom':
+        specifier: ^1.7.4
+        version: 1.8.0
+      '@proto.ui/core':
+        specifier: workspace:*
+        version: link:../../core
+      '@proto.ui/module-base':
+        specifier: workspace:*
+        version: link:../base
 
   packages/modules/presence:
     dependencies:
@@ -856,6 +883,9 @@ importers:
       '@proto.ui/module-overlay':
         specifier: workspace:*
         version: link:../modules/overlay
+      '@proto.ui/module-positioning':
+        specifier: workspace:*
+        version: link:../modules/positioning
       '@proto.ui/module-presence':
         specifier: workspace:*
         version: link:../modules/presence
@@ -1483,6 +1513,15 @@ packages:
 
   '@expressive-code/plugin-text-markers@0.41.7':
     resolution: {integrity: sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==}
+
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -4387,6 +4426,17 @@ snapshots:
   '@expressive-code/plugin-text-markers@0.41.7':
     dependencies:
       '@expressive-code/core': 0.41.7
+
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@img/colour@1.1.0': {}
 

--- a/spec/contracts/C-ANCHORED-POSITIONING-0001.yaml
+++ b/spec/contracts/C-ANCHORED-POSITIONING-0001.yaml
@@ -1,0 +1,55 @@
+id: C-ANCHORED-POSITIONING-0001
+type: contract
+title: Anchored positioning is host-mediated geometry with bounded lifetime
+status: draft
+since: 0.2.0
+summary: Proto modules declare anchor-relative placement while a host capability measures, resolves collisions, writes coordinates, and observes geometry only while the floating view is active.
+statement:
+  zh-CN: >-
+    Anchored Positioning 必须把语义 placement 与宿主几何分离。Proto module 只声明 anchor、floating、side、align、offset、strategy 与 collision policy；测量、overflow ancestor 发现、坐标写入和 scroll/resize/element-resize observation 必须由 host-cap 完成。默认碰撞边界是 floating 的 clipping ancestors，并以 visual viewport 为 root boundary。positioning lease 只能在浮层 view active 且 anchor/floating 同时可用时存在；Portal 是独立能力，用于逃逸无法通过几何重新定位消除的 ancestor clipping。
+
+
+  en: >-
+    Anchored Positioning must separate semantic placement from host geometry. A Proto module declares only the anchor, floating target, side, align, offsets, strategy, and collision policy; measurement, overflow-ancestor discovery, coordinate writes, and scroll, resize, and element-resize observation are performed by a host capability. The default collision boundary is the floating target's clipping ancestors with the visual viewport as root boundary. A positioning lease may exist only while the floating view is active and both anchor and floating targets are available. Portal remains an independent capability for escaping ancestor clipping that geometry alone cannot remove.
+
+
+criteria:
+  - id: C-ANCHORED-POSITIONING-0001-A
+    text:
+      zh-CN: Proto author 与通用 module 不得直接测量或写入宿主几何；这些操作必须由 Anchored Position host-cap 执行。
+      en: Prototype authors and generic modules must not directly measure or write host geometry; those operations must be performed by the Anchored Position host capability.
+  - id: C-ANCHORED-POSITIONING-0001-B
+    text:
+      zh-CN: 配置必须至少表达 side、align、sideOffset、alignOffset、absolute/fixed strategy、avoidCollisions、collisionBoundary 与 collisionPadding。
+      en: Configuration must express at least side, align, sideOffset, alignOffset, absolute or fixed strategy, avoidCollisions, collisionBoundary, and collisionPadding.
+  - id: C-ANCHORED-POSITIONING-0001-C
+    text:
+      zh-CN: avoidCollisions 启用时，host 必须执行 flip 与 shift；默认 boundary 为 clipping ancestors，root boundary 为 visual viewport，并返回 resolved side/align。
+      en: When avoidCollisions is enabled, the host must perform flip and shift, default the boundary to clipping ancestors and the root boundary to the visual viewport, and report the resolved side and align.
+  - id: C-ANCHORED-POSITIONING-0001-D
+    text:
+      zh-CN: host 必须把坐标写入 position/left/top，避免占用 transform，以便 Transition 或下游样式独立拥有 transform；并投射 resolved data-side/data-align 与可用尺寸变量。
+      en: The host must write coordinates through position, left, and top without taking ownership of transform so Transition or downstream styling can own transform independently; it also projects resolved data-side and data-align plus available-size variables.
+  - id: C-ANCHORED-POSITIONING-0001-E
+    text:
+      zh-CN: 自动更新只能在 active view 的 lease 生命周期内监听 scroll、resize 与 element resize，默认不得启用逐帧 animation-frame polling，detach/dispose 必须撤销全部监听。
+      en: Automatic updates may observe scroll, resize, and element resize only for the lifetime of an active-view lease, must not enable per-frame animation-frame polling by default, and must revoke every observer on detach or dispose.
+  - id: C-ANCHORED-POSITIONING-0001-F
+    text:
+      zh-CN: collision detection 与 Portal 不得合并为同一策略；inline floating 使用实际 clipping ancestors，Portal 可改变宿主 containing/clipping context，但 logical owner 必须保持不变。
+      en: Collision detection and Portal must not be merged into one policy; an inline floating target uses its actual clipping ancestors, while Portal may change its host containing and clipping context without changing its logical owner.
+sources:
+  - path: packages/core/src/positioning.ts
+  - path: packages/modules/positioning/src/impl.ts
+  - path: packages/modules/positioning/src/web/floating-ui-host.ts
+dependsOn:
+  decisions:
+    - D-ANATOMY-PARTVIEW-TARGET-0001
+verifies:
+  tests:
+    - T-ANCHORED-POSITIONING-0001
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Defined host-mediated anchored geometry, collision defaults, output projection, Portal separation, and bounded observation lifetime.
+tags: [positioning, overlay, geometry, collision, host-capability]

--- a/spec/contracts/C-AS-OVERLAY-0001.yaml
+++ b/spec/contracts/C-AS-OVERLAY-0001.yaml
@@ -62,6 +62,18 @@ criteria:
     text:
       zh-CN: Presence signal 在 runtime callback chain 内变为 active 时，Overlay host resource reconciliation 必须由 runtime/module 边界推迟到最外层 callback 完成后；author-facing hook 不得直接选择 `queueMicrotask` 或其它宿主线程调度机制。
       en: When a Presence signal becomes active within a runtime callback chain, Overlay host-resource reconciliation must be deferred by the runtime/module boundary until the outermost callback completes; the author-facing hook must not directly choose `queueMicrotask` or another host-thread scheduling mechanism.
+  - id: C-AS-OVERLAY-0001-M
+    text:
+      zh-CN: anchored opt-in 必须由 Overlay 编排但委托 Positioning module/host-cap 执行几何；Overlay 只提交 anchor、content 与 placement policy，不得自行测量宿主节点。
+      en: Anchored opt-in must be orchestrated by Overlay but delegate geometry to the Positioning module and host capability; Overlay submits only anchor, content, and placement policy and must not measure host nodes itself.
+  - id: C-AS-OVERLAY-0001-N
+    text:
+      zh-CN: Overlay 可以把 author-facing AnatomyPartView 注册为 anchor，但 raw target 解析必须只发生在 Anatomy 与 Overlay 的 module-internal port 之间，不得向 prototype author 暴露宿主引用。
+      en: Overlay may register an author-facing AnatomyPartView as its anchor, but raw-target resolution must occur only between Anatomy and Overlay module-internal ports and must not expose a host reference to prototype authors.
+  - id: C-AS-OVERLAY-0001-O
+    text:
+      zh-CN: positioning lease 必须跟随 bound Presence 的 active view，而非仅跟随 logical open；Portal、layer 与 positioning 的建立必须在最外层 runtime callback 完成后协调。
+      en: The positioning lease must follow the bound Presence active view rather than logical open alone; Portal, layer, and positioning establishment must be reconciled after the outermost runtime callback completes.
 sources:
   - path: internal/contracts/overlay/as-overlay.v0.md
   - path: packages/hooks/src/as-overlay.ts
@@ -70,6 +82,8 @@ sources:
   - path: packages/modules/overlay/src/impl.ts
     sections:
       - OverlayModuleImpl
+  - path: packages/modules/positioning/src/impl.ts
+  - path: packages/modules/anatomy/src/impl.ts
   - path: packages/adapters/react/src/adapt.ts
     sections:
       - AdaptToReact
@@ -82,6 +96,8 @@ dependsOn:
     - C-LIFECYCLE-0008
     - C-AS-TRANSITION-0001
     - C-BOUNDARY-0001
+    - id: C-ANCHORED-POSITIONING-0001
+      since: 0.2.0
   decisions:
     - D-AS-HOOK-PRIVILEGED-NO-ARG-MIGRATION-0001
 verifies:
@@ -103,9 +119,13 @@ revisions:
   - version: 0.1.4
     change: refined
     summary: Moved post-callback host-resource reconciliation from hook-selected microtasks into the runtime and Overlay module boundary.
+  - version: 0.2.0
+    change: extended
+    summary: Added delegated anchored positioning, internal Anatomy part resolution, and active-view positioning lifetime.
 tags:
   - overlay
   - as-hook
   - presence
   - lifecycle
   - boundary
+  - positioning

--- a/spec/host-caps/HC-ANCHORED-POSITION-0001.yaml
+++ b/spec/host-caps/HC-ANCHORED-POSITION-0001.yaml
@@ -1,0 +1,17 @@
+id: HC-ANCHORED-POSITION-0001
+type: host-cap
+title: Host measures and maintains anchored floating geometry
+status: draft
+since: 0.2.0
+summary: The host attaches a bounded positioning lease that measures anchor and floating targets, resolves collision policy, writes non-transform coordinates, and observes relevant geometry changes.
+satisfies:
+  contracts:
+    - C-ANCHORED-POSITIONING-0001
+sources:
+  - path: packages/modules/positioning/src/caps.ts
+  - path: packages/modules/positioning/src/web/floating-ui-host.ts
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Added the high-level anchored positioning host capability and lease boundary.
+tags: [host-capability, positioning, overlay, geometry]

--- a/spec/modules/M-POSITIONING-0001.yaml
+++ b/spec/modules/M-POSITIONING-0001.yaml
@@ -1,0 +1,25 @@
+id: M-POSITIONING-0001
+type: module
+title: Positioning module owns anchored host-session lifetime
+status: draft
+since: 0.2.0
+summary: The Positioning module converts an anchor and floating declaration into one host positioning lease, retains only categorical resolved placement, and revokes the lease with view or prototype lifetime.
+satisfies:
+  contracts:
+    - C-ANCHORED-POSITIONING-0001
+requires:
+  hostCaps:
+    - HC-ANCHORED-POSITION-0001
+verifies:
+  tests:
+    - T-ANCHORED-POSITIONING-0001
+sources:
+  - path: packages/modules/positioning/src/create.ts
+  - path: packages/modules/positioning/src/types.ts
+  - path: packages/modules/positioning/src/caps.ts
+  - path: packages/modules/positioning/src/impl.ts
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged the adapter-independent positioning session and host-capability boundary.
+tags: [positioning, module, overlay, host-capability]

--- a/spec/prototypes/P-BASE-HOVER-CARD-CONTENT.yaml
+++ b/spec/prototypes/P-BASE-HOVER-CARD-CONTENT.yaml
@@ -3,10 +3,10 @@ type: prototype
 title: Base Hover Card Content is a transitional non-modal preview surface
 status: draft
 since: 0.2.0
-summary: Hover Card Content consumes Root open through Overlay and Transition, retains the hover bridge, and provides minimal side and alignment positioning without becoming an interactive modal surface.
+summary: Hover Card Content consumes Root open through Overlay and Transition, retains the hover bridge, and uses portaled collision-aware positioning without becoming an interactive modal surface.
 statement:
-  zh-CN: Hover Card Content 是至多一个的 non-modal preview surface。它从 Root open 派生 Overlay/Transition presence，在 leave 完成前保留当前 view，并通过自身 hover 延续 Trigger 与 Content 间的 pointer bridge。Content 不建立 focus scope、outside/Escape dismissal 或 dialog semantics；当前 Base 定位只保证 side/align，portal、collision geometry、Arrow、forceMount 与数值 offset 明确延期。
-  en: Hover Card Content is an optional, at-most-one non-modal preview surface. It derives Overlay and Transition presence from Root open, retains the current view until leave completes, and extends the pointer bridge between Trigger and Content through its own hover. Content establishes no focus scope, outside or Escape dismissal, or dialog semantics; current Base positioning guarantees only side and align, while portal, collision geometry, Arrow, forceMount, and numeric offsets are explicitly deferred.
+  zh-CN: Hover Card Content 是至多一个的 non-modal preview surface。它从 Root open 派生 Overlay/Transition presence，在 leave 完成前保留当前 view，并通过自身 hover 延续 Trigger 与 Content 间的 pointer bridge。Content 不建立 focus scope、outside/Escape dismissal 或 dialog semantics。它以 Trigger anatomy part 为 anchor，通过 Overlay 委托 Positioning host-cap，支持 side/align、数值 offsets、默认 flip/shift 与 collision padding；Content 使用 Portal 和 fixed strategy 逃逸 DemoPreviewer 等 clipping ancestor，但 logical owner、Context 与 Anatomy 域保持不变。
+  en: Hover Card Content is an optional, at-most-one non-modal preview surface. It derives Overlay and Transition presence from Root open, retains the current view until leave completes, and extends the pointer bridge between Trigger and Content through its own hover. Content establishes no focus scope, outside or Escape dismissal, or dialog semantics. It anchors to the Trigger anatomy part and delegates through Overlay to the Positioning host capability, supporting side and align, numeric offsets, default flip and shift, and collision padding. Content uses Portal with fixed strategy to escape clipping ancestors such as DemoPreviewer while preserving its logical owner, Context, and Anatomy domain.
 criteria:
   - id: P-BASE-HOVER-CARD-CONTENT-AUTHORING-ENTRIES
     text:
@@ -40,12 +40,24 @@ criteria:
       en: Content must not establish focus trapping or entry, a modal lock, a dialog role, or interaction required for keyboard users to complete a task.
   - id: P-BASE-HOVER-CARD-CONTENT-POSITION
     text:
-      zh-CN: Content 必须接受 `side=top|right|bottom|left` 与 `align=start|center|end`，默认分别为 bottom 与 center，并在 Root-relative Base layout 中投射对应方向与对齐。
-      en: Content must accept `side=top|right|bottom|left` and `align=start|center|end`, defaulting to bottom and center respectively, and project the corresponding direction and alignment in the Root-relative Base layout.
+      zh-CN: Content 必须接受 `side=top|right|bottom|left`、`align=start|center|end`、sideOffset、alignOffset、avoidCollisions 与 collisionPadding；默认依次为 bottom、center、4、0、true、0，并把运行时 prop 更新提交给 Overlay positioning policy。
+      en: Content must accept `side=top|right|bottom|left`, `align=start|center|end`, sideOffset, alignOffset, avoidCollisions, and collisionPadding; defaults are bottom, center, 4, 0, true, and 0 respectively, and runtime prop updates are submitted to Overlay positioning policy.
+  - id: P-BASE-HOVER-CARD-CONTENT-ANCHOR
+    text:
+      zh-CN: Content mounted 后必须把同一 Hover Card Anatomy 域中的 Trigger PartView 注册为 Overlay anchor；不得从 PartView 获得或保存 raw host target。
+      en: After Content mounts, it must register the Trigger PartView in the same Hover Card Anatomy domain as the Overlay anchor and must not obtain or retain a raw host target from the PartView.
+  - id: P-BASE-HOVER-CARD-CONTENT-COLLISION
+    text:
+      zh-CN: Content 必须启用 Anchored Positioning，默认以 clipping ancestors 为 collision boundary、visual viewport 为 root boundary，并执行 flip/shift；resolved side/align 必须投射为宿主 data attributes。
+      en: Content must enable Anchored Positioning with clipping ancestors as the default collision boundary and the visual viewport as root boundary, perform flip and shift, and project resolved side and align as host data attributes.
+  - id: P-BASE-HOVER-CARD-CONTENT-PORTAL
+    text:
+      zh-CN: Content 必须使用 renderer-owned Portal 与 fixed positioning 逃逸局部 clipping context；Portal 不得改变 Hover Card 的 logical Context/Anatomy ownership，且只能在 Transition present 期间保持 active。
+      en: Content must use renderer-owned Portal and fixed positioning to escape local clipping contexts; Portal must not change Hover Card logical Context or Anatomy ownership and remains active only while Transition is present.
   - id: P-BASE-HOVER-CARD-CONTENT-DEFERRED-EXTENSIONS
     text:
-      zh-CN: portal、collision geometry、Arrow、forceMount、sideOffset 与 alignOffset 不属于当前 Base Content 保证；下游原型不得把缺失能力宣称为兼容。
-      en: Portal, collision geometry, Arrow, forceMount, sideOffset, and alignOffset are not current Base Content guarantees; downstream prototypes must not claim compatibility for missing capabilities.
+      zh-CN: Arrow、forceMount、自定义 Element collision boundary、sticky 与 hideWhenDetached 不属于当前 Base Content 保证；下游原型不得把缺失能力宣称为兼容。
+      en: Arrow, forceMount, custom Element collision boundaries, sticky positioning, and hideWhenDetached are not current Base Content guarantees; downstream prototypes must not claim compatibility for missing capabilities.
 sources:
   - path: packages/prototypes/base/src/hover-card/content.ts
   - path: packages/prototypes/base/test/hover-card.test.ts
@@ -53,10 +65,14 @@ sources:
     label: Radix Hover Card Content
 dependsOn:
   prototypes: [P-BASE-HOVER-CARD]
-  contracts: [C-AS-OVERLAY-0001, C-AS-TRANSITION-0001, C-LIFECYCLE-0008]
+  contracts:
+    [C-AS-OVERLAY-0001, C-ANCHORED-POSITIONING-0001, C-AS-TRANSITION-0001, C-LIFECYCLE-0008]
 verifies: { tests: [T-BASE-HOVER-CARD-CONTENT-0001] }
 revisions:
   - version: 0.2.0
     change: introduced
     summary: Cataloged non-modal Content presence, hover bridge, positioning, and deferred extensions.
-tags: [prototype, base, hover-card, content, overlay, transition]
+  - version: 0.2.1
+    change: extended
+    summary: Added Trigger PartView anchoring, host-mediated offsets and collision handling, Portal escape, and fixed positioning.
+tags: [prototype, base, hover-card, content, overlay, transition, positioning, portal]

--- a/spec/tests/T-ANCHORED-POSITIONING-0001.yaml
+++ b/spec/tests/T-ANCHORED-POSITIONING-0001.yaml
@@ -1,0 +1,70 @@
+id: T-ANCHORED-POSITIONING-0001
+type: test
+title: Anchored positioning contract and host integration tests
+status: draft
+since: 0.2.0
+summary: Covers host-mediated offsets, collision resolution, non-transform coordinate projection, Overlay lease lifetime, and Hover Card adapter integration.
+cases:
+  - id: T-ANCHORED-POSITIONING-0001-CASE-OFFSET
+    title: Floating UI host applies side, alignment, offsets, and non-transform coordinates
+    covers:
+      - C-ANCHORED-POSITIONING-0001-A
+      - C-ANCHORED-POSITIONING-0001-B
+      - C-ANCHORED-POSITIONING-0001-D
+    expectation: host-applies-fixed-left-top-and-categorical-placement
+  - id: T-ANCHORED-POSITIONING-0001-CASE-COLLISION
+    title: Floating UI host reports collision-resolved placement
+    covers:
+      - C-ANCHORED-POSITIONING-0001-C
+    expectation: host-flips-and-shifts-against-viewport-root-boundary
+  - id: T-ANCHORED-POSITIONING-0001-CASE-LIFETIME
+    title: Overlay creates and disposes one positioning lease with active view lifetime
+    covers:
+      - C-ANCHORED-POSITIONING-0001-E
+    expectation: anchored-host-lease-exists-only-for-live-overlay-view
+  - id: T-ANCHORED-POSITIONING-0001-CASE-PORTAL
+    title: Hover Card uses Portal separately from positioning and preserves its logical compound protocol
+    covers:
+      - C-ANCHORED-POSITIONING-0001-F
+    expectation: portaled-hover-card-escapes-previewer-clipping-with-logical-owner-intact
+implementations:
+  - id: module-positioning-floating-ui-host
+    kind: module-test
+    status: passing
+    path: packages/modules/positioning/test/floating-ui-host.test.ts
+    required: true
+    consumesCases:
+      - T-ANCHORED-POSITIONING-0001-CASE-OFFSET
+      - T-ANCHORED-POSITIONING-0001-CASE-COLLISION
+  - id: runtime-overlay-positioning-contract
+    kind: runtime-test
+    status: passing
+    path: packages/runtime/test/contract/overlay.v0.contract.test.ts
+    required: true
+    consumesCases:
+      - T-ANCHORED-POSITIONING-0001-CASE-LIFETIME
+  - id: base-hover-card-positioning-integration
+    kind: adapter-test
+    status: passing
+    path: packages/prototypes/base/test/hover-card.test.ts
+    required: true
+    consumesCases:
+      - T-ANCHORED-POSITIONING-0001-CASE-PORTAL
+verifies:
+  contracts:
+    - id: C-ANCHORED-POSITIONING-0001
+      anchors:
+        - C-ANCHORED-POSITIONING-0001-A
+        - C-ANCHORED-POSITIONING-0001-B
+        - C-ANCHORED-POSITIONING-0001-C
+        - C-ANCHORED-POSITIONING-0001-D
+        - C-ANCHORED-POSITIONING-0001-E
+        - C-ANCHORED-POSITIONING-0001-F
+exercises:
+  modules: [M-POSITIONING-0001]
+  hostCaps: [HC-ANCHORED-POSITION-0001]
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Added module, host, Overlay lifetime, and Hover Card Portal integration coverage.
+tags: [positioning, overlay, hover-card, test]

--- a/spec/tests/T-AS-OVERLAY-0001.yaml
+++ b/spec/tests/T-AS-OVERLAY-0001.yaml
@@ -58,6 +58,13 @@ cases:
     covers:
       - C-AS-OVERLAY-0001-L
     expectation: runtime-owned-post-callback-overlay-reconciliation
+  - id: T-AS-OVERLAY-0001-CASE-ANCHORED
+    title: Anchored Overlay delegates one active-view lease to Positioning
+    covers:
+      - C-AS-OVERLAY-0001-M
+      - C-AS-OVERLAY-0001-N
+      - C-AS-OVERLAY-0001-O
+    expectation: overlay-delegates-positioning-without-exposing-anatomy-target
 implementations:
   - id: runtime-overlay-contract
     kind: runtime-test
@@ -71,6 +78,7 @@ implementations:
       - T-AS-OVERLAY-0001-CASE-BOUNDARY-HIT
       - T-AS-OVERLAY-0001-CASE-DISMISS
       - T-AS-OVERLAY-0001-CASE-POST-CALLBACK-RECONCILE
+      - T-AS-OVERLAY-0001-CASE-ANCHORED
   - id: base-overlay-transition-contract
     kind: runtime-test
     status: passing
@@ -123,6 +131,9 @@ verifies:
         - C-AS-OVERLAY-0001-J
         - C-AS-OVERLAY-0001-K
         - C-AS-OVERLAY-0001-L
+        - C-AS-OVERLAY-0001-M
+        - C-AS-OVERLAY-0001-N
+        - C-AS-OVERLAY-0001-O
     - id: C-LIFECYCLE-0008
       anchors:
         - C-LIFECYCLE-0008-E
@@ -148,8 +159,12 @@ revisions:
   - version: 0.1.4
     change: refined
     summary: Added runtime coverage for post-callback Overlay host-resource reconciliation.
+  - version: 0.2.0
+    change: extended
+    summary: Added delegated anchored positioning and active-view lease coverage.
 tags:
   - overlay
   - presence
   - transition
   - contract-test
+  - positioning

--- a/spec/tests/T-BASE-HOVER-CARD-CONTENT-0001.yaml
+++ b/spec/tests/T-BASE-HOVER-CARD-CONTENT-0001.yaml
@@ -3,7 +3,7 @@ type: test
 title: Base Hover Card Content protocol tests
 status: draft
 since: 0.2.0
-summary: Covers Content non-modal Overlay behavior, Transition presence, hover bridge, side and alignment positioning, and deferred extension boundaries.
+summary: Covers Content non-modal Overlay behavior, Transition presence, hover bridge, Trigger anchoring, collision-aware positioning, Portal escape, and deferred extension boundaries.
 cases:
   - id: T-BASE-HOVER-CARD-CONTENT-0001-CASE-PRESENCE
     title: Content retains leave view through Transition-bound Overlay presence
@@ -19,11 +19,14 @@ cases:
     covers: [P-BASE-HOVER-CARD-CONTENT-HOVER-BRIDGE]
     expectation: content-hover-keeps-hover-card-open-after-trigger-leave
   - id: T-BASE-HOVER-CARD-CONTENT-0001-CASE-POSITION
-    title: Content supports the guaranteed side and alignment surface only
+    title: Content supports side, alignment, offsets, collision policy, and resolved host projection
     covers:
       - P-BASE-HOVER-CARD-CONTENT-POSITION
+      - P-BASE-HOVER-CARD-CONTENT-ANCHOR
+      - P-BASE-HOVER-CARD-CONTENT-COLLISION
+      - P-BASE-HOVER-CARD-CONTENT-PORTAL
       - P-BASE-HOVER-CARD-CONTENT-DEFERRED-EXTENSIONS
-    expectation: hover-card-content-projects-side-align-and-omits-deferred-api
+    expectation: hover-card-content-portals-and-positions-from-trigger-with-collision-policy
 implementations:
   - id: prototypes-base-hover-card-content-contract
     kind: module-test
@@ -53,9 +56,15 @@ verifies:
         - P-BASE-HOVER-CARD-CONTENT-PRESENCE
         - P-BASE-HOVER-CARD-CONTENT-HOVER-BRIDGE
         - P-BASE-HOVER-CARD-CONTENT-POSITION
+        - P-BASE-HOVER-CARD-CONTENT-ANCHOR
+        - P-BASE-HOVER-CARD-CONTENT-COLLISION
+        - P-BASE-HOVER-CARD-CONTENT-PORTAL
 exercises: { prototypes: [P-BASE-HOVER-CARD-CONTENT] }
 revisions:
   - version: 0.2.0
     change: introduced
     summary: Added Content Overlay, Transition, hover bridge, positioning, and boundary coverage.
-tags: [prototype, base, hover-card, content, test]
+  - version: 0.2.1
+    change: extended
+    summary: Added Trigger PartView anchor, collision-aware host positioning, offsets, and Portal escape coverage.
+tags: [prototype, base, hover-card, content, positioning, portal, test]


### PR DESCRIPTION
## Summary

- catalog the Anchored Positioning contract, host capability, module, and validation entity
- add a Floating UI-backed web host and wire it through the Web Component, React, and Vue adapters
- extend `asOverlay` with anchored positioning policy and lease lifecycle
- refactor Base and Shadcn Hover Card content to use Trigger anatomy anchoring, fixed positioning, collision handling, and renderer-owned Portal
- isolate Shadcn Hover Card keyframe animation from host-managed `left/top` positioning

## Why

Local temporary overlays need collision-aware positioning without making `asOverlay` own browser geometry. This change keeps policy in Overlay, positioning state in a dedicated module, and DOM measurement/mutation behind a host capability.

The React Hover Card also exposed a first-measure timing issue: its initial centered coordinate was computed before `w-64` committed, then corrected by 128px. Because `duration-200` implicitly enabled transitions for all properties, the corrected `left` value animated from right to left. `transition-none` now prevents host-managed coordinates from entering the content transition while preserving the 200ms fade, scale, and directional keyframe.

## Impact

- Hover Card supports `side`, `align`, offsets, collision avoidance, resolved side/align projection, and Portal escape across all adapters.
- DemoPreviewer clipping no longer constrains the floating surface.
- React no longer shows the unintended horizontal entrance motion.
- Switch and other components that explicitly use `transition-all` retain their existing transitions.

## Validation

- `corepack pnpm@10.32.1 exec vitest run packages/cli/test/proto-style-css.test.ts packages/prototypes/shadcn/test/hover-card.test.ts`
- `corepack pnpm@10.32.1 test`
  - 222 test files passed
  - 1000 tests passed
- `git diff --check`
- interactive demo-matrix acceptance for Base/Shadcn Hover Card across Web Components, React, and Vue
- React frame sampling confirmed stable computed `left`, `transition-property: none`, zero horizontal transform, and preserved 200ms vertical/fade/scale entry animation