### PR TITLE
feat: add React release consumer smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,40 @@ jobs:
       - name: Release stage (tsc + npm publish --dry-run for all packages)
         run: corepack pnpm@"${PROTO_PNPM_VERSION}" -s release:stage
 
+  release-consumer-react:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm (corepack)
+        run: |
+          set -euo pipefail
+          PACKAGE_MANAGER=$(node -p "require('./package.json').packageManager || ''")
+          LOCKFILE_VERSION=$(node -e "const fs=require('fs');const text=fs.readFileSync('pnpm-lock.yaml','utf8');const m=text.match(/^lockfileVersion:\s*['\"]?([^'\"\n]+)['\"]?/m);if(!m){throw new Error('lockfileVersion not found');}process.stdout.write(m[1]);")
+          echo "packageManager=${PACKAGE_MANAGER}"
+          echo "lockfileVersion=${LOCKFILE_VERSION}"
+          case "${LOCKFILE_VERSION}" in
+            6* ) PNPM_VERSION="8.13.1" ;;
+            9* ) PNPM_VERSION="10.32.1" ;;
+            * ) echo "Unsupported pnpm lockfileVersion: ${LOCKFILE_VERSION}"; exit 1 ;;
+          esac
+          corepack enable
+          corepack prepare pnpm@"${PNPM_VERSION}" --activate
+          echo "PROTO_PNPM_VERSION=${PNPM_VERSION}" >> "$GITHUB_ENV"
+          echo "COREPACK_ENABLE_PROJECT_SPEC=0" >> "$GITHUB_ENV"
+          corepack pnpm@"${PNPM_VERSION}" --version
+
+      - name: Install
+        run: corepack pnpm@"${PROTO_PNPM_VERSION}" install --frozen-lockfile
+
+      - name: Smoke exact release tarballs in isolated React + Vite consumer
+        run: corepack pnpm@"${PROTO_PNPM_VERSION}" -s release:smoke:react
+
   cli-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/internal/governance/ci-cd.md
+++ b/internal/governance/ci-cd.md
@@ -23,6 +23,8 @@ CI runs for pull requests, pushes to `main`, and manual dispatch. In addition to
 
 Every new numeric version must therefore be a reviewed release train; a package-local bump cannot bypass the gate.
 
+`release-consumer-react` additionally builds tarballs for every public package and installs the current declared release closure in a temporary React + Vite project outside the monorepo. The gate prevents `@proto.ui/*` from falling back to the npm registry or workspace sources, then verifies CLI facade generation, TypeScript, a production build, and baseline runtime behavior.
+
 ## Release Workflow (`release-packages.yml`)
 
 The workflow is triggered manually through `workflow_dispatch`.
@@ -60,8 +62,9 @@ These tiers do not control the real npm publish set. Global exact-version govern
 1. Create or update the draft V entity and align `VERSION` plus package manifests in one PR.
 2. Run `pnpm check:release-version` and `pnpm release:scan:launch`; review the launch product scope.
 3. Run `pnpm release:stage` to rehearse the final tarballs for every public package.
-4. After merge to `main`, run `publish-all` with the `workspace` profile.
-5. Verify the GitHub release/spec-snapshot evidence and promote the V entity to `active` in a follow-up PR.
+4. Run `pnpm release:smoke:react` to verify that an isolated React + Vite project can consume the exact tarballs.
+5. After merge to `main`, run `publish-all` with the `workspace` profile.
+6. Verify the GitHub release/spec-snapshot evidence and promote the V entity to `active` in a follow-up PR.
 
 ## Local Shortcuts
 
@@ -69,5 +72,6 @@ These tiers do not control the real npm publish set. Global exact-version govern
 - `pnpm release:scan:launch`
 - `pnpm release:stage:launch`
 - `pnpm release:stage`
+- `pnpm release:smoke:react`
 
 There is no package-local real-publish shortcut. Package-local fixes enter the next global release train.

--- a/internal/governance/ci-cd.zh-CN.md
+++ b/internal/governance/ci-cd.zh-CN.md
@@ -23,6 +23,8 @@ CI 在 pull request、`main` push 和手动触发时运行。除常规类型与�
 
 任何新数字版本都必须先成为受评审的 release train，不能通过局部 package 改版绕过。
 
+`release-consumer-react` 进一步从当前源码构建全部公开 package tarball，并在 monorepo 外的临时 React + Vite 项目中安装当前发布依赖闭包。该门禁禁止 `@proto.ui/*` 回退到 npm registry 或 workspace 源码，并验证 CLI facade 生成、TypeScript、production build 和基础运行时行为。
+
 ## 发布工作流（`release-packages.yml`）
 
 该工作流仅通过 `workflow_dispatch` 手动触发。
@@ -60,8 +62,9 @@ CI 在 pull request、`main` push 和手动触发时运行。除常规类型与�
 1. 创建或更新 draft V 实体，并在 PR 中统一 `VERSION` 与 package manifests。
 2. 运行 `pnpm check:release-version` 与 `pnpm release:scan:launch`，审阅首发产品范围。
 3. 运行 `pnpm release:stage`，彩排全部公开 package 的最终 tarball。
-4. 合入 `main` 后，用 `workspace` profile 运行 `publish-all`。
-5. 发布成功后核对 GitHub release/spec snapshot 证据，再通过后续 PR 将 V 实体转为 `active`。
+4. 运行 `pnpm release:smoke:react`，验证精确 tarball 能被隔离 React + Vite 项目消费。
+5. 合入 `main` 后，用 `workspace` profile 运行 `publish-all`。
+6. 发布成功后核对 GitHub release/spec snapshot 证据，再通过后续 PR 将 V 实体转为 `active`。
 
 ## 本地快捷命令
 
@@ -69,5 +72,6 @@ CI 在 pull request、`main` push 和手动触发时运行。除常规类型与�
 - `pnpm release:scan:launch`
 - `pnpm release:stage:launch`
 - `pnpm release:stage`
+- `pnpm release:smoke:react`
 
 仓库不提供局部真实发布快捷命令；package 局部修复进入下一次全局 release train。

--- a/internal/records/2026-07-19-react-release-consumer-smoke.zh-CN.md
+++ b/internal/records/2026-07-19-react-release-consumer-smoke.zh-CN.md
@@ -1,0 +1,45 @@
+# 2026-07-19 React release consumer smoke 记录
+
+> Internal record. Not normative. 本文记录 `0.2.0-rc.0` 发布前第一份 monorepo 外消费模板的验证范围、发现与后续边界；正式 CI 与发版规则以治理文档和流水线为准。
+
+## 1）目的
+
+已有 `release-stage` 能证明公开 package 可以 build 并通过 `npm publish --dry-run`，已有 `cli-smoke` 能证明 CLI 可以操作 npm 上的历史发布包，但二者都不能证明当前 37 个 `0.2.0-rc.0` 产物可以组成一套真实可消费的 release train。
+
+本轮新增 React + Vite 消费模板，要求 Proto UI 产物只来自当前工作树生成的 tarball，不允许使用 `workspace:*`、源码路径或 npm registry 中的旧版 `@proto.ui/*`。
+
+## 2）产物与安装模型
+
+- release staging 为 37 个公开 package 全部生成 tarball，并输出包含 name、version、相对路径和 integrity 的 `pack-manifest.json`。
+- React 消费项目以 CLI、React Adapter 和 Shadcn Prototype library 为根，根据 staged manifest 计算声明依赖闭包；当前闭包包含 34 个 Proto UI package。
+- 闭包中的每个 Proto UI package 都以本地 `file:` tarball 安装；lockfile 中出现 HTTP registry resolution 会使 smoke 失败。
+- React、Vite、TypeScript 和 happy-dom 等第三方依赖仍正常来自 npm registry。
+
+这种模型验证发布 manifest 所声明的实际闭包，同时不会用“把所有 package 都直接装进项目”掩盖缺失依赖。
+
+## 3）消费路径
+
+隔离项目使用已打包 CLI 执行 `init`，并生成 React 的 Shadcn Button、Switch、Select 和 Dialog facade。随后执行：
+
+- 严格 TypeScript 检查；
+- Vite production build；
+- happy-dom 中的真实 React mount；
+- Button 异步 disabled prop 更新；
+- Switch 初始状态与点击切换；
+- Select 的 combobox/listbox/selected option；
+- Dialog role 与 accessible name；
+- 完整 unmount 后再次 mount。
+
+## 4）本轮发现并修正的问题
+
+1. CLI registry 遗漏了已有实现与编目的 `shadcn-select`，导致消费者无法通过推荐路径生成 Select family。
+2. React Adapter 把 `useContext` 参数错误描述为不完整的结构对象，导致 CLI 生成的 `createReactAdapter(React)` 无法通过真实 React 类型检查。
+3. React Adapter 把模板的静态多根结果作为动态数组 child 传入 React，导致 Select Trigger 出现无意义的缺少 `key` 警告。
+
+修正后，34 个声明闭包 tarball 的安装、CLI 生成、TypeScript、Vite build 和上述运行时断言均通过。
+
+## 5）观察与非目标
+
+- 当前示例 production chunk 约为 561 kB、gzip 约为 150 kB，并触发 Vite 默认 chunk-size warning。本轮只记录该信号，不把未经拆分的单页 fixture bundle 直接解释为稳定的 package 成本；后续真实项目试用需要继续检查 tree-shaking 和按需加载。
+- happy-dom smoke 不是完整浏览器、视觉回归或辅助技术测试，不能替代真实浏览器中的焦点、Portal、CSS 和 reduced-motion 验证。
+- 本轮只建立 React 模板。Vue 与原生 Web Component 应复用相同的 tarball manifest、registry 泄漏检查和隔离安装规则，分别增加自己的 build/runtime 断言。

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "release:sync-metadata": "node scripts/release/sync-metadata.mjs",
     "release:stage": "node scripts/release/publish.mjs --dry-run",
     "release:stage:launch": "node scripts/release/publish.mjs --dry-run --profile launch --check-governance",
+    "release:smoke:react": "node scripts/release/consumer-smoke-react.mjs",
     "release:publish": "node scripts/release/publish.mjs --publish",
     "issues:good-first:dry-run": "node scripts/issues/publish-good-first-issues.mjs --dry-run",
     "issues:good-first:publish": "node scripts/issues/publish-good-first-issues.mjs --publish",

--- a/packages/adapters/react/package.json
+++ b/packages/adapters/react/package.json
@@ -27,6 +27,7 @@
     "@proto.ui/module-rule-meta": "workspace:*"
   },
   "devDependencies": {
+    "@types/react": "^19.2.0",
     "@proto.ui/prototypes-base": "workspace:*"
   },
   "exports": {

--- a/packages/adapters/react/src/adapt.ts
+++ b/packages/adapters/react/src/adapt.ts
@@ -48,7 +48,10 @@ export type ReactRuntime = ReactRenderRuntime & {
   createElement: (type: any, props?: any, ...children: any[]) => any;
   createPortal?: (children: any, container: Element) => any;
   createContext?: <T>(defaultValue: T) => { Provider: any };
-  useContext?: <T>(context: { Provider: any }) => T;
+  // Context is an opaque runtime handle to the adapter. Keeping the input
+  // structural would incorrectly require React.useContext to accept a partial
+  // Context object, which the real React type correctly rejects.
+  useContext?: <T>(context: any) => T;
 };
 
 export type ReactAdapterHandle = {
@@ -430,6 +433,10 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
       const rendered = renderTemplateToReact(runtime, renderChildren, {
         slot: props.children,
       });
+      // Template roots are a static child list. Passing that list as one array
+      // makes React treat it as a dynamic collection and warn that anatomy
+      // siblings such as Select Value + Chevron need authored keys.
+      const renderedChildren = Array.isArray(rendered) ? rendered : [rendered];
 
       const overlayPort = ownerRef.current?.session?.caps.getPort<OverlayPort>('overlay');
       const portalContainer =
@@ -453,7 +460,7 @@ export function createReactAdapter(runtimeInput: ReactRuntimeInput) {
               'data-pui-style': serializeStyleTokens(hostTokens),
               'data-demo-ref': props['data-demo-ref' as keyof typeof props] as string | undefined,
             },
-            rendered
+            ...renderedChildren
           );
       const projectedContent = portalContainer
         ? runtime.createPortal!(content, portalContainer)

--- a/packages/adapters/react/test/react-runtime.type-test.ts
+++ b/packages/adapters/react/test/react-runtime.type-test.ts
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+import { createReactAdapter } from '../src';
+
+// The public adapter signature must accept the real React module emitted by
+// the CLI (`import * as React from 'react'`) without a consumer-side cast.
+createReactAdapter(React);

--- a/packages/cli/src/registry/components.ts
+++ b/packages/cli/src/registry/components.ts
@@ -181,6 +181,34 @@ export const COMPONENT_REGISTRY: Record<string, ComponentEntry> = {
     },
   ]),
 
+  'shadcn-select': shadcnCompound('shadcn-select', 'shadcn Select', [
+    {
+      prototypeImport: 'shadcnSelectRoot',
+      exportBaseName: 'ShadcnSelectRoot',
+      elementName: 'proto-ui-shadcn-select-root',
+    },
+    {
+      prototypeImport: 'shadcnSelectTrigger',
+      exportBaseName: 'ShadcnSelectTrigger',
+      elementName: 'proto-ui-shadcn-select-trigger',
+    },
+    {
+      prototypeImport: 'shadcnSelectValue',
+      exportBaseName: 'ShadcnSelectValue',
+      elementName: 'proto-ui-shadcn-select-value',
+    },
+    {
+      prototypeImport: 'shadcnSelectContent',
+      exportBaseName: 'ShadcnSelectContent',
+      elementName: 'proto-ui-shadcn-select-content',
+    },
+    {
+      prototypeImport: 'shadcnSelectItem',
+      exportBaseName: 'ShadcnSelectItem',
+      elementName: 'proto-ui-shadcn-select-item',
+    },
+  ]),
+
   'shadcn-dialog': shadcnCompound('shadcn-dialog', 'shadcn Dialog', [
     {
       prototypeImport: 'shadcnDialogRoot',

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -180,6 +180,34 @@ describe('@proto.ui/cli', () => {
     expect(config.components.react).toEqual(['shadcn-button']);
   });
 
+  it('adds the complete shadcn Select React facade', async () => {
+    const cwd = await createTempProject('pui-cli-add-shadcn-select', {
+      name: 'pui-cli-add-shadcn-select',
+      private: true,
+      dependencies: {
+        react: '^19.0.0',
+        'react-dom': '^19.0.0',
+      },
+    });
+
+    expect(runCli(cwd, ['init', '--no-interactive', '--no-styles']).status).toBe(0);
+    const result = runCli(cwd, ['add', 'react', 'shadcn-select', '--no-install']);
+
+    expect(result.status).toBe(0);
+    const reactIndex = await fs.readFile(
+      path.join(cwd, 'proto-ui/components/react/index.ts'),
+      'utf8'
+    );
+    const config = JSON.parse(await fs.readFile(path.join(cwd, 'proto-ui/config.json'), 'utf8'));
+
+    for (const part of ['Root', 'Trigger', 'Value', 'Content', 'Item']) {
+      expect(reactIndex).toContain(
+        `export const ShadcnSelect${part} = adapt(shadcnSelect${part});`
+      );
+    }
+    expect(config.components.react).toEqual(['shadcn-select']);
+  });
+
   it('adds a compound Web Component facade from base prototypes', async () => {
     const cwd = await createTempProject('pui-cli-add-wc', {
       name: 'pui-cli-add-wc',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,9 @@ importers:
       '@proto.ui/prototypes-base':
         specifier: workspace:*
         version: link:../../prototypes/base
+      '@types/react':
+        specifier: ^19.2.0
+        version: 19.2.14
 
   packages/adapters/vue:
     dependencies:

--- a/scripts/release/consumer-smoke-react.mjs
+++ b/scripts/release/consumer-smoke-react.mjs
@@ -1,0 +1,239 @@
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+import { getAllPackages, ROOT_DIR, selectPackages } from './lib.mjs';
+import { readVersion } from './version-utils.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(__dirname, 'consumer-smoke', 'react-vite');
+const RELEASE_ROOTS = ['@proto.ui/cli', '@proto.ui/adapter-react', '@proto.ui/prototypes-shadcn'];
+
+const args = parseArgs(process.argv.slice(2));
+const workDir = args.workDir ?? mkdtempSync(join(tmpdir(), 'proto-ui-react-consumer-'));
+const releaseDir = join(workDir, 'release');
+const consumerDir = join(workDir, 'consumer');
+let succeeded = false;
+
+try {
+  run(process.execPath, [
+    join(ROOT_DIR, 'scripts', 'release', 'publish.mjs'),
+    '--pack',
+    '--out-dir',
+    releaseDir,
+  ]);
+
+  const packManifestPath = join(releaseDir, 'pack-manifest.json');
+  const packManifest = JSON.parse(readFileSync(packManifestPath, 'utf8'));
+  const releaseVersion = readVersion().raw;
+  const expectedPackages = selectPackages(getAllPackages())
+    .map((pkg) => pkg.name)
+    .sort();
+  const packedPackages = packManifest.packages.map((pkg) => pkg.name).sort();
+
+  assert(packManifest.releaseVersion === releaseVersion, 'pack manifest release version drifted');
+  assert(
+    JSON.stringify(packedPackages) === JSON.stringify(expectedPackages),
+    `packed package set drifted: expected ${expectedPackages.length}, got ${packedPackages.length}`
+  );
+
+  cpSync(FIXTURE_DIR, consumerDir, { recursive: true });
+  const packageByName = new Map(packManifest.packages.map((pkg) => [pkg.name, pkg]));
+  const consumerPackageNames = collectDeclaredClosure(RELEASE_ROOTS, packageByName, releaseDir);
+  const protoDependencies = Object.fromEntries(
+    consumerPackageNames.map((name) => {
+      const entry = packageByName.get(name);
+      const tarballPath = join(releaseDir, entry.tarball);
+      assert(existsSync(tarballPath), `missing packed tarball for ${name}`);
+      return [name, toFileSpec(relative(consumerDir, tarballPath))];
+    })
+  );
+
+  const packageJson = {
+    name: 'proto-ui-react-consumer-smoke',
+    private: true,
+    version: '0.0.0',
+    type: 'module',
+    scripts: {
+      build: 'tsc --noEmit && vite build',
+      smoke: 'node --import tsx ./smoke.tsx',
+    },
+    dependencies: {
+      ...protoDependencies,
+      react: '19.2.6',
+      'react-dom': '19.2.6',
+    },
+    devDependencies: {
+      '@happy-dom/global-registrator': '20.11.0',
+      '@types/react': '19.2.14',
+      '@types/react-dom': '19.2.3',
+      tsx: '4.21.0',
+      typescript: '5.9.3',
+      vite: '6.4.1',
+    },
+  };
+  writeFileSync(join(consumerDir, 'package.json'), `${JSON.stringify(packageJson, null, 2)}\n`);
+
+  run('npm', ['install', '--no-audit', '--no-fund'], { cwd: consumerDir });
+  verifyInstalledRelease({
+    consumerDir,
+    expectedNames: consumerPackageNames,
+    releaseVersion,
+  });
+
+  const cli = join(consumerDir, 'node_modules', '@proto.ui', 'cli', 'bin', 'proto-ui.js');
+  run(process.execPath, [cli, 'init', '--yes', '--no-interactive', '--no-styles'], {
+    cwd: consumerDir,
+  });
+  for (const component of ['shadcn-button', 'shadcn-switch', 'shadcn-select', 'shadcn-dialog']) {
+    run(process.execPath, [cli, 'add', 'react', component, '--no-install', '--no-interactive'], {
+      cwd: consumerDir,
+    });
+  }
+
+  run('npm', ['run', 'build'], { cwd: consumerDir });
+  run('npm', ['run', 'smoke'], { cwd: consumerDir });
+
+  succeeded = true;
+  console.log(
+    `release consumer smoke: react ok (${consumerPackageNames.length}/${expectedPackages.length} packed packages consumed)`
+  );
+  if (args.keep) console.log(`artifacts kept at ${workDir}`);
+} catch (error) {
+  console.error(`release consumer smoke failed; artifacts kept at ${workDir}`);
+  throw error;
+} finally {
+  if (succeeded && !args.keep) rmSync(workDir, { recursive: true, force: true });
+}
+
+function collectDeclaredClosure(rootNames, packageByName, releaseDir) {
+  const closure = new Set();
+  const queue = [...rootNames];
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (closure.has(name)) continue;
+    const entry = packageByName.get(name);
+    assert(entry, `release root ${name} is missing from the pack manifest`);
+    closure.add(name);
+
+    assert(entry.stage, `pack manifest has no stage path for ${name}`);
+    const manifest = JSON.parse(
+      readFileSync(join(releaseDir, entry.stage, 'package.json'), 'utf8')
+    );
+    for (const field of ['dependencies', 'peerDependencies', 'optionalDependencies']) {
+      for (const dependencyName of Object.keys(manifest[field] ?? {})) {
+        if (packageByName.has(dependencyName) && !closure.has(dependencyName)) {
+          queue.push(dependencyName);
+        }
+      }
+    }
+  }
+  return [...closure].sort();
+}
+
+function verifyInstalledRelease({ consumerDir, expectedNames, releaseVersion }) {
+  const packageLock = JSON.parse(readFileSync(join(consumerDir, 'package-lock.json'), 'utf8'));
+  const installedProtoEntries = Object.entries(packageLock.packages ?? {}).filter(([key]) =>
+    key.startsWith('node_modules/@proto.ui/')
+  );
+  const installedNames = installedProtoEntries
+    .map(([key]) => key.slice('node_modules/'.length))
+    .sort();
+
+  assert(
+    JSON.stringify(installedNames) === JSON.stringify(expectedNames),
+    `installed Proto UI set drifted: expected ${expectedNames.length}, got ${installedNames.length}`
+  );
+  for (const [key, entry] of installedProtoEntries) {
+    const name = key.slice('node_modules/'.length);
+    assert(entry.version === releaseVersion, `${name} installed as ${entry.version}`);
+    assert(
+      typeof entry.resolved === 'string' && !/^https?:/.test(entry.resolved),
+      `${name} leaked to a registry resolution: ${entry.resolved ?? '<missing>'}`
+    );
+  }
+
+  const protoScopeDir = join(consumerDir, 'node_modules', '@proto.ui');
+  const installedDirs = readdirSync(protoScopeDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `@proto.ui/${entry.name}`)
+    .sort();
+  assert(
+    JSON.stringify(installedDirs) === JSON.stringify(expectedNames),
+    'node_modules Proto UI packages do not match the declared tarball closure'
+  );
+
+  for (const name of expectedNames) {
+    const manifest = JSON.parse(
+      readFileSync(join(protoScopeDir, name.slice('@proto.ui/'.length), 'package.json'), 'utf8')
+    );
+    assert(manifest.version === releaseVersion, `${name} manifest version drifted`);
+    for (const field of ['dependencies', 'peerDependencies', 'optionalDependencies']) {
+      for (const [dependencyName, dependencyVersion] of Object.entries(manifest[field] ?? {})) {
+        if (!dependencyName.startsWith('@proto.ui/')) continue;
+        assert(
+          dependencyVersion === releaseVersion,
+          `${name} has non-exact ${field} edge ${dependencyName}@${dependencyVersion}`
+        );
+      }
+    }
+  }
+}
+
+function run(command, commandArgs, options = {}) {
+  const result = spawnSync(command, commandArgs, {
+    cwd: options.cwd ?? ROOT_DIR,
+    encoding: 'utf8',
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+    env: process.env,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${commandArgs.join(' ')} exited with ${result.status}`);
+  }
+}
+
+function parseArgs(argv) {
+  const parsed = { keep: false, workDir: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') continue;
+    else if (arg === '--keep') parsed.keep = true;
+    else if (arg === '--work-dir') {
+      const value = argv[++index];
+      if (!value) throw new Error('--work-dir expects a path');
+      parsed.workDir = isAbsolute(value) ? value : resolve(ROOT_DIR, value);
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(
+        'Usage: node scripts/release/consumer-smoke-react.mjs [--keep] [--work-dir <path>]'
+      );
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (parsed.workDir) {
+    rmSync(parsed.workDir, { recursive: true, force: true });
+  }
+  return parsed;
+}
+
+function toFileSpec(path) {
+  const normalized = path.replaceAll('\\', '/');
+  return `file:${normalized.startsWith('.') ? normalized : `./${normalized}`}`;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}

--- a/scripts/release/consumer-smoke/react-vite/index.html
+++ b/scripts/release/consumer-smoke/react-vite/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Proto UI React consumer smoke</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/scripts/release/consumer-smoke/react-vite/smoke.tsx
+++ b/scripts/release/consumer-smoke/react-vite/smoke.tsx
@@ -1,0 +1,70 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+GlobalRegistrator.register();
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const React = await import('react');
+const ReactDOMClient = await import('react-dom/client');
+const { App } = await import('./src/App');
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 80));
+
+async function mountAndAssert(label: string) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = ReactDOMClient.createRoot(container);
+  await React.act(async () => {
+    root.render(React.createElement(App));
+    await flush();
+  });
+
+  const main = container.querySelector('main');
+  assert(main?.getAttribute('data-consumer-ready') === 'true', `${label}: async update failed`);
+
+  const button = container.querySelector('.consumer-button');
+  assert(button?.getAttribute('tabindex') === '0', `${label}: Button is not focusable`);
+  assert(button?.getAttribute('aria-disabled') === 'false', `${label}: Button prop update failed`);
+  assert(
+    button?.getAttribute('data-pui-style')?.includes('group/button'),
+    `${label}: Button prototype styles are missing`
+  );
+
+  const switchRoot = container.querySelector('.consumer-switch');
+  assert(switchRoot?.getAttribute('role') === 'switch', `${label}: Switch role is missing`);
+  assert(switchRoot?.getAttribute('aria-checked') === 'true', `${label}: Switch state is missing`);
+  await React.act(async () => {
+    switchRoot?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flush();
+  });
+  assert(switchRoot?.getAttribute('aria-checked') === 'false', `${label}: Switch click failed`);
+
+  const selectTrigger = container.querySelector('.consumer-select-trigger');
+  assert(selectTrigger?.getAttribute('role') === 'combobox', `${label}: Select role is missing`);
+  assert(selectTrigger?.getAttribute('aria-expanded') === 'true', `${label}: Select did not open`);
+  const selectedOption = document.body.querySelector('[role="option"][aria-selected="true"]');
+  assert(selectedOption?.textContent?.includes('Comfortable'), `${label}: Select value is missing`);
+
+  const dialog = document.body.querySelector('[role="dialog"]');
+  assert(dialog, `${label}: Dialog role is missing`);
+  assert(
+    dialog?.getAttribute('aria-label') === 'Preference details' ||
+      dialog?.getAttribute('aria-labelledby'),
+    `${label}: Dialog accessible name is missing`
+  );
+
+  await React.act(async () => root.unmount());
+  container.remove();
+  await flush();
+}
+
+await mountAndAssert('first mount');
+await mountAndAssert('remount');
+
+console.log(
+  'react consumer runtime smoke ok | Button + Switch + Select + Dialog + async + remount'
+);
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}

--- a/scripts/release/consumer-smoke/react-vite/src/App.tsx
+++ b/scripts/release/consumer-smoke/react-vite/src/App.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+
+import {
+  ShadcnButton,
+  ShadcnDialogClose,
+  ShadcnDialogContent,
+  ShadcnDialogDescription,
+  ShadcnDialogMask,
+  ShadcnDialogRoot,
+  ShadcnDialogTitle,
+  ShadcnDialogTrigger,
+  ShadcnSelectContent,
+  ShadcnSelectItem,
+  ShadcnSelectRoot,
+  ShadcnSelectTrigger,
+  ShadcnSelectValue,
+  ShadcnSwitchRoot,
+  ShadcnSwitchThumb,
+} from '../proto-ui/components/react';
+
+export function App() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    Promise.resolve().then(() => setReady(true));
+  }, []);
+
+  return (
+    <main data-consumer-ready={ready ? 'true' : 'false'}>
+      <ShadcnButton disabled={!ready} className="consumer-button">
+        Save preference
+      </ShadcnButton>
+
+      <ShadcnSwitchRoot defaultChecked className="consumer-switch">
+        <ShadcnSwitchThumb />
+      </ShadcnSwitchRoot>
+
+      <ShadcnSelectRoot defaultOpen defaultValue="comfortable">
+        <ShadcnSelectTrigger className="consumer-select-trigger">
+          <ShadcnSelectValue placeholder="Choose density" />
+        </ShadcnSelectTrigger>
+        <ShadcnSelectContent position="popper" className="consumer-select-content">
+          <ShadcnSelectItem value="compact" textValue="Compact">
+            Compact
+          </ShadcnSelectItem>
+          <ShadcnSelectItem value="comfortable" textValue="Comfortable">
+            Comfortable
+          </ShadcnSelectItem>
+        </ShadcnSelectContent>
+      </ShadcnSelectRoot>
+
+      <ShadcnDialogRoot defaultOpen a11yLabel="Preference details">
+        <ShadcnDialogTrigger>Open details</ShadcnDialogTrigger>
+        <ShadcnDialogMask />
+        <ShadcnDialogContent className="consumer-dialog-content">
+          <ShadcnDialogTitle>Preference details</ShadcnDialogTitle>
+          <ShadcnDialogDescription>Review the selected preference.</ShadcnDialogDescription>
+          <ShadcnDialogClose>Close</ShadcnDialogClose>
+        </ShadcnDialogContent>
+      </ShadcnDialogRoot>
+    </main>
+  );
+}

--- a/scripts/release/consumer-smoke/react-vite/src/main.tsx
+++ b/scripts/release/consumer-smoke/react-vite/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { App } from './App';
+
+const container = document.getElementById('root');
+if (!container) throw new Error('missing #root');
+
+createRoot(container).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/scripts/release/consumer-smoke/react-vite/tsconfig.json
+++ b/scripts/release/consumer-smoke/react-vite/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "proto-ui", "smoke.tsx"]
+}

--- a/scripts/release/lib.mjs
+++ b/scripts/release/lib.mjs
@@ -38,6 +38,7 @@ export function parseArgs(argv) {
     includeTest: false,
     checkBuild: false,
     checkGovernance: false,
+    pack: false,
     publish: false,
     resumePublished: false,
     tag: undefined,
@@ -62,6 +63,7 @@ export function parseArgs(argv) {
     else if (arg === '--include-approved-candidates') args.includeApprovedCandidates = true;
     else if (arg === '--check-build') args.checkBuild = true;
     else if (arg === '--check-governance') args.checkGovernance = true;
+    else if (arg === '--pack') args.pack = true;
     else if (arg === '--publish') args.publish = true;
     else if (arg === '--resume-published') args.resumePublished = true;
     else if (arg === '--tag') args.tag = argv[++i];
@@ -335,6 +337,7 @@ export function stagePackage(pkg, options) {
     outDir,
     version,
     access = 'public',
+    pack = false,
     publish = false,
     dryRun = false,
     tag = 'latest',
@@ -447,6 +450,32 @@ export function stagePackage(pkg, options) {
     }
   }
 
+  let packResult = null;
+  if (pack) {
+    const tarballDir = join(outDir, 'tarballs');
+    mkdirSync(tarballDir, { recursive: true });
+    const result = spawnSync('npm', ['pack', '--json', '--pack-destination', tarballDir], {
+      cwd: stageDir,
+      encoding: 'utf8',
+      shell: IS_WINDOWS,
+      env: {
+        ...process.env,
+        npm_config_cache: npmCacheDir,
+      },
+    });
+    if (result.status !== 0) {
+      throw new Error(`npm pack failed for ${pkg.name}\n${result.stderr || result.stdout}`);
+    }
+    const packed = JSON.parse(result.stdout || '[]');
+    if (packed.length !== 1 || !packed[0]?.filename) {
+      throw new Error(`npm pack returned no tarball metadata for ${pkg.name}`);
+    }
+    packResult = {
+      ...packed[0],
+      path: join(tarballDir, packed[0].filename),
+    };
+  }
+
   let publishResult = null;
   if (publish || dryRun) {
     if (publish && publishSequenceIndex > 0 && publishDelayMs > 0) {
@@ -530,6 +559,7 @@ export function stagePackage(pkg, options) {
     stageDir,
     buildCode: buildResult.status ?? 0,
     buildErrors,
+    packResult,
     publishResult,
   };
 }

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -1,6 +1,6 @@
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import {
   buildPrerequisitePackages,
   ROOT_DIR,
@@ -19,6 +19,7 @@ function printHelp() {
 
 Options:
   --dry-run                     Run npm publish --dry-run against staged packages
+  --pack                        Create installable tarballs for every staged package
   --publish                     Run npm publish for real
   --resume-published            Recovery only: skip an existing identical registry tarball
   --tag <tag>                   Override npm dist-tag for dry-run inspection only
@@ -63,7 +64,7 @@ if (args.publish) assertPublishSource();
 const releaseVersion = readVersion();
 args.tag ??= releaseVersion.isPrerelease ? 'next' : 'latest';
 
-if (!args.publish && !args.dryRun) {
+if (!args.publish && !args.dryRun && !args.pack) {
   args.dryRun = true;
 }
 
@@ -140,6 +141,23 @@ for (const [index, pkg] of ordered.entries()) {
   results.push(result);
 }
 
+if (args.pack) {
+  const manifestPath = join(args.outDir, 'pack-manifest.json');
+  const packManifest = {
+    schemaVersion: 1,
+    releaseVersion: releaseVersion.raw,
+    packages: results.map((result) => ({
+      name: result.name,
+      version: releaseVersion.raw,
+      stage: relative(args.outDir, result.stageDir).replaceAll('\\', '/'),
+      tarball: relative(args.outDir, result.packResult.path).replaceAll('\\', '/'),
+      integrity: result.packResult.integrity,
+      shasum: result.packResult.shasum,
+    })),
+  };
+  writeFileSync(manifestPath, `${JSON.stringify(packManifest, null, 2)}\n`);
+}
+
 console.log(`Staged ${results.length} packages into ${args.outDir}`);
 console.log('');
 
@@ -176,6 +194,9 @@ for (const result of results) {
         `  npm publish attempt: ${result.publishResult.attempt}/${result.publishResult.maxAttempts}`
       );
     }
+  }
+  if (result.packResult) {
+    console.log(`  tarball: ${result.packResult.filename}`);
   }
 }
 

--- a/scripts/release/test/publish-manifest.test.mjs
+++ b/scripts/release/test/publish-manifest.test.mjs
@@ -8,6 +8,11 @@ test('partial recovery is an explicit release argument', () => {
   assert.equal(parseArgs(['--resume-published']).resumePublished, true);
 });
 
+test('tarball packing is an explicit release argument', () => {
+  assert.equal(parseArgs([]).pack, false);
+  assert.equal(parseArgs(['--pack']).pack, true);
+});
+
 test('workspace dependencies use exact package versions in published manifests', () => {
   const manifest = createPublishManifest(
     {

--- a/tsconfig.workspace.json
+++ b/tsconfig.workspace.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["apps/www", "node_modules", "dist"]
+  "exclude": ["apps/www", "node_modules", "dist", "scripts/release/consumer-smoke"]
 }


### PR DESCRIPTION
## Summary

- stage all public packages as exact `0.2.0-rc.0` tarballs with a machine-readable pack manifest
- add an isolated React + Vite consumer that installs only the declared Proto UI dependency closure
- generate and exercise Shadcn Button, Switch, Select, and Dialog through the packaged CLI
- run the consumer smoke as a dedicated pull-request CI job
- fix the Shadcn Select CLI registry entry, real React runtime typing, and static multi-root React child keys discovered by the external consumer

## Why

The existing release stage proved that individual packages could be built and dry-run published, but it did not prove that the current release train could be installed and used together outside the monorepo. This adds the first release-consumer gate using only packed artifacts, without workspace or source-path fallbacks.

## Impact

The release pipeline now catches missing package dependencies, registry leakage, generated facade drift, TypeScript incompatibilities, Vite build failures, and basic React runtime regressions before publication.

Bundle size is recorded as an observation only. Prototype family-level import boundaries and tree-shaking improvements remain separate follow-up work.

## Validation

- `pnpm release:smoke:react`: 37 packages packed; 34-package declared closure installed and consumed
- workspace test suite: 1037 passed, 34 todo
- workspace and docs type checks: 0 errors and 0 warnings
- release publish dry-run: all 37 public packages passed
