### PR TITLE
feat: prepare exact 0.2 RC release train

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -159,9 +159,19 @@ jobs:
       - name: Validate reviewed global release identity
         run: node scripts/release/check-version-governance.mjs
 
+      - name: Validate reviewed release notes and package BOM
+        run: node scripts/release/check-release-assets.mjs --check
+
       - name: Generate deterministic spec release snapshot
         if: ${{ inputs.mode == 'publish-all' }}
-        run: corepack pnpm@"${PROTO_PNPM_VERSION}" spec:snapshot:release -- --out-dir release-artifacts
+        run: |
+          set -euo pipefail
+          VERSION_VALUE=$(cat VERSION)
+          RELEASE_DIR="internal/releases/${VERSION_VALUE}"
+
+          corepack pnpm@"${PROTO_PNPM_VERSION}" spec:snapshot:release -- --out-dir release-artifacts
+          cp "${RELEASE_DIR}/package-bom.json" "release-artifacts/package-bom-${VERSION_VALUE}.json"
+          cp "${RELEASE_DIR}/release-notes.zh-CN.md" "release-artifacts/release-notes-${VERSION_VALUE}.zh-CN.md"
 
       - name: Run Release Command
         run: |
@@ -240,15 +250,20 @@ jobs:
           set -euo pipefail
           VERSION_VALUE=$(cat VERSION)
           TAG_NAME="v${VERSION_VALUE}"
+          RELEASE_DIR="internal/releases/${VERSION_VALUE}"
+          RELEASE_NOTES="${RELEASE_DIR}/release-notes.md"
           SNAPSHOT="release-artifacts/spec-snapshot-${VERSION_VALUE}.json"
           CHECKSUM="${SNAPSHOT}.sha256"
+          BOM="release-artifacts/package-bom-${VERSION_VALUE}.json"
+          ZH_NOTES="release-artifacts/release-notes-${VERSION_VALUE}.zh-CN.md"
 
           if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
-            gh release upload "${TAG_NAME}" "${SNAPSHOT}" "${CHECKSUM}" --clobber
+            gh release edit "${TAG_NAME}" --notes-file "${RELEASE_NOTES}"
+            gh release upload "${TAG_NAME}" "${SNAPSHOT}" "${CHECKSUM}" "${BOM}" "${ZH_NOTES}" --clobber
           else
-            RELEASE_ARGS=(--verify-tag --title "Proto UI ${VERSION_VALUE}" --generate-notes)
+            RELEASE_ARGS=(--verify-tag --title "Proto UI ${VERSION_VALUE}" --notes-file "${RELEASE_NOTES}")
             if [[ "${VERSION_VALUE}" == *-* ]]; then
               RELEASE_ARGS+=(--prerelease)
             fi
-            gh release create "${TAG_NAME}" "${RELEASE_ARGS[@]}" "${SNAPSHOT}" "${CHECKSUM}"
+            gh release create "${TAG_NAME}" "${RELEASE_ARGS[@]}" "${SNAPSHOT}" "${CHECKSUM}" "${BOM}" "${ZH_NOTES}"
           fi

--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -12,6 +12,11 @@ const inProgressBadge = {
   class:
     'text-xs px-1.5 h-4.5 rounded-full bg-amber-100 text-amber-900 dark:bg-amber-900 dark:text-amber-100',
 };
+const prereleaseBadge = {
+  text: 'RC',
+  class:
+    'text-xs px-1.5 h-4.5 rounded-full bg-violet-100 text-violet-900 dark:bg-violet-900 dark:text-violet-100',
+};
 // https://astro.build/config
 export default defineConfig({
   site: 'https://www.proto-ui.com',
@@ -94,6 +99,15 @@ export default defineConfig({
                 'zh-CN': '快速开始',
               },
               slug: 'start-here/quick-start',
+            },
+            {
+              label: '0.2 RC 试用',
+              translations: {
+                en: '0.2 RC Trial',
+                'zh-CN': '0.2 RC 试用',
+              },
+              slug: 'start-here/rc-trial',
+              badge: prereleaseBadge,
             },
           ],
         },

--- a/apps/www/src/content/docs/en/start-here/quick-start.mdx
+++ b/apps/www/src/content/docs/en/start-here/quick-start.mdx
@@ -1,197 +1,32 @@
 ---
 title: 'Quick Start'
-desp: 'Initialize Proto UI and install components into your project'
-description: 'Initialize Proto UI and install components into your project'
+description: 'Start using Proto UI from the stable npm latest release'
 ---
 
 import DocStageNotice from '@/components/DocStageNotice.astro';
 
 <DocStageNotice
-  tone="blue"
-  title="Proto UI is in its early public stage."
-  body="Core ideas are already visible, but component coverage and ecosystem readiness are still being built up."
+  tone="amber"
+  title="The Proto UI 0.2 stable onboarding flow is not open yet."
+  body="The main Quick Start always follows npm latest and does not put prerelease builds on the default user path."
 />
 
-:::caution[Pre-release Stage] Proto UI is in its early public stage. This page describes the current onboarding path. Command behavior or generated file structure may still change before the v0 launch. :::
+## Stable-version contract
 
-## Install the Proto UI CLI
-
-You can use the Proto UI CLI directly with `npx`. There is no need to install it globally in advance.
+This page is the stable Proto UI onboarding entry. After `0.2.0` is published, its commands will always use npm's default `latest` channel:
 
 ```bash
 npx @proto.ui/cli --help
 ```
 
----
+Before the stable release, this page will not substitute `@next` for the official onboarding flow or ask the current `0.1.x` packages to follow instructions written for the `0.2` code generator.
 
-## Initialize your project
+## Join the 0.2 RC trial
 
-Run this in your project root:
-
-```bash
-npx @proto.ui/cli init
-```
-
-After initialization, a `proto-ui/` folder will be created at the project root.
-
-A typical structure looks like this:
-
-```txt
-your-project/
-├── src/
-├── proto-ui/
-│   ├── adapters/
-│   ├── prototypes/
-│   ├── components/
-│   │   ├── react/
-│   │   │   └── index.ts
-│   │   └── index.ts
-│   └── config.json
-├── package.json
-└── ...
-```
-
-Where:
-
-- `config.json`: project configuration read by later CLI commands
-- `components/`: generated component entries you import from your app
-- `adapters/` and `prototypes/`: CLI-managed areas, not user-facing import surfaces
-
-You usually do not need to maintain these files manually. The CLI manages them for you.
-
----
-
-## Import the styles
-
-`init` generates Proto UI style preset files by default. Import the generated stylesheet once from your app entry:
-
-```ts
-import './styles/proto-ui-style.css';
-```
-
-Adjust the relative path if your app entry is not next to `src/styles`.
-
----
-
-## Add a component
-
-Once initialization is done, you can install Proto UI components one component at a time.
-
-For example, to add a `shadcn-button` in a React project:
-
-```bash
-npx @proto.ui/cli add react shadcn-button
-```
-
-This command will:
-
-1. Detect the host adapter you selected (`react`)
-2. Check that the React runtime exists in your project
-3. Install the corresponding adapter and prototype packages
-4. Assemble everything locally
-5. Generate a component entry point that your current project can use directly
-
-If you want to inspect what will be generated without letting the CLI install dependencies, run:
-
-```bash
-npx @proto.ui/cli add react shadcn-button --no-install
-```
-
-This prints the Proto UI packages you still need to install and still generates the local component entry.
-
----
-
-## Use it in your project
-
-After installation, import the component from the generated host entry:
-
-```tsx
-import { Button } from '../proto-ui/components/react';
-
-export function Demo() {
-  return <Button>Click me</Button>;
-}
-```
-
-The relative import is intentional. Projects do not share the same path aliases or directory depth, so the CLI does not assume that a bare specifier such as `proto-ui/components` is already configured.
-
----
-
-## Keep adding more components
-
-Proto UI is adopted one component at a time.
-
-You can continue with commands like:
-
-```bash
-npx @proto.ui/cli add react shadcn-toggle
-npx @proto.ui/cli add react shadcn-dialog
-```
-
-Then keep using them from the same host entry:
-
-```tsx
-import { Button, DialogRoot, Toggle } from '../proto-ui/components/react';
-```
-
----
-
-## Use multiple hosts
-
-If the same project needs both React and Web Components, add them separately:
-
-```bash
-npx @proto.ui/cli add react shadcn-button
-npx @proto.ui/cli add wc shadcn-button
-```
-
-React components are exported from the React host entry:
-
-```tsx
-import { Button } from '../proto-ui/components/react';
-```
-
-Web Component constructors are exported from the Web Component host entry:
-
-```ts
-import { ButtonElement } from '../proto-ui/components/wc';
-```
-
-`proto-ui/components/index.ts` also re-exports host-prefixed or explicit names to avoid naming conflicts when multiple hosts are used in the same project.
-
----
-
-## It does not ask you to migrate your whole project at once
-
-You can use Proto UI only in new features, or replace just one or two components in an existing project.
-
-A more common way to start is:
-
-1. Initialize Proto UI first
-2. Install the simplest component first, such as Button
-3. Try it in one local page or feature
-4. Then decide whether to keep expanding
-
----
-
-## Current boundary
-
-The current CLI onboarding path installs official prototype packages and generates local component facades.
-
-It does not yet write shadcn styled prototype source into your project for direct editing. That direction is already planned, but it is not part of the first v0 onboarding path.
-
----
+To verify installation, generation, and component usage after `0.2.0-rc.0` is published, use the separate [0.2 RC Trial](/en/start-here/rc-trial/). That page pins the exact RC version, keeping trial results reproducible when the `next` dist-tag moves.
 
 ## Next
 
-If you want to understand the most basic model behind it:
-
-- Go to [How It Works](/en/start-here/how-it-works/)
-
-If you want to decide whether it is worth introducing:
-
-- Go to [Why Proto UI](/en/start-here/why-proto-ui/)
-
-If you want to learn more about its underlying principles and boundaries:
-
-- Go to [Whitepaper](/en/whitepaper/component-as-protocol/)
+- [0.2 RC Trial](/en/start-here/rc-trial/)
+- [How It Works](/en/start-here/how-it-works/)
+- [Why Proto UI](/en/start-here/why-proto-ui/)

--- a/apps/www/src/content/docs/en/start-here/rc-trial.mdx
+++ b/apps/www/src/content/docs/en/start-here/rc-trial.mdx
@@ -1,0 +1,196 @@
+---
+title: '0.2 RC Trial'
+description: 'Verify the Proto UI onboarding flow with the exact 0.2.0-rc.0 release'
+---
+
+import DocStageNotice from '@/components/DocStageNotice.astro';
+
+<DocStageNotice
+  tone="amber"
+  title="This is the isolated 0.2.0-rc.0 prerelease trial flow."
+  body="It does not change the main Quick Start contract, which follows the stable npm latest release."
+/>
+
+:::caution[Waiting for the RC] The commands below work only after `0.2.0-rc.0` has been published to npm. Trial findings are not stable-version promises, and commands or generated structure may still change before `0.2.0`. :::
+
+## Install the Proto UI CLI
+
+You can use the Proto UI CLI directly with `npx`. There is no need to install it globally in advance. This page pins `0.2.0-rc.0` so trial results remain reproducible; the CLI pins Adapter and Prototype packages to its own exact version so historical release trains cannot be mixed in.
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 --help
+```
+
+---
+
+## Initialize your project
+
+Run this in your project root:
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 init
+```
+
+After initialization, a `proto-ui/` folder will be created at the project root.
+
+A typical structure looks like this:
+
+```txt
+your-project/
+├── src/
+├── proto-ui/
+│   ├── adapters/
+│   ├── prototypes/
+│   ├── components/
+│   │   ├── react/
+│   │   │   └── index.ts
+│   │   └── index.ts
+│   └── config.json
+├── package.json
+└── ...
+```
+
+Where:
+
+- `config.json`: project configuration read by later CLI commands
+- `components/`: generated component entries you import from your app
+- `adapters/` and `prototypes/`: CLI-managed areas, not user-facing import surfaces
+
+You usually do not need to maintain these files manually. The CLI manages them for you.
+
+---
+
+## Import the styles
+
+`init` generates Proto UI style preset files by default. Import the generated stylesheet once from your app entry:
+
+```ts
+import './styles/proto-ui-style.css';
+```
+
+Adjust the relative path if your app entry is not next to `src/styles`.
+
+---
+
+## Add a component
+
+Once initialization is done, you can install Proto UI components one component at a time.
+
+For example, to add a `shadcn-button` in a React project:
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-button
+```
+
+This command will:
+
+1. Detect the host adapter you selected (`react`)
+2. Check that the React runtime exists in your project
+3. Install the corresponding adapter and prototype packages
+4. Assemble everything locally
+5. Generate a component entry point that your current project can use directly
+
+If you want to inspect what will be generated without letting the CLI install dependencies, run:
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-button --no-install
+```
+
+This prints the Proto UI packages you still need to install and still generates the local component entry.
+
+---
+
+## Use it in your project
+
+After installation, import the component from the generated host entry:
+
+```tsx
+import { ShadcnButton } from '../proto-ui/components/react';
+
+export function Demo() {
+  return <ShadcnButton>Click me</ShadcnButton>;
+}
+```
+
+The relative import is intentional. Projects do not share the same path aliases or directory depth, so the CLI does not assume that a bare specifier such as `proto-ui/components` is already configured.
+
+---
+
+## Keep adding more components
+
+Proto UI is adopted one component at a time.
+
+You can continue with commands like:
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-toggle
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-dialog
+```
+
+Then keep using them from the same host entry:
+
+```tsx
+import { ShadcnButton, ShadcnDialogRoot, ShadcnToggle } from '../proto-ui/components/react';
+```
+
+---
+
+## Use multiple hosts
+
+If the same project needs both React and Web Components, add them separately:
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-button
+npx @proto.ui/cli@0.2.0-rc.0 add wc shadcn-button
+```
+
+React components are exported from the React host entry:
+
+```tsx
+import { ShadcnButton } from '../proto-ui/components/react';
+```
+
+Web Component constructors are exported from the Web Component host entry:
+
+```ts
+import { ShadcnButtonElement } from '../proto-ui/components/wc';
+```
+
+`proto-ui/components/index.ts` also re-exports host-prefixed or explicit names to avoid naming conflicts when multiple hosts are used in the same project.
+
+---
+
+## It does not ask you to migrate your whole project at once
+
+You can use Proto UI only in new features, or replace just one or two components in an existing project.
+
+A more common way to start is:
+
+1. Initialize Proto UI first
+2. Install the simplest component first, such as Button
+3. Try it in one local page or feature
+4. Then decide whether to keep expanding
+
+---
+
+## Current boundary
+
+The current CLI onboarding path installs official prototype packages and generates local component facades.
+
+It does not yet write shadcn styled prototype source into your project for direct editing. That direction is already planned, but it is not part of the first v0 onboarding path.
+
+---
+
+## Next
+
+If you want to understand the most basic model behind it:
+
+- Go to [How It Works](/en/start-here/how-it-works/)
+
+If you want to decide whether it is worth introducing:
+
+- Go to [Why Proto UI](/en/start-here/why-proto-ui/)
+
+If you want to learn more about its underlying principles and boundaries:
+
+- Go to [Whitepaper](/en/whitepaper/component-as-protocol/)

--- a/apps/www/src/content/docs/zh-cn/start-here/quick-start.mdx
+++ b/apps/www/src/content/docs/zh-cn/start-here/quick-start.mdx
@@ -1,196 +1,32 @@
 ---
 title: '快速开始'
-description: '初始化 Proto UI，并把组件安装到你的项目中'
+description: '使用 npm latest 稳定版本开始使用 Proto UI'
 ---
 
 import DocStageNotice from '@/components/DocStageNotice.astro';
 
 <DocStageNotice
   tone="amber"
-  title="Proto UI 目前处于公开发布初期。"
-  body="核心思路已经清晰可见，但组件储备与生态能力仍在持续补齐。"
+  title="Proto UI 0.2 stable 上手流程尚未开放。"
+  body="官网主 Quick Start 永远跟随 npm latest，不会默认把预发布版本交给普通使用者。"
 />
 
-:::caution[预发布阶段] Proto UI 目前处于公开发布初期。本文描述的是当前的上手路径，命令和生成结构可能在 v0 发布前继续调整。:::
+## 稳定版本约定
 
-## 安装 Proto UI CLI
-
-你可以直接通过 `npx` 使用 Proto UI CLI，不需要提前全局安装。
+本页面是 Proto UI 的稳定上手入口。`0.2.0` 发布后，这里提供的命令将始终使用 npm 默认的 `latest` channel：
 
 ```bash
 npx @proto.ui/cli --help
 ```
 
----
+在稳定版发布之前，本页面不会用 `@next` 替代正式上手流程，也不会让当前 `0.1.x` package 执行面向 `0.2` codegen 编写的说明。
 
-## 初始化项目
+## 参与 0.2 RC 试用
 
-在你的项目根目录执行：
-
-```bash
-npx @proto.ui/cli init
-```
-
-初始化完成后，项目根目录会生成一个 `proto-ui/` 文件夹。
-
-一个典型结构可能像这样：
-
-```txt
-your-project/
-├── src/
-├── proto-ui/
-│   ├── adapters/
-│   ├── prototypes/
-│   ├── components/
-│   │   ├── react/
-│   │   │   └── index.ts
-│   │   └── index.ts
-│   └── config.json
-├── package.json
-└── ...
-```
-
-其中：
-
-- `config.json`：CLI 后续命令会读取的项目配置
-- `components/`：当前项目可直接导入的组件入口
-- `adapters/`、`prototypes/`：CLI 管理区，不作为用户导入入口
-
-你通常不需要手动维护这些文件，CLI 会负责管理它们。
-
----
-
-## 引入样式
-
-`init` 会默认生成 Proto UI 的样式预设文件。你需要在应用入口引入一次：
-
-```ts
-import './styles/proto-ui-style.css';
-```
-
-如果你的项目入口与 `src/styles` 的相对位置不同，请按实际路径调整。
-
----
-
-## 添加一个组件
-
-初始化之后，就可以按组件安装 Proto UI 组件。
-
-例如，在 React 项目中添加一个 `shadcn-button`：
-
-```bash
-npx @proto.ui/cli add react shadcn-button
-```
-
-这个命令会：
-
-1. 识别你选择的宿主适配器（`react`）
-2. 检查 React runtime 是否已经存在
-3. 安装对应的 adapter 与 prototype package
-4. 在本地完成组装
-5. 生成当前项目可以直接使用的组件入口
-
-如果你想先查看会生成什么，而不让 CLI 安装依赖，可以使用：
-
-```bash
-npx @proto.ui/cli add react shadcn-button --no-install
-```
-
-这会打印需要安装的 Proto UI package，并仍然生成本地组件入口。
-
----
-
-## 在项目中使用它
-
-安装完成后，你可以从生成的 host 入口导入组件：
-
-```tsx
-import { Button } from '../proto-ui/components/react';
-
-export function Demo() {
-  return <Button>Click me</Button>;
-}
-```
-
-这里使用相对路径是有意的。不同项目的路径别名和目录层级并不相同，CLI 不会默认假设你已经配置了 `proto-ui/components` 这样的裸导入路径。
-
----
-
-## 继续添加更多组件
-
-Proto UI 的接入是按组件进行的。
-
-你可以继续执行：
-
-```bash
-npx @proto.ui/cli add react shadcn-toggle
-npx @proto.ui/cli add react shadcn-dialog
-```
-
-然后继续从同一个 host 入口使用它们：
-
-```tsx
-import { Button, DialogRoot, Toggle } from '../proto-ui/components/react';
-```
-
----
-
-## 同时使用多个宿主
-
-如果同一个项目里同时需要 React 与 Web Component，也可以分别添加：
-
-```bash
-npx @proto.ui/cli add react shadcn-button
-npx @proto.ui/cli add wc shadcn-button
-```
-
-React 组件会从 React 子入口导出：
-
-```tsx
-import { Button } from '../proto-ui/components/react';
-```
-
-Web Component 构造会从 Web Component 子入口导出：
-
-```ts
-import { ButtonElement } from '../proto-ui/components/wc';
-```
-
-`proto-ui/components/index.ts` 也会生成带宿主前缀或明确名称的再导出，避免多宿主场景下命名冲突。
-
----
-
-## 它不会要求你一次性迁移整个项目
-
-你可以只在新功能里使用 Proto UI，也可以只替换现有项目中的一两个组件。
-
-一个更常见的起步方式是：
-
-1. 先初始化 Proto UI
-2. 先安装一个最简单的组件（如 Button）
-3. 在局部页面里试用
-4. 再决定是否继续扩展
-
----
-
-## 当前边界
-
-当前 CLI 的首个闭环会安装官方 prototype package，并在本地生成 component facade。
-
-它暂时还不会把 shadcn 这类 styled prototype 的源码写入到你的项目里供你直接二次修改。这个方向已经在规划中，但不会阻塞当前 v0 的第一条上手路径。
-
----
+如果你希望在 `0.2.0-rc.0` 发布后验证安装、生成和组件使用流程，请前往独立的 [0.2 RC 试用页面](/zh-cn/start-here/rc-trial/)。该页面固定使用精确 RC 版本，试用结果不会因 `next` dist-tag 移动而失去复现能力。
 
 ## 下一步
 
-如果你想理解它最基本是怎么工作的：
-
-- 前往 [它是怎么工作的？](/zh-cn/start-here/how-it-works/)
-
-如果你想判断它是否值得引入：
-
-- 前往 [Why Proto UI](/zh-cn/start-here/why-proto-ui/)
-
-如果你想进一步了解它背后的原则与边界：
-
-- 前往 [Whitepaper](/zh-cn/whitepaper/component-as-protocol/)
+- [0.2 RC 试用](/zh-cn/start-here/rc-trial/)
+- [它是怎么工作的？](/zh-cn/start-here/how-it-works/)
+- [Why Proto UI](/zh-cn/start-here/why-proto-ui/)

--- a/apps/www/src/content/docs/zh-cn/start-here/rc-trial.mdx
+++ b/apps/www/src/content/docs/zh-cn/start-here/rc-trial.mdx
@@ -1,0 +1,196 @@
+---
+title: '0.2 RC 试用'
+description: '使用精确的 0.2.0-rc.0 版本验证 Proto UI 上手流程'
+---
+
+import DocStageNotice from '@/components/DocStageNotice.astro';
+
+<DocStageNotice
+  tone="amber"
+  title="这是独立的 0.2.0-rc.0 预发布试用流程。"
+  body="它不会改变官网主 Quick Start 对 npm latest 稳定版本的承诺。"
+/>
+
+:::caution[等待 RC 发布] 以下命令只有在 `0.2.0-rc.0` 已发布到 npm 后才能执行。试用发现不代表稳定版承诺，命令和生成结构仍可能在 `0.2.0` 前调整。:::
+
+## 安装 Proto UI CLI
+
+你可以直接通过 `npx` 使用 Proto UI CLI，不需要提前全局安装。本文固定使用 `0.2.0-rc.0`，以便试用结果可以复现；CLI 会将 Adapter 与 Prototype package 固定到和自身完全一致的版本，避免混用历史 release。
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 --help
+```
+
+---
+
+## 初始化项目
+
+在你的项目根目录执行：
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 init
+```
+
+初始化完成后，项目根目录会生成一个 `proto-ui/` 文件夹。
+
+一个典型结构可能像这样：
+
+```txt
+your-project/
+├── src/
+├── proto-ui/
+│   ├── adapters/
+│   ├── prototypes/
+│   ├── components/
+│   │   ├── react/
+│   │   │   └── index.ts
+│   │   └── index.ts
+│   └── config.json
+├── package.json
+└── ...
+```
+
+其中：
+
+- `config.json`：CLI 后续命令会读取的项目配置
+- `components/`：当前项目可直接导入的组件入口
+- `adapters/`、`prototypes/`：CLI 管理区，不作为用户导入入口
+
+你通常不需要手动维护这些文件，CLI 会负责管理它们。
+
+---
+
+## 引入样式
+
+`init` 会默认生成 Proto UI 的样式预设文件。你需要在应用入口引入一次：
+
+```ts
+import './styles/proto-ui-style.css';
+```
+
+如果你的项目入口与 `src/styles` 的相对位置不同，请按实际路径调整。
+
+---
+
+## 添加一个组件
+
+初始化之后，就可以按组件安装 Proto UI 组件。
+
+例如，在 React 项目中添加一个 `shadcn-button`：
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-button
+```
+
+这个命令会：
+
+1. 识别你选择的宿主适配器（`react`）
+2. 检查 React runtime 是否已经存在
+3. 安装对应的 adapter 与 prototype package
+4. 在本地完成组装
+5. 生成当前项目可以直接使用的组件入口
+
+如果你想先查看会生成什么，而不让 CLI 安装依赖，可以使用：
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-button --no-install
+```
+
+这会打印需要安装的 Proto UI package，并仍然生成本地组件入口。
+
+---
+
+## 在项目中使用它
+
+安装完成后，你可以从生成的 host 入口导入组件：
+
+```tsx
+import { ShadcnButton } from '../proto-ui/components/react';
+
+export function Demo() {
+  return <ShadcnButton>Click me</ShadcnButton>;
+}
+```
+
+这里使用相对路径是有意的。不同项目的路径别名和目录层级并不相同，CLI 不会默认假设你已经配置了 `proto-ui/components` 这样的裸导入路径。
+
+---
+
+## 继续添加更多组件
+
+Proto UI 的接入是按组件进行的。
+
+你可以继续执行：
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-toggle
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-dialog
+```
+
+然后继续从同一个 host 入口使用它们：
+
+```tsx
+import { ShadcnButton, ShadcnDialogRoot, ShadcnToggle } from '../proto-ui/components/react';
+```
+
+---
+
+## 同时使用多个宿主
+
+如果同一个项目里同时需要 React 与 Web Component，也可以分别添加：
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-button
+npx @proto.ui/cli@0.2.0-rc.0 add wc shadcn-button
+```
+
+React 组件会从 React 子入口导出：
+
+```tsx
+import { ShadcnButton } from '../proto-ui/components/react';
+```
+
+Web Component 构造会从 Web Component 子入口导出：
+
+```ts
+import { ShadcnButtonElement } from '../proto-ui/components/wc';
+```
+
+`proto-ui/components/index.ts` 也会生成带宿主前缀或明确名称的再导出，避免多宿主场景下命名冲突。
+
+---
+
+## 它不会要求你一次性迁移整个项目
+
+你可以只在新功能里使用 Proto UI，也可以只替换现有项目中的一两个组件。
+
+一个更常见的起步方式是：
+
+1. 先初始化 Proto UI
+2. 先安装一个最简单的组件（如 Button）
+3. 在局部页面里试用
+4. 再决定是否继续扩展
+
+---
+
+## 当前边界
+
+当前 CLI 的首个闭环会安装官方 prototype package，并在本地生成 component facade。
+
+它暂时还不会把 shadcn 这类 styled prototype 的源码写入到你的项目里供你直接二次修改。这个方向已经在规划中，但不会阻塞当前 v0 的第一条上手路径。
+
+---
+
+## 下一步
+
+如果你想理解它最基本是怎么工作的：
+
+- 前往 [它是怎么工作的？](/zh-cn/start-here/how-it-works/)
+
+如果你想判断它是否值得引入：
+
+- 前往 [Why Proto UI](/zh-cn/start-here/why-proto-ui/)
+
+如果你想进一步了解它背后的原则与边界：
+
+- 前往 [Whitepaper](/zh-cn/whitepaper/component-as-protocol/)

--- a/internal/governance/ci-cd.md
+++ b/internal/governance/ci-cd.md
@@ -60,18 +60,22 @@ These tiers do not control the real npm publish set. Global exact-version govern
 ## Suggested Release Runbook
 
 1. Create or update the draft V entity and align `VERSION` plus package manifests in one PR.
-2. Run `pnpm check:release-version` and `pnpm release:scan:launch`; review the launch product scope.
-3. Run `pnpm release:stage` to rehearse the final tarballs for every public package.
-4. Run `pnpm release:smoke:react` to verify that an isolated React + Vite project can consume the exact tarballs.
+2. Regenerate and review the release BOM and notes, then run `pnpm release:assets:check`.
+3. Run `pnpm release:rehearse` for the complete sequential non-publishing gate. CI keeps the same checks split into parallel jobs for feedback speed.
+4. Review the launch product scope and isolated React plus multi-host CLI tarball consumer results.
 5. After merge to `main`, run `publish-all` with the `workspace` profile.
 6. Verify the GitHub release/spec-snapshot evidence and promote the V entity to `active` in a follow-up PR.
 
 ## Local Shortcuts
 
 - `pnpm check:release-version`
+- `pnpm release:bom`
+- `pnpm release:assets:check`
 - `pnpm release:scan:launch`
 - `pnpm release:stage:launch`
 - `pnpm release:stage`
 - `pnpm release:smoke:react`
+- `pnpm release:smoke:cli`
+- `pnpm release:rehearse`
 
 There is no package-local real-publish shortcut. Package-local fixes enter the next global release train.

--- a/internal/governance/ci-cd.zh-CN.md
+++ b/internal/governance/ci-cd.zh-CN.md
@@ -60,18 +60,22 @@ CI 在 pull request、`main` push 和手动触发时运行。除常规类型与�
 ## 建议发版流程
 
 1. 创建或更新 draft V 实体，并在 PR 中统一 `VERSION` 与 package manifests。
-2. 运行 `pnpm check:release-version` 与 `pnpm release:scan:launch`，审阅首发产品范围。
-3. 运行 `pnpm release:stage`，彩排全部公开 package 的最终 tarball。
-4. 运行 `pnpm release:smoke:react`，验证精确 tarball 能被隔离 React + Vite 项目消费。
+2. 重新生成并评审 release BOM 与说明，然后运行 `pnpm release:assets:check`。
+3. 运行 `pnpm release:rehearse`，完成整套顺序执行的不发布门禁。CI 为了缩短反馈时间，仍将同一组检查拆成并行 job。
+4. 审阅 launch 产品范围，以及隔离 React 与 CLI 多宿主 tarball consumer 结果。
 5. 合入 `main` 后，用 `workspace` profile 运行 `publish-all`。
 6. 发布成功后核对 GitHub release/spec snapshot 证据，再通过后续 PR 将 V 实体转为 `active`。
 
 ## 本地快捷命令
 
 - `pnpm check:release-version`
+- `pnpm release:bom`
+- `pnpm release:assets:check`
 - `pnpm release:scan:launch`
 - `pnpm release:stage:launch`
 - `pnpm release:stage`
 - `pnpm release:smoke:react`
+- `pnpm release:smoke:cli`
+- `pnpm release:rehearse`
 
 仓库不提供局部真实发布快捷命令；package 局部修复进入下一次全局 release train。

--- a/internal/governance/release-workflow.md
+++ b/internal/governance/release-workflow.md
@@ -48,6 +48,8 @@ A V entity becomes `active` only after npm packages, the Git tag, and the spec s
 5. Run version governance, spec, types, tests, release scan, and tarball consumer smoke.
 6. Merge through pull request review.
 
+The main Quick Start always follows npm `latest` and must not silently switch ordinary users to a prerelease. A separate prerelease trial page must pin the exact V-entity version for reproducible verification; `@next` may remain a convenience channel but is not the recorded test identity. When the CLI installs Adapter and Prototype packages, it must pin each package spec to the CLI's own exact version and save an exact dependency in the consumer manifest. An unversioned `latest` resolution or an automatically widening semver range must not mix another release train into the project.
+
 Package-local fixes do not use `publish-single`; they enter the next global release train.
 
 ## 4. Publication

--- a/internal/governance/release-workflow.md
+++ b/internal/governance/release-workflow.md
@@ -52,6 +52,8 @@ The main Quick Start always follows npm `latest` and must not silently switch or
 
 Package-local fixes do not use `publish-single`; they enter the next global release train.
 
+Each release train owns `internal/releases/<version>/release-notes.md`, its Chinese projection, and a deterministic `package-bom.json`. `pnpm release:bom` regenerates the BOM from the public workspace package graph and launch-governance roles; `pnpm release:assets:check` fails when the reviewed BOM drifts or either release note is absent. The English note becomes the GitHub Release body, while the BOM, Chinese note, spec snapshot, and checksum are attached as release evidence.
+
 ## 4. Publication
 
 Real publication is manually triggered from `main` and protected by the GitHub `npm` environment approval.
@@ -83,11 +85,14 @@ Historical `0.1.x` package versions are fragmented releases from before global l
 ## 6. Required Checks
 
 - `pnpm check:release-version`
+- `pnpm release:assets:check`
 - `pnpm release:scan:launch`
 - `pnpm release:stage`
 - zero spec workspace issues
 - repository types and tests
 - current-source tarball consumer smoke
 - Quick Start commands matching the verified install path
+
+`pnpm release:rehearse` is the non-publishing, one-command preparation gate. It runs the identity and asset checks, catalog and test suites, type checks, a temporary spec snapshot, launch scan, package publish dry-run, React and multi-host CLI tarball consumer smokes, and the documentation build. It may access the npm registry for dry-run or temporary consumer dependency installation, but it never invokes the real publish path.
 
 Docs-only or private-app changes do not need to publish immediately. Creating a new numeric version or changing `VERSION`, however, must enter this release-train workflow.

--- a/internal/governance/release-workflow.zh-CN.md
+++ b/internal/governance/release-workflow.zh-CN.md
@@ -52,6 +52,8 @@
 
 普通 package 局部修复不会使用 `publish-single`。它进入下一次全局 release train。
 
+每条 release train 在 `internal/releases/<version>/` 下维护 `release-notes.md`、对应中文投射与确定性的 `package-bom.json`。`pnpm release:bom` 根据公开 workspace package 图和 launch governance 角色重新生成 BOM；`pnpm release:assets:check` 会在已评审 BOM 漂移或任一 release note 缺失时失败。英文说明作为 GitHub Release 正文，BOM、中文说明、spec snapshot 与 checksum 作为 release evidence 附件。
+
 ## 4. 发布流程
 
 真实发布只允许从 `main` 手动触发，并由 GitHub `npm` environment 审批保护。
@@ -83,11 +85,14 @@
 ## 6. 必须通过的检查
 
 - `pnpm check:release-version`
+- `pnpm release:assets:check`
 - `pnpm release:scan:launch`
 - `pnpm release:stage`
 - spec workspace 0 issue
 - 全仓类型与测试
 - 当前源码 tarball consumer smoke
 - Quick Start 与实际安装命令一致
+
+`pnpm release:rehearse` 是不发布的一键准备门禁。它会依次执行发行身份与物料检查、编目和测试、类型检查、临时 spec snapshot、launch scan、package publish dry-run、React 与 CLI 多宿主 tarball consumer smoke，以及官网构建。该命令可能因 dry-run 或临时 consumer 安装访问 npm registry，但绝不会进入真实 publish 路径。
 
 纯文档或内部 app 的变化可以不立即触发 release；但一旦创建新的数字版本或修改 `VERSION`，就必须通过上述 release train 流程。

--- a/internal/governance/release-workflow.zh-CN.md
+++ b/internal/governance/release-workflow.zh-CN.md
@@ -48,6 +48,8 @@
 5. 运行版本治理、spec、类型、测试、release scan 和 tarball consumer smoke。
 6. 通过 PR 评审后合入 `main`。
 
+官网主 Quick Start 始终跟随 npm `latest`，不得把普通使用者静默切换到预发布版本。独立的 prerelease trial 页面必须固定到 V 实体声明的精确版本，以便复现验证；`@next` 可以作为便利 channel，但不是试用记录的版本身份。CLI 在安装 Adapter 与 Prototype package 时，必须把 package spec 固定为 CLI 自身的精确版本并以 exact dependency 写入 consumer manifest；不得让未标注版本的 `latest` 或自动扩张的 semver range 混入其他 release train。
+
 普通 package 局部修复不会使用 `publish-single`。它进入下一次全局 release train。
 
 ## 4. 发布流程

--- a/internal/records/2026-07-20-0.2-rc-release-assets-and-rehearsal.zh-CN.md
+++ b/internal/records/2026-07-20-0.2-rc-release-assets-and-rehearsal.zh-CN.md
@@ -1,0 +1,52 @@
+# 2026-07-20 0.2 RC 发行物料与不发布演练记录
+
+> Internal record. Not normative. 本文记录 `v0.2.0-rc.0` 的 release note、package BOM 与完整不发布演练。正式发行约束仍以 V 实体、`D-GLOBAL-RELEASE-VERSION-0001` 和 release governance 文档为准。
+
+## 1）目标
+
+此前流水线已经能对全部公开 package 执行 build、`npm publish --dry-run` 与 tarball consumer smoke，但 release note 和 package BOM 仍只是治理文档中的要求，没有进入可检查、可发布的实际产物链路。维护者也需要组合多条命令才能判断一条 release train 是否已经完成准备。
+
+本轮将三件事收口：
+
+- 为 `0.2.0-rc.0` 形成中英文 release note。
+- 从 workspace package 拓扑和 launch governance 分层生成确定性 BOM。
+- 提供一条绝不真实发布的完整 rehearsal 命令，并让实际发布 workflow 消费已评审物料。
+
+## 2）落地边界
+
+- `internal/releases/0.2.0-rc.0/` 保存中英文说明和 37 个公开 package 的 BOM。
+- BOM 固定 release version、Git tag、npm dist-tag、全局精确版本策略、package path、治理角色、发布拓扑顺序和内部依赖。
+- `pnpm release:bom` 重新生成 BOM；输出经过项目 Prettier 配置格式化，生成器与格式化器保持字节幂等。
+- `pnpm release:assets:check` 检查 BOM 是否与当前 package 图完全一致，并要求当前 VERSION 对应的两份 release note 存在且声明精确版本。
+- 普通 CI test 纳入 release assets check；手动 Release Packages workflow 在 scan、stage 和 publish-all 前也会检查物料。
+- 真实 GitHub Release 使用英文说明作为正文，并附带版本化 BOM、中文说明、spec snapshot 与 checksum。
+- `pnpm release:rehearse` 顺序执行发行身份、物料、Prototype 编目、类型和测试、临时 spec snapshot、launch scan、37 包 npm dry-run、React tarball consumer、CLI 多宿主 tarball consumer 与官网构建。该入口不包含 `--publish`，不会创建 tag、GitHub Release 或 npm 版本。
+
+## 3）演练结果
+
+2026-07-20 本地完整演练通过：
+
+- VERSION：`0.2.0-rc.0`
+- 公开 package：37
+- Prototype catalog：60 个 declaration file、91 个静态 authoring entry、59 个 P 实体、0 个 known debt file
+- release script test：30 项通过
+- runtime test：230 个文件通过、3 个跳过；1039 项测试通过、34 个 todo
+- spec snapshot：0 validation issue，成功生成临时快照
+- package stage：37 个 package build 与 `npm publish --dry-run` 全部通过
+- React consumer：消费 34/37 个 tarball，family 边界、类型、production build 与 Button / Switch / Select / Dialog / async / remount smoke 通过
+- CLI consumer：消费 36/37 个 tarball，React / Vue / Web Component facade 与运行时 smoke 通过
+- 官网：152 页构建完成，Pagefind 为 150 页建立索引
+
+演练快照曾产生 `sha256:45244d4adfa478384f07dc9721338c3f3f43ed09836fde03f13bfe52bbfdfae1`，但它来自 topic branch 的临时演练，不是已发布 tag 的证据，不得据此把 V 实体转为 `active`。
+
+## 4）已知非阻塞信号
+
+- React 完整 fixture 仍报告约 510 kB 的 minified chunk，官网也有大于 500 kB 的 chunk；Prototype family 边界检查本身通过。本轮继续把 bundle 组成分析保留为独立工作方向，不把固定体积阈值加入 RC 阻塞门禁。
+- 官网仍报告 Geist 字体在 build time 无法解析、需要运行时解析的既有警告。
+- npm 在 pnpm 环境下报告若干未知 env config 的未来兼容警告；本轮所有安装、build 和 smoke 均成功。
+
+## 5）下一步
+
+本变更通过评审并合入 `main` 后，阶段 A 只剩真实 `publish-all` 与发布后证据回填。真实发布必须由维护者从 `main` 手工触发受保护的 Release Packages workflow；发布完成后应核对 37 个 npm package、`next` dist-tag、`v0.2.0-rc.0` tag、GitHub Release 附件与 snapshot digest，再用单独 PR 将 V 实体转为 `active`。
+
+随后进入阶段 B：由维护者在仓库外创建真实项目，按照精确版本 RC Trial 流程进行人工试用并记录首次成功耗时、安装和类型问题、API escape、Adapter 差异、SSR / CSS / a11y / bundle 反馈。

--- a/internal/records/2026-07-20-cli-exact-release-install.zh-CN.md
+++ b/internal/records/2026-07-20-cli-exact-release-install.zh-CN.md
@@ -1,0 +1,39 @@
+# 2026-07-20 CLI 精确 release train 安装记录
+
+> Internal record. Not normative. 本文记录 `v0.2.0-rc.0` 发布准备中发现的 CLI 版本串线风险，以及本轮采用的安装与 Quick Start 边界。正式版本规则以 `D-GLOBAL-RELEASE-VERSION-0001` 和 release governance 文档为准。
+
+## 1）发现
+
+Prototype family subpath 合入后，当前 CLI 会生成 `@proto.ui/prototypes-base/button` 等新入口。但 `proto-ui add` 过去只把裸 package name 交给 npm、pnpm 或 Yarn，例如 `@proto.ui/prototypes-base`。
+
+`v0.2.0-rc.0` 使用 `next` dist-tag，而历史 `0.1.x` 仍位于 `latest`。因此用户即使通过 `npx @proto.ui/cli@next` 启动当前 CLI，后续裸安装也会重新解析到旧 Adapter 或 Prototype package，形成“当前 CLI + 历史 package”的跨 release train 组合。旧 package 没有 family subpath export，最终会在真实项目构建或运行时失败。
+
+#307 的 CI 修复已经让隔离 smoke 使用当前 tarball 闭包，但 `--no-install` 只解决了测试环境，不能替代真实 CLI 的安装语义。
+
+## 2）决策
+
+- CLI 读取自身 package manifest 中的精确 version。
+- CLI 安装官方 `@proto.ui/*` 依赖时，把每个 package spec 写为 `name@<cli-exact-version>`。
+- npm 与 pnpm 使用 `--save-exact`，Yarn 使用 `--exact`，避免 consumer manifest 再把精确安装扩张为 semver range。
+- `--no-install` 输出同样的精确命令，使人工安装不会重新落回 `latest`。
+- 官网主 Quick Start 永久跟随 `latest`，不会在 RC 阶段切换为 `@next`。
+- 独立的 RC Trial 页面固定使用 `@proto.ui/cli@0.2.0-rc.0`，使人工试用记录可复现；`@next` 只保留为便利 channel。
+
+## 3）文档校正
+
+审计原 Quick Start 时同时发现示例使用了 `Button`、`Toggle`、`DialogRoot` 与 `ButtonElement`，但 CLI 的实际 Shadcn facade 导出带有 `Shadcn` 前缀。本轮将完整上手流程迁入 RC Trial，并把示例改为 `ShadcnButton`、`ShadcnToggle`、`ShadcnDialogRoot` 与 `ShadcnButtonElement`，使试用文档与当前 codegen 一致。主 Quick Start 在 `0.2.0` stable 发布前只声明稳定入口与 RC 引导，不让旧 `latest` 执行新 codegen 文档。
+
+## 4）验证边界
+
+本轮验证应覆盖：
+
+- 三种 package manager 的 exact install command；
+- official package spec 与 CLI package version 精确一致；
+- `--no-install` 输出精确版本提示；
+- CLI build 与既有 CLI tests；
+- 中英文稳定 Quick Start 与 RC Trial build；
+- 当前 tarball consumer smoke 继续通过。
+
+## 5）后续
+
+完成该阻塞点后，阶段 A 的下一项是形成 `v0.2.0-rc.0` release note 与 package BOM，并进行一次不发布的完整 release rehearsal。真实 npm 发布仍必须从 `main` 手工触发受保护 workflow。

--- a/internal/releases/0.2.0-rc.0/package-bom.json
+++ b/internal/releases/0.2.0-rc.0/package-bom.json
@@ -1,0 +1,463 @@
+{
+  "format": "proto-ui-package-bom-v1",
+  "releaseVersion": "0.2.0-rc.0",
+  "gitTag": "v0.2.0-rc.0",
+  "npmDistTag": "next",
+  "packageVersionPolicy": "exact",
+  "packageScope": "public-@proto.ui",
+  "packageCount": 37,
+  "packages": [
+    {
+      "name": "@proto.ui/cli",
+      "version": "0.2.0-rc.0",
+      "path": "packages/cli",
+      "releaseRole": "launch-commitment",
+      "publishOrder": 1,
+      "internalDependencies": []
+    },
+    {
+      "name": "@proto.ui/core",
+      "version": "0.2.0-rc.0",
+      "path": "packages/core",
+      "releaseRole": "public-non-launch-commitment",
+      "publishOrder": 2,
+      "internalDependencies": []
+    },
+    {
+      "name": "@proto.ui/module-base",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/base",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 3,
+      "internalDependencies": ["@proto.ui/core"]
+    },
+    {
+      "name": "@proto.ui/module-expose",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/expose",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 4,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base"]
+    },
+    {
+      "name": "@proto.ui/module-anatomy",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/anatomy",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 5,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/module-expose"]
+    },
+    {
+      "name": "@proto.ui/module-feedback",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/feedback",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 6,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base"]
+    },
+    {
+      "name": "@proto.ui/module-positioning",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/positioning",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 7,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base"]
+    },
+    {
+      "name": "@proto.ui/prototypes-lucide",
+      "version": "0.2.0-rc.0",
+      "path": "packages/prototypes/lucide",
+      "releaseRole": "launch-commitment",
+      "publishOrder": 8,
+      "internalDependencies": ["@proto.ui/core"]
+    },
+    {
+      "name": "@proto.ui/types",
+      "version": "0.2.0-rc.0",
+      "path": "packages/types",
+      "releaseRole": "public-non-launch-commitment",
+      "publishOrder": 9,
+      "internalDependencies": []
+    },
+    {
+      "name": "@proto.ui/module-collection",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/collection",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 10,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-anatomy",
+        "@proto.ui/module-base",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/hooks",
+      "version": "0.2.0-rc.0",
+      "path": "packages/hooks",
+      "releaseRole": "public-non-launch-commitment",
+      "publishOrder": 11,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-anatomy",
+        "@proto.ui/module-collection",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/module-context",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/context",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 12,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/types"]
+    },
+    {
+      "name": "@proto.ui/module-event",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/event",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 13,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/types"]
+    },
+    {
+      "name": "@proto.ui/module-as-trigger",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/as-trigger",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 14,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/module-event"]
+    },
+    {
+      "name": "@proto.ui/module-boundary",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/boundary",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 15,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-base",
+        "@proto.ui/module-event",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/module-hit-participation",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/hit-participation",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 16,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/types"]
+    },
+    {
+      "name": "@proto.ui/module-overlay",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/overlay",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 17,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-anatomy",
+        "@proto.ui/module-base",
+        "@proto.ui/module-boundary",
+        "@proto.ui/module-event",
+        "@proto.ui/module-positioning",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/module-presence",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/presence",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 18,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/types"]
+    },
+    {
+      "name": "@proto.ui/module-props",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/props",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 19,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/types"]
+    },
+    {
+      "name": "@proto.ui/module-state",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/state",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 20,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/types"]
+    },
+    {
+      "name": "@proto.ui/module-a11y",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/a11y",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 21,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/module-state"]
+    },
+    {
+      "name": "@proto.ui/module-expose-state",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/expose-state",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 22,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-base",
+        "@proto.ui/module-expose",
+        "@proto.ui/module-state",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/module-expose-state-web",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/expose-state-web",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 23,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-base",
+        "@proto.ui/module-expose-state",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/module-focus",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/focus",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 24,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-base",
+        "@proto.ui/module-event",
+        "@proto.ui/module-state",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/module-rule",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/rule",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 25,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-base",
+        "@proto.ui/module-context",
+        "@proto.ui/module-feedback",
+        "@proto.ui/module-props",
+        "@proto.ui/module-state",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/module-rule-expose-state-web",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/rule-expose-state-web",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 26,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-base",
+        "@proto.ui/module-expose-state-web",
+        "@proto.ui/module-feedback",
+        "@proto.ui/module-rule",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/module-rule-meta",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/rule-meta",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 27,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/module-rule"]
+    },
+    {
+      "name": "@proto.ui/module-state-accessibility",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/state-accessibility",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 28,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/module-state"]
+    },
+    {
+      "name": "@proto.ui/module-state-interaction",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/state-interaction",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 29,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/module-base",
+        "@proto.ui/module-event",
+        "@proto.ui/module-state"
+      ]
+    },
+    {
+      "name": "@proto.ui/module-test-sys",
+      "version": "0.2.0-rc.0",
+      "path": "packages/modules/test-sys",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 30,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/module-base", "@proto.ui/types"]
+    },
+    {
+      "name": "@proto.ui/prototypes-base",
+      "version": "0.2.0-rc.0",
+      "path": "packages/prototypes/base",
+      "releaseRole": "launch-commitment",
+      "publishOrder": 31,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/hooks"]
+    },
+    {
+      "name": "@proto.ui/prototypes-shadcn",
+      "version": "0.2.0-rc.0",
+      "path": "packages/prototypes/shadcn",
+      "releaseRole": "launch-commitment",
+      "publishOrder": 32,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/prototypes-base"]
+    },
+    {
+      "name": "@proto.ui/runtime",
+      "version": "0.2.0-rc.0",
+      "path": "packages/runtime",
+      "releaseRole": "internal-or-dependency-directed",
+      "publishOrder": 33,
+      "internalDependencies": [
+        "@proto.ui/core",
+        "@proto.ui/hooks",
+        "@proto.ui/module-a11y",
+        "@proto.ui/module-anatomy",
+        "@proto.ui/module-as-trigger",
+        "@proto.ui/module-base",
+        "@proto.ui/module-boundary",
+        "@proto.ui/module-collection",
+        "@proto.ui/module-context",
+        "@proto.ui/module-event",
+        "@proto.ui/module-expose",
+        "@proto.ui/module-expose-state",
+        "@proto.ui/module-expose-state-web",
+        "@proto.ui/module-feedback",
+        "@proto.ui/module-focus",
+        "@proto.ui/module-hit-participation",
+        "@proto.ui/module-overlay",
+        "@proto.ui/module-positioning",
+        "@proto.ui/module-presence",
+        "@proto.ui/module-props",
+        "@proto.ui/module-rule",
+        "@proto.ui/module-rule-expose-state-web",
+        "@proto.ui/module-rule-meta",
+        "@proto.ui/module-state",
+        "@proto.ui/module-state-accessibility",
+        "@proto.ui/module-state-interaction",
+        "@proto.ui/module-test-sys",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/adapter-base",
+      "version": "0.2.0-rc.0",
+      "path": "packages/adapters/base",
+      "releaseRole": "public-non-launch-commitment",
+      "publishOrder": 34,
+      "internalDependencies": ["@proto.ui/core", "@proto.ui/runtime", "@proto.ui/types"]
+    },
+    {
+      "name": "@proto.ui/adapter-react",
+      "version": "0.2.0-rc.0",
+      "path": "packages/adapters/react",
+      "releaseRole": "launch-commitment",
+      "publishOrder": 35,
+      "internalDependencies": [
+        "@proto.ui/adapter-base",
+        "@proto.ui/core",
+        "@proto.ui/hooks",
+        "@proto.ui/module-a11y",
+        "@proto.ui/module-anatomy",
+        "@proto.ui/module-as-trigger",
+        "@proto.ui/module-boundary",
+        "@proto.ui/module-context",
+        "@proto.ui/module-event",
+        "@proto.ui/module-expose-state",
+        "@proto.ui/module-expose-state-web",
+        "@proto.ui/module-feedback",
+        "@proto.ui/module-focus",
+        "@proto.ui/module-hit-participation",
+        "@proto.ui/module-overlay",
+        "@proto.ui/module-positioning",
+        "@proto.ui/module-props",
+        "@proto.ui/module-rule-expose-state-web",
+        "@proto.ui/module-rule-meta",
+        "@proto.ui/runtime",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/adapter-vue",
+      "version": "0.2.0-rc.0",
+      "path": "packages/adapters/vue",
+      "releaseRole": "launch-commitment",
+      "publishOrder": 36,
+      "internalDependencies": [
+        "@proto.ui/adapter-base",
+        "@proto.ui/core",
+        "@proto.ui/hooks",
+        "@proto.ui/module-a11y",
+        "@proto.ui/module-anatomy",
+        "@proto.ui/module-as-trigger",
+        "@proto.ui/module-boundary",
+        "@proto.ui/module-context",
+        "@proto.ui/module-event",
+        "@proto.ui/module-expose-state",
+        "@proto.ui/module-expose-state-web",
+        "@proto.ui/module-feedback",
+        "@proto.ui/module-focus",
+        "@proto.ui/module-hit-participation",
+        "@proto.ui/module-overlay",
+        "@proto.ui/module-positioning",
+        "@proto.ui/module-props",
+        "@proto.ui/module-rule-expose-state-web",
+        "@proto.ui/module-rule-meta",
+        "@proto.ui/runtime",
+        "@proto.ui/types"
+      ]
+    },
+    {
+      "name": "@proto.ui/adapter-web-component",
+      "version": "0.2.0-rc.0",
+      "path": "packages/adapters/web-component",
+      "releaseRole": "launch-commitment",
+      "publishOrder": 37,
+      "internalDependencies": [
+        "@proto.ui/adapter-base",
+        "@proto.ui/core",
+        "@proto.ui/hooks",
+        "@proto.ui/module-a11y",
+        "@proto.ui/module-anatomy",
+        "@proto.ui/module-as-trigger",
+        "@proto.ui/module-boundary",
+        "@proto.ui/module-context",
+        "@proto.ui/module-event",
+        "@proto.ui/module-expose-state",
+        "@proto.ui/module-expose-state-web",
+        "@proto.ui/module-feedback",
+        "@proto.ui/module-focus",
+        "@proto.ui/module-hit-participation",
+        "@proto.ui/module-overlay",
+        "@proto.ui/module-positioning",
+        "@proto.ui/module-props",
+        "@proto.ui/module-rule-expose-state-web",
+        "@proto.ui/module-rule-meta",
+        "@proto.ui/module-test-sys",
+        "@proto.ui/runtime",
+        "@proto.ui/types"
+      ]
+    }
+  ]
+}

--- a/internal/releases/0.2.0-rc.0/release-notes.md
+++ b/internal/releases/0.2.0-rc.0/release-notes.md
@@ -1,0 +1,37 @@
+# Proto UI 0.2.0-rc.0
+
+`0.2.0-rc.0` is the first Proto UI release candidate governed as one exact ecosystem release. Every public `@proto.ui/*` package, its internal package edges, the Git tag, and the spec snapshot share the same version.
+
+This is a prerelease for external trial, not the stable `latest` onboarding path.
+
+## What to validate
+
+- The CLI can initialize an existing project and add component facades one family at a time.
+- React, Vue, and Web Component adapters can consume the same prototype protocols.
+- Base and Shadcn prototype families remain independently importable; adding one family should not pull unrelated prototype families into the consumer bundle.
+- The CLI pins Adapter and Prototype packages to its own exact release version, preventing mixed release trains.
+- The current Prototype catalog connects public `.proto.ts` declarations to P and T entities, including standalone Transition behavior and its reduced-motion fallback.
+
+## Try the exact RC
+
+After this version is available from npm:
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 init
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-button
+```
+
+Follow the [0.2 RC Trial](https://www.proto-ui.com/en/start-here/rc-trial/) for the complete flow. The main Quick Start continues to track the stable npm `latest` channel.
+
+## Current boundaries
+
+- APIs and generated structure may still change before `0.2.0` stable.
+- The CLI currently installs official Prototype packages and generates local component facades; it does not yet copy styled prototype source into the consumer project for editing.
+- Shadcn compatibility is intentional but not complete. Proto UI deliberately does not expose Radix-style `asChild`; known compatibility differences remain prerelease feedback targets.
+- Documentation, external-project evidence, and bundle composition analysis are still incomplete. Adapter size is treated as an architectural cost for this RC, while prototype families are expected to preserve on-demand import boundaries.
+
+Please report installation, type, runtime, SSR, CSS, accessibility, bundle, or API-escape findings in [GitHub Issues](https://github.com/Proto-UI/Proto-UI/issues).
+
+## Release evidence
+
+The GitHub release attaches the reviewed package BOM and deterministic spec snapshot. The V entity remains `draft` until npm publication, the `v0.2.0-rc.0` tag, and snapshot digest are all verified and recorded in a follow-up evidence change.

--- a/internal/releases/0.2.0-rc.0/release-notes.zh-CN.md
+++ b/internal/releases/0.2.0-rc.0/release-notes.zh-CN.md
@@ -1,0 +1,37 @@
+# Proto UI 0.2.0-rc.0
+
+`0.2.0-rc.0` 是 Proto UI 第一个按照全局精确版本治理的候选版本。全部公开 `@proto.ui/*` package、内部 package 依赖边、Git tag 与 spec snapshot 共享同一个精确版本。
+
+这是用于外部试用的预发布版本，不是 npm `latest` 对应的稳定上手路径。
+
+## 建议验证的内容
+
+- CLI 能否在已有项目中完成初始化，并按 family 逐个添加 component facade。
+- React、Vue 与 Web Component Adapter 能否消费同一套 Prototype protocol。
+- Base 与 Shadcn prototype family 能否保持独立按需引入；添加一个 family 时，不应把无关 prototype family 带入 consumer bundle。
+- CLI 会把 Adapter 与 Prototype package 固定到自身的精确版本，避免混用不同 release train。
+- 当前 Prototype 编目已将公开 `.proto.ts` 声明连接到 P 与 T 实体，包括可独立使用的 Transition 及其 reduced-motion fallback。
+
+## 试用精确 RC
+
+等待此版本发布到 npm 后执行：
+
+```bash
+npx @proto.ui/cli@0.2.0-rc.0 init
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-button
+```
+
+完整流程见 [0.2 RC 试用](https://www.proto-ui.com/zh-cn/start-here/rc-trial/)。官网主 Quick Start 会继续跟随 npm 稳定的 `latest` channel。
+
+## 当前边界
+
+- API 与生成结构在 `0.2.0` stable 前仍可能调整。
+- CLI 当前会安装官方 Prototype package 并生成本地 component facade；暂时还不会把 styled prototype 源码复制到 consumer 项目中供直接修改。
+- Shadcn 兼容是明确目标，但尚不完整。Proto UI 有意不提供 Radix 风格的 `asChild`；已知兼容差异仍属于本轮预发布的反馈目标。
+- 文档、外部项目证据与 bundle 组成分析仍不完整。本 RC 暂时接受 Adapter 体积作为架构成本，同时要求 Prototype family 保持按需引入边界。
+
+请通过 [GitHub Issues](https://github.com/Proto-UI/Proto-UI/issues) 反馈安装、类型、运行时、SSR、CSS、a11y、bundle 或 API escape 问题。
+
+## 发布证据
+
+GitHub Release 会附带已评审的 package BOM 与确定性 spec snapshot。在 npm 发布、`v0.2.0-rc.0` tag 与 snapshot digest 均完成核验并通过后续证据变更回填前，对应 V 实体仍保持 `draft`。

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "release:scan": "node scripts/release/scan.mjs",
     "release:scan:launch": "node scripts/release/scan.mjs --profile launch --check-governance",
     "release:sync-metadata": "node scripts/release/sync-metadata.mjs",
+    "release:bom": "node scripts/release/check-release-assets.mjs --write",
+    "release:assets:check": "node scripts/release/check-release-assets.mjs --check",
+    "release:rehearse": "node scripts/release/rehearse.mjs",
     "release:stage": "node scripts/release/publish.mjs --dry-run",
     "release:stage:launch": "node scripts/release/publish.mjs --dry-run --profile launch --check-governance",
     "release:smoke:react": "node scripts/release/consumer-smoke-react.mjs",
@@ -45,7 +48,7 @@
     "check:types": "corepack pnpm@10.32.1 -s check:types:workspace && corepack pnpm@10.32.1 -s check:types:docs",
     "format": "prettier --write .",
     "prepare": "husky install",
-    "test": "corepack pnpm@10.32.1 -s check:release-version && corepack pnpm@10.32.1 -s check:prototype-catalog && corepack pnpm@10.32.1 -s test:release && corepack pnpm@10.32.1 -s test:types && corepack pnpm@10.32.1 -s test:runtime",
+    "test": "corepack pnpm@10.32.1 -s check:release-version && corepack pnpm@10.32.1 -s release:assets:check && corepack pnpm@10.32.1 -s check:prototype-catalog && corepack pnpm@10.32.1 -s test:release && corepack pnpm@10.32.1 -s test:types && corepack pnpm@10.32.1 -s test:runtime",
     "test:release": "node --test scripts/release/test/*.test.mjs",
     "test:types": "echo \"[types] checking type contracts...\" && tsc -p internal/contracts/types/tsconfig.json && echo \"[types] OK\"",
     "test:runtime": "vitest run"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,13 +7,13 @@ Proto UI command line tooling for initializing a local `proto-ui/` workspace, ge
 Initialize the local workspace:
 
 ```bash
-npx @proto.ui/cli init
+npx @proto.ui/cli@0.2.0-rc.0 init
 ```
 
 Add a component for a host adapter:
 
 ```bash
-npx @proto.ui/cli add react shadcn-button
+npx @proto.ui/cli@0.2.0-rc.0 add react shadcn-button
 ```
 
 The generated component facade is written under:
@@ -25,7 +25,7 @@ proto-ui/components/<host>/index.ts
 For example, React users can import from the generated host entry:
 
 ```tsx
-import { Button } from '../proto-ui/components/react';
+import { ShadcnButton } from '../proto-ui/components/react';
 ```
 
 ## Commands
@@ -52,7 +52,7 @@ proto-ui theme shadcn --out ./src/styles/shadcn-theme.css
 
 ## Current Scope
 
-The v0 CLI installs Proto UI adapter/prototype packages through the project package manager and generates local component facade files.
+The v0 CLI installs Proto UI adapter/prototype packages through the project package manager and generates local component facade files. This prerelease README pins `0.2.0-rc.0` for reproducible trials; the CLI saves required official packages at its own exact version so a consumer cannot accidentally mix release trains.
 
 Prototype packages remain the installation and versioning unit. Generated facades import the selected anatomy family through a package subpath such as `@proto.ui/prototypes-shadcn/button`, so unrelated prototype families do not enter the consumer module graph.
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -9,6 +9,7 @@ import {
   hasPackage,
   installPackages,
   readProjectPackageJson,
+  toExactProtoUiInstallSpec,
 } from '../services/package-manager.js';
 import { ensureRuntimePackages } from '../services/runtime-check.js';
 import { isInteractiveDisabled, parseArgv } from '../utils/args.js';
@@ -70,14 +71,17 @@ export async function runAddCommand(argv: string[]): Promise<void> {
     (pkg, index, list) => list.indexOf(pkg) === index
   );
   const missingPackages = requiredPackages.filter((pkg) => !hasPackage(projectPkg, pkg));
+  const missingInstallSpecs = missingPackages.map((pkg) => toExactProtoUiInstallSpec(pkg));
 
   if (!noInstall && missingPackages.length > 0) {
-    installPackages(packageManager, cwd, missingPackages);
-    console.log(`[proto-ui] add: installed ${missingPackages.join(', ')} via ${packageManager}`);
+    installPackages(packageManager, cwd, missingInstallSpecs, { exact: true });
+    console.log(
+      `[proto-ui] add: installed ${missingInstallSpecs.join(', ')} via ${packageManager}`
+    );
   } else if (noInstall && missingPackages.length > 0) {
     console.log('[proto-ui] add: required Proto UI packages are not installed yet:');
-    for (const pkg of missingPackages) {
-      console.log(`  ${formatInstallCommand(packageManager, [pkg])}`);
+    for (const spec of missingInstallSpecs) {
+      console.log(`  ${formatInstallCommand(packageManager, [spec], { exact: true })}`);
     }
   }
 

--- a/packages/cli/src/services/package-manager.ts
+++ b/packages/cli/src/services/package-manager.ts
@@ -1,9 +1,22 @@
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import { fileExists, readJsonFile } from '../utils/fs.js';
 
 export type PackageManager = 'npm' | 'pnpm' | 'yarn';
+
+const cliManifest = JSON.parse(
+  readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+) as { version?: unknown };
+
+const cliReleaseVersion = cliManifest.version;
+
+if (typeof cliReleaseVersion !== 'string' || cliReleaseVersion.length === 0) {
+  throw new Error('@proto.ui/cli package.json must declare a release version');
+}
+
+export const CLI_RELEASE_VERSION = cliReleaseVersion;
 
 export async function detectPackageManager(cwd: string): Promise<PackageManager> {
   if (await fileExists(path.join(cwd, 'pnpm-lock.yaml'))) return 'pnpm';
@@ -14,19 +27,31 @@ export async function detectPackageManager(cwd: string): Promise<PackageManager>
 export function formatInstallCommand(
   pm: PackageManager,
   packages: string[],
-  { dev = false }: { dev?: boolean } = {}
+  { dev = false, exact = false }: { dev?: boolean; exact?: boolean } = {}
 ): string {
   const list = packages.join(' ');
-  if (pm === 'pnpm') return dev ? `pnpm add -D ${list}` : `pnpm add ${list}`;
-  if (pm === 'yarn') return dev ? `yarn add -D ${list}` : `yarn add ${list}`;
-  return dev ? `npm install --save-dev ${list}` : `npm install --save ${list}`;
+  const exactFlag = exact ? (pm === 'yarn' ? ' --exact' : ' --save-exact') : '';
+  if (pm === 'pnpm')
+    return dev ? `pnpm add -D${exactFlag} ${list}` : `pnpm add${exactFlag} ${list}`;
+  if (pm === 'yarn')
+    return dev ? `yarn add -D${exactFlag} ${list}` : `yarn add${exactFlag} ${list}`;
+  return dev
+    ? `npm install --save-dev${exactFlag} ${list}`
+    : `npm install --save${exactFlag} ${list}`;
+}
+
+export function toExactProtoUiInstallSpec(
+  packageName: string,
+  version = CLI_RELEASE_VERSION
+): string {
+  return packageName.startsWith('@proto.ui/') ? `${packageName}@${version}` : packageName;
 }
 
 export function installPackages(
   pm: PackageManager,
   cwd: string,
   packages: string[],
-  { dev = false }: { dev?: boolean } = {}
+  { dev = false, exact = false }: { dev?: boolean; exact?: boolean } = {}
 ): void {
   if (packages.length === 0) return;
 
@@ -34,14 +59,17 @@ export function installPackages(
   let args: string[];
   if (pm === 'pnpm') {
     cmd = 'pnpm';
-    args = dev ? ['add', '-D', ...packages] : ['add', ...packages];
+    args = ['add', ...(dev ? ['-D'] : []), ...(exact ? ['--save-exact'] : []), ...packages];
   } else if (pm === 'yarn') {
     cmd = 'yarn';
-    args = dev ? ['add', '-D', ...packages] : ['add', ...packages];
-  } else if (dev) {
-    args = ['install', '--save-dev', ...packages];
+    args = ['add', ...(dev ? ['-D'] : []), ...(exact ? ['--exact'] : []), ...packages];
   } else {
-    args = ['install', '--save', ...packages];
+    args = [
+      'install',
+      dev ? '--save-dev' : '--save',
+      ...(exact ? ['--save-exact'] : []),
+      ...packages,
+    ];
   }
 
   // Windows: spawnSync needs shell:true to resolve npm/yarn/pnpm via .cmd shims.

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -11,8 +11,12 @@ import { COMPONENT_REGISTRY } from '../src/registry/components';
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const CLI_DIR = path.resolve(TEST_DIR, '..');
 const BIN_PATH = path.join(CLI_DIR, 'bin/proto-ui.js');
+let cliVersion = '';
 
-beforeAll(() => {
+beforeAll(async () => {
+  const manifest = JSON.parse(await fs.readFile(path.join(CLI_DIR, 'package.json'), 'utf8'));
+  cliVersion = manifest.version;
+
   // bin/proto-ui.js imports ../dist/index.js, so the cli must be compiled
   // before any spawnSync call below. building unconditionally here keeps
   // the test hermetic — `pnpm -s test` from the repo root works even when
@@ -48,6 +52,40 @@ async function createTempProject(name: string, packageJson: Record<string, unkno
 }
 
 describe('@proto.ui/cli', () => {
+  it('pins official packages to the exact built CLI release train', () => {
+    const moduleUrl = pathToFileURL(
+      path.join(CLI_DIR, 'dist', 'services', 'package-manager.js')
+    ).href;
+    const script = `
+      import {
+        CLI_RELEASE_VERSION,
+        formatInstallCommand,
+        toExactProtoUiInstallSpec,
+      } from ${JSON.stringify(moduleUrl)};
+      console.log(JSON.stringify({
+        version: CLI_RELEASE_VERSION,
+        proto: toExactProtoUiInstallSpec('@proto.ui/adapter-react'),
+        external: toExactProtoUiInstallSpec('react'),
+        npm: formatInstallCommand('npm', ['@proto.ui/adapter-react@${cliVersion}'], { exact: true }),
+        pnpm: formatInstallCommand('pnpm', ['@proto.ui/adapter-react@${cliVersion}'], { exact: true }),
+        yarn: formatInstallCommand('yarn', ['@proto.ui/adapter-react@${cliVersion}'], { exact: true }),
+      }));
+    `;
+    const result = spawnSync('node', ['--input-type=module', '--eval', script], {
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      version: cliVersion,
+      proto: `@proto.ui/adapter-react@${cliVersion}`,
+      external: 'react',
+      npm: `npm install --save --save-exact @proto.ui/adapter-react@${cliVersion}`,
+      pnpm: `pnpm add --save-exact @proto.ui/adapter-react@${cliVersion}`,
+      yarn: `yarn add --exact @proto.ui/adapter-react@${cliVersion}`,
+    });
+  });
+
   it('keeps installation packages separate from family import paths', () => {
     for (const entry of Object.values(COMPONENT_REGISTRY)) {
       expect(entry.importPath).toBe(
@@ -174,8 +212,8 @@ describe('@proto.ui/cli', () => {
     const result = runCli(cwd, ['add', 'react', 'shadcn-button', '--no-install']);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain('@proto.ui/adapter-react');
-    expect(result.stdout).toContain('@proto.ui/prototypes-shadcn');
+    expect(result.stdout).toContain(`@proto.ui/adapter-react@${cliVersion}`);
+    expect(result.stdout).toContain(`@proto.ui/prototypes-shadcn@${cliVersion}`);
 
     const reactIndex = await fs.readFile(
       path.join(cwd, 'proto-ui/components/react/index.ts'),

--- a/scripts/release/check-release-assets.mjs
+++ b/scripts/release/check-release-assets.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { format, resolveConfig } from 'prettier';
+
+import { getAllPackages, ROOT_DIR, selectPackages, topoSortPackages } from './lib.mjs';
+import { loadLaunchPackageGovernance } from './governance.mjs';
+import { readVersion } from './version-utils.mjs';
+
+const args = parseArgs(process.argv.slice(2));
+const version = readVersion();
+const releaseDir = join(ROOT_DIR, 'internal', 'releases', version.raw);
+const bomPath = join(releaseDir, 'package-bom.json');
+const notePaths = [
+  join(releaseDir, 'release-notes.md'),
+  join(releaseDir, 'release-notes.zh-CN.md'),
+];
+const expectedBom = createBom();
+const prettierConfig = (await resolveConfig(bomPath)) ?? {};
+const expectedContents = await format(JSON.stringify(expectedBom), {
+  ...prettierConfig,
+  filepath: bomPath,
+  parser: 'json',
+});
+
+if (args.write) {
+  mkdirSync(releaseDir, { recursive: true });
+  writeFileSync(bomPath, expectedContents);
+  console.log(`release package BOM: wrote ${bomPath}`);
+}
+
+const violations = [];
+if (!existsSync(bomPath)) {
+  violations.push(`missing package BOM: ${bomPath}`);
+} else if (readFileSync(bomPath, 'utf8') !== expectedContents) {
+  violations.push(`package BOM is stale: run pnpm release:bom`);
+}
+
+for (const notePath of notePaths) {
+  if (!existsSync(notePath)) {
+    violations.push(`missing release note: ${notePath}`);
+    continue;
+  }
+  const contents = readFileSync(notePath, 'utf8');
+  if (!contents.includes(version.raw)) {
+    violations.push(`release note does not name ${version.raw}: ${notePath}`);
+  }
+}
+
+if (violations.length > 0) {
+  console.error(`check-release-assets: ${violations.length} violation(s)`);
+  for (const violation of violations) console.error(`- ${violation}`);
+  process.exit(1);
+}
+
+console.log(
+  `check-release-assets: ${version.raw}, ${expectedBom.packageCount} packages, release notes present`
+);
+
+function createBom() {
+  const governance = loadLaunchPackageGovernance();
+  const selected = topoSortPackages(selectPackages(getAllPackages()));
+  const releaseRoles = new Map();
+
+  register(governance.launchCommitmentPackages, 'launch-commitment');
+  register(governance.publicNonLaunchCommitmentPackages, 'public-non-launch-commitment');
+  register(governance.internalOrDependencyDirectedPackages, 'internal-or-dependency-directed');
+  for (const candidate of governance.candidatePackages ?? []) {
+    register([candidate.name], `candidate-${candidate.status ?? 'pending'}`);
+  }
+
+  const selectedNames = new Set(selected.map((pkg) => pkg.name));
+  const missingRoles = selected.filter((pkg) => !releaseRoles.has(pkg.name));
+  const extraRoles = [...releaseRoles.keys()].filter((name) => !selectedNames.has(name));
+  if (missingRoles.length > 0 || extraRoles.length > 0) {
+    const diagnostics = [];
+    if (missingRoles.length > 0) {
+      diagnostics.push(`unclassified: ${missingRoles.map((pkg) => pkg.name).join(', ')}`);
+    }
+    if (extraRoles.length > 0) diagnostics.push(`not selected: ${extraRoles.join(', ')}`);
+    throw new Error(`Package BOM governance mismatch (${diagnostics.join('; ')})`);
+  }
+
+  return {
+    format: 'proto-ui-package-bom-v1',
+    releaseVersion: version.raw,
+    gitTag: `v${version.raw}`,
+    npmDistTag: version.isPrerelease ? 'next' : 'latest',
+    packageVersionPolicy: 'exact',
+    packageScope: 'public-@proto.ui',
+    packageCount: selected.length,
+    packages: selected.map((pkg, index) => ({
+      name: pkg.name,
+      version: version.raw,
+      path: pkg.relDir,
+      releaseRole: releaseRoles.get(pkg.name),
+      publishOrder: index + 1,
+      internalDependencies: [...pkg.internalDeps].sort(),
+    })),
+  };
+
+  function register(names = [], role) {
+    for (const name of names) {
+      if (!name) continue;
+      if (releaseRoles.has(name)) {
+        throw new Error(`Package ${name} has multiple release roles`);
+      }
+      releaseRoles.set(name, role);
+    }
+  }
+}
+
+function parseArgs(argv) {
+  let write = false;
+  for (const arg of argv) {
+    if (arg === '--write') write = true;
+    else if (arg === '--check') continue;
+    else if (arg === '--help' || arg === '-h') {
+      console.log('Usage: node scripts/release/check-release-assets.mjs [--check | --write]');
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return { write };
+}

--- a/scripts/release/rehearse.mjs
+++ b/scripts/release/rehearse.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import { ROOT_DIR } from './lib.mjs';
+
+const packageManager = JSON.parse(
+  readFileSync(join(ROOT_DIR, 'package.json'), 'utf8')
+).packageManager;
+const artifactDir = mkdtempSync(join(tmpdir(), 'proto-ui-release-rehearsal-'));
+let succeeded = false;
+
+const steps = [
+  ['Release identity', process.execPath, ['scripts/release/check-version-governance.mjs']],
+  ['Release assets', process.execPath, ['scripts/release/check-release-assets.mjs', '--check']],
+  ['Prototype catalog', process.execPath, ['scripts/spec/check-prototype-catalog.mjs']],
+  ['Workspace and docs types', 'corepack', [packageManager, '-s', 'check:types']],
+  ['Release script tests', 'corepack', [packageManager, '-s', 'test:release']],
+  ['Contract type tests', 'corepack', [packageManager, '-s', 'test:types']],
+  ['Runtime tests', 'corepack', [packageManager, '-s', 'test:runtime']],
+  [
+    'Spec snapshot',
+    'corepack',
+    [packageManager, '-s', 'spec:snapshot:release', '--', '--out-dir', artifactDir],
+  ],
+  [
+    'Launch governance scan',
+    process.execPath,
+    ['scripts/release/scan.mjs', '--profile', 'launch', '--check-governance'],
+  ],
+  ['Package publish dry-run', 'corepack', [packageManager, '-s', 'release:stage']],
+  ['React tarball consumer', 'corepack', [packageManager, '-s', 'release:smoke:react']],
+  ['CLI multi-host tarball consumer', 'corepack', [packageManager, '-s', 'release:smoke:cli']],
+  ['Documentation build', 'corepack', [packageManager, '-s', 'docs:build']],
+];
+
+try {
+  for (const [label, command, args] of steps) {
+    console.log(`\n[release rehearsal] ${label}`);
+    const result = spawnSync(command, args, {
+      cwd: ROOT_DIR,
+      env: process.env,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(`${label} failed with exit code ${result.status}`);
+    }
+  }
+  succeeded = true;
+  console.log('\n[release rehearsal] complete: no publication was performed');
+} finally {
+  if (succeeded) rmSync(artifactDir, { recursive: true, force: true });
+  else console.error(`[release rehearsal] snapshot artifacts kept at ${artifactDir}`);
+}

--- a/spec/decisions/D-GLOBAL-RELEASE-VERSION-0001.yaml
+++ b/spec/decisions/D-GLOBAL-RELEASE-VERSION-0001.yaml
@@ -24,10 +24,18 @@ criteria:
     text:
       en: Equal release versions are a necessary compatibility precondition, while full Prototype and Adapter compatibility still requires conformance evidence.
       zh-CN: 相同 release version 是兼容性的必要前提；Prototype 与 Adapter 的完全兼容仍需 conformance 证据。
+  - id: D-GLOBAL-RELEASE-VERSION-0001-CLI-INSTALL
+    text:
+      en: The official CLI must install required public Proto UI packages from its own exact release version rather than allowing npm dist-tags or semver ranges to mix release trains.
+      zh-CN: 官方 CLI 必须按自身精确 release version 安装所需的公开 Proto UI package，不得让 npm dist-tag 或 semver range 混合不同 release train。
 openQuestions: []
 sources:
+  - path: internal/governance/versioning-policy.md
   - path: internal/governance/versioning-policy.zh-CN.md
+  - path: internal/governance/release-workflow.md
   - path: internal/governance/release-workflow.zh-CN.md
+  - path: packages/cli/src/commands/add.ts
+  - path: packages/cli/src/services/package-manager.ts
 revisions:
   - version: 0.2.0-rc.0
     change: introduced


### PR DESCRIPTION
## Summary

- pin CLI-installed official Adapter and Prototype packages to the CLI's exact release version
- keep the stable Quick Start on npm `latest` and move reproducible prerelease onboarding to separate exact-version RC trial pages
- add reviewed bilingual `0.2.0-rc.0` release notes and a deterministic 37-package BOM
- add release-asset drift checks and a one-command, non-publishing release rehearsal
- make the publication workflow use the reviewed release note and attach the BOM, Chinese note, spec snapshot, and checksum

## Why

The `next` CLI could previously resolve unversioned Adapter or Prototype dependencies from `latest`, mixing the current CLI with historical packages. Release notes and the package BOM were also governance requirements without checked artifacts or a direct connection to the GitHub Release workflow.

This PR closes those gaps before the first globally exact Proto UI release candidate.

## Impact

- ordinary users remain on the stable `latest` documentation path
- RC trials pin `@proto.ui/cli@0.2.0-rc.0` and the CLI saves its official dependencies exactly
- package-graph or governance drift makes the reviewed BOM check fail
- `pnpm release:rehearse` provides a sequential audit trail without invoking real publication
- real publication remains restricted to the protected `publish-all` workflow on `main`

## Validation

A complete local `pnpm release:rehearse` passed:

- 37 public packages and one draft V entity aligned to `0.2.0-rc.0`
- Prototype catalog: 60 declaration files, 91 static authoring entries, 59 P entities, zero known debt
- 30 release-script tests passed
- 230 runtime test files passed, 3 skipped; 1039 tests passed, 34 todo
- zero-issue deterministic spec snapshot generated
- all 37 packages passed build and `npm publish --dry-run`
- React tarball consumer passed family-boundary, type, build, and runtime smoke checks
- CLI tarball consumer passed React, Vue, and Web Component generation/runtime smoke checks
- docs built 152 pages and indexed 150 pages

No npm package, Git tag, or GitHub Release was published by this rehearsal.

Existing non-blocking warnings remain for the Geist font runtime resolution and large bundle chunks.