### PR TITLE
refactor: catalog transition prototype

### DIFF
--- a/internal/contracts/prototype-base/transition.v0.md
+++ b/internal/contracts/prototype-base/transition.v0.md
@@ -96,4 +96,10 @@ Rapid input is latest-intent governed; it must not behave as an unbounded FIFO.
 
 Transition does not define physics animation, layout/shared-element motion, staggering, child coordination, or host event detection. A host or higher-level capability may call `complete()` when native animation finishes; duration is the portable fallback.
 
+## Reduced motion
+
+Official adapters currently expose the host preference as environment meta under `reducedMotion`. When that value is `reduce`, Transition retains the same `entering` / `leaving` phases, lifecycle signals, and ViewIntent ordering, but schedules its portable fallback completion with a `0ms` delay. This removes the non-essential sustained wait without collapsing observable protocol boundaries into one synchronous operation.
+
+The final ownership and naming of this environment input remains deferred to Module, host-capability, and adapter-profile cataloging. Consumers should depend on the Transition behavior rather than reading adapter globals directly.
+
 The legacy Presence host bridge is not a structural authority for Transition. Structural materialization is governed exclusively through `run.lifecycle.setPresent()` and ViewIntent reconciliation.

--- a/internal/records/2026-07-18-0.2-closure-and-followup-roadmap.zh-CN.md
+++ b/internal/records/2026-07-18-0.2-closure-and-followup-roadmap.zh-CN.md
@@ -1,0 +1,147 @@
+# 2026-07-18 0.2 收口判断与后续路线记录
+
+> Internal record. Not normative. 本文记录 2026-07-18 对 spec、历史契约、实现、测试、官网与发布状态的一次横向审计，以及当前采用的后续推进顺序。稳定结论仍应提升到对应的 `P-*`、`C-*`、`T-*`、`M-*`、`HC-*` 或后续 adapter entity；本文不替代这些真相源。
+
+---
+
+## 1）背景
+
+Proto UI 处于 0.2 阶段。项目以 `spec/` 中的知识实体为真理之源，当前主要工作是减少“已有定义、实现、旧契约或测试，但尚未进入实体体系”的未编目事实。
+
+最近一轮已经完成现有 Base 原型的大部分 `P-*` 编目，并在 2026-07-18 将 Select 编目合入 `main`。此前暂缓的 Module、host capability 与 adapter 编目仍未形成系统闭环；官网内容、外部试用与 npm 发布也明显落后于仓库实现。
+
+本记录回答两个问题：
+
+1. 当前是否可以把 Prototype 编目视为完成。
+2. 0.2 接下来应按什么顺序推进，避免继续积累 spec、实现、文档与发行之间的漂移。
+
+## 2）观察事实
+
+### 2.1 Spec 与验证基线
+
+审计时生成的 spec workspace 包含 316 个实体：143 Contract、42 Decision、4 Host Cap、5 Knowledge、5 Module、30 Prototype 与 87 Test。最新语义修订版本为 0.2.7。
+
+全仓测试通过：227 个 test file 通过、3 个跳过；1017 个 test 通过、34 个 todo。官网 production build 通过并生成 150 个页面，Pagefind 为 148 个页面建立索引。构建仍报告 Geist 字体资源无法在 build time 解析的警告。
+
+这些结果说明当前基线可工作，但不说明编目和产品闭环已经完成。
+
+### 2.2 Prototype 编目尚未完全收口
+
+Select 合入后，`spec/prototypes/` 中已有 30 个 `P-*` 实体。对 Base package 的公开 authoring protocol 逐项核对后，仍确认存在一个明确缺口：
+
+- `base-transition` direct prototype 已实现、可独立执行并公开导出。
+- `asTransition()` 已有实现、旧契约 `internal/contracts/prototype-base/transition.v0.md`、`C-AS-TRANSITION-0001`、`T-AS-TRANSITION-0001` 与较完整测试。
+- 但不存在 `P-BASE-TRANSITION`，也不存在验证该 prototype protocol 的 `T-BASE-TRANSITION-*` 实体。
+
+因此，不能仅根据现有 `P-*` 文件数宣布 Prototype 编目完成。完成 Transition 后，还需要明确两个范围问题：
+
+- standalone `lucide-icon` direct prototype / `asHook` 是否需要一个共享的 `P-LUCIDE-ICON` 身份。
+- Shadcn 实现是 Base `P-*` 的 conforming projection，还是部分组件应拥有独立的 design-language prototype identity。
+
+### 2.3 Module、host-cap 与 adapter 的断口
+
+`packages/modules/` 有 25 个公开 module package，目前只有 5 个 `M-*` 实体，且多数实体仍缺少 criteria、open question 与 test implementation 映射。代码中存在大量 capability token，而 `spec/host-caps/` 只有 4 个草案实体，provider、consumer、required/optional、missing policy 与 adapter support 尚未形成统一描述。
+
+公开 adapter package 包括 Base、React、Vue 与 Web Component。它们已有实现、测试和旧契约，但 schema 尚无 adapter entity 类型。现阶段不宜直接批量创建空壳 `M-*` 或把每个 capability token 机械映射成一个 `HC-*`。
+
+### 2.4 官网不是单纯的样式欠账
+
+官网已经能够构建和搜索，但仍有多类影响使用与贡献的断口：
+
+- 至少 17 个中英文页面仍是实质性占位页。
+- 大量组件缺少完整文档；现有组件页普遍缺 API 表、行为边界、adapter 支持与 spec/test 追溯。
+- Base Button、Dropdown、Switch、Tabs、Toggle 等缺少独立完整页面。
+- Header 的 Prototypes 链接指向 404 路由。
+- project status 与治理文档仍保留过期的 2026-05-14 launch 目标。
+- 英文搜索弹窗未命中只针对中文 `aria-label` 的定制样式。
+- 普通 Markdown code block 与专用 previewer 的样式体系没有统一。
+
+因此，导航正确性、内容真实性和 API 信息应优先于纯视觉打磨。
+
+### 2.5 发行时钟已经漂移
+
+审计时存在三套没有明确关系的版本时钟：
+
+- spec 语义修订已到 0.2.7。
+- 根目录 `VERSION` 与多数本地 package manifest 仍为 0.1.0。
+- npm 上公开包分布在 0.1.0、0.1.2 与 0.1.4，部分新增 module 尚未发布。
+
+自最近一次 npm 发布后，仓库又积累了大量提交和文件变更。launch governance map 仍停留在 0.1.0，并遗漏 a11y、collection、positioning，导致 release governance scan 失败。仓库也尚未形成统一的 changeset/changelog/release note 流程。
+
+### 2.6 缺少可审计的外部落地证据
+
+仓库中未发现独立 consumer project、case study 或外部试用记录。这不能证明不存在外部用户，但意味着当前没有可复验的证据说明 npm 包能够在 monorepo 之外顺利安装、构建和组合，也缺少真实项目对 API、adapter、SSR、CSS、a11y 与 bundle 边界的反馈。
+
+## 3）当前决策
+
+0.2 后续采用以下顺序：
+
+1. 先完成 0.2 编目与发行闭环，不继续横向扩张原型集合。
+2. Select 合入后的直接下一项是补齐 `P-BASE-TRANSITION` 与 `T-BASE-TRANSITION-0001`。
+3. Transition 作为一个可独立使用的 direct prototype 编目；`base-transition` 与 `asTransition()` 是同一 protocol 的两个 authoring entries，而不是两个独立协议。
+4. Transition 必须承担 reduced-motion 兼容责任：保留 transition phase、事件顺序与 ViewIntent 边界，但在宿主声明 reduce preference 时不保留非必要的持续时间等待。
+5. Transition 完成后，明确 Lucide 与 Shadcn 的 P identity 范围，并建立“公开导出 → P → T → docs”的自动覆盖检查。
+6. 随后优先建立可安装的 0.2 prerelease 和 monorepo 外部试用，再进入 Module/HC/Adapter 的系统编目。
+
+## 4）推荐路线
+
+### 阶段 A：0.2 编目与发行收口
+
+- 完成 Transition P/T 编目，并把 reduced-motion 行为提升到可执行契约。
+- 决定 Lucide 与 Shadcn 的 P identity 边界。
+- 增加公开 protocol 与 P/T/docs 的覆盖检查，避免靠人工数文件判断完成度。
+- 统一 spec version、repo `VERSION` 与 package version 的关系。
+- 更新 launch governance map，修复当前 release scan。
+- 修复官网 404、过期状态、英文搜索样式与字体警告。
+- 发布 `0.2.0-rc` prerelease；退出条件是 npm 安装得到的代码、Quick Start、spec 与官网描述一致。
+
+### 阶段 B：外部试用
+
+建立三个不引用 workspace/source 的独立 consumer：React + Vite、Vue、原生 Web Component。用同一真实偏好设置流程覆盖 Dialog、Select、Switch、Button、异步状态与 remount。
+
+每个试用至少记录：首次成功耗时、安装/构建/类型错误、API escape、adapter 差异、SSR/CSS/a11y/bundle 问题。原始发现先写 record，稳定事实再提升到实体。
+
+### 阶段 C：Module + HC + Adapter 垂直切片
+
+不按 package 数量横向创建空实体，而按真实消费链推进：
+
+1. Dialog / Hover Card / Select
+2. Overlay + Positioning + Presence
+3. Portal + Anchored Position host capabilities
+4. Web Component adapter profile
+5. React / Vue conformance
+
+第一条链路收口后，再进入 Focus + A11y + Collection。
+
+### 阶段 D：文档投射与补全
+
+统一组件页结构：status/since、adapter support、demo、anatomy、props、events、exposes/methods、state、a11y、deferred surfaces、P/C/T 链接与可运行示例。
+
+API 表应尽量从 TypeScript public surface 与 spec 联合生成或校验，避免官网再次成为独立且漂移的真相源。
+
+## 5）暂不采用的方向
+
+- 不在外部试用前继续大规模增加新 prototype；只有真实试用 blocker 才例外。
+- 不批量创建 20 个只有标题的 `M-*` 实体。
+- 不把 capability token 数量直接等同于 `HC-*` 实体数量。
+- 不继续积累数月更改而不发布可试用 package。
+- 不先做大规模视觉润色，再处理 404、占位内容、API 缺失与过期事实。
+- 不再以 `P-*` 文件总数作为 Prototype 编目完成的唯一判据。
+
+## 6）后续断口
+
+- `reducedMotion` 当前由 official adapters 通过 environment meta 提供；其最终归属是 adapter profile、host capability 还是更系统的 environment/configuration 抽象，应在 Module/HC/Adapter 编目阶段定案。
+- adapter entity 是否需要 schema 一级类型仍需单独决策。
+- 0.2 prerelease 的 package 集合、版本提升规则与 release note 机制需要形成正式发布记录。
+- 外部试用结果可能反向改变 0.2 release scope，尤其是缺失的基础输入、form 与 SSR 能力。
+
+## 7）本轮落地结果
+
+本记录形成后，同一工作轮次已经完成：
+
+- 新增 `P-BASE-TRANSITION` 与 `T-BASE-TRANSITION-0001`，把 direct prototype 和 authored asHook 收敛为同一协议身份。
+- 修订 `C-AS-TRANSITION-0001` 与 `T-AS-TRANSITION-0001`，固定 reduced-motion 下的 0ms fallback completion 和 sequencing 保证。
+- 为 runtime callback handle 增加 module-backed meta 只读投射，使首次 `appear` 与后续 enter/leave 都能在调度前读取 official adapter 提供的 `reducedMotion`。
+- 增加 standalone direct prototype 与 reduced-motion executable tests。
+
+落地后 spec workspace 包含 318 个实体并保持 0 个 validation issue；全仓为 227 个 test file 通过、3 个跳过，1019 个 test 通过、34 个 todo。此时 Base `P-*` 数量为 31，明确的 Transition 缺口已关闭，但 Lucide / Shadcn identity scope 仍需按本文路线确认。

--- a/packages/core/src/handles.ts
+++ b/packages/core/src/handles.ts
@@ -161,6 +161,11 @@ export interface RunHandle<Props extends PropsBaseType> {
     get(): unknown;
   };
 
+  /** Optional module-backed host/environment metadata. */
+  meta?: {
+    get(key: string): unknown;
+  };
+
   props: {
     get(): PropsSnapshot<Props>;
     getRaw(): Readonly<Props & PropsBaseType>;

--- a/packages/modules/rule-meta/src/create.ts
+++ b/packages/modules/rule-meta/src/create.ts
@@ -20,6 +20,11 @@ class RuleMetaModuleImpl extends ModuleBase {
       },
     });
   }
+
+  get(key: string): unknown {
+    const getter = this.caps.has(RULE_META_GET_CAP) ? this.caps.get(RULE_META_GET_CAP) : null;
+    return getter ? getter(key) : undefined;
+  }
 }
 
 export function createRuleMetaModule(ctx: ModuleFactoryArgs): RuleMetaModule {
@@ -34,7 +39,9 @@ export function createRuleMetaModule(ctx: ModuleFactoryArgs): RuleMetaModule {
     build: ({ caps, deps }) => {
       const impl = new RuleMetaModuleImpl(caps, deps);
       return {
-        facade: {},
+        facade: {
+          get: (key: string) => impl.get(key),
+        },
         hooks: {
           onProtoPhase: (p) => impl.onProtoPhase(p),
         },

--- a/packages/modules/rule-meta/src/types.ts
+++ b/packages/modules/rule-meta/src/types.ts
@@ -1,6 +1,9 @@
 import type { ModuleInstance } from '@proto.ui/core';
 
-export type RuleMetaFacade = {};
+export type RuleMetaFacade = {
+  /** Reads the current host/environment value when the adapter provides one. */
+  get(key: string): unknown;
+};
 
 export type RuleMetaModule = ModuleInstance<RuleMetaFacade> & {
   name: 'rule-meta';

--- a/packages/prototypes/base/src/transition/as-transition.ts
+++ b/packages/prototypes/base/src/transition/as-transition.ts
@@ -83,14 +83,19 @@ export const asTransition = defineAsHook<
         currentRun?.props.isProvided('interrupt')
           ? ((getProps()?.interrupt as TransitionInterrupt | undefined) ?? interruptDefault.get())
           : interruptDefault.get(),
-      getDuration: (state) =>
-        state === 'entering'
+      getDuration: (state) => {
+        // A zero-duration fallback preserves phase/event scheduling while removing
+        // non-essential sustained motion waits for reduced-motion users.
+        // P-BASE-TRANSITION-REDUCED-MOTION
+        if (currentRun?.meta?.get('reducedMotion') === 'reduce') return 0;
+        return state === 'entering'
           ? currentRun?.props.isProvided('enterDuration')
             ? (getProps()?.enterDuration ?? enterDurationDefault.get())
             : enterDurationDefault.get()
           : currentRun?.props.isProvided('leaveDuration')
             ? (getProps()?.leaveDuration ?? leaveDurationDefault.get())
-            : leaveDurationDefault.get(),
+            : leaveDurationDefault.get();
+      },
       schedule: (durationMs, callback) => delay(durationMs, callback),
       setViewPresent(present) {
         if (!currentRun) {

--- a/packages/prototypes/base/src/transition/transition.ts
+++ b/packages/prototypes/base/src/transition/transition.ts
@@ -15,9 +15,10 @@ import { asTransition } from './as-transition';
 export const transition = definePrototype({
   name: 'base-transition',
   setup() {
+    // P-BASE-TRANSITION-AUTHORING-ENTRIES, P-BASE-TRANSITION-STANDALONE
     asTransition();
-    // Transition 组件本身不渲染具体 DOM，只提供状态机治理
-    // 子组件或宿主平台通过 exposes 驱动实际动画
+    // P-BASE-TRANSITION-HOST-NEUTRAL
+    // Transition 本身不创建语义元素或宿主动画引擎，只透明保留调用者内容。
     return (r) => r.slot();
   },
 });

--- a/packages/prototypes/base/test/as-transition.test.ts
+++ b/packages/prototypes/base/test/as-transition.test.ts
@@ -6,14 +6,21 @@ import { executeWithHost } from '@proto.ui/runtime';
 import { EXPOSE_STATE_SET_EXPOSES_CAP } from '@proto.ui/module-expose-state';
 import { PRESENCE_HOST_BRIDGE_CAP } from '@proto.ui/module-presence';
 import { EVENT_EMIT_CAP } from '@proto.ui/module-event';
+import { RULE_META_GET_CAP } from '@proto.ui/module-rule-meta';
 import { asOverlay } from '@proto.ui/hooks';
 import { OVERLAY_GLOBAL_MOUNT_CAP, OVERLAY_MODAL_CAP } from '@proto.ui/module-overlay';
-import { asTransition, type TransitionProps, type TransitionExposes } from '../src/transition';
+import {
+  asTransition,
+  transition as baseTransition,
+  type TransitionProps,
+  type TransitionExposes,
+} from '../src/transition';
 
 function createHost(
   initialRaw: Partial<TransitionProps> = {},
   opts: {
     bridge?: { mount?: () => void; unmount?: () => void };
+    reducedMotion?: 'reduce' | 'no-preference';
     overlay?: {
       hostElement: HTMLElement;
       mount(): void;
@@ -73,6 +80,13 @@ function createHost(
       wiring.attach('event', [
         [EVENT_EMIT_CAP, (key: string, payload: unknown) => emitted.push({ key, payload })],
       ]);
+      wiring.attach('rule-meta', [
+        [
+          RULE_META_GET_CAP,
+          (key: string) =>
+            key === 'reducedMotion' ? (opts.reducedMotion ?? 'no-preference') : undefined,
+        ],
+      ]);
       if (opts.overlay) {
         wiring.attach('overlay', [
           [HOST_ELEMENT_CAP, opts.overlay.hostElement],
@@ -128,6 +142,21 @@ function createTransitionProto(
 }
 
 describe('prototypes/base: asTransition', () => {
+  it('BASE-TRANSITION-0100: direct prototype independently installs the shared surface', () => {
+    const ctx = createHost({ defaultOpen: true });
+
+    mountTransition(baseTransition as Prototype<TransitionProps>, ctx);
+
+    expect(baseTransition.name).toBe('base-transition');
+    expect(ctx.getExposes().transitionState.get()).toBe('entered');
+    expect(ctx.getExposes().isPresent.get()).toBe(true);
+    expect(ctx.getExposes().controls).toMatchObject({
+      enter: expect.any(Function),
+      leave: expect.any(Function),
+      complete: expect.any(Function),
+    });
+  });
+
   it('AS-TRANSITION-0100: initializes to closed state by default', () => {
     const ctx = createHost();
     const P = createTransitionProto('x-as-transition-0100');
@@ -773,5 +802,38 @@ describe('prototypes/base: asTransition', () => {
     expect(() =>
       result.invokeInCallbackScope(() => transition.configure({ enterDuration: 100 }))
     ).toThrow(/exec-phase violation/i);
+  });
+
+  it('AS-TRANSITION-2900: reduced motion uses zero-duration fallback without collapsing ordering', () => {
+    const ctx = createHost(
+      { open: true, appear: true, enterDuration: 240, leaveDuration: 180 },
+      { reducedMotion: 'reduce' }
+    );
+    const P = createTransitionProto('x-as-transition-2900');
+
+    const result = mountTransition(P, ctx);
+
+    expect(ctx.getExposes().transitionState.get()).toBe('entering');
+    expect(ctx.getDelays().map((entry) => entry.durationMs)).toEqual([0]);
+    expect(ctx.getEmitted().map((entry) => entry.key)).toEqual(['beforeEnter']);
+
+    ctx.flushDelay(0);
+    expect(ctx.getExposes().transitionState.get()).toBe('entered');
+    expect(ctx.getEmitted().map((entry) => entry.key)).toEqual(['beforeEnter', 'afterEnter']);
+
+    result.invokeInCallbackScope(() => ctx.getExposes().controls.leave());
+    expect(ctx.getExposes().transitionState.get()).toBe('leaving');
+    expect(result.session.viewIntent.getSnapshot().present).toBe(true);
+    expect(ctx.getDelays().map((entry) => entry.durationMs)).toEqual([0, 0]);
+
+    ctx.flushDelay(1);
+    expect(ctx.getExposes().transitionState.get()).toBe('closed');
+    expect(result.session.viewIntent.getSnapshot().present).toBe(false);
+    expect(ctx.getEmitted().map((entry) => entry.key)).toEqual([
+      'beforeEnter',
+      'afterEnter',
+      'beforeLeave',
+      'afterLeave',
+    ]);
   });
 });

--- a/packages/runtime/src/kernel/handles/run.ts
+++ b/packages/runtime/src/kernel/handles/run.ts
@@ -7,6 +7,7 @@ import { ContextFacade } from '@proto.ui/module-context';
 import { EventFacade } from '@proto.ui/module-event';
 import { AnatomyFacade } from '@proto.ui/module-anatomy';
 import { FeedbackFacade } from '@proto.ui/module-feedback';
+import type { RuleMetaFacade } from '@proto.ui/module-rule-meta';
 
 export const createRunHandle = <P extends PropsBaseType>(
   update: RunHandle<P>['update'],
@@ -19,12 +20,18 @@ export const createRunHandle = <P extends PropsBaseType>(
   const event = facades['event'] as EventFacade;
   const anatomy = facades['anatomy'] as AnatomyFacade | undefined;
   const feedback = facades['feedback'] as FeedbackFacade;
+  const meta = facades['rule-meta'] as RuleMetaFacade | undefined;
 
   return {
     update,
     lifecycle: {
       setPresent,
     },
+    meta: meta
+      ? {
+          get: (key) => meta.get(key),
+        }
+      : undefined,
     props: {
       get: () => props.get(),
       getRaw: () => props.getRaw(),

--- a/spec/contracts/C-AS-TRANSITION-0001.yaml
+++ b/spec/contracts/C-AS-TRANSITION-0001.yaml
@@ -66,6 +66,10 @@ criteria:
     text:
       zh-CN: 显式宿主 prop 必须优先于对应的 configure 默认值；多次 setup 配置只 patch 显式字段，并以最后一次提供的值为准。
       en: An explicit host prop must take precedence over its corresponding configured default; repeated setup configuration patches only supplied fields and the last supplied value wins.
+  - id: C-AS-TRANSITION-0001-N
+    text:
+      zh-CN: 当宿主 environment meta 声明 reducedMotion=reduce 时，自动 fallback completion 必须以 0ms delay 调度，在不保留非必要持续运动等待的同时保留 entering/leaving phase、before/after event 与 ViewIntent sequencing；meta 的最终实体归属由后续 Module/HC/Adapter 编目决定。
+      en: When host environment meta declares reducedMotion=reduce, automatic fallback completion must be scheduled with a 0ms delay, preserving entering and leaving phases, before and after events, and ViewIntent sequencing without retaining non-essential sustained-motion waits; final entity ownership of the meta source is left to later Module, HC, and Adapter cataloging.
 sources:
   - path: internal/contracts/prototype-base/transition.v0.md
   - path: packages/prototypes/base/src/transition/as-transition.ts
@@ -98,6 +102,9 @@ revisions:
   - version: 0.1.2
     change: revised
     summary: Added setup-only transition default configuration and explicit-host-prop precedence.
+  - version: 0.2.0
+    change: revised
+    summary: Added reduced-motion consumption semantics while deferring final environment capability ownership.
 tags:
   - transition
   - as-hook

--- a/spec/prototypes/P-BASE-TRANSITION.yaml
+++ b/spec/prototypes/P-BASE-TRANSITION.yaml
@@ -1,0 +1,137 @@
+id: P-BASE-TRANSITION
+type: prototype
+title: Base Transition governs host-neutral perceptual presence
+status: draft
+since: 0.2.0
+summary: Base Transition is an independently usable, slot-preserving protocol whose direct prototype and authored asHook share one host-neutral state machine for perceptual phases, ViewIntent sequencing, controls, interruption, fallback completion, and reduced-motion compatibility.
+statement:
+  zh-CN: >-
+    Base Transition 治理 closed、entering、entered、leaving 四个感知 phase，并把感知存在性与 lifecycle ViewIntent、实际 view epoch 和 Proto instance lifetime 保持为不同事实。`base-transition` direct prototype 与 `asTransition()` authored asHook 是同一 protocol 的两个 authoring entries；前者可以独立使用并保留 slot，后者适合由 Dialog、Hover Card、Select 等高层协议注入。Transition 不提供宿主专属动画引擎，但必须在 reduced-motion 偏好下消除非必要的持续时间等待，同时保留 phase、事件与 ViewIntent 的可观察顺序。
+
+
+  en: >-
+    Base Transition governs the four perceptual phases closed, entering, entered, and leaving while keeping perceptual presence distinct from lifecycle ViewIntent, actual view epochs, and Proto instance lifetime. The `base-transition` direct prototype and the `asTransition()` authored asHook are two authoring entries of one protocol: the former is independently usable and preserves its slot while the latter is suited for injection into higher-level protocols such as Dialog, Hover Card, and Select. Transition does not provide a host-specific animation engine, but it must remove non-essential duration waits under a reduced-motion preference while preserving observable phase, event, and ViewIntent ordering.
+
+
+criteria:
+  - id: P-BASE-TRANSITION-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`base-transition` direct prototype 与 `asTransition()` authored asHook 必须是同一 Transition protocol 的两个 authoring entries。'
+      en: 'The `base-transition` direct prototype and the `asTransition()` authored asHook must be two authoring entries of the same Transition protocol.'
+    dependsOn:
+      contracts: [C-CORE-SYNTAX-0003, C-AS-HOOK-0001, C-AS-TRANSITION-0001]
+      decisions: [D-PROTOTYPE-ENTITY-NAMING-0001]
+  - id: P-BASE-TRANSITION-STANDALONE
+    text:
+      zh-CN: '`base-transition` 必须能够作为 direct prototype 独立执行，安装完整 Transition public surface，并以透明 slot 保留调用者内容；独立使用不得要求先组合 Dialog、Overlay 或其他 protocol。'
+      en: '`base-transition` must execute independently as a direct prototype, install the complete Transition public surface, and preserve caller content through a transparent slot; standalone use must not require prior composition with Dialog, Overlay, or another protocol.'
+    dependsOn:
+      contracts: [C-TEMPLATE-0001, C-AS-TRANSITION-0001]
+  - id: P-BASE-TRANSITION-PERCEPTUAL-OWNER
+    text:
+      zh-CN: Transition 只拥有 closed、entering、entered、leaving 感知 phase 与由其派生的 isPresent；不得把感知状态伪装成实际 mount、DOM 存在或 Proto instance disposal 的真相。
+      en: Transition owns only the closed, entering, entered, and leaving perceptual phases and the isPresent fact derived from them; it must not disguise perceptual state as the truth of actual mount, DOM existence, or Proto instance disposal.
+    dependsOn:
+      contracts: [C-AS-TRANSITION-0001, C-LIFECYCLE-0008, C-STATE-0001]
+  - id: P-BASE-TRANSITION-PROPS
+    text:
+      zh-CN: Transition 必须接受 `open`、`defaultOpen`、`appear`、`enterDuration`、`leaveDuration` 与 `interrupt` props；`open` 被提供时由 owner 控制目标，未提供时 controls 在 `defaultOpen` 初值之后拥有目标。
+      en: Transition must accept `open`, `defaultOpen`, `appear`, `enterDuration`, `leaveDuration`, and `interrupt` props; when `open` is provided the owner controls the target, and when it is absent the controls own the target after the `defaultOpen` initial value.
+    dependsOn:
+      contracts: [C-PROPS-0001, C-PROPS-0003, C-AS-TRANSITION-0001]
+  - id: P-BASE-TRANSITION-PUBLIC-SURFACE
+    text:
+      zh-CN: Transition 必须 expose `transitionState`、`isPresent`、`enter`、`leave`、`complete`、分组 `controls`，以及 `beforeEnter`、`afterEnter`、`beforeLeave`、`afterLeave` signals；authored asHook handle 必须投射对应 state、controls 与 setup-only `configure`。
+      en: Transition must expose `transitionState`, `isPresent`, `enter`, `leave`, `complete`, grouped `controls`, and the `beforeEnter`, `afterEnter`, `beforeLeave`, and `afterLeave` signals; the authored-asHook handle must project the corresponding state, controls, and setup-only `configure`.
+    dependsOn:
+      contracts: [C-EXPOSE-STATE-0001, C-EXPOSE-EVENT-0001, C-EXPOSE-0002, C-AS-TRANSITION-0001]
+  - id: P-BASE-TRANSITION-ENTER-SEQUENCING
+    text:
+      zh-CN: 从 detached closed 进入或初始 open 且 appear=true 时，Transition 必须先请求 ViewIntent present，等待 view epoch mounted 后再发出 beforeEnter 并进入 entering；完成后必须进入 entered 并发出 afterEnter。
+      en: When entering from detached closed or initially open with appear=true, Transition must request present ViewIntent first, wait for the view epoch to mount, then emit beforeEnter and enter entering; completion must enter entered and emit afterEnter.
+    dependsOn:
+      contracts: [C-AS-TRANSITION-0001, C-LIFECYCLE-0008]
+  - id: P-BASE-TRANSITION-LEAVE-SEQUENCING
+    text:
+      zh-CN: Transition 必须在 leaving 全程保留当前 view；完成时进入 closed、发出 afterLeave，随后才能请求 ViewIntent detached，且 detached 后 controls 与 exposes 在 owner terminal dispose 前仍可用。
+      en: Transition must retain the current view throughout leaving; on completion it enters closed, emits afterLeave, and only then may request detached ViewIntent, while controls and exposes remain usable after detach until owner terminal disposal.
+    dependsOn:
+      contracts: [C-AS-TRANSITION-0001, C-LIFECYCLE-0008]
+  - id: P-BASE-TRANSITION-FALLBACK-COMPLETION
+    text:
+      zh-CN: enterDuration 与 leaveDuration 只提供可移植 fallback completion；宿主或高层能力可在实际视觉效果结束时调用 complete，过期 delay 不得完成新的 phase。
+      en: enterDuration and leaveDuration provide portable fallback completion only; a host or higher-level capability may call complete when the actual visual effect ends, and a stale delay must not complete a newer phase.
+    dependsOn:
+      contracts: [C-AS-TRANSITION-0001, C-DELAY-0001]
+  - id: P-BASE-TRANSITION-INTERRUPTION
+    text:
+      zh-CN: Transition 必须按最新目标实现 reverse、wait 与 immediate 中断策略；wait 最多保留一个 latest pending direction，不得形成无界队列。
+      en: Transition must implement reverse, wait, and immediate interruption policies against the latest target; wait may retain at most one latest pending direction and must not form an unbounded queue.
+    dependsOn:
+      contracts: [C-AS-TRANSITION-0001]
+  - id: P-BASE-TRANSITION-CONFIGURE
+    text:
+      zh-CN: authored asHook 的 setup-only `configure` 必须能够 patch appear、durations 与 interrupt 默认值；显式 host props 的优先级必须高于配置默认值。
+      en: The authored asHook's setup-only `configure` must patch appear, duration, and interrupt defaults, while explicit host props retain precedence over configured defaults.
+    dependsOn:
+      contracts: [C-AS-TRANSITION-0001]
+  - id: P-BASE-TRANSITION-REDUCED-MOTION
+    text:
+      zh-CN: 当宿主环境声明 reduced-motion preference 为 reduce 时，Transition 必须把自动 fallback completion 的有效等待缩短为 0ms，不执行非必要的持续运动等待；before/after signals、entering/leaving phase、ViewIntent materialize/retain/detach 顺序仍必须保留。
+      en: When the host environment declares a reduced-motion preference of reduce, Transition must shorten the effective wait for automatic fallback completion to 0ms and perform no non-essential sustained-motion wait; before and after signals, entering and leaving phases, and ViewIntent materialize, retain, and detach ordering must remain intact.
+    dependsOn:
+      contracts: [C-AS-TRANSITION-0001, C-DELAY-0001, C-RULE-WHEN-0002]
+  - id: P-BASE-TRANSITION-HOST-NEUTRAL
+    text:
+      zh-CN: Base Transition 不定义 CSS class、keyframe、easing、physics、layout/shared-element motion、stagger、子级编排、宿主 animation event detection 或组件语义 role；这些视觉与宿主投射责任属于下游 prototype、adapter 或后续 capability。
+      en: Base Transition does not define CSS classes, keyframes, easing, physics, layout or shared-element motion, staggering, child orchestration, host animation-event detection, or a component semantic role; these visual and host-projection responsibilities belong to downstream prototypes, adapters, or later capabilities.
+    dependsOn:
+      knowledge: [K-DESIGN-TRADEOFF-0001]
+openQuestions:
+  - id: P-BASE-TRANSITION-Q-REDUCED-MOTION-SOURCE
+    question:
+      zh-CN: reduced-motion preference 的稳定真相源最终应归属于 adapter profile、host capability，还是统一的 environment/configuration 实体？
+      en: Should the stable source of reduced-motion preference ultimately belong to an adapter profile, a host capability, or a unified environment/configuration entity?
+    context:
+      zh-CN: 当前 official adapters 已通过 environment meta 提供 `reducedMotion`，但 meta 的命名与重评估边界仍处于治理中；本轮只固定 Transition 的消费语义，不提前定案最终实体归属。
+      en: Official adapters currently provide `reducedMotion` through environment meta, but meta naming and re-evaluation boundaries remain under governance; this pass fixes only Transition consumption semantics without deciding final entity ownership.
+    blocks: [transition environment capability catalog]
+sources:
+  - path: internal/contracts/prototype-base/transition.v0.md
+  - path: packages/prototypes/base/src/transition/transition.ts
+  - path: packages/prototypes/base/src/transition/as-transition.ts
+  - path: packages/prototypes/base/src/transition/machine.ts
+  - path: packages/prototypes/base/test/as-transition.test.ts
+  - path: spec/contracts/C-AS-TRANSITION-0001.yaml
+  - path: spec/tests/T-AS-TRANSITION-0001.yaml
+  - path: https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html
+    label: WCAG 2.2 Understanding Animation from Interactions
+  - path: https://www.w3.org/WAI/WCAG22/Understanding/pause-stop-hide.html
+    label: WCAG 2.2 Understanding Pause, Stop, Hide
+dependsOn:
+  contracts:
+    [
+      C-CORE-SYNTAX-0003,
+      C-PROPS-0001,
+      C-PROPS-0003,
+      C-AS-HOOK-0001,
+      C-AS-TRANSITION-0001,
+      C-DELAY-0001,
+      C-LIFECYCLE-0008,
+      C-STATE-0001,
+      C-EXPOSE-0002,
+      C-EXPOSE-STATE-0001,
+      C-EXPOSE-EVENT-0001,
+      C-RULE-WHEN-0002,
+      C-TEMPLATE-0001,
+    ]
+  decisions: [D-PROTOTYPE-ENTITY-NAMING-0001]
+relates:
+  prototypes: [P-BASE-DIALOG-CONTENT, P-BASE-HOVER-CARD-CONTENT, P-BASE-SELECT-CONTENT]
+  decisions: [D-AS-HOOK-NO-ARG-ONCE-0001, D-AS-HOOK-CALLER-NAME-0001]
+verifies: { tests: [T-BASE-TRANSITION-0001] }
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged standalone and authored-asHook Transition entries, perceptual phase and ViewIntent boundaries, public controls, interruption, fallback completion, host neutrality, and reduced-motion behavior.
+tags: [prototype, base, transition, as-hook, lifecycle, view-intent, reduced-motion, accessibility]

--- a/spec/tests/T-AS-TRANSITION-0001.yaml
+++ b/spec/tests/T-AS-TRANSITION-0001.yaml
@@ -47,6 +47,11 @@ cases:
       - C-AS-TRANSITION-0001-L
       - C-AS-TRANSITION-0001-M
     expectation: setup-only-configured-defaults-with-host-prop-precedence
+  - id: T-AS-TRANSITION-0001-CASE-REDUCED-MOTION
+    title: Reduced motion uses zero-duration fallback while preserving transition ordering
+    covers:
+      - C-AS-TRANSITION-0001-N
+    expectation: reduced-motion-zero-duration-fallback-preserves-transition-ordering
 implementations:
   - id: base-transition-state-machine
     kind: runtime-test
@@ -61,6 +66,7 @@ implementations:
       - T-AS-TRANSITION-0001-CASE-INTERRUPT
       - T-AS-TRANSITION-0001-CASE-CONTROL
       - T-AS-TRANSITION-0001-CASE-CONFIGURE
+      - T-AS-TRANSITION-0001-CASE-REDUCED-MOTION
   - id: react-transition-view-intent
     kind: adapter-test
     status: passing
@@ -85,6 +91,11 @@ implementations:
 verifies:
   contracts:
     - id: C-AS-TRANSITION-0001
+      anchors:
+        - C-AS-TRANSITION-0001-A
+        - C-AS-TRANSITION-0001-D
+        - C-AS-TRANSITION-0001-E
+        - C-AS-TRANSITION-0001-N
 exercises:
   contracts:
     - id: C-DELAY-0001
@@ -97,6 +108,9 @@ revisions:
   - version: 0.1.0
     change: introduced
     summary: Added state-machine and cross-adapter conformance coverage for the rewritten Transition model.
+  - version: 0.2.0
+    change: refined
+    summary: Added reduced-motion fallback coverage and explicit contract anchors.
 tags:
   - transition
   - view-intent

--- a/spec/tests/T-BASE-TRANSITION-0001.yaml
+++ b/spec/tests/T-BASE-TRANSITION-0001.yaml
@@ -1,0 +1,73 @@
+id: T-BASE-TRANSITION-0001
+type: test
+title: Base Transition prototype protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers Base Transition direct and authored-asHook entries, standalone execution, public surface, perceptual and ViewIntent sequencing, fallback completion, interruption, configuration, host neutrality, and reduced-motion compatibility.
+cases:
+  - id: T-BASE-TRANSITION-0001-CASE-AUTHORING-ENTRIES
+    title: base-transition and asTransition are independently usable entries of one protocol
+    covers:
+      - P-BASE-TRANSITION-AUTHORING-ENTRIES
+      - P-BASE-TRANSITION-STANDALONE
+    expectation: base-transition-direct-prototype-installs-the-shared-transition-surface
+  - id: T-BASE-TRANSITION-0001-CASE-SURFACE
+    title: Transition exposes host-neutral props, states, controls, configuration, and lifecycle signals
+    covers:
+      - P-BASE-TRANSITION-PROPS
+      - P-BASE-TRANSITION-PUBLIC-SURFACE
+      - P-BASE-TRANSITION-CONFIGURE
+      - P-BASE-TRANSITION-HOST-NEUTRAL
+    expectation: transition-public-surface-remains-host-neutral-and-configurable
+  - id: T-BASE-TRANSITION-0001-CASE-SEQUENCING
+    title: Transition keeps perceptual phases distinct and sequences materialize, retain, and detach
+    covers:
+      - P-BASE-TRANSITION-PERCEPTUAL-OWNER
+      - P-BASE-TRANSITION-ENTER-SEQUENCING
+      - P-BASE-TRANSITION-LEAVE-SEQUENCING
+    expectation: transition-perceptual-phases-preserve-view-intent-ordering
+  - id: T-BASE-TRANSITION-0001-CASE-COMPLETION-AND-INTERRUPTION
+    title: Transition uses lifecycle-bound fallback completion and latest-target interruption
+    covers:
+      - P-BASE-TRANSITION-FALLBACK-COMPLETION
+      - P-BASE-TRANSITION-INTERRUPTION
+    expectation: transition-fallback-and-interruption-remain-latest-target-safe
+  - id: T-BASE-TRANSITION-0001-CASE-REDUCED-MOTION
+    title: reduced motion removes sustained fallback waits without collapsing protocol ordering
+    covers:
+      - P-BASE-TRANSITION-REDUCED-MOTION
+    expectation: reduced-motion-uses-zero-duration-fallback-and-preserves-phase-events
+implementations:
+  - id: prototypes-base-transition-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/as-transition.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TRANSITION-0001-CASE-AUTHORING-ENTRIES
+      - T-BASE-TRANSITION-0001-CASE-SURFACE
+      - T-BASE-TRANSITION-0001-CASE-SEQUENCING
+      - T-BASE-TRANSITION-0001-CASE-COMPLETION-AND-INTERRUPTION
+      - T-BASE-TRANSITION-0001-CASE-REDUCED-MOTION
+    exercises: [P-BASE-TRANSITION]
+    notes:
+      - Exercises both the exported base-transition direct prototype and authored asTransition handle.
+      - Existing phase, interruption, ViewIntent, Overlay binding, configuration, and adapter tests provide the detailed executable matrix behind this prototype-level mapping.
+verifies:
+  prototypes:
+    - id: P-BASE-TRANSITION
+      anchors:
+        - P-BASE-TRANSITION-AUTHORING-ENTRIES
+        - P-BASE-TRANSITION-STANDALONE
+        - P-BASE-TRANSITION-PERCEPTUAL-OWNER
+        - P-BASE-TRANSITION-ENTER-SEQUENCING
+        - P-BASE-TRANSITION-LEAVE-SEQUENCING
+        - P-BASE-TRANSITION-REDUCED-MOTION
+exercises:
+  prototypes: [P-BASE-TRANSITION]
+  contracts: [C-AS-TRANSITION-0001, C-LIFECYCLE-0008, C-DELAY-0001]
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Added prototype-level coverage for standalone and authored Transition entries, public behavior, ViewIntent sequencing, interruption, configuration, and reduced-motion fallback.
+tags: [prototype, base, transition, test, reduced-motion, accessibility]


### PR DESCRIPTION
## Summary

- catalog `base-transition` and `asTransition()` as two authoring entries of `P-BASE-TRANSITION`
- add prototype-level test coverage for standalone use, public controls, perceptual phases, ViewIntent sequencing, interruption, and fallback completion
- consume `reducedMotion=reduce` by using zero-duration fallback completion while preserving phase, signal, and ViewIntent ordering
- align setup configuration with explicit host-prop precedence and record the remaining environment-capability ownership question
- record the v0.2 closure and follow-up roadmap

## Why

Transition is independently usable even though higher-level prototypes often consume it through `asTransition()`. It therefore needs its own P entity and executable T mapping, including the accessibility boundary for reduced motion.

## Impact

This makes Transition discoverable in the spec workspace, fixes the explicit-prop versus configured-default boundary, and preserves host-neutral behavior. The stable ownership of the reduced-motion environment source remains an explicit open question for later Module, Host-Cap, and Adapter cataloging.

## Checks

- `pnpm --filter apps-workspace build`
- `vitest run packages/prototypes/base/test/as-transition.test.ts` — 29 tests passed
- `pnpm check:types:workspace`
- spec workspace generated 318 entities with 0 validation issues
