### PR TITLE
refactor: catalog external prototype libraries

### DIFF
--- a/apps/workspace/src/main.tsx
+++ b/apps/workspace/src/main.tsx
@@ -84,6 +84,7 @@ const UI_TEXT = {
     relationKinds: {
       relates: 'Relates',
       dependsOn: 'Depends On',
+      inherits: 'Inherits',
       references: 'References',
       refines: 'Refines',
       satisfies: 'Satisfies',
@@ -189,6 +190,7 @@ const UI_TEXT = {
     relationKinds: {
       relates: '关联',
       dependsOn: '依赖',
+      inherits: '继承',
       references: '参考',
       refines: '细化',
       satisfies: '满足',

--- a/internal/records/2026-07-18-external-prototype-library-governance.zh-CN.md
+++ b/internal/records/2026-07-18-external-prototype-library-governance.zh-CN.md
@@ -1,0 +1,119 @@
+# 2026-07-18 外部来源原型库治理记录
+
+> Internal record. Not normative. 本文记录 Proto UI 对 Base、Lucide、Shadcn 以及未来社区风格原型库的身份、来源、P 实体粒度与上游冲突处理原则。稳定规则可在实践验证后提升为 `D-*` 决策实体；本文不替代上游许可证、商标政策或法律意见。
+
+---
+
+## 1）背景
+
+Proto UI 当前维护三类公开原型库：
+
+- `@proto.ui/prototypes-base`：由 Proto UI 定义和拥有的基础协议库。
+- `@proto.ui/prototypes-lucide`：消费 Lucide SVG 数据并转换为 Proto UI 原型语法的图标库。
+- `@proto.ui/prototypes-shadcn`：参考 shadcn/ui 官方实现并以 Proto UI 协议、adapter 与样式能力重建的组件库。
+
+未来还可能出现 Ant Design、Material 等社区风格原型库。此类实现可能由 Proto UI 社区维护，但不应因为进入 Proto UI 仓库就被描述为对应上游项目的官方实现。
+
+## 2）问题
+
+如果所有公开原型都只按源码文件编目，会出现两个相反的问题：
+
+- Lucide 的上千个 glyph 会制造上千个内容高度重复的 `P-*` 实体。
+- Shadcn 的复合组件若只用一个库级实体，又无法表达 Root 与各 anatomy part 在 Base 之上的不同封装和兼容范围。
+
+此外，P 实体属于 Proto UI 的规范治理，但 Lucide 图形数据与 Shadcn 设计/API 来源于外部项目。需要明确“Proto UI 治理自身实现”与“Proto UI 主张上游所有权”不是同一件事。
+
+## 3）当前判断
+
+### 3.1 P 实体治理范围
+
+`P-*` 实体描述 Proto UI 发布的 prototype protocol，并约束 Proto UI 自己维护的实现、测试和文档。外部来源原型仍应进入 P 实体体系，因为它们的 package API、生成方式、adapter 行为与兼容声明由 Proto UI 发布和维护。
+
+P 实体的存在不表示：
+
+- Proto UI 拥有上游图形、设计、名称、商标或原始源码。
+- Proto UI 得到上游官方认证。
+- Proto UI 可以忽略上游许可证、归属声明或明确反对。
+
+### 3.2 Base
+
+Base 是 Proto UI 的 first-party protocol library。Base P 实体完整描述交互语义、状态、a11y、anatomy、事件与扩展边界，并作为上层原型库可依赖的稳定协议。
+
+### 3.3 Lucide
+
+所有 Lucide 图标共用一个 `P-LUCIDE-ICON`：
+
+- `lucide-icon` / `asLucideIcon` 是 name-based authoring entries。
+- `lucide-{name}-icon` / `asLucide{Name}Icon` / `renderLucide{Name}Icon` 是同一协议的生成特化和 tree-shakable projections。
+- 单个 glyph 是 catalog data，不是独立 prototype protocol，因此不为每个图标创建 P 实体。
+
+当前实现从 `lucide-static/icon-nodes.json` 读取 SVG node data，并批量重写为 Proto UI `renderer.svg` 语法。这是 Proto UI 当前缺少通用 SVG 资源解析能力时的过渡实现，不改变图形来源。
+
+每次重新生成必须至少记录：
+
+- 上游 package 与精确版本。
+- 生成配置。
+- 支持的 SVG tag 与 normalization。
+- manifest 中的名称、固定导出和动态加载映射。
+- 上游许可证与 attribution follow-up。
+
+当前编目基线为 `lucide-static@1.8.0`。该 package 声明 ISC，且其 license text 另列出部分 Feather-derived icons 的 MIT notice。仓库顶层或 package 自身的 MIT 声明不能被解释为覆盖或替换这些上游 notice。
+
+### 3.4 Shadcn
+
+Shadcn 原型按 Base 类似粒度建立 `P-SHADCN-*`：
+
+- 每个稳定 component protocol 一个实体。
+- 每个拥有独立协议增量的 anatomy part 单独一个实体。
+- Shadcn 可以比 Base 拥有更多 part，因为上层封装允许扩展 anatomy 与 API。
+
+Shadcn P 实体采用 delta-style：
+
+1. 通过一等 `inherits.prototypes` 关系指向对应 `P-BASE-*`，不把原型继承混同为一般依赖。
+2. 默认继承 Base 已经保证的交互、状态、a11y 与事件准则，不重复定义。
+3. 这种继承可反悔：消费 Base authored asHook 后，上层可以对某个已引入能力施加 setup-only 负向补丁或替换。每一个放弃或修改都必须在上层 P 实体的独立准则中说明被取消的 Base 能力、理由与替代语义；没有明示偏离的 Base guarantee 保持有效。建立计划与取消计划都发生在 setup 期，因此单纯取消通常不为对应能力留下 runtime 分支开销；如果实现依赖 runtime flag 才“取消”行为，它就不是这里所说的 setup 负向补丁。
+4. 只描述 Shadcn 在 Base 之上新增或改变的 API、anatomy、视觉规则、组合方式和兼容边界。
+5. 明确区分 upstream compatibility target、当前 passing subset、planned gap 与 intentional deviation；同一 P 实体的当前全部 upstream 差异集中维护在一个 open question 中。
+
+“参考官方”必须有可复验基线。实体 source 应尽量固定到上游 tag、package version 或 commit/path；上游更新不会自动改变 Proto UI 当前 guarantee，必须经过同步、测试和 revision 记录。
+
+Shadcn Button 试点使用的上游基线是：
+
+- repository：`shadcn-ui/ui`
+- file：`apps/v4/registry/new-york-v4/ui/button.tsx`
+- revision：`f31ed81983653919dd4fe77aee4b4859f610f1dc`
+
+### 3.5 `asChild` 是有意不兼容项
+
+Proto UI 不提供 Radix-style `asChild` 兼容 API。trigger 组合应由组件作者声明角色，并由特权 `asTrigger()` 自动合并连续 trigger event route；不应把事件代理、handler 合并或 trigger ownership 转交责任放给组件调用者。
+
+因此：
+
+- 当 Shadcn 或其他 upstream API 包含 `asChild` 时，Proto UI 投射应忽略该参数并声明 intentional deviation。
+- 不得仅为了模拟 `asChild` 而扩展 `asTrigger()` 使其选择性停止默认 route 合并。
+- 透明 slot、元素替换与 native prop forwarding 是不同能力，不得因为实现了其中一项就宣称与 Radix Slot 或 `asChild` 等价。
+- 正式决策实体为 `D-AS-CHILD-OMISSION-0001`，相关 P 实体应引用它并保留独立准则。
+
+### 3.6 社区与潜在官方关系
+
+未来的 Ant Design、Material 或其他风格库默认是 Proto UI 社区维护的非官方实现。只有上游明确认证并就维护责任、名称使用、发布与治理达成方案后，才可以改变官方状态描述。
+
+当来源权利人明确提出归属修正、名称冲突、停止分发或下架要求时，Proto UI 应优先核验并配合上游决定，而不是以本地 P 实体或重写实现为理由对抗。需要下架时，可把实体标记 deprecated/removed 并保留必要的迁移记录；不得删除历史事实来伪装从未分发。
+
+## 4）本轮决定
+
+1. 新增一个 `P-LUCIDE-ICON` 与一个对应 T 实体，不为每个 glyph 建实体。
+2. Shadcn 使用 `P-SHADCN-{COMPONENT/PART}`，并通过 `inherits.prototypes` 以 Base P 作为可显式负向补丁的默认继承基线。
+3. Shadcn Button 作为 delta-style 编目模版；完成后暂停，验收模版再批量展开。
+4. 外部来源、上游版本和非官方状态必须在 record、entity source、README 或生成 manifest 中至少有可追溯入口。
+5. 新增 `D-AS-CHILD-OMISSION-0001`，把跨 Shadcn 原型反复出现的 `asChild` 有意不兼容收敛为一次治理决策。
+6. 先用 Lucide 与 Shadcn Button 两个不同形态验证治理模型；Shadcn Button 模版验收后再批量展开。
+
+## 5）后续断口
+
+- 是否为 prototype entity schema 增加结构化 `provenance`、`upstreamRevision`、`compatibility` 与 `officialStatus` 字段。
+- 第三方 notice 应采用 package-local 文件、仓库总表还是发布阶段自动聚合。
+- Lucide 生成器的原始输出与仓库 Prettier 结果目前不是字节幂等；正式 regeneration workflow 应内置格式化或增加 clean-tree check，避免上游同步制造数千个纯格式 diff。
+- Shadcn upstream API 中 React/native-specific props 如何映射为跨 adapter Proto UI API。
+- upstream deletion、rename 与 breaking change 如何映射到 P entity revision/deprecation。
+- 官方认证发生时，维护责任、发布权限与实体治理权如何迁移。

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "docs:dev": "corepack pnpm@10.32.1 --filter apps-www dev",
+    "dev:workspace": "corepack pnpm@10.32.1 --filter apps-workspace dev",
     "docs:build": "corepack pnpm@10.32.1 --filter apps-www build",
     "docs:preview": "corepack pnpm@10.32.1 --filter apps-www preview",
     "sync:links": "node scripts/sync-shared-links.mjs",

--- a/packages/prototypes/lucide/README.md
+++ b/packages/prototypes/lucide/README.md
@@ -16,6 +16,7 @@ Provides:
 - Icon visual definitions are derived from [Lucide](https://lucide.dev/).
 - This package is a Proto UI-side consumption layer and is **not** an official Lucide package.
 - Please keep upstream Lucide license/attribution in distribution and documentation workflows.
+- The current generated baseline is `lucide-static@1.8.0`; the generated manifest exports the exact package, version, and license metadata.
 
 ## Package Role
 
@@ -77,4 +78,4 @@ Generated outputs include:
 
 ## License
 
-MIT
+The Proto UI integration code is MIT-licensed. Generated icon definitions are derived from `lucide-static` and retain the upstream Lucide/Feather notices. The current upstream package declares ISC and includes an additional MIT notice for Feather-derived icons. Do not interpret the Proto UI package license field as replacing those upstream notices.

--- a/packages/prototypes/lucide/README.md
+++ b/packages/prototypes/lucide/README.md
@@ -61,6 +61,8 @@ Generated outputs include:
 - `src/snippets.generated.ts`
 - `src/loaders.generated.ts`
 
+The generator formats every emitted TypeScript file with the repository Prettier configuration before writing it. Running generation repeatedly without changing the config or upstream package must therefore leave the working tree byte-for-byte unchanged.
+
 ## Recommended Consumption
 
 - Static, tree-shakable import:

--- a/packages/prototypes/lucide/package.json
+++ b/packages/prototypes/lucide/package.json
@@ -11,7 +11,8 @@
     "generate:icons": "node ./scripts/generate-icons.mjs"
   },
   "devDependencies": {
-    "@proto.ui/runtime": "workspace:*"
+    "@proto.ui/runtime": "workspace:*",
+    "prettier": "^3.8.1"
   },
   "exports": {
     ".": {

--- a/packages/prototypes/lucide/scripts/generate-icons.mjs
+++ b/packages/prototypes/lucide/scripts/generate-icons.mjs
@@ -194,7 +194,7 @@ ${lines.join('\n')}
 `;
 }
 
-function createManifestSource(iconNames) {
+function createManifestSource(iconNames, upstream) {
   const toEntryLiteral = (name) => {
     const pascal = toPascalCase(name);
     return `{
@@ -220,6 +220,10 @@ function createManifestSource(iconNames) {
 // Source: packages/prototypes/lucide/icons.config.json + lucide-static/icon-nodes.json
 
 import type { LucideIconName } from './icon/icons';
+
+export const LUCIDE_UPSTREAM_PACKAGE = ${JSON.stringify(upstream.name)};
+export const LUCIDE_UPSTREAM_VERSION = ${JSON.stringify(upstream.version)};
+export const LUCIDE_UPSTREAM_LICENSE = ${JSON.stringify(upstream.license)};
 
 export interface LucideIconManifestEntry {
   name: LucideIconName;
@@ -386,6 +390,7 @@ async function main() {
 
   const lucidePkgPath = require.resolve('lucide-static/package.json');
   const lucideDir = path.dirname(lucidePkgPath);
+  const lucidePackage = JSON.parse(await fs.readFile(lucidePkgPath, 'utf8'));
   const nodeMapPath = path.join(lucideDir, 'icon-nodes.json');
   const nodeMap = JSON.parse(await fs.readFile(nodeMapPath, 'utf8'));
 
@@ -442,7 +447,17 @@ async function main() {
 
   writeJobs.push(fs.writeFile(output.iconRegistry, createIconRegistrySource(iconNames), 'utf8'));
   writeJobs.push(fs.writeFile(output.iconIndex, createIconIndexSource(iconNames), 'utf8'));
-  writeJobs.push(fs.writeFile(output.manifest, createManifestSource(iconNames), 'utf8'));
+  writeJobs.push(
+    fs.writeFile(
+      output.manifest,
+      createManifestSource(iconNames, {
+        name: lucidePackage.name,
+        version: lucidePackage.version,
+        license: lucidePackage.license,
+      }),
+      'utf8'
+    )
+  );
   writeJobs.push(fs.writeFile(output.snippets, createSnippetsSource(iconNames), 'utf8'));
   writeJobs.push(fs.writeFile(output.loaders, createLoadersSource(iconNames), 'utf8'));
 

--- a/packages/prototypes/lucide/scripts/generate-icons.mjs
+++ b/packages/prototypes/lucide/scripts/generate-icons.mjs
@@ -4,12 +4,14 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
+import { format, resolveConfig } from 'prettier';
 
 const require = createRequire(import.meta.url);
 const pkgDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const configPath = path.join(pkgDir, 'icons.config.json');
 const iconDir = path.join(pkgDir, 'src', 'icons');
 const shapeDir = path.join(pkgDir, 'src', 'shapes');
+const WRITE_CONCURRENCY = 16;
 
 const output = {
   iconRegistry: path.join(pkgDir, 'src', 'icon', 'icons.generated.ts'),
@@ -385,6 +387,27 @@ async function clearGeneratedShapeModules() {
   );
 }
 
+async function writeGeneratedSources(entries) {
+  const prettierConfig = (await resolveConfig(output.manifest)) ?? {};
+  let nextIndex = 0;
+
+  async function writeNext() {
+    while (nextIndex < entries.length) {
+      const entry = entries[nextIndex];
+      nextIndex += 1;
+      const source = await format(entry.source, {
+        ...prettierConfig,
+        filepath: entry.filePath,
+      });
+      await fs.writeFile(entry.filePath, source, 'utf8');
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(WRITE_CONCURRENCY, entries.length) }, () => writeNext())
+  );
+}
+
 async function main() {
   const config = JSON.parse(await fs.readFile(configPath, 'utf8'));
 
@@ -426,42 +449,45 @@ async function main() {
   await clearGeneratedIconModules();
   await clearGeneratedShapeModules();
 
-  const writeJobs = [];
+  const generatedSources = [];
   for (const iconName of iconNames) {
     const nodes = nodeMap[iconName];
-    writeJobs.push(
-      fs.writeFile(
-        path.join(iconDir, `${iconName}.ts`),
-        createIconModuleSource(iconName, nodes),
-        'utf8'
-      )
-    );
-    writeJobs.push(
-      fs.writeFile(
-        path.join(shapeDir, `${iconName}.ts`),
-        createShapeModuleSource(iconName, nodes),
-        'utf8'
-      )
-    );
+    generatedSources.push({
+      filePath: path.join(iconDir, `${iconName}.ts`),
+      source: createIconModuleSource(iconName, nodes),
+    });
+    generatedSources.push({
+      filePath: path.join(shapeDir, `${iconName}.ts`),
+      source: createShapeModuleSource(iconName, nodes),
+    });
   }
 
-  writeJobs.push(fs.writeFile(output.iconRegistry, createIconRegistrySource(iconNames), 'utf8'));
-  writeJobs.push(fs.writeFile(output.iconIndex, createIconIndexSource(iconNames), 'utf8'));
-  writeJobs.push(
-    fs.writeFile(
-      output.manifest,
-      createManifestSource(iconNames, {
-        name: lucidePackage.name,
-        version: lucidePackage.version,
-        license: lucidePackage.license,
-      }),
-      'utf8'
-    )
-  );
-  writeJobs.push(fs.writeFile(output.snippets, createSnippetsSource(iconNames), 'utf8'));
-  writeJobs.push(fs.writeFile(output.loaders, createLoadersSource(iconNames), 'utf8'));
+  generatedSources.push({
+    filePath: output.iconRegistry,
+    source: createIconRegistrySource(iconNames),
+  });
+  generatedSources.push({
+    filePath: output.iconIndex,
+    source: createIconIndexSource(iconNames),
+  });
+  generatedSources.push({
+    filePath: output.manifest,
+    source: createManifestSource(iconNames, {
+      name: lucidePackage.name,
+      version: lucidePackage.version,
+      license: lucidePackage.license,
+    }),
+  });
+  generatedSources.push({
+    filePath: output.snippets,
+    source: createSnippetsSource(iconNames),
+  });
+  generatedSources.push({
+    filePath: output.loaders,
+    source: createLoadersSource(iconNames),
+  });
 
-  await Promise.all(writeJobs);
+  await writeGeneratedSources(generatedSources);
   process.stdout.write(
     `[prototypes-lucide] generated ${iconNames.length} icon modules and manifests under src/icons\n`
   );

--- a/packages/prototypes/lucide/src/icon/fixed.ts
+++ b/packages/prototypes/lucide/src/icon/fixed.ts
@@ -12,6 +12,7 @@ const DEFAULT_STROKE = 'currentColor';
 const DEFAULT_FILL = 'none';
 
 function setupFixedIcon(def: DefHandle<LucideFixedIconProps, LucideFixedIconExposes>): void {
+  // P-LUCIDE-ICON-FIXED-PROPS
   def.props.define({
     size: { type: 'number', empty: 'fallback' },
     strokeWidth: { type: 'number', empty: 'fallback' },
@@ -41,6 +42,7 @@ export function createLucideFixedIcon(options: {
   prototypeName: string;
   shapeFactory: LucideShapeFactory;
 }) {
+  // P-LUCIDE-ICON-SINGLE-PROTOCOL, P-LUCIDE-ICON-AUTHORING-ENTRIES
   const asHook = defineAsHook<
     LucideFixedIconProps,
     LucideFixedIconExposes,

--- a/packages/prototypes/lucide/src/icon/icon.ts
+++ b/packages/prototypes/lucide/src/icon/icon.ts
@@ -10,6 +10,7 @@ const DEFAULT_STROKE = 'currentColor';
 const DEFAULT_FILL = 'none';
 
 function setupLucideIcon(def: DefHandle<LucideIconProps, LucideIconExposes>): void {
+  // P-LUCIDE-ICON-NAME-BASED-PROPS
   def.props.define({
     name: { type: 'enum', empty: 'fallback', options: [...LUCIDE_ICON_NAMES] },
     size: { type: 'number', empty: 'fallback' },
@@ -39,6 +40,7 @@ export const asLucideIcon = defineAsHook<
 const lucideIcon = definePrototype<LucideIconProps, LucideIconExposes>({
   name: 'lucide-icon',
   setup(def) {
+    // P-LUCIDE-ICON-AUTHORING-ENTRIES
     setupLucideIcon(def);
     return (renderer) => {
       const props = renderer.read.props.get();

--- a/packages/prototypes/lucide/src/icon/render.ts
+++ b/packages/prototypes/lucide/src/icon/render.ts
@@ -33,6 +33,7 @@ export function renderLucideShape(
   shapeFactory: LucideShapeFactory,
   options: RenderLucideShapeOptions = {}
 ): SvgRenderResult {
+  // P-LUCIDE-ICON-SVG-PROJECTION, P-LUCIDE-ICON-VISUAL-NORMALIZATION
   const visual = resolveVisualOptions(options);
 
   return renderer.svg.root(

--- a/packages/prototypes/lucide/src/manifest.generated.ts
+++ b/packages/prototypes/lucide/src/manifest.generated.ts
@@ -3,6 +3,10 @@
 
 import type { LucideIconName } from './icon/icons';
 
+export const LUCIDE_UPSTREAM_PACKAGE = 'lucide-static';
+export const LUCIDE_UPSTREAM_VERSION = '1.8.0';
+export const LUCIDE_UPSTREAM_LICENSE = 'ISC';
+
 export interface LucideIconManifestEntry {
   name: LucideIconName;
   importPath: string;

--- a/packages/prototypes/lucide/test/icon.test.ts
+++ b/packages/prototypes/lucide/test/icon.test.ts
@@ -3,17 +3,39 @@ import { createRendererPrimitives, isSvgTemplateNode, type TemplateChildren } fr
 import type { RuntimeHost } from '@proto.ui/runtime';
 import { executeWithHost } from '@proto.ui/runtime';
 import lucideIcon from '../src/icon/icon';
+import { asLucideIcon } from '../src/icon/icon';
 import { renderLucideIcon } from '../src/icon/render';
 import {
   asLucideChevronDownIcon,
   lucideChevronDownIcon,
   renderLucideChevronDownIcon,
 } from '../src/icons/chevron-down';
-import { LUCIDE_ICON_MANIFEST, LUCIDE_ICON_MANIFEST_MAP } from '../src/manifest.generated';
+import {
+  LUCIDE_ICON_MANIFEST,
+  LUCIDE_ICON_MANIFEST_MAP,
+  LUCIDE_UPSTREAM_LICENSE,
+  LUCIDE_UPSTREAM_PACKAGE,
+  LUCIDE_UPSTREAM_VERSION,
+} from '../src/manifest.generated';
 import { getLucideIconSnippet } from '../src/snippets.generated';
 import { loadLucideIcon } from '../src/loaders.generated';
 
 describe('prototypes/lucide: icon', () => {
+  it('keeps name-based and fixed glyphs under one Lucide Icon protocol', () => {
+    // T-LUCIDE-ICON-0001-CASE-SHARED-PROTOCOL
+    expect(lucideIcon.name).toBe('lucide-icon');
+    expect(asLucideIcon.kind).toBe('asHook');
+    expect(asLucideIcon.definition.name).toBe('as-lucide-icon');
+    expect(LUCIDE_ICON_MANIFEST.length).toBeGreaterThan(1000);
+  });
+
+  it('records the exact upstream generation baseline', () => {
+    // T-LUCIDE-ICON-0001-CASE-PROVENANCE
+    expect(LUCIDE_UPSTREAM_PACKAGE).toBe('lucide-static');
+    expect(LUCIDE_UPSTREAM_VERSION).toBe('1.8.0');
+    expect(LUCIDE_UPSTREAM_LICENSE).toBe('ISC');
+  });
+
   it('renderLucideIcon() returns svg root node from renderer.svg', () => {
     const { svg } = createRendererPrimitives();
     const node = renderLucideIcon({ svg } as any, {

--- a/packages/prototypes/shadcn/README.md
+++ b/packages/prototypes/shadcn/README.md
@@ -6,6 +6,15 @@ shadcn-style Proto UI prototype library for adapter-driven components.
 
 Provides a shadcn-style Proto UI prototype library that works with Proto UI adapters.
 
+## Source Attribution And Status
+
+- Component APIs and visual definitions are derived from [shadcn/ui](https://github.com/shadcn-ui/ui).
+- This package is maintained by Proto UI and is not an official shadcn/ui package.
+- Each cataloged component pins an upstream comparison revision and declares its current compatible subset; uncataloged or unimplemented upstream API must not be implied as supported.
+- The first pinned catalog baseline is the v4 new-york Button at shadcn-ui/ui revision `f31ed81983653919dd4fe77aee4b4859f610f1dc`.
+- Shadcn prototypes inherit their Base protocols by default. A setup-time negative patch is allowed only when the derived P entity explicitly declares the abandoned or replaced Base capability.
+- Proto UI intentionally does not expose upstream `asChild`: trigger event routes remain component-author-owned and are merged automatically through `asTrigger`; transparent slots are not claimed as Radix Slot equivalents.
+
 ## Package Role
 
 Prototype library package intended to be consumed together with Proto UI adapters.

--- a/packages/prototypes/shadcn/src/button/index.ts
+++ b/packages/prototypes/shadcn/src/button/index.ts
@@ -52,6 +52,7 @@ const SIZE_TOKENS: Record<ShadcnButtonSize, string> = {
 const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
   name: 'shadcn-button',
   setup(def) {
+    // P-SHADCN-BUTTON-VARIANT-PROP, P-SHADCN-BUTTON-SIZE-PROP
     def.props.define({
       variant: {
         type: 'enum',
@@ -67,12 +68,17 @@ const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
       disabled: false,
     });
 
+    // P-SHADCN-BUTTON-BASE-INHERITANCE,
+    // P-SHADCN-BUTTON-CURRENT-BASE-DEVIATIONS
+    // The current projection keeps every asButton-introduced behavior. A future
+    // setup-only negative patch must first be declared as a P-entity deviation.
     const buttonState = asButton().stateHandles;
     if (!buttonState) {
       throw new Error('[shadcn-button] asButton must project Button state handles.');
     }
     const { disabled, hovered, focusVisible, pressed } = buttonState;
 
+    // P-SHADCN-BUTTON-DIRECT-ENTRY
     // Base skeleton shared by every shadcn-style button.
     def.feedback.style.use(tw(BUTTON_BASE_TOKENS));
 
@@ -93,6 +99,7 @@ const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
       });
     });
 
+    // P-SHADCN-BUTTON-INTERACTION-STYLES
     // Focus/press are shared interaction states exposed by `asButton()`, so
     // shadcn styling can stay inside rule semantics instead of hard-coding
     // host-specific pseudo selectors.
@@ -138,6 +145,7 @@ const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
       intent: (i) => i.feedback.style.use(tw('bg-destructive/20')),
     });
 
+    // P-SHADCN-BUTTON-COLOR-SCHEME-STYLES
     // Dark mode stays in meta so the prototype remains host-agnostic while web
     // adapters still have a clean place to optimize to `dark:*`.
     def.rule({
@@ -184,6 +192,14 @@ const button = definePrototype<ShadcnButtonProps, ShadcnButtonExposes>({
     });
   },
 });
+
+/**
+ * P-SHADCN-BUTTON-COMPATIBILITY-SUBSET:
+ * The one catalog open question centralizes every upstream difference.
+ * P-SHADCN-BUTTON-AS-CHILD-OMISSION is intentional under D-AS-CHILD-OMISSION-0001;
+ * native/className forwarding, aria-invalid/nested-svg selectors, extra sizes,
+ * and exact token parity remain implementation or review gaps.
+ */
 
 export type { ShadcnButtonProps, ShadcnButtonExposes, ShadcnButtonSize, ShadcnButtonVariant };
 export default button;

--- a/packages/prototypes/shadcn/test/button.test.ts
+++ b/packages/prototypes/shadcn/test/button.test.ts
@@ -47,6 +47,13 @@ describe('prototypes/shadcn: button', () => {
 
     const { controller } = executeWithHost(button as any, host as any);
 
+    // T-SHADCN-BUTTON-0001-CASE-IDENTITY-AND-INHERITANCE:
+    // the current projection installs asButton and declares no negative patch.
+    expect(button.name).toBe('shadcn-button');
+    expect((button as any).__asHooks).toContainEqual(
+      expect.objectContaining({ name: 'as-button', mode: 'once' })
+    );
+
     let tokens = controller.getRuleStyleTokens();
     expect(tokens).toContain('bg-primary');
     expect(tokens).not.toContain('border-border');

--- a/packages/spec/fixtures/test/prototype-inheritance-schema.test.ts
+++ b/packages/spec/fixtures/test/prototype-inheritance-schema.test.ts
@@ -1,0 +1,56 @@
+import { validateSpecEntity } from '@proto.ui/spec-schema';
+import { describe, expect, it } from 'vitest';
+
+const baseEntity = {
+  title: 'Inheritance fixture',
+  status: 'draft' as const,
+  since: '0.2.0',
+  criteria: [],
+};
+
+describe('prototype inheritance schema', () => {
+  it('accepts a prototype-to-prototype inheritance relation', () => {
+    const entity = validateSpecEntity({
+      ...baseEntity,
+      id: 'P-INHERITANCE-SOURCE',
+      type: 'prototype',
+      inherits: {
+        prototypes: [
+          {
+            id: 'P-INHERITANCE-TARGET',
+            note: 'Inherited by default; explicit criteria may apply setup-time negative patches.',
+          },
+        ],
+      },
+    });
+
+    expect(entity.inherits?.prototypes).toEqual([
+      {
+        id: 'P-INHERITANCE-TARGET',
+        note: 'Inherited by default; explicit criteria may apply setup-time negative patches.',
+      },
+    ]);
+  });
+
+  it('rejects inheritance on a non-prototype entity', () => {
+    expect(() =>
+      validateSpecEntity({
+        ...baseEntity,
+        id: 'D-INHERITANCE-0001',
+        type: 'decision',
+        inherits: { prototypes: ['P-INHERITANCE-TARGET'] },
+      })
+    ).toThrow('Only prototype entities may declare prototype inheritance.');
+  });
+
+  it('rejects non-prototype inheritance targets structurally', () => {
+    expect(() =>
+      validateSpecEntity({
+        ...baseEntity,
+        id: 'P-INHERITANCE-SOURCE',
+        type: 'prototype',
+        inherits: { contracts: ['C-INHERITANCE-0001'] },
+      })
+    ).toThrow();
+  });
+});

--- a/packages/spec/graph/test/prototype-inheritance.test.ts
+++ b/packages/spec/graph/test/prototype-inheritance.test.ts
@@ -1,0 +1,42 @@
+import { buildSpecGraph } from '@proto.ui/spec-graph';
+import { validateSpecEntity } from '@proto.ui/spec-schema';
+import { describe, expect, it } from 'vitest';
+
+describe('prototype inheritance graph projection', () => {
+  it('projects inheritance as a distinct graph edge', () => {
+    const base = validateSpecEntity({
+      id: 'P-GRAPH-BASE',
+      type: 'prototype',
+      title: 'Graph base prototype',
+      status: 'draft',
+      since: '0.2.0',
+      criteria: [],
+    });
+    const derived = validateSpecEntity({
+      id: 'P-GRAPH-DERIVED',
+      type: 'prototype',
+      title: 'Graph derived prototype',
+      status: 'draft',
+      since: '0.2.0',
+      criteria: [],
+      inherits: { prototypes: ['P-GRAPH-BASE'] },
+    });
+
+    const graph = buildSpecGraph({
+      version: '0.2.0',
+      generatedAt: '2026-07-18T00:00:00.000Z',
+      entities: [base, derived],
+    });
+
+    expect(graph.edges).toContainEqual({
+      id: 'P-GRAPH-DERIVED:inherits:prototypes:P-GRAPH-BASE',
+      from: 'P-GRAPH-DERIVED',
+      to: 'P-GRAPH-BASE',
+      kind: 'inherits',
+      relation: 'prototypes',
+      anchors: [],
+      role: undefined,
+      coverageImpact: undefined,
+    });
+  });
+});

--- a/packages/spec/schema/src/index.ts
+++ b/packages/spec/schema/src/index.ts
@@ -26,6 +26,7 @@ export const SPEC_ENTITY_STATUSES = ['draft', 'active', 'deprecated', 'removed']
 export const SPEC_RELATION_KINDS = [
   'relates',
   'dependsOn',
+  'inherits',
   'references',
   'refines',
   'satisfies',
@@ -123,6 +124,13 @@ export const specRelationsSchema = z
     knowledge: z.array(specRelationTargetSchema).optional(),
   })
   .partial()
+  .optional();
+
+export const specPrototypeInheritanceSchema = z
+  .object({
+    prototypes: z.array(specRelationTargetSchema).min(1),
+  })
+  .strict()
   .optional();
 
 export const specRevisionSchema = z.object({
@@ -326,6 +334,7 @@ export const specEntitySchema = z
     sources: z.array(specSourceRefSchema).default([]),
     relates: specRelationsSchema,
     dependsOn: specRelationsSchema,
+    inherits: specPrototypeInheritanceSchema,
     references: specRelationsSchema,
     refines: specRelationsSchema,
     satisfies: specRelationsSchema,
@@ -362,6 +371,14 @@ export const specEntitySchema = z
         code: 'custom',
         path: ['removedSince'],
         message: 'Removed entities must set removedSince.',
+      });
+    }
+
+    if (entity.inherits && entity.type !== 'prototype') {
+      context.addIssue({
+        code: 'custom',
+        path: ['inherits'],
+        message: 'Only prototype entities may declare prototype inheritance.',
       });
     }
 
@@ -458,6 +475,7 @@ export const specEntitySchema = z
 
 export type SpecRelationTarget = z.infer<typeof specRelationTargetSchema>;
 export type SpecRelations = z.infer<typeof specRelationsSchema>;
+export type SpecPrototypeInheritance = z.infer<typeof specPrototypeInheritanceSchema>;
 export type SpecRevision = z.infer<typeof specRevisionSchema>;
 export type SpecSourceRef = z.infer<typeof specSourceRefSchema>;
 export type SpecAnatomy = z.infer<typeof specAnatomySchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -807,6 +807,9 @@ importers:
       '@proto.ui/runtime':
         specifier: workspace:*
         version: link:../../runtime
+      prettier:
+        specifier: ^3.8.1
+        version: 3.8.1
 
   packages/prototypes/shadcn:
     dependencies:

--- a/spec/decisions/D-AS-CHILD-OMISSION-0001.yaml
+++ b/spec/decisions/D-AS-CHILD-OMISSION-0001.yaml
@@ -1,0 +1,52 @@
+id: D-AS-CHILD-OMISSION-0001
+type: decision
+title: Proto UI intentionally omits asChild compatibility APIs
+status: draft
+since: 0.2.0
+summary: Proto UI keeps interaction-route composition under component-author and role-system ownership, so upstream-derived prototypes intentionally omit asChild rather than exposing a weaker event-proxy analogue.
+statement:
+  zh-CN: >-
+    Proto UI 有意不提供 Radix-style `asChild` 兼容 API。Proto UI 的 trigger 组合由组件作者声明角色，并由特权 `asTrigger()` 自动合并连续 trigger 的 event route；组件调用者不需要承担显式事件代理、handler 合并或 trigger ownership 转交责任。即使未来 `asTrigger` 在技术上可以增加“不要合并”的分支，也不得仅为了模拟 `asChild` 而把默认的自动角色合并退化为调用者必须关注的代理机制。引用 upstream `asChild` API 的衍生原型必须把其缺失记录为 intentional deviation，而不是把透明 slot、元素替换或 native prop forwarding 宣称为 Radix Slot 等价物。
+
+
+  en: >-
+    Proto UI intentionally does not provide a Radix-style `asChild` compatibility API. Trigger composition is declared by component authors and continuous trigger event routes are merged automatically by the privileged `asTrigger()` role mechanism; component consumers do not own explicit event proxying, handler merging, or trigger-ownership transfer. Even if `asTrigger` could technically gain a branch that disables merging, it must not do so merely to emulate `asChild` and regress the default role-based automation into a consumer-managed proxy mechanism. Upstream-derived prototypes that reference an `asChild` API must record its absence as an intentional deviation and must not claim that transparent slots, element replacement, or native prop forwarding are equivalent to Radix Slot.
+
+
+criteria:
+  - id: D-AS-CHILD-OMISSION-0001-A
+    text:
+      zh-CN: Proto UI 维护的 upstream-derived prototype 不得把 `asChild` 作为兼容参数公开；遇到 upstream `asChild` 时应明确忽略并记录 intentional deviation。
+      en: Proto UI-maintained upstream-derived prototypes must not expose `asChild` as a compatibility parameter; an upstream `asChild` API must be explicitly omitted and recorded as an intentional deviation.
+  - id: D-AS-CHILD-OMISSION-0001-B
+    text:
+      zh-CN: trigger event route 的组合责任必须保留在组件作者声明的角色与 `asTrigger()` 自动合并机制中，不得转移给组件调用者。
+      en: Responsibility for trigger event-route composition must remain with component-author role declarations and automatic `asTrigger()` merging rather than move to component consumers.
+  - id: D-AS-CHILD-OMISSION-0001-C
+    text:
+      zh-CN: 不得仅为模拟 `asChild` 而扩展 `asTrigger()` 以选择性关闭连续 trigger route 合并；任何改变自动合并默认值的提案必须作为独立契约与决策重新审查。
+      en: '`asTrigger()` must not gain selective disabling of continuous trigger-route merging merely to emulate `asChild`; any proposal to change the automatic-merge default requires separate contract and decision review.'
+  - id: D-AS-CHILD-OMISSION-0001-D
+    text:
+      zh-CN: 透明 slot、元素替换与 native prop forwarding 是彼此独立的能力；其中任何能力存在时，都不得自动宣称为 Radix Slot 或 `asChild` 等价实现。
+      en: Transparent slots, element replacement, and native prop forwarding are distinct capabilities; the presence of any one of them must not be claimed as a Radix Slot or `asChild` equivalent.
+  - id: D-AS-CHILD-OMISSION-0001-E
+    text:
+      zh-CN: 面向含 `asChild` upstream API 的 P 实体必须引用本决策，并在自身准则和集中 compatibility comparison 中持续标明这一有意差异。
+      en: A P entity targeting an upstream API with `asChild` must reference this decision and keep the intentional difference visible in its own criteria and centralized compatibility comparison.
+sources:
+  - path: spec/contracts/C-AS-TRIGGER-0001.yaml
+  - path: packages/hooks/src/as-trigger.ts
+  - path: packages/modules/as-trigger/src/impl.ts
+  - path: internal/records/2026-07-18-external-prototype-library-governance.zh-CN.md
+  - path: https://github.com/shadcn-ui/ui/blob/f31ed81983653919dd4fe77aee4b4859f610f1dc/apps/v4/registry/new-york-v4/ui/button.tsx
+    label: shadcn/ui Button asChild comparison baseline
+dependsOn:
+  contracts: [C-AS-TRIGGER-0001, C-AS-HOOK-PRIVILEGED-0001]
+relates:
+  prototypes: [P-SHADCN-BUTTON]
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Recorded the intentional omission of asChild in favor of component-author-owned role declarations and automatic asTrigger event-route merging.
+tags: [as-child, as-trigger, shadcn, composition, event-routing, intentional-deviation]

--- a/spec/prototypes/P-LUCIDE-ICON.yaml
+++ b/spec/prototypes/P-LUCIDE-ICON.yaml
@@ -1,0 +1,95 @@
+id: P-LUCIDE-ICON
+type: prototype
+title: Lucide Icon projects one upstream glyph protocol through generated Proto UI SVG
+status: draft
+since: 0.2.0
+summary: Lucide Icon is one upstream-derived icon protocol shared by the name-based lucide-icon entries and every generated fixed-glyph projection, with auditable source-version metadata, common visual props, deterministic SVG structure, and explicit accessibility and ownership boundaries.
+statement:
+  zh-CN: >-
+    Lucide Icon 是 Proto UI 对 Lucide SVG node data 的单一 prototype protocol 投射。`lucide-icon` / `asLucideIcon` 通过 name 选择 glyph；每个生成的 `lucide-{name}-icon`、固定 asHook 与 render helper 只是同一协议的 tree-shakable 特化，不建立独立 P 实体。Proto UI 治理生成 API、props、SVG 投射、manifest 与测试，但不主张 Lucide glyph 的上游所有权或官方认证。当前生成基线为 `lucide-static@1.8.0`。
+
+
+  en: >-
+    Lucide Icon is Proto UI's single prototype-protocol projection of Lucide SVG node data. `lucide-icon` and `asLucideIcon` select a glyph by name, while every generated `lucide-{name}-icon`, fixed asHook, and render helper is only a tree-shakable specialization of the same protocol and does not receive its own P entity. Proto UI governs the generated API, props, SVG projection, manifest, and tests without claiming upstream ownership of Lucide glyphs or official endorsement. The current generation baseline is `lucide-static@1.8.0`.
+
+
+criteria:
+  - id: P-LUCIDE-ICON-SINGLE-PROTOCOL
+    text:
+      zh-CN: 所有 Lucide glyph 必须共用 `P-LUCIDE-ICON`；单个 glyph name 与生成文件是 catalog data 和协议特化，不得按图标数量创建 P 实体。
+      en: Every Lucide glyph must share `P-LUCIDE-ICON`; individual glyph names and generated files are catalog data and protocol specializations and must not create P entities per icon.
+    dependsOn:
+      decisions: [D-PROTOTYPE-ENTITY-NAMING-0001]
+  - id: P-LUCIDE-ICON-AUTHORING-ENTRIES
+    text:
+      zh-CN: '`lucide-icon` direct prototype 与 `asLucideIcon` authored asHook 必须提供同一 name-based props protocol；生成的 fixed prototype、fixed asHook 与 render helper 必须保留同一 visual props 与 glyph identity。'
+      en: 'The `lucide-icon` direct prototype and `asLucideIcon` authored asHook must provide the same name-based props protocol; generated fixed prototypes, fixed asHooks, and render helpers must preserve the same visual props and glyph identity.'
+    dependsOn:
+      contracts: [C-CORE-SYNTAX-0003, C-AS-HOOK-0001]
+  - id: P-LUCIDE-ICON-UPSTREAM-PROVENANCE
+    text:
+      zh-CN: 生成输出必须标明来自 `lucide-static/icon-nodes.json`，manifest 必须暴露精确 upstream package、version 与 license metadata；更新上游版本必须重新生成、验证并记录 P revision。
+      en: Generated output must identify `lucide-static/icon-nodes.json` as its source, and the manifest must expose exact upstream package, version, and license metadata; updating the upstream version requires regeneration, verification, and a recorded P revision.
+  - id: P-LUCIDE-ICON-NAME-BASED-PROPS
+    text:
+      zh-CN: name-based entry 必须接受 `name`、`size`、`strokeWidth`、`stroke` 与 `fill`；默认值分别为 circle、24、2、currentColor 与 none，无效 name 必须回落到 circle。
+      en: The name-based entry must accept `name`, `size`, `strokeWidth`, `stroke`, and `fill` with defaults of circle, 24, 2, currentColor, and none respectively, and an invalid name must fall back to circle.
+    dependsOn:
+      contracts: [C-PROPS-0001, C-PROPS-0003]
+  - id: P-LUCIDE-ICON-FIXED-PROPS
+    text:
+      zh-CN: fixed-glyph entry 不接受可变 name，但必须接受与 name-based entry 一致的 `size`、`strokeWidth`、`stroke` 与 `fill` visual props。
+      en: A fixed-glyph entry does not accept a variable name but must accept the same `size`, `strokeWidth`, `stroke`, and `fill` visual props as the name-based entry.
+    dependsOn:
+      contracts: [C-PROPS-0001, C-PROPS-0003]
+  - id: P-LUCIDE-ICON-SVG-PROJECTION
+    text:
+      zh-CN: renderer 必须输出 viewBox=`0 0 24 24` 的 SVG root，把 size 同步到 width/height，并投射 stroke、fill、strokeWidth、round linecap 与 round linejoin；glyph child nodes 必须由上游 node data 通过受支持的 Proto UI SVG factories 生成。
+      en: The renderer must output an SVG root with viewBox=`0 0 24 24`, apply size to both width and height, and project stroke, fill, strokeWidth, round linecap, and round linejoin; glyph child nodes must be generated from upstream node data through supported Proto UI SVG factories.
+    dependsOn:
+      contracts: [C-TEMPLATE-0001]
+  - id: P-LUCIDE-ICON-VISUAL-NORMALIZATION
+    text:
+      zh-CN: 非有限、非正数 size 或 strokeWidth 必须回落到协议默认值；生成器遇到不支持的 SVG tag、缺失 glyph、空 shape 或重复配置时必须失败而不是静默丢失图形。
+      en: Non-finite or non-positive size or strokeWidth values must fall back to protocol defaults, and generation must fail rather than silently lose graphics when it encounters an unsupported SVG tag, missing glyph, empty shape, or duplicate configuration.
+  - id: P-LUCIDE-ICON-DISTRIBUTION-SURFACES
+    text:
+      zh-CN: package 必须提供 name-based renderer、按图标静态入口、manifest、snippet 与 dynamic loader；manifest 中每个 glyph 的 import、asHook、prototype 与 render export 名称必须一致且可追溯。
+      en: The package must provide a name-based renderer, per-icon static entrypoints, a manifest, snippets, and dynamic loaders; each glyph's import, asHook, prototype, and render export names in the manifest must remain consistent and traceable.
+  - id: P-LUCIDE-ICON-A11Y-DEFERRED
+    text:
+      zh-CN: 当前 Lucide Icon 只保证视觉 SVG 投射，不提供 `decorative`、accessible label、title 或 role API；调用者与 owning component 不得把“成功渲染 SVG”误认为已经满足可访问名称要求。
+      en: The current Lucide Icon guarantees visual SVG projection only and provides no `decorative`, accessible-label, title, or role API; callers and owning components must not treat successful SVG rendering as satisfying accessible-name requirements.
+    dependsOn:
+      contracts: [C-A11Y-0001]
+openQuestions:
+  - id: P-LUCIDE-ICON-Q-A11Y-SURFACE
+    question:
+      zh-CN: Icon protocol 应直接提供 decorative/label/title，还是由 owning component 与 adapter 负责 SVG a11y 投射？
+      en: Should the Icon protocol directly provide decorative, label, and title inputs, or should the owning component and adapter own SVG accessibility projection?
+    context:
+      zh-CN: 当前 renderer.svg 只承载视觉结构；本轮如实记录缺口，不提前发明未实现的跨宿主 API。
+      en: The current renderer.svg surface carries visual structure only; this pass records the gap without inventing an unimplemented cross-host API.
+    blocks: [icon accessibility protocol, svg adapter accessibility]
+sources:
+  - path: internal/records/2026-07-18-external-prototype-library-governance.zh-CN.md
+  - path: packages/prototypes/lucide/package.json
+  - path: packages/prototypes/lucide/icons.config.json
+  - path: packages/prototypes/lucide/scripts/generate-icons.mjs
+  - path: packages/prototypes/lucide/src/icon/icon.ts
+  - path: packages/prototypes/lucide/src/icon/fixed.ts
+  - path: packages/prototypes/lucide/src/icon/render.ts
+  - path: packages/prototypes/lucide/src/manifest.generated.ts
+  - path: packages/prototypes/lucide/test/icon.test.ts
+  - path: https://github.com/lucide-icons/lucide
+    label: Lucide upstream repository
+dependsOn:
+  contracts:
+    [C-CORE-SYNTAX-0003, C-PROPS-0001, C-PROPS-0003, C-AS-HOOK-0001, C-TEMPLATE-0001, C-A11Y-0001]
+  decisions: [D-PROTOTYPE-ENTITY-NAMING-0001]
+verifies: { tests: [T-LUCIDE-ICON-0001] }
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Cataloged all generated Lucide glyph entries as one upstream-derived Icon protocol with source-version, rendering, distribution, and accessibility boundaries.
+tags: [prototype, lucide, icon, svg, generated, upstream-derived, accessibility]

--- a/spec/prototypes/P-SHADCN-BUTTON.yaml
+++ b/spec/prototypes/P-SHADCN-BUTTON.yaml
@@ -1,0 +1,128 @@
+id: P-SHADCN-BUTTON
+type: prototype
+title: Shadcn Button inherits Base Button and layers a pinned visual API subset
+status: draft
+since: 0.2.0
+summary: Shadcn Button is an unofficial Proto UI-maintained projection that inherits Base Button by default, may declare setup-time negative patches explicitly, and adds a pinned, currently partial shadcn/ui visual API without duplicating Base semantics.
+statement:
+  zh-CN: >-
+    Shadcn Button 是在 `P-BASE-BUTTON` 之上提供 shadcn/ui Button 外观与 API 投射的 direct prototype。当前协议保留 Base Button 的 command、activation、focus、disabled、a11y 与 outward-signal 行为，并新增六种 `variant`、四种 `size`、由 Button interaction state 驱动的视觉反馈，以及 outline 与 destructive 在 dark color scheme 下的样式增量。兼容比较基线固定到 shadcn-ui/ui revision `f31ed81983653919dd4fe77aee4b4859f610f1dc` 的 v4 new-york Button；`asChild` 是明确不提供的 API，其他未对齐项统一记录为 compatibility differences。
+
+
+  en: >-
+    Shadcn Button is a direct prototype that projects the shadcn/ui Button API and appearance over `P-BASE-BUTTON`. The current protocol retains Base Button command, activation, focus, disabled, accessibility, and outward-signal behavior while adding six `variant` values, four `size` values, visual feedback driven by Button interaction state, and dark-color-scheme styling deltas for outline and destructive variants. Its compatibility baseline is the v4 new-york Button at shadcn-ui/ui revision `f31ed81983653919dd4fe77aee4b4859f610f1dc`; `asChild` is explicitly unavailable, and every other divergence is tracked as a compatibility difference.
+
+
+criteria:
+  - id: P-SHADCN-BUTTON-UPSTREAM-IDENTITY
+    text:
+      zh-CN: Shadcn Button 必须明确标记为 Proto UI 维护的非官方 shadcn/ui 衍生实现，并以固定 upstream revision/path 作为兼容比较基线；P 实体只治理 Proto UI 投射，不主张上游所有权或认证。
+      en: Shadcn Button must identify itself as an unofficial Proto UI-maintained shadcn/ui-derived implementation and use a pinned upstream revision and path as its compatibility baseline; the P entity governs only the Proto UI projection and does not claim upstream ownership or endorsement.
+  - id: P-SHADCN-BUTTON-BASE-INHERITANCE
+    text:
+      zh-CN: '`shadcn-button` 必须通过一等 `inherits.prototypes` 关系指向 `P-BASE-BUTTON`，并通过 `asButton()` 在 setup 期默认引入其 guarantee。上层原型允许对某个引入能力施加 setup-only 负向补丁或替代，但必须在自身准则中标明被放弃或改写的 Base 能力及替代语义；未声明偏离的 Base guarantee 保持有效。取消应在 setup 计划中完成，通常不为已取消能力留下 runtime 分支开销；不得用 runtime flag 伪装 setup 负向补丁。'
+      en: '`shadcn-button` must point to `P-BASE-BUTTON` through the first-class `inherits.prototypes` relation and call `asButton()` to introduce its guarantees by default during setup. The upper-layer prototype may apply a setup-only negative patch or replacement to an introduced capability, but its own criteria must identify the abandoned or rewritten Base capability and the replacement semantics; every Base guarantee without a declared deviation remains effective. Cancellation should complete in the setup plan and normally leave no runtime branch cost for the canceled capability; a runtime flag must not masquerade as a setup-time negative patch.'
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            [
+              P-BASE-BUTTON-ROLE-COMMAND,
+              P-BASE-BUTTON-AUTHORING-ENTRIES,
+              P-BASE-BUTTON-NO-VISUAL-VARIANT-CORE,
+            ]
+    dependsOn:
+      contracts: [C-AS-HOOK-0001, C-CORE-SYNTAX-0007]
+  - id: P-SHADCN-BUTTON-CURRENT-BASE-DEVIATIONS
+    text:
+      zh-CN: 当前 Shadcn Button 实现不对 `asButton()` 引入的 command role、activation、focus、disabled、a11y、state 或 outward signal 施加负向补丁；本实体新增的 props 与 style rules 是视觉/API 增量，不构成 Base 行为反转。
+      en: The current Shadcn Button implementation applies no negative patch to the command role, activation, focus, disabled, accessibility, state, or outward signals introduced by `asButton()`; its added props and style rules are visual and API deltas rather than Base-behavior reversals.
+  - id: P-SHADCN-BUTTON-DIRECT-ENTRY
+    text:
+      zh-CN: 当前 Shadcn Button protocol 以 `shadcn-button` direct prototype 公开，并透明保留 Button 内容 slot；本层不额外提供 authored asHook。
+      en: The current Shadcn Button protocol is exposed as the `shadcn-button` direct prototype and transparently preserves Button content through its slot; this layer does not provide an additional authored asHook.
+    dependsOn:
+      contracts: [C-CORE-SYNTAX-0003, C-TEMPLATE-0001]
+  - id: P-SHADCN-BUTTON-VARIANT-PROP
+    text:
+      zh-CN: 当前 passing API 必须提供 `variant`，可选 default、destructive、outline、secondary、ghost、link，默认 default；每个值必须投射对应的 shadcn-style surface tokens。
+      en: The current passing API must provide `variant` with default, destructive, outline, secondary, ghost, and link options and a default of default; each value must project its corresponding shadcn-style surface tokens.
+    dependsOn:
+      contracts: [C-PROPS-0001, C-PROPS-0003, C-RULE-INTENT-FEEDBACK-STYLE-0001]
+  - id: P-SHADCN-BUTTON-SIZE-PROP
+    text:
+      zh-CN: 当前 passing API 必须提供 `size`，可选 default、sm、lg、icon，默认 default；每个值必须投射对应的尺寸与间距 tokens。
+      en: The current passing API must provide `size` with default, sm, lg, and icon options and a default of default; each value must project its corresponding size and spacing tokens.
+    dependsOn:
+      contracts: [C-PROPS-0001, C-PROPS-0003, C-RULE-INTENT-FEEDBACK-STYLE-0001]
+  - id: P-SHADCN-BUTTON-INTERACTION-STYLES
+    text:
+      zh-CN: Shadcn Button 必须从 inherited hovered、focusVisible、pressed 与 disabled state 派生 hover、focus ring、press offset 与 disabled visual rules；视觉 rule 不得成为另一套交互状态真相。
+      en: Shadcn Button must derive hover, focus-ring, press-offset, and disabled visual rules from inherited hovered, focusVisible, pressed, and disabled state; visual rules must not become a second source of interaction-state truth.
+    dependsOn:
+      contracts: [C-RULE-WHEN-0002, C-RULE-INTENT-FEEDBACK-STYLE-0001]
+    references:
+      prototypes:
+        - id: P-BASE-BUTTON
+          anchors:
+            [
+              P-BASE-BUTTON-POINTER-HOVER,
+              P-BASE-BUTTON-FOCUSABLE,
+              P-BASE-BUTTON-PRESS-LIFECYCLE,
+              P-BASE-BUTTON-DISABLED-EXPOSE,
+            ]
+  - id: P-SHADCN-BUTTON-COLOR-SCHEME-STYLES
+    text:
+      zh-CN: outline 与 destructive variant 必须能够通过 environment colorScheme meta 投射当前 dark-mode 增量；meta 只影响 visual intent，不改变 Button protocol facts。
+      en: Outline and destructive variants must project the current dark-mode deltas through environment colorScheme meta; meta affects visual intent only and does not change Button protocol facts.
+    dependsOn:
+      contracts: [C-RULE-WHEN-0002, C-RULE-INTENT-FEEDBACK-STYLE-0001]
+  - id: P-SHADCN-BUTTON-COMPATIBILITY-SUBSET
+    text:
+      zh-CN: 当前实体只声明已测试的 variant、size、disabled 与 style behavior；对固定 upstream baseline 的所有差异必须集中维护在唯一 compatibility open question 中，并区分 intentional deviation 与尚未实现的 parity gap。
+      en: This entity claims only the tested variant, size, disabled, and style behavior; every difference from the pinned upstream baseline must be maintained in one centralized compatibility open question and classified as either an intentional deviation or an unimplemented parity gap.
+  - id: P-SHADCN-BUTTON-AS-CHILD-OMISSION
+    text:
+      zh-CN: upstream `asChild` 依 `D-AS-CHILD-OMISSION-0001` 有意不进入 Shadcn Button API；透明保留 content slot 不得被宣称为 Radix Slot 或 `asChild` 等价实现。
+      en: Upstream `asChild` is intentionally omitted from the Shadcn Button API under `D-AS-CHILD-OMISSION-0001`; transparently preserving the content slot must not be claimed as a Radix Slot or `asChild` equivalent.
+    dependsOn:
+      decisions: [D-AS-CHILD-OMISSION-0001]
+openQuestions:
+  - id: P-SHADCN-BUTTON-Q-UPSTREAM-DIFFERENCES
+    question:
+      zh-CN: 相较固定的 shadcn/ui Button baseline，当前全部差异分别是有意偏离还是待实现 gap，以及待实现项应按什么顺序收敛？
+      en: Against the pinned shadcn/ui Button baseline, which current differences are intentional deviations versus implementation gaps, and in what order should the implementation gaps converge?
+    context:
+      zh-CN: 已确定的 intentional deviation 是不提供 `asChild`，且透明 slot 不等价于 Radix Slot。当前待实现/待评审差异至少包括 className 与 native button prop forwarding、aria-invalid styling、nested SVG sizing、xs/icon-xs/icon-sm/icon-lg sizes，以及现有 size 和 visual token 与 upstream 的精确差异。current passing guarantee 在这些项目实现并通过测试前不得扩大。
+      en: The decided intentional deviation is omission of `asChild`, and the transparent slot is not a Radix Slot equivalent. Current implementation or review gaps include at least className and native-button prop forwarding, aria-invalid styling, nested-SVG sizing, xs/icon-xs/icon-sm/icon-lg sizes, and exact differences between current size and visual tokens and upstream. The current passing guarantee must not expand until an item is implemented and tested.
+    blocks: [shadcn button parity roadmap]
+sources:
+  - path: internal/records/2026-07-18-external-prototype-library-governance.zh-CN.md
+  - path: packages/prototypes/shadcn/src/button/index.ts
+  - path: packages/prototypes/shadcn/src/button/types.ts
+  - path: packages/prototypes/shadcn/test/button.test.ts
+  - path: https://github.com/shadcn-ui/ui/blob/f31ed81983653919dd4fe77aee4b4859f610f1dc/apps/v4/registry/new-york-v4/ui/button.tsx
+    label: shadcn/ui v4 new-york Button pinned baseline
+dependsOn:
+  contracts:
+    [
+      C-AS-HOOK-0001,
+      C-CORE-SYNTAX-0003,
+      C-CORE-SYNTAX-0007,
+      C-PROPS-0001,
+      C-PROPS-0003,
+      C-TEMPLATE-0001,
+      C-RULE-WHEN-0002,
+      C-RULE-INTENT-FEEDBACK-STYLE-0001,
+    ]
+  decisions: [D-PROTOTYPE-ENTITY-NAMING-0001, D-AS-CHILD-OMISSION-0001]
+inherits:
+  prototypes:
+    - id: P-BASE-BUTTON
+      note: Default inherited protocol; explicit setup-time negative-patch criteria may override individual guarantees.
+verifies: { tests: [T-SHADCN-BUTTON-0001] }
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Introduced the delta-style Shadcn Button catalog template with reversible Base inheritance, pinned upstream identity, current visual API guarantees, intentional asChild omission, and centralized compatibility differences.
+tags: [prototype, shadcn, button, upstream-derived, delta, compatibility, visual]

--- a/spec/tests/T-LUCIDE-ICON-0001.yaml
+++ b/spec/tests/T-LUCIDE-ICON-0001.yaml
@@ -1,0 +1,68 @@
+id: T-LUCIDE-ICON-0001
+type: test
+title: Lucide Icon shared protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers the shared name-based and fixed-glyph Lucide protocol, exact upstream metadata, visual props and SVG projection, generated distribution surfaces, and the explicit accessibility gap.
+cases:
+  - id: T-LUCIDE-ICON-0001-CASE-SHARED-PROTOCOL
+    title: name-based and generated fixed entries remain projections of one Icon protocol
+    covers:
+      - P-LUCIDE-ICON-SINGLE-PROTOCOL
+      - P-LUCIDE-ICON-AUTHORING-ENTRIES
+    expectation: lucide-entries-share-one-generated-icon-protocol
+  - id: T-LUCIDE-ICON-0001-CASE-PROVENANCE
+    title: generated manifest exposes the exact upstream package version and license
+    covers:
+      - P-LUCIDE-ICON-UPSTREAM-PROVENANCE
+    expectation: lucide-manifest-records-exact-upstream-generation-baseline
+  - id: T-LUCIDE-ICON-0001-CASE-PROPS-AND-SVG
+    title: name-based and fixed entries normalize visual props and project Lucide SVG structure
+    covers:
+      - P-LUCIDE-ICON-NAME-BASED-PROPS
+      - P-LUCIDE-ICON-FIXED-PROPS
+      - P-LUCIDE-ICON-SVG-PROJECTION
+      - P-LUCIDE-ICON-VISUAL-NORMALIZATION
+    expectation: lucide-visual-props-project-normalized-svg
+  - id: T-LUCIDE-ICON-0001-CASE-DISTRIBUTION
+    title: manifest snippets static modules and dynamic loaders stay consistent
+    covers:
+      - P-LUCIDE-ICON-DISTRIBUTION-SURFACES
+    expectation: lucide-generated-distribution-surfaces-remain-consistent
+  - id: T-LUCIDE-ICON-0001-CASE-A11Y-GAP
+    title: current Icon protocol does not claim an unimplemented accessibility surface
+    covers:
+      - P-LUCIDE-ICON-A11Y-DEFERRED
+    expectation: lucide-accessibility-surface-remains-explicitly-deferred
+implementations:
+  - id: prototypes-lucide-icon-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/lucide/test/icon.test.ts
+    required: true
+    consumesCases:
+      - T-LUCIDE-ICON-0001-CASE-SHARED-PROTOCOL
+      - T-LUCIDE-ICON-0001-CASE-PROVENANCE
+      - T-LUCIDE-ICON-0001-CASE-PROPS-AND-SVG
+      - T-LUCIDE-ICON-0001-CASE-DISTRIBUTION
+      - T-LUCIDE-ICON-0001-CASE-A11Y-GAP
+    exercises: [P-LUCIDE-ICON]
+    notes:
+      - Uses representative name-based and fixed-glyph rendering plus the exhaustive generated manifest as the executable protocol projection.
+      - Accessibility is covered as an explicit absence boundary; positive SVG a11y behavior remains future work.
+verifies:
+  prototypes:
+    - id: P-LUCIDE-ICON
+      anchors:
+        - P-LUCIDE-ICON-SINGLE-PROTOCOL
+        - P-LUCIDE-ICON-AUTHORING-ENTRIES
+        - P-LUCIDE-ICON-UPSTREAM-PROVENANCE
+        - P-LUCIDE-ICON-SVG-PROJECTION
+        - P-LUCIDE-ICON-DISTRIBUTION-SURFACES
+        - P-LUCIDE-ICON-A11Y-DEFERRED
+exercises: { prototypes: [P-LUCIDE-ICON] }
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Added shared Lucide Icon protocol coverage across generated provenance, SVG rendering, per-icon projections, distribution helpers, and the deferred accessibility surface.
+tags: [prototype, lucide, icon, svg, generated, test]

--- a/spec/tests/T-SHADCN-BUTTON-0001.yaml
+++ b/spec/tests/T-SHADCN-BUTTON-0001.yaml
@@ -1,0 +1,72 @@
+id: T-SHADCN-BUTTON-0001
+type: test
+title: Shadcn Button delta protocol contract tests
+status: draft
+since: 0.2.0
+summary: Covers Shadcn Button's first-class reversible Base inheritance, current absence of Base-behavior reversals, direct entry, visual API, intentional asChild omission, and centralized upstream compatibility boundary.
+cases:
+  - id: T-SHADCN-BUTTON-0001-CASE-IDENTITY-AND-INHERITANCE
+    title: Shadcn Button is a direct unofficial projection that inherits Base Button
+    covers:
+      - P-SHADCN-BUTTON-UPSTREAM-IDENTITY
+      - P-SHADCN-BUTTON-BASE-INHERITANCE
+      - P-SHADCN-BUTTON-CURRENT-BASE-DEVIATIONS
+      - P-SHADCN-BUTTON-DIRECT-ENTRY
+    expectation: shadcn-button-direct-entry-inherits-as-button-protocol
+  - id: T-SHADCN-BUTTON-0001-CASE-VARIANT-AND-SIZE
+    title: current variant and size props project the passing visual token subset
+    covers:
+      - P-SHADCN-BUTTON-VARIANT-PROP
+      - P-SHADCN-BUTTON-SIZE-PROP
+    expectation: shadcn-button-current-variant-and-size-matrix
+  - id: T-SHADCN-BUTTON-0001-CASE-INTERACTION-STYLES
+    title: inherited Button facts drive hover focus press and disabled visual rules
+    covers:
+      - P-SHADCN-BUTTON-INTERACTION-STYLES
+    expectation: shadcn-button-styles-derive-from-base-button-facts
+  - id: T-SHADCN-BUTTON-0001-CASE-COLOR-SCHEME
+    title: dark color-scheme meta affects outline and destructive visuals only
+    covers:
+      - P-SHADCN-BUTTON-COLOR-SCHEME-STYLES
+    expectation: shadcn-button-dark-meta-projects-visual-deltas
+  - id: T-SHADCN-BUTTON-0001-CASE-COMPATIBILITY-SUBSET
+    title: intentional asChild omission and remaining upstream gaps stay outside the passing claim
+    covers:
+      - P-SHADCN-BUTTON-COMPATIBILITY-SUBSET
+      - P-SHADCN-BUTTON-AS-CHILD-OMISSION
+    expectation: shadcn-button-does-not-overclaim-upstream-parity
+implementations:
+  - id: prototypes-shadcn-button-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/shadcn/test/button.test.ts
+    required: true
+    consumesCases:
+      - T-SHADCN-BUTTON-0001-CASE-IDENTITY-AND-INHERITANCE
+      - T-SHADCN-BUTTON-0001-CASE-VARIANT-AND-SIZE
+      - T-SHADCN-BUTTON-0001-CASE-INTERACTION-STYLES
+      - T-SHADCN-BUTTON-0001-CASE-COLOR-SCHEME
+      - T-SHADCN-BUTTON-0001-CASE-COMPATIBILITY-SUBSET
+    exercises: [P-SHADCN-BUTTON, P-BASE-BUTTON]
+    notes:
+      - Positive tests cover only the current Proto UI guarantee; asChild omission is governed by D-AS-CHILD-OMISSION-0001, while remaining upstream gaps are covered through declared prop enums, source review, and the single catalog-visible compatibility question.
+verifies:
+  prototypes:
+    - id: P-SHADCN-BUTTON
+      anchors:
+        - P-SHADCN-BUTTON-UPSTREAM-IDENTITY
+        - P-SHADCN-BUTTON-BASE-INHERITANCE
+        - P-SHADCN-BUTTON-CURRENT-BASE-DEVIATIONS
+        - P-SHADCN-BUTTON-VARIANT-PROP
+        - P-SHADCN-BUTTON-SIZE-PROP
+        - P-SHADCN-BUTTON-INTERACTION-STYLES
+        - P-SHADCN-BUTTON-COLOR-SCHEME-STYLES
+        - P-SHADCN-BUTTON-COMPATIBILITY-SUBSET
+        - P-SHADCN-BUTTON-AS-CHILD-OMISSION
+exercises:
+  prototypes: [P-SHADCN-BUTTON, P-BASE-BUTTON]
+revisions:
+  - version: 0.2.0
+    change: introduced
+    summary: Added delta-style Shadcn Button coverage for reversible Base inheritance, current visual API, intentional asChild omission, environment styling, and centralized upstream compatibility differences.
+tags: [prototype, shadcn, button, delta, compatibility, test]


### PR DESCRIPTION
## Summary

- record governance for Base, Lucide, Shadcn, and future upstream-derived prototype libraries
- catalog the Lucide icon library as one name-driven `P-LUCIDE-ICON` protocol with pinned upstream package, version, license, manifest, and test coverage
- catalog Shadcn Button as a delta over Base Button, including a first-class prototype `inherits` relation, reversible-inheritance criteria, pinned upstream comparison, and a centralized compatibility question
- record the intentional omission of Radix-style `asChild` in favor of component-author-owned `asTrigger` event-route composition
- add the root `pnpm dev:workspace` entry
- make Lucide generation format emitted TypeScript with the repository Prettier configuration, eliminating regeneration-only formatting diffs

## Why

The spec directory is the project source of truth, but upstream-derived prototype libraries previously lacked consistent entity granularity, provenance, compatibility boundaries, and inheritance semantics. The Lucide generator also emitted pre-Prettier source, causing thousands of byte-only diffs on every regeneration.

## Impact

Lucide and the Shadcn Button pilot are now inspectable through the semantic workspace without claiming upstream ownership or unsupported API parity. Prototype inheritance is distinct from ordinary dependency. Re-running the complete 1,695-icon generator no longer changes tracked generated files when inputs are unchanged.

## Checks

- `pnpm --filter apps-workspace build`
- `pnpm test` — 229 test files passed, 3 skipped; 1,023 tests passed, 34 todo
- `pnpm check:types:workspace`
- ran Lucide generation twice; `packages/prototypes/lucide/src` remained byte-for-byte clean
- spec workspace generated 321 entities with 0 validation issues
