### PR TITLE
chore: align root dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
     "yaml": "^2.8.3"
   },
   "scripts": {
+    "dev": "corepack pnpm@10.32.1 --parallel --stream --filter apps-www --filter apps-workspace dev",
     "docs:dev": "corepack pnpm@10.32.1 --filter apps-www dev",
-    "dev:workspace": "corepack pnpm@10.32.1 --filter apps-workspace dev",
+    "workspace:dev": "corepack pnpm@10.32.1 --filter apps-workspace dev",
     "docs:build": "corepack pnpm@10.32.1 --filter apps-www build",
     "docs:preview": "corepack pnpm@10.32.1 --filter apps-www preview",
     "sync:links": "node scripts/sync-shared-links.mjs",


### PR DESCRIPTION
## Summary

- rename the workspace development script from `dev:workspace` to `workspace:dev`
- add a root `dev` script that starts the docs and spec workspace apps in parallel
- stream child-process output with app-specific prefixes

## Why

Development scripts should consistently put the app scope before the action. A single root command also makes it easier to inspect the docs and spec workspace together during local development.

## Validation

- started `corepack pnpm@10.32.1 dev` and confirmed both Astro docs and Vite workspace servers reached their ready state
- confirmed generated spec and style artifacts remained byte-idempotent
- `corepack pnpm@10.32.1 exec prettier --check package.json`
- `git diff --check`