### PR TITLE
feat: close 0.2 RC publication loop

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -162,6 +162,10 @@ jobs:
       - name: Validate reviewed release notes and package BOM
         run: node scripts/release/check-release-assets.mjs --check
 
+      - name: Validate npm package identities
+        if: ${{ inputs.mode == 'stage' || inputs.mode == 'publish-all' }}
+        run: node scripts/release/check-registry-readiness.mjs
+
       - name: Generate deterministic spec release snapshot
         if: ${{ inputs.mode == 'publish-all' }}
         run: |

--- a/apps/www/src/content/docs/en/start-here/rc-trial.mdx
+++ b/apps/www/src/content/docs/en/start-here/rc-trial.mdx
@@ -11,7 +11,7 @@ import DocStageNotice from '@/components/DocStageNotice.astro';
   body="It does not change the main Quick Start contract, which follows the stable npm latest release."
 />
 
-:::caution[Waiting for the RC] The commands below work only after `0.2.0-rc.0` has been published to npm. Trial findings are not stable-version promises, and commands or generated structure may still change before `0.2.0`. :::
+:::caution[Prerelease trial] `0.2.0-rc.0` is now available from npm. Trial findings are not stable-version promises, and commands or generated structure may still change before `0.2.0`. :::
 
 ## Install the Proto UI CLI
 

--- a/apps/www/src/content/docs/zh-cn/start-here/rc-trial.mdx
+++ b/apps/www/src/content/docs/zh-cn/start-here/rc-trial.mdx
@@ -11,7 +11,7 @@ import DocStageNotice from '@/components/DocStageNotice.astro';
   body="它不会改变官网主 Quick Start 对 npm latest 稳定版本的承诺。"
 />
 
-:::caution[等待 RC 发布] 以下命令只有在 `0.2.0-rc.0` 已发布到 npm 后才能执行。试用发现不代表稳定版承诺，命令和生成结构仍可能在 `0.2.0` 前调整。:::
+:::caution[预发布试用] `0.2.0-rc.0` 现已发布到 npm。试用发现不代表稳定版承诺，命令和生成结构仍可能在 `0.2.0` 前调整。:::
 
 ## 安装 Proto UI CLI
 

--- a/internal/governance/ci-cd.md
+++ b/internal/governance/ci-cd.md
@@ -44,6 +44,7 @@ The workflow does not accept ad hoc `version`, `tag`, or `only` inputs. Version 
 - `publish-all` is allowed only on `main`.
 - `publish-all` requires the `workspace` profile; `launch` is for product-scope audit and rehearsal only.
 - Real publication is protected by the GitHub `npm` environment and npm Trusted Publishing through OIDC.
+- `stage` and `publish-all` fail before package staging unless every public package identity is already readable from the npm registry. The check cannot inspect private Trusted Publisher settings, which remain a maintainer responsibility.
 - Concurrency prevents overlapping release runs for the same ref.
 - The workflow creates `v<version>` only after every public package publishes successfully.
 
@@ -61,16 +62,18 @@ These tiers do not control the real npm publish set. Global exact-version govern
 
 1. Create or update the draft V entity and align `VERSION` plus package manifests in one PR.
 2. Regenerate and review the release BOM and notes, then run `pnpm release:assets:check`.
-3. Run `pnpm release:rehearse` for the complete sequential non-publishing gate. CI keeps the same checks split into parallel jobs for feedback speed.
-4. Review the launch product scope and isolated React plus multi-host CLI tarball consumer results.
-5. After merge to `main`, run `publish-all` with the `workspace` profile.
-6. Verify the GitHub release/spec-snapshot evidence and promote the V entity to `active` in a follow-up PR.
+3. For every newly named public package, publish a clearly non-release bootstrap version and configure its Trusted Publisher before the release rehearsal.
+4. Run `pnpm release:rehearse` for the complete sequential non-publishing gate. CI keeps the same checks split into parallel jobs for feedback speed.
+5. Review the launch product scope and isolated React plus multi-host CLI tarball consumer results.
+6. After merge to `main`, run `publish-all` with the `workspace` profile.
+7. Verify the GitHub release/spec-snapshot evidence and promote the V entity to `active` in a follow-up PR.
 
 ## Local Shortcuts
 
 - `pnpm check:release-version`
 - `pnpm release:bom`
 - `pnpm release:assets:check`
+- `pnpm release:registry:check`
 - `pnpm release:scan:launch`
 - `pnpm release:stage:launch`
 - `pnpm release:stage`

--- a/internal/governance/ci-cd.zh-CN.md
+++ b/internal/governance/ci-cd.zh-CN.md
@@ -44,6 +44,7 @@ CI 在 pull request、`main` push 和手动触发时运行。除常规类型与�
 - `publish-all` 仅允许在 `main` 上运行。
 - `publish-all` 必须使用 `workspace` profile；`launch` 只用于产品范围审计和彩排。
 - 真实发布由 GitHub `npm` environment 审批与 npm Trusted Publishing OIDC 保护。
+- `stage` 与 `publish-all` 在 package 暂存前检查全部公开 package identity 均已可从 npm registry 读取；该检查无法读取私有的 Trusted Publisher 设置，后者仍由维护者负责核对。
 - 同一 ref 上启用并发互斥，避免重叠发布任务。
 - 全部公开 package 发布成功后才创建 `v<version>` tag。
 
@@ -61,16 +62,18 @@ CI 在 pull request、`main` push 和手动触发时运行。除常规类型与�
 
 1. 创建或更新 draft V 实体，并在 PR 中统一 `VERSION` 与 package manifests。
 2. 重新生成并评审 release BOM 与说明，然后运行 `pnpm release:assets:check`。
-3. 运行 `pnpm release:rehearse`，完成整套顺序执行的不发布门禁。CI 为了缩短反馈时间，仍将同一组检查拆成并行 job。
-4. 审阅 launch 产品范围，以及隔离 React 与 CLI 多宿主 tarball consumer 结果。
-5. 合入 `main` 后，用 `workspace` profile 运行 `publish-all`。
-6. 发布成功后核对 GitHub release/spec snapshot 证据，再通过后续 PR 将 V 实体转为 `active`。
+3. 对每个首次出现的公开 package 名称，先发布明确不属于正式发行的 bootstrap 版本，并配置 Trusted Publisher。
+4. 运行 `pnpm release:rehearse`，完成整套顺序执行的不发布门禁。CI 为了缩短反馈时间，仍将同一组检查拆成并行 job。
+5. 审阅 launch 产品范围，以及隔离 React 与 CLI 多宿主 tarball consumer 结果。
+6. 合入 `main` 后，用 `workspace` profile 运行 `publish-all`。
+7. 发布成功后核对 GitHub release/spec snapshot 证据，再通过后续 PR 将 V 实体转为 `active`。
 
 ## 本地快捷命令
 
 - `pnpm check:release-version`
 - `pnpm release:bom`
 - `pnpm release:assets:check`
+- `pnpm release:registry:check`
 - `pnpm release:scan:launch`
 - `pnpm release:stage:launch`
 - `pnpm release:stage`

--- a/internal/governance/release-workflow.md
+++ b/internal/governance/release-workflow.md
@@ -54,9 +54,13 @@ Package-local fixes do not use `publish-single`; they enter the next global rele
 
 Each release train owns `internal/releases/<version>/release-notes.md`, its Chinese projection, and a deterministic `package-bom.json`. `pnpm release:bom` regenerates the BOM from the public workspace package graph and launch-governance roles; `pnpm release:assets:check` fails when the reviewed BOM drifts or either release note is absent. The English note becomes the GitHub Release body, while the BOM, Chinese note, spec snapshot, and checksum are attached as release evidence.
 
+npm Trusted Publisher configuration is package-scoped and therefore cannot be attached before a package identity exists. Every newly named public package must be created before the release train with a clearly non-release bootstrap version, configured for the reviewed release workflow, and kept out of `latest` and release-channel dist-tags. `pnpm release:registry:check` proves that every identity is publicly readable; it does not claim to inspect the private Trusted Publisher configuration.
+
 ## 4. Publication
 
 Real publication is manually triggered from `main` and protected by the GitHub `npm` environment approval.
+
+Both `stage` and `publish-all` run the registry-identity preflight before any package is staged or published. A missing identity aborts the run with the complete missing-package list, preventing an avoidable partial publication.
 
 The workflow:
 

--- a/internal/governance/release-workflow.zh-CN.md
+++ b/internal/governance/release-workflow.zh-CN.md
@@ -54,9 +54,13 @@
 
 每条 release train 在 `internal/releases/<version>/` 下维护 `release-notes.md`、对应中文投射与确定性的 `package-bom.json`。`pnpm release:bom` 根据公开 workspace package 图和 launch governance 角色重新生成 BOM；`pnpm release:assets:check` 会在已评审 BOM 漂移或任一 release note 缺失时失败。英文说明作为 GitHub Release 正文，BOM、中文说明、spec snapshot 与 checksum 作为 release evidence 附件。
 
+npm Trusted Publisher 是 package 级配置，因此 package identity 不存在时无法预先绑定。每个首次出现的公开 package 都必须在 release train 前使用明确不属于正式发行的 bootstrap 版本完成创建，绑定到已评审的发布 workflow，并且不得占据 `latest` 或发行 channel dist-tag。`pnpm release:registry:check` 只证明所有 identity 已可公开读取，不宣称能够检查私有的 Trusted Publisher 配置。
+
 ## 4. 发布流程
 
 真实发布只允许从 `main` 手动触发，并由 GitHub `npm` environment 审批保护。
+
+`stage` 与 `publish-all` 都会在任何 package 暂存或发布前运行 registry identity preflight。任一 identity 缺失都会一次性列出全部缺口并中止，避免形成可预防的部分发布。
 
 发布 workflow：
 

--- a/internal/records/2026-07-20-0.2-rc-post-publication-priority-audit.zh-CN.md
+++ b/internal/records/2026-07-20-0.2-rc-post-publication-priority-audit.zh-CN.md
@@ -1,0 +1,159 @@
+# 2026-07-20 0.2 RC 发布后进展与优先级复审记录
+
+> Internal record. Not normative. 本文以 `2026-07-18-0.2-closure-and-followup-roadmap.zh-CN.md` 为主要比较基线，记录 `0.2.0-rc.0` 发布后的实际完成状态与下一阶段排序。正式版本、发布和实体语义仍以 V/D/P/C/T 等实体及治理文档为准。
+
+## 1）复审结论
+
+7 月 18 日路线中的阶段 A 已从“准备 0.2 prerelease”推进到“RC 已公开且可从仓库外试用”。当前不再把 Module、Host Capability 与 Adapter 的系统编目作为直接下一项；工作重心应切换到阶段 B：使用真实仓库外项目完成首轮人工试用，根据实际阻塞项决定 `0.2.0-rc.1` 或稳定版前的修正范围。
+
+发布后仍有两个收尾面：
+
+- 本分支需要把公开发行证据回填到 `V-PROTO-UI-0001`，并合入 registry identity preflight，避免未来新增 package 再造成部分发布。
+- 三个 registry bootstrap package 的占位版本已经 deprecated，但 `latest` 与 `bootstrap` tag 仍指向占位版本。它们不阻塞当前 CLI RC 试用，但在稳定版发布前必须清理或取得 npm 官方处理结论。
+
+除真实试用发现的 blocker 外，当前不继续扩张 Prototype 表面，不提前批量创建 Module/HC/Adapter 空壳实体，也不把 bundle 优化或官网视觉润色提升为 RC 首要工作。
+
+## 2）相较 7 月 18 日路线的进展
+
+### 2.1 Prototype 编目与覆盖门禁：已完成当前范围
+
+7 月 18 日确认的 Transition 缺口已关闭。`P-BASE-TRANSITION`、`T-BASE-TRANSITION-0001`、direct prototype、authored asHook 与 reduced-motion sequencing 已形成同一可验证协议闭环。
+
+外部来源原型库的身份边界也已落地：
+
+- Lucide 使用共享的 `P-LUCIDE-ICON`，单个 glyph 作为 catalog data，不制造逐图标实体。
+- Shadcn 按 component/anatomy part 建立 delta-style P 实体，通过 `inherits.prototypes` 表达对 Base 的默认继承，并允许以明示准则记录负向补丁。
+- Radix-style `asChild` 作为有意不兼容项由独立 D 实体治理。
+- Lucide 与 Shadcn 的第三方来源说明已经进入对应 npm tarball。
+
+Prototype declaration file 已采用 `.proto.ts` / `.proto.js` 命名抓手。当前覆盖检查报告：60 个 declaration file、91 个静态 authoring entry、59 个 P 实体、0 个 known debt file，以及 1 个单独识别的 dynamic factory file。由此，当前公开 Prototype 实现可以视为已进入覆盖门禁，而不是仅靠人工比较 P 文件数量。
+
+### 2.2 版本与发行治理：首条全局 release train 已成立
+
+历史上的 spec 修订数字、根 `VERSION`、局部 package 版本和 npm 实际状态已经收敛到首个全局精确版本：
+
+- version：`0.2.0-rc.0`
+- npm dist-tag：`next`
+- Git tag：`v0.2.0-rc.0`
+- public package set：37
+- package version policy：全局精确版本与精确内部依赖
+
+37 个公开 package 均已发布 `0.2.0-rc.0`，GitHub prerelease、BOM、spec snapshot 与 checksum 已生成。发布提交为 `8252e6eaf26e98b15746a712f356cb6770a88075`，snapshot digest 为 `sha256:45244d4adfa478384f07dc9721338c3f3f43ed09836fde03f13bfe52bbfdfae1`。这些证据满足 `V-PROTO-UI-0001` 从 `draft` 转为 `active` 的条件。
+
+首次发布因三个新 Module package identity 尚不存在而在第 7 个 package 中断。恢复流程在 bootstrap identity、Trusted Publisher 与 tarball integrity 校验建立后完成全部发布。本分支新增 registry identity preflight，使 rehearsal、stage 与 publish-all 在首个写操作前一次性发现全部缺失名称。它不能检查私有 Trusted Publisher 配置，后者仍是维护者责任。
+
+### 2.3 消费边界与自动 smoke：已达到人工试用起点
+
+React + Vite tarball consumer 已证明当前 release 闭包可以在隔离项目中完成类型检查、production build、Button/Switch/Select/Dialog 运行时断言与 remount。CLI tarball consumer 覆盖 React、Vue 与 Web Component facade。Base 与 Shadcn 已公开 family subpath，Button-only module graph 不再带入其他 Prototype family。
+
+`@proto.ui/cli@0.2.0-rc.0` 安装官方 Adapter/Prototype package 时会固定到 CLI 自身的精确版本，并以 exact dependency 写入 consumer manifest。因此：
+
+- `npx @proto.ui/cli@0.2.0-rc.0 ...` 是人工试用记录的规范入口，结果长期可复现。
+- `npx @proto.ui/cli@next ...` 当前同样解析到 `0.2.0-rc.0`，可以作为便利入口，但不能替代试用记录中的精确版本身份。
+- 官网主 Quick Start 继续跟随稳定 `latest`；独立 RC Trial 承担预发布试用，不把普通使用者静默切换到 prerelease。
+
+本次发布后复核确认 37/37 个 package 的 `next` 均指向 `0.2.0-rc.0`。已发布 CLI 的 `--help`、`init` 与 React Shadcn Button `--no-install` 路径可以从 npm 正常执行，并输出精确的 `@proto.ui/adapter-react@0.2.0-rc.0` 与 `@proto.ui/prototypes-shadcn@0.2.0-rc.0` 安装要求。
+
+### 2.4 Spec 与官网：结构基线健康，内容债务仍然存在
+
+当前 spec workspace 包含 377 个实体：143 Contract、44 Decision、4 Host Cap、5 Knowledge、5 Module、59 Prototype、116 Test 与 1 Version，validation issue 为 0；可选版本只剩 `0.2.0-rc.0`。
+
+官网已修正过期 launch 状态、错误导航、本机绝对源码链接和第三方声明，并提供独立 RC Trial。但 7 月 18 日记录中的主要内容债务仍未消失：大量组件缺完整页面与 API 表，知识型文档仍不足，搜索和普通 code block 样式也未完成统一。本轮只把 RC Trial 从“等待发布”改为“现已可试用”，不把文档补全误报为已经完成。
+
+## 3）发布后的已知边界
+
+### 3.1 Bootstrap tag 尚未清理
+
+截至本次复审，以下三个 package 的 registry 状态相同：
+
+- `@proto.ui/module-positioning`
+- `@proto.ui/module-collection`
+- `@proto.ui/module-a11y`
+
+它们均满足：
+
+- `next -> 0.2.0-rc.0`
+- `latest -> 0.0.0-bootstrap.0`
+- `bootstrap -> 0.0.0-bootstrap.0`
+- `0.0.0-bootstrap.0` 已标记 deprecated，说明为 `Registry bootstrap only; use 0.2.0-rc.0 or later.`
+
+CLI 的精确版本安装保证 RC Trial 不会命中占位版本；直接执行无版本的 `npm install <package>` 仍会命中错误的 `latest`，因此它是发行卫生问题而不是当前 CLI 试用 blocker。CLI WebAuth 完成 2FA 后删除 tag 持续收到 registry `400 Bad Request`；后续应尝试显式 OTP/新版 npm、npm 网站维护入口或 npm Support，但不得通过发布伪造稳定版本来覆盖该问题。
+
+### 3.2 Bundle 信号保留为专项方向
+
+Prototype family 边界已经消除了明显的跨 family 误打包，但 Adapter 仍会携带 runtime 与当前完整 Module 集合。`0.2` 接受这是 Adapter 架构成本，不设置固定 kB 发布阈值。真实项目仍应记录 chunk 组成；是否优化 Module/Adapter 体积，应在外部试用证实它是现实阻力后作为专项推进。
+
+### 3.3 自动 smoke 不等于真实使用
+
+现有 smoke 证明 tarball 闭包、生成入口和有限运行时路径成立，但仍不能替代：
+
+- 真实项目已有构建配置、CSS 和依赖组合；
+- 浏览器中的焦点、Portal、键盘、reduced-motion 与辅助技术；
+- 调用者对 API、错误提示、生成结构和二次定制成本的判断；
+- SSR/hydration、开发服务器体验与实际 bundle 组成。
+
+## 4）重新排序后的工作方向
+
+### P0：完成本次发布证据 PR
+
+- 激活 `V-PROTO-UI-0001` 并记录不可变发行证据。
+- 合入 registry identity preflight、治理说明和发布恢复记录。
+- 校正 RC Trial 已发布状态。
+
+本项完成后，阶段 A 可以正式关闭。
+
+### P1：立即开展首轮仓库外人工试用
+
+先在全新 React + TypeScript 项目中使用精确版本 `0.2.0-rc.0` 完成：
+
+1. CLI `--help` 与 `init`。
+2. 添加 Shadcn Button，再逐步加入 Switch、Select 与 Dialog。
+3. 验证生成入口、样式引入、开发服务器、类型检查与 production build。
+4. 在真实浏览器中检查键盘、焦点、Dialog/Select overlay、disabled/async、remount 与 reduced-motion。
+5. 记录首次成功耗时、每条命令、环境版本、错误、API escape、CSS/a11y/SSR/bundle 反馈。
+
+试用记录必须写精确版本；可以额外验证 `@next` 便利入口，但不能只写 `@next`。首轮 React 形成稳定模板后，再以同一方法扩展 Vue 与 Web Component，不要求在发现第一个 blocker 前一次性完成三个宿主。
+
+### P2：按试用结果修正，并决定下一条 release train
+
+- 影响已发布 package 的修正进入新的全局精确版本；若仍需候选验证，则创建 `0.2.0-rc.1`，不覆盖 `rc.0`。
+- 仅影响官网或内部 record 的修正可以独立合入，但不得改变已发布 package 的行为声明。
+- 安装、codegen、类型、基础运行时或关键 a11y blocker 优先于新增组件和视觉完善。
+- 稳定 `0.2.0` 只有在仓库外试用可复验、关键 blocker 已关闭、三个 bootstrap package 的 `latest` 不再误导直接安装者后才进入发布准备。
+
+### P3：以真实缺口驱动文档补全
+
+人工试用会暴露最先需要的知识路径。优先把这些路径投射为中英文文档，再批量补齐组件页模板：status/since、adapter support、demo、anatomy、props、events、state、a11y、P/C/T 追溯和可运行示例。API 表应由 TypeScript public surface 与 spec 联合生成或校验。
+
+导航、事实和可执行示例继续优先于 code block、搜索弹窗等纯样式统一；但影响阅读或检索的样式缺陷可以随对应内容一并修正。
+
+### P4：外部证据建立后再进入 Module/HC/Adapter 垂直切片
+
+仍采用 7 月 18 日确定的垂直消费链，而不是横向批量建空实体：
+
+1. Dialog / Hover Card / Select
+2. Overlay + Positioning + Presence
+3. Portal + Anchored Position host capabilities
+4. Web Component adapter profile
+5. React / Vue conformance
+
+第一条链路收口后，再进入 Focus + A11y + Collection。若人工试用在此之前暴露某条链上的 blocker，可以把对应垂直切片前移；否则不改变排序。
+
+## 5）当前不做
+
+- 不在首轮人工试用前继续新增大型 Prototype family。
+- 不把 25 个 Module package 机械转换成 25 个缺少准则和证据的 M 实体。
+- 不把 capability token 数量直接等同于 HC 实体数量。
+- 不因为三个 bootstrap tag 难以删除而制造假的稳定 package 版本。
+- 不以自动 smoke 已通过为由跳过真实项目验证。
+- 不把 Adapter bundle 优化或官网大规模视觉重做提升为 `0.2.0` 的默认 blocker。
+
+## 6）下一次复审触发点
+
+完成至少一份仓库外 React 人工试用记录后重新复审。届时应基于实际发现回答：
+
+- 是否需要 `0.2.0-rc.1`。
+- 哪些文档断口直接阻碍首次成功。
+- Vue 与 Web Component 人工试用是否仍可按原计划展开。
+- Module/HC/Adapter 的哪条垂直切片应最先进入实体编目。
+- bundle、SSR、CSS 与 a11y 中哪些问题已经从观察信号升级为版本 blocker。

--- a/internal/records/2026-07-20-0.2-rc-publication-and-registry-bootstrap.zh-CN.md
+++ b/internal/records/2026-07-20-0.2-rc-publication-and-registry-bootstrap.zh-CN.md
@@ -1,0 +1,69 @@
+# 0.2 RC 发布、registry bootstrap 与恢复记录
+
+## 结论
+
+Proto UI `0.2.0-rc.0` 已于 2026-07-20 完成首次全局精确版本发布：37 个公开 `@proto.ui/*` package 均存在精确版本 `0.2.0-rc.0`，prerelease channel 为 `next`，Git tag 为 `v0.2.0-rc.0`，GitHub prerelease 与 spec snapshot 证据均已生成。
+
+首次 `publish-all` 暴露了一个此前未进入门禁的 npm 约束：Trusted Publisher 是 package 级配置，尚未存在于 registry 的 package 无法提前绑定 OIDC。发布恢复已完成；后续 release 必须在任何逐包发布开始前检查全部 package identity 是否已经存在。
+
+## 首次发布失败
+
+- 发布提交：`8252e6eaf26e98b15746a712f356cb6770a88075`
+- 失败运行：<https://github.com/Proto-UI/Proto-UI/actions/runs/29720181939>
+- 失败位置：发布顺序第 7 项 `@proto.ui/module-positioning`
+- npm 错误：`ENEEDAUTH`
+- 失败前已经成功发布：`@proto.ui/cli`、`@proto.ui/core`、`@proto.ui/module-base`、`@proto.ui/module-expose`、`@proto.ui/module-anatomy`、`@proto.ui/module-feedback`
+
+registry 审计确认 37 个发布包中有三个 package identity 从未创建：
+
+- `@proto.ui/module-positioning`
+- `@proto.ui/module-collection`
+- `@proto.ui/module-a11y`
+
+由于发布脚本按拓扑顺序逐包执行，而 dry-run 不需要完成真实身份认证，原有 `stage` 无法在第一个写请求前发现这类缺口。
+
+## Bootstrap 与 Trusted Publisher
+
+三个缺失 package 分别以 `0.0.0-bootstrap.0` 完成首次创建。该版本只承载 package identity，不包含 Proto UI 运行时代码，不属于任何 release train，也不得作为使用者安装入口。
+
+三个 package 随后使用相同的 Trusted Publisher 配置：
+
+- provider：GitHub Actions
+- repository：`Proto-UI/Proto-UI`
+- workflow：`release-packages.yml`
+- environment：`npm`
+- permission：`npm publish`
+
+bootstrap 版本应保留为可审计的历史事实并标记 deprecated，不应 unpublish；其 `latest` 与 `bootstrap` 占位 tag 应在发布后移除，只保留 `next -> 0.2.0-rc.0`。
+
+## 恢复发布
+
+- 恢复运行：<https://github.com/Proto-UI/Proto-UI/actions/runs/29721767843>
+- profile：`workspace`
+- mode：`publish-all`
+- `resume_published`：`true`
+
+恢复运行对已经存在的 `0.2.0-rc.0` tarball 重新打包并比对 SHA-512 integrity；只有内容完全相同的 package 才会跳过。三个新 package 通过刚绑定的 OIDC 发布正式 RC 版本，其余 package 继续使用同一提交、同一版本和同一发布集合完成。
+
+## 发行证据
+
+- GitHub prerelease：<https://github.com/Proto-UI/Proto-UI/releases/tag/v0.2.0-rc.0>
+- 发布时间：`2026-07-20T06:35:20Z`
+- tag commit：`8252e6eaf26e98b15746a712f356cb6770a88075`
+- spec snapshot：`spec-snapshot-0.2.0-rc.0.json`
+- snapshot digest：`sha256:45244d4adfa478384f07dc9721338c3f3f43ed09836fde03f13bfe52bbfdfae1`
+- package BOM：37 个公开 package
+
+以上证据满足 `V-PROTO-UI-0001` 从 `draft` 转为 `active` 的条件。
+
+## 门禁修正
+
+新增 registry identity preflight：
+
+- `pnpm release:registry:check` 并发检查全部公开 package 名称是否可从 npm registry 读取；
+- `release:rehearse` 在 package dry-run 前执行该检查；
+- `Release Packages` 的 `stage` 与 `publish-all` 在任何 package staging/publish 前执行该检查；
+- 一次性报告所有缺失 identity，避免发布到中途才发现下一个新 package；
+- 明确说明该公开检查无法读取私有 Trusted Publisher 设置，绑定关系仍需维护者单独核验。
+
+后续新 package 的推荐流程是：先创建明确的非发行 bootstrap 版本，移除用户可见的默认 tag，绑定 Trusted Publisher，再进入全局 release train。

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "release:sync-metadata": "node scripts/release/sync-metadata.mjs",
     "release:bom": "node scripts/release/check-release-assets.mjs --write",
     "release:assets:check": "node scripts/release/check-release-assets.mjs --check",
+    "release:registry:check": "node scripts/release/check-registry-readiness.mjs",
     "release:rehearse": "node scripts/release/rehearse.mjs",
     "release:stage": "node scripts/release/publish.mjs --dry-run",
     "release:stage:launch": "node scripts/release/publish.mjs --dry-run --profile launch --check-governance",

--- a/scripts/release/check-registry-readiness.mjs
+++ b/scripts/release/check-registry-readiness.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
+
+import { findProtoPackages } from './version-utils.mjs';
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+
+export async function checkRegistryReadiness(
+  packageNames,
+  {
+    registry = process.env.npm_config_registry ?? DEFAULT_REGISTRY,
+    fetchImpl = globalThis.fetch,
+    timeoutMs = 15_000,
+  } = {}
+) {
+  if (typeof fetchImpl !== 'function') throw new Error('A fetch implementation is required.');
+
+  const registryBase = `${registry.replace(/\/+$/, '')}/`;
+  const checks = await Promise.all(
+    [...new Set(packageNames)].sort().map(async (name) => {
+      const url = new URL(encodeURIComponent(name), registryBase);
+      try {
+        const response = await fetchImpl(url, {
+          headers: { accept: 'application/json' },
+          signal: timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined,
+        });
+        if (response.status === 200) return { name, state: 'ready' };
+        if (response.status === 404) return { name, state: 'missing' };
+
+        const detail = (await response.text()).trim().replace(/\s+/g, ' ').slice(0, 240);
+        return {
+          name,
+          state: 'error',
+          detail: `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ''}${
+            detail ? `: ${detail}` : ''
+          }`,
+        };
+      } catch (error) {
+        return {
+          name,
+          state: 'error',
+          detail: error instanceof Error ? error.message : String(error),
+        };
+      }
+    })
+  );
+
+  return {
+    ready: checks.filter((check) => check.state === 'ready').map((check) => check.name),
+    missing: checks.filter((check) => check.state === 'missing').map((check) => check.name),
+    errors: checks
+      .filter((check) => check.state === 'error')
+      .map(({ name, detail }) => ({ name, detail })),
+  };
+}
+
+export function parseRegistryReadinessArgs(argv) {
+  const args = {
+    registry: process.env.npm_config_registry ?? DEFAULT_REGISTRY,
+    timeoutMs: 15_000,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--registry') args.registry = argv[++index];
+    else if (arg === '--timeout-ms') args.timeoutMs = Number(argv[++index]);
+    else if (arg === '--help' || arg === '-h') args.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!args.registry) throw new Error('--registry requires a value');
+  if (!Number.isInteger(args.timeoutMs) || args.timeoutMs <= 0) {
+    throw new Error('--timeout-ms must be a positive integer');
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseRegistryReadinessArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(
+      'Usage: node scripts/release/check-registry-readiness.mjs [--registry <url>] [--timeout-ms <ms>]'
+    );
+    return;
+  }
+
+  const packageNames = findProtoPackages().map(({ manifest }) => manifest.name);
+  const report = await checkRegistryReadiness(packageNames, args);
+  if (report.missing.length === 0 && report.errors.length === 0) {
+    console.log(`check-registry-readiness: ${report.ready.length} package identities ready`);
+    return;
+  }
+
+  console.error(
+    `check-registry-readiness: ${report.missing.length} missing package identity, ${report.errors.length} registry error(s)`
+  );
+  for (const name of report.missing) console.error(`- missing: ${name}`);
+  for (const { name, detail } of report.errors)
+    console.error(`- registry error: ${name}: ${detail}`);
+  if (report.missing.length > 0) {
+    console.error('');
+    console.error(
+      'Create each missing public package with a non-release bootstrap version, then configure its Trusted Publisher before publish-all.'
+    );
+    console.error(
+      'This public registry check proves package identity readiness only; it cannot inspect private Trusted Publisher settings.'
+    );
+  }
+  process.exitCode = 1;
+}
+
+const entryPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : undefined;
+if (entryPath === import.meta.url) await main();

--- a/scripts/release/rehearse.mjs
+++ b/scripts/release/rehearse.mjs
@@ -31,6 +31,11 @@ const steps = [
     process.execPath,
     ['scripts/release/scan.mjs', '--profile', 'launch', '--check-governance'],
   ],
+  [
+    'Registry package identities',
+    process.execPath,
+    ['scripts/release/check-registry-readiness.mjs'],
+  ],
   ['Package publish dry-run', 'corepack', [packageManager, '-s', 'release:stage']],
   ['React tarball consumer', 'corepack', [packageManager, '-s', 'release:smoke:react']],
   ['CLI multi-host tarball consumer', 'corepack', [packageManager, '-s', 'release:smoke:cli']],

--- a/scripts/release/test/check-registry-readiness.test.mjs
+++ b/scripts/release/test/check-registry-readiness.test.mjs
@@ -1,0 +1,89 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  checkRegistryReadiness,
+  parseRegistryReadinessArgs,
+} from '../check-registry-readiness.mjs';
+
+test('registry readiness reports public package identities and encodes scoped names', async () => {
+  const requested = [];
+  const report = await checkRegistryReadiness(['@proto.ui/core', '@proto.ui/hooks'], {
+    registry: 'https://registry.example.test/',
+    timeoutMs: 1_000,
+    fetchImpl: async (url) => {
+      requested.push(url.href);
+      return response(200);
+    },
+  });
+
+  assert.deepEqual(report, {
+    ready: ['@proto.ui/core', '@proto.ui/hooks'],
+    missing: [],
+    errors: [],
+  });
+  assert.deepEqual(requested, [
+    'https://registry.example.test/%40proto.ui%2Fcore',
+    'https://registry.example.test/%40proto.ui%2Fhooks',
+  ]);
+});
+
+test('registry readiness distinguishes missing identities from registry failures', async () => {
+  const report = await checkRegistryReadiness(
+    ['@proto.ui/ready', '@proto.ui/missing', '@proto.ui/unavailable'],
+    {
+      timeoutMs: 1_000,
+      fetchImpl: async (url) => {
+        if (url.href.endsWith('%2Fready')) return response(200);
+        if (url.href.endsWith('%2Fmissing')) return response(404);
+        return response(503, 'Service Unavailable', 'retry later');
+      },
+    }
+  );
+
+  assert.deepEqual(report.ready, ['@proto.ui/ready']);
+  assert.deepEqual(report.missing, ['@proto.ui/missing']);
+  assert.deepEqual(report.errors, [
+    {
+      name: '@proto.ui/unavailable',
+      detail: 'HTTP 503 Service Unavailable: retry later',
+    },
+  ]);
+});
+
+test('registry readiness records transport failures without treating packages as missing', async () => {
+  const report = await checkRegistryReadiness(['@proto.ui/core'], {
+    timeoutMs: 1_000,
+    fetchImpl: async () => {
+      throw new Error('network unavailable');
+    },
+  });
+
+  assert.deepEqual(report, {
+    ready: [],
+    missing: [],
+    errors: [{ name: '@proto.ui/core', detail: 'network unavailable' }],
+  });
+});
+
+test('registry readiness arguments validate timeout and registry values', () => {
+  assert.deepEqual(
+    parseRegistryReadinessArgs([
+      '--registry',
+      'https://registry.example.test',
+      '--timeout-ms',
+      '2500',
+    ]),
+    { registry: 'https://registry.example.test', timeoutMs: 2_500 }
+  );
+  assert.throws(() => parseRegistryReadinessArgs(['--timeout-ms', '0']), /positive integer/);
+  assert.throws(() => parseRegistryReadinessArgs(['--unknown']), /Unknown argument/);
+});
+
+function response(status, statusText = '', body = '') {
+  return {
+    status,
+    statusText,
+    text: async () => body,
+  };
+}

--- a/spec/versions/V-PROTO-UI-0001.yaml
+++ b/spec/versions/V-PROTO-UI-0001.yaml
@@ -1,7 +1,7 @@
 id: V-PROTO-UI-0001
 type: version
 title: Proto UI 0.2.0-rc.0
-status: draft
+status: active
 since: 0.2.0-rc.0
 summary: First release prepared under Proto UI global exact-version governance.
 statement:
@@ -14,6 +14,9 @@ release:
   npmDistTag: next
   packageVersionPolicy: exact
   packageScope: public-@proto.ui
+  publishedAt: 2026-07-20T06:35:20Z
+  commit: 8252e6eaf26e98b15746a712f356cb6770a88075
+  specSnapshotDigest: sha256:45244d4adfa478384f07dc9721338c3f3f43ed09836fde03f13bfe52bbfdfae1
 dependsOn:
   decisions:
     - D-GLOBAL-RELEASE-VERSION-0001
@@ -31,6 +34,9 @@ revisions:
   - version: 0.2.0-rc.0
     change: introduced
     summary: Established the first globally exact Proto UI release candidate identity.
+  - version: 0.2.0-rc.0
+    change: updated
+    summary: Activated after publishing all 37 packages, the Git tag, GitHub prerelease, and immutable spec snapshot evidence.
 tags:
   - release
   - prerelease


### PR DESCRIPTION
## What changed

- activate `V-PROTO-UI-0001` with the published tag, commit, timestamp, and spec snapshot digest
- record the initial partial npm publication, registry bootstrap, OIDC recovery, and final release evidence
- add an npm package-identity preflight to local rehearsal and the `stage` / `publish-all` workflow paths
- document the post-publication progress audit and move the immediate roadmap to repository-external RC trials
- update the English and Chinese RC Trial pages now that `0.2.0-rc.0` is available

## Why

The first global exact-version release exposed that a new npm package cannot receive Trusted Publisher configuration before its registry identity exists. The original dry-run gates could therefore pass and still leave a real publication partially complete. This PR preserves the recovery evidence and makes future missing identities fail before package staging or publication begins.

The new audit also closes the July 18 phase-A roadmap and keeps Module/Host Capability/Adapter cataloging deferred until external trial evidence exists.

## User and maintainer impact

- maintainers get a complete missing-package list before a release write begins
- the published RC now has an active V-entity evidence trail
- trial users see an accurate RC Trial page and can use the exact `0.2.0-rc.0` CLI
- three bootstrap versions are deprecated, but their erroneous `latest` / `bootstrap` tags remain a documented non-blocking release-hygiene follow-up

## Validation

- `corepack pnpm@10.32.1 test`
  - 35 release tests
  - 230 runtime test files passed, 3 skipped
  - 1039 tests passed, 34 todo
- `corepack pnpm@10.32.1 docs:build`
- `corepack pnpm@10.32.1 --filter apps-workspace build`
  - 377 entities, 0 validation issues
- `corepack pnpm@10.32.1 release:registry:check`
  - 37 package identities ready
- `git diff --check`
