### PR TITLE
docs: record next release and product directions

### DIFF
--- a/internal/records/2026-07-20-calendar-release-and-support-lifecycle-direction.zh-CN.md
+++ b/internal/records/2026-07-20-calendar-release-and-support-lifecycle-direction.zh-CN.md
@@ -1,0 +1,217 @@
+# 2026-07-20 日历发版与 v0 支持生命周期方向记录
+
+> Internal record. Not normative. 本文记录 Proto UI 在 `v0` 阶段采用固定日历 minor release train、支持线迁移、npm deprecation 与 V 实体扩展的一次阶段性治理判断。正式规则稳定后应提升到 `internal/governance/versioning-policy*`、`release-workflow*`、V entity schema 与 release automation；本文不自行改变当前 npm registry 状态。
+
+---
+
+## 1）背景
+
+Proto UI 已从 `0.2.0-rc.0` 开始采用全局精确版本：一个数字版本标识一次完整生态发行，全部公开 `@proto.ui/*` package、根 `VERSION` 与 spec snapshot 使用同一精确版本。
+
+现有版本策略已经规定：
+
+- `v0` minor 可以包含用户侧新能力、跨包假设变化和 breaking change。
+- Patch 属于同一 minor 内相对安全的修复边界。
+- 公开 package 不允许 package-local patch autonomy。
+- V 实体以 `draft/active` 表达发行准备与不可变发布证据。
+
+现有规则尚未规定：
+
+- Minor 的固定发版节奏。
+- Previous/archived release line 的支持窗口。
+- npm deprecate 何时使用。
+- 外部人工 journey 是否是发布门禁。
+- V 实体如何表达支持生命周期、successor 与迁移资料。
+
+相关既有文档：
+
+- `internal/governance/versioning-policy.zh-CN.md`
+- `internal/governance/release-workflow.zh-CN.md`
+- `spec/decisions/D-GLOBAL-RELEASE-VERSION-0001.yaml`
+- `internal/records/2026-07-20-0.2-rc-post-publication-priority-audit.zh-CN.md`
+
+## 2）当前决定：固定三个月 minor release train
+
+Proto UI 在 `v0` 阶段承诺每三个月发布一个新的 minor release train。发版日期与功能目标分离：
+
+- Release train 有固定时间承诺。
+- 研究、架构、原型、文档和工程目标通常不设置 deadline。
+- 到达发版时间时，无论当前目标完成多少，都发布当时已通过门禁的真实生态快照。
+- 未完成工作自然延续到下一条 minor，不为了“完成里程碑”推迟 release。
+- 提前完成当前目标后，可以转向其他修正或功能；新能力根据兼容边界进入下一次 patch 或下一 minor。
+
+因此，版本号表达“某个日期真实发布的生态身份”，不表达：
+
+- 所有计划功能已经完成。
+- 项目达到某种主观成熟度。
+- 外部试用、文档或原型集合已经达到理想状态。
+
+每次 release notes 必须诚实说明已完成能力、已知边界、未完成验证和延续工作。
+
+## 3）`0.2.0` 与人工 journey
+
+稳定 `0.2.0` 是否按时发布，不依赖“至少完成一份仓库外人工 journey”。外部试用是高优先级产品证据，但不是日历 release 的必要条件。
+
+如果到达发布时间时人工 journey 尚未完成：
+
+- `0.2.0` 仍按发布门禁和时间表推进。
+- Release notes 明确记录外部人工验证仍在进行。
+- 未完成的 trial、Style Compiler、本地 Shadcn 或文档工作继续在 `0.2` 后推进，必要时进入 `0.3`。
+
+如果人工 journey 提前完成并发现 blocker：
+
+- 能在 release cut 前安全修正的内容进入当前 train。
+- 需要 breaking change 或更大设计的内容进入下一 minor。
+- 不为了追齐所有发现无限延迟当前 train。
+
+## 4）支持生命周期
+
+在任一新 minor 发布后，release line 分为：
+
+| 生命周期 | 含义 | 默认维护行为 |
+| --- | --- | --- |
+| `current` | 最新 stable minor | 唯一正常维护线，接收常规修复、文档和工具改进 |
+| `previous` / project-deprecated | 前一 stable minor | 作为迁移来源和历史消费基线；不接收常规修复，安全问题单独评估 |
+| `archived` / closed | 更早 stable minor | 不运行常规 CI、不处理普通问题、不发布常规修复 |
+
+若三个月节奏稳定，一条 release line 大致经历：
+
+- 约三个月 `current`。
+- 约三个月 `previous`。
+- 此后进入 `archived`。
+
+状态迁移由下一条 minor 实际发布触发，而不是在 registry 中按日历自动执行。历史 npm tarball、Git tag、spec snapshot、release note 和 BOM 保留，不因为 archived 而 unpublish 或删除历史事实。
+
+## 5）Previous line 的安全问题
+
+当前不承诺同时维护两条完整 release line。Previous line 接受安全问题评估，但是否 backport 根据以下因素决定：
+
+- 严重度与可利用性。
+- 是否存在已知受影响用户。
+- 修复是否能低风险回移。
+- 团队能力与当前用户规模。
+- Current line 是否已经提供可接受升级路径。
+
+Current line 始终优先。除非未来真实用户规模和维护能力支持，不对外宣称 previous line 拥有固定安全补丁 SLA。
+
+## 6）项目生命周期与 npm deprecate 分离
+
+npm deprecate 会给安装目标版本的用户显示消息，支持单版本或 semver range，也可以通过清空消息撤销。npm 官方建议在鼓励升级或停止维护时优先 deprecate，而不是 unpublish：
+
+- https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions/
+- https://docs.npmjs.com/cli/v11/commands/npm-deprecate/
+
+Proto UI 有大量精确锁步 package。若每次新 minor 发布后立即对 previous line 的全部 package 执行 npm deprecate，普通安装可能收到大量重复警告。因此当前采用：
+
+1. `previous` 生命周期先通过官网、V 实体、release notes 与迁移文档表达，不机械执行 npm deprecate。
+2. 正常生命周期进入 `archived` 后，优先对用户直接入口 package 执行 npm deprecate，例如 CLI、Adapters 与 Prototype libraries。
+3. Module/Core/Runtime 等传递依赖是否批量 deprecate，需权衡警告噪音和直接消费者，默认不因为正常生命周期机械执行。
+4. 某个版本确认 unsafe、broken、registry identity 错误或会误导安装时，可以立即对全部受影响精确 package/version 执行 npm deprecate。
+5. 不用 unpublish 伪装版本未曾存在。
+
+普通生命周期消息应避免暗示安全漏洞，例如：
+
+```text
+Proto UI 0.3 is outside active support. Upgrade to 0.5. Migration guide: <url>
+```
+
+安全/严重缺陷消息应明确风险、受影响范围和修复版本。
+
+## 7）Dist-tag 与安装入口
+
+- `latest` 始终指向 current stable release train。
+- `next` 指向当前 prerelease train。
+- 精确版本是试用、证据和迁移记录的身份。
+- Previous/archived line 不通过 `latest` 或普通 Quick Start 暗示为推荐版本。
+- 是否增加 `previous` 等额外 dist-tag 暂不决定；当前没有必要增加新的长期 channel。
+
+## 8）V 实体的发行状态与支持状态分离
+
+现有 V 实体 `draft/active` 表达发行事实：
+
+- `draft`：release train 正在准备，尚未具备完整发布证据。
+- `active`：npm、Git tag 与 spec snapshot 证据成立。
+
+这与 current/previous/archived 支持生命周期不是同一维度。后续可以在 V entity schema 中增加独立字段，例如：
+
+```yaml
+support:
+  lifecycle: current
+  scheduledFor: 2026-10-20
+  successor: null
+  deprecatedAt: null
+  archivedAt: null
+  migrationGuide: null
+```
+
+还可记录：
+
+- Calendar train identity。
+- 实际发布时间与计划时间。
+- Successor V entity。
+- Known boundaries。
+- Migration guide。
+- 外部 Lab evidence 链接。
+
+外部 evidence 是参考事实，不是 V 实体转为 active 的必要条件。
+
+## 9）Fresh install 与 upgrade evidence
+
+每个 stable minor 推荐产生两类外部证据：
+
+1. 从空项目开始使用 current 文档的 fresh install。
+2. 从 previous baseline 升级到 current 的 migration journey。
+
+Upgrade 流程：
+
+1. 冻结 previous consumer 的 Git tag、lockfile 和可工作证据。
+2. 只升级 Proto UI 精确 release version，先不修改业务代码。
+3. 保存类型、构建、运行时、生成文件和样式的原始失败。
+4. 根据 migration guide 完成修改。
+5. 记录手工修改量、CLI diff、API 变化与语义差异。
+6. 将迁移后实现作为新的 current baseline。
+
+这两类证据服务版本治理和文档，但不阻塞固定日期发版。
+
+外部 Lab 方向见：
+
+- `internal/records/2026-07-20-consumer-evidence-lab-and-dogfood-direction.zh-CN.md`
+
+## 10）当前不做
+
+- 不把功能 milestone 完成度作为延迟 minor release 的理由。
+- 不承诺 previous line 的常规 patch 或固定安全 SLA。
+- 不在正常生命周期中 unpublish 历史 package。
+- 不对 37 个 package 机械产生重复 deprecation warning。
+- 不把人工 journey、官网完善或 Style Compiler 完成度设为 V entity active 的硬门禁。
+- 不允许 package-local patch 绕过全局精确 release train。
+
+## 11）工作顺序
+
+1. 确定三个月 release train 的首个正式日历锚点和 release cut 流程。
+2. 在下一次 versioning policy 修订中加入 calendar cadence 与生命周期定义。
+3. 为 V entity 设计独立 `support` 元数据，而不复用 `draft/active`。
+4. 定义用户入口 package 集合与 npm deprecate 操作清单。
+5. 在 release workflow 中生成生命周期迁移和消息的 dry-run 报告。
+6. 在 Lab 中冻结 `0.2` baseline，并在 `0.3` 首次执行完整 fresh/upgrade 双车道。
+7. 根据实际用户规模复审 previous-line security backport 策略。
+
+## 12）Open questions
+
+- 三个月 cadence 的正式锚点、cut 日期、prerelease 窗口和时区。
+- 当 release date 恰逢 registry/GitHub 故障时，如何定义“按时发布”的允许恢复窗口。
+- 哪些公开 package 属于 npm deprecate 的用户直接入口集合。
+- Unsafe/broken release 触发全量 deprecation 的判定与审批方式。
+- Previous line security backport 在出现真实用户后是否升级为正式承诺。
+- V entity schema 如何表达 lifecycle history，而不仅是当前 support snapshot。
+- Migration guide、Lab evidence 与 GitHub Release 之间的稳定链接方式。
+
+## 13）后续提升目标
+
+本记录稳定后应提升到：
+
+- `internal/governance/versioning-policy.zh-CN.md` 及英文投射。
+- `internal/governance/release-workflow.zh-CN.md` 及英文投射。
+- Version entity schema 与 Workspace 展示。
+- Release automation 的 lifecycle/deprecate dry-run。
+- 官网 Status、support policy 与 migration 文档。

--- a/internal/records/2026-07-20-consumer-evidence-lab-and-dogfood-direction.zh-CN.md
+++ b/internal/records/2026-07-20-consumer-evidence-lab-and-dogfood-direction.zh-CN.md
@@ -1,0 +1,219 @@
+# 2026-07-20 外部消费证据 Lab 与内部狗粮方向记录
+
+> Internal record. Not normative. 本文记录 `0.2.0-rc.0` 发布后，对仓库外消费证据、内部应用狗粮、journey 与证据回流方式的一次阶段性讨论。稳定规则仍应分别提升到 Lab 仓库约定、官网贡献文档、发布治理或对应 spec 实体；本文不替代这些真相源。
+
+---
+
+## 1）背景
+
+Proto UI `0.2.0-rc.0` 已形成首条全局精确 release train。仓库现有自动验证能够证明：
+
+- 公开 package 可以 staging、pack 并形成精确依赖闭包。
+- React + Vite 隔离 consumer 可以完成 CLI 生成、类型检查、production build 与有限运行时断言。
+- CLI smoke 可以为 React、Vue 与 Web Component 生成 facade。
+- 官网已有 `PrototypePreviewer` 与跨 adapter `DemoMatrix`。
+
+这些证据仍不能回答真实使用者在仓库外会经历什么。当前缺少可复验的人工记录来说明：
+
+- 第一次安装和第一次成功需要多少步骤。
+- 生成组件的实际 API 是否容易发现和组合。
+- 文档是否足以让使用者独立完成任务。
+- 浏览器中的焦点、Portal、键盘、reduced motion 与样式是否成立。
+- 真实工程配置、CSS、SSR、bundle 与第三方依赖是否形成阻力。
+- 一个旧 consumer 升级到下一条 minor release train 时需要修改什么。
+
+同时，官网与 Workspace 是 Proto UI 自身长期维护的真实应用。它们能够提供复杂且持续的狗粮证据，但都位于 monorepo 内，不能替代 registry 安装与独立 lockfile。
+
+相关既有记录：
+
+- `internal/records/2026-07-18-0.2-closure-and-followup-roadmap.zh-CN.md`
+- `internal/records/2026-07-19-react-release-consumer-smoke.zh-CN.md`
+- `internal/records/2026-07-20-0.2-rc-post-publication-priority-audit.zh-CN.md`
+
+## 2）当前判断：建立互补证据组合
+
+不寻找一个同时承担所有目标的“完美外部项目”。当前采用四种互补证据角色：
+
+1. **内部 HEAD 狗粮**：官网与 Workspace 使用当前工作树，尽早暴露集成问题。
+2. **外部 release consumer**：独立项目只消费 registry 中的精确版本，验证真实安装与应用使用。
+3. **跨版本 upgrade lane**：从上一 minor 的冻结 consumer 升级到当前 minor，记录失败和迁移成本。
+4. **专业 authoring canary**：后续用很小的仓库外 styled prototype 试验验证组件物料作者体验。
+
+官网、Workspace、自动 smoke 与外部 Lab 不是替代关系：
+
+- 自动 smoke 证明最低机械闭包。
+- 外部 Lab 证明当前 release 的使用体验。
+- 官网和 Workspace 证明 HEAD 在长期复杂应用中的表现。
+- upgrade lane 证明版本演进成本。
+
+## 3）外部 Lab 仓库形态
+
+建立一个位于 Proto UI GitHub 组织下的公开 Git 仓库。该仓库前期作为可审计工程证据留档，不主动作为官网 Showcase 或营销入口。
+
+仓库采用“单 Git 仓库、多个隔离项目”的形态：
+
+- 不声明 npm/pnpm/yarn workspace。
+- 每个实验拥有独立 `package.json`、lockfile、构建配置和 CI job。
+- 实验之间不得依赖彼此源码或共享 `node_modules`。
+- 根目录只维护 README、证据模板、命名规则与 CI 约定。
+- 不使用 Proto UI monorepo 源码、`workspace:*`、软链接或未发布入口。
+- 每份证据固定 Proto UI 精确版本；dist-tag 只能作为便利验证，不能成为记录身份。
+
+概念结构：
+
+```text
+proto-ui-labs/
+  README.md
+  evidence-template.md
+  experiments/
+    react-shadcn-api-0.2/
+      package.json
+      package-lock.json
+      evidence.md
+    vue-shadcn-api-0.2/
+      package.json
+      pnpm-lock.yaml
+      evidence.md
+    wc-content-site-0.2/
+      package.json
+      package-lock.json
+      evidence.md
+```
+
+具体仓库名称、package manager 选择和目录名可以在创建时调整；独立 lockfile 与无 workspace hoisting 是稳定边界。
+
+## 4）首轮 journey：Shadcn API field study
+
+首轮不急于模拟复杂业务产品，而先系统试用 Proto UI Shadcn 产物的 API 与功能面。原因是当前官网组件 API 文档尚不完整；先建立消费视角的 API 事实，能够直接反哺文档结构，并为后续真实任务流提供可靠组件知识。
+
+首轮以 React + TypeScript + Vite 为起点，使用当时公开的推荐安装方式完成：
+
+- CLI `--help` 与 `init`。
+- 添加 Shadcn Button、Switch、Select、Dialog，并根据试用需要扩展其他 family。
+- 记录生成的 facade、导入入口、anatomy parts 与宿主 API。
+- 观察 props、events、slots/children、methods/exposes、controlled/uncontrolled 与状态更新。
+- 观察组件组合、样式接入、dev server、类型检查与 production build。
+- 在真实浏览器中观察键盘、焦点、Portal、reduced motion、remount 与基础 a11y。
+- 标记 API 存在但难以发现、文档遗漏、API escape 与宿主差异。
+
+首轮主要目标不是把所有组件变成自动测试，而是回答：
+
+1. 一个外部使用者实际拿到了什么 API。
+2. 组件 API 文档应采用怎样的统一结构。
+3. 当前哪些缺口最阻碍第一次成功与正确组合。
+4. 哪些观察应进入官网，哪些应回到 CLI、Prototype、Adapter 或 spec。
+
+## 5）Markdown evidence 基线
+
+前期证据以 Markdown 为主，不要求先建立专用 schema 或测试框架。每个实验至少记录：
+
+- 实验 ID、日期与目标。
+- OS、Node、package manager、宿主框架、bundler 与浏览器版本。
+- Proto UI 精确 release version。
+- 从空目录开始的命令与安装结果。
+- CLI 生成文件与必要的手工修改。
+- 组件/API inventory。
+- 尝试的任务与可观察结果。
+- 类型、构建、运行时、CSS、a11y、SSR 与 bundle 发现。
+- API escape、错误信息与文档缺口。
+- 与 Proto UI issue、record、`P-*`、`T-*`、`M-*`、`HC-*` 的关联。
+- 当前结论、未确认项与后续建议。
+
+当某项行为稳定且需要防回归时，再逐步把 Markdown 观察提升为浏览器测试、conformance fixture 或 Proto UI `T-*` 实体。Markdown 本身不是规范真理之源。
+
+## 6）Journey 与版本的关系
+
+Journey 首先描述稳定的用户任务和可观察结果，不与某一套 API 写法绑定。每个新 minor 应同时保留：
+
+- **Fresh install**：从空项目按当前文档重新完成任务。
+- **Upgrade**：从上一 minor 的冻结 baseline 直接升级，先保存原始失败，再完成迁移。
+
+Lab `main` 只维护当前推荐实现。历史可工作 consumer 通过 Git tag、release artifact 或明确 baseline 保存，不在主分支持续复制多套长期维护目录。
+
+完整版本生命周期见：
+
+- `internal/records/2026-07-20-calendar-release-and-support-lifecycle-direction.zh-CN.md`
+
+## 7）官网狗粮边界
+
+官网是复杂内容站和多 adapter 集成 canary，但不是外部安装证据。当前决定采用“消费者墙”：
+
+- 普通官网/Starlight 应用代码不得直接消费 `@proto.ui/core`、runtime、module、adapter 或 raw prototype library。
+- 应优先消费 CLI 生成的 Web Component 组件和稳定样式入口。
+- prototype/style 基础设施区域由核心维护者负责；当前核心维护者包括项目维护者在内共两人。
+- 外围贡献者无需为了修改官网学习 prototype authoring。
+- Proto UI 暂无合适原型时，外围贡献者可以按正常 Web/Astro 方式完成实现。
+- 只有已经存在合适 prototype，或某个场景具有明确战略价值时，才建立低优先级 `dogfood-candidate` 跟进；不为每段原生交互机械制造迁移债务。
+
+官网以 Astro/Starlight 为基础，优先消费 Web Component。但导航、搜索、语言选择等 SEO/可访问性关键区域不能只服务端输出空 custom element：
+
+1. Astro 应先输出语义 HTML、内容与基础表单/链接。
+2. 无 JavaScript 时关键内容仍可读取和导航。
+3. Web Component adapter 在客户端渐进增强现有 light DOM 或等价语义结构。
+4. hydration/upgrade 前后不得丢失关键内容、accessible name 与 SEO 信息。
+
+如果当前 WC adapter 不能增强既有 SSR 内容，关键区域继续保留原生 Astro，相关缺口进入 adapter/host capability 研究，而不是由官网私有 hack 掩盖。
+
+## 8）Workspace 狗粮边界
+
+Workspace 是持续演进的内部 React 应用，适合验证：
+
+- 长寿命状态与高频更新。
+- 树、图、导航和版本对比。
+- 大数据量、性能与键盘交互。
+- 组件 API 在真实工具中的长期维护成本。
+
+短期不安排纯迁移项目。下一次集中强化 GUI、图结构展示、预览或其他功能时，选择一个真实垂直区域开始消费 Proto UI 生成组件。普通应用代码同样遵守消费者墙；原型迭代由核心维护者承担。
+
+## 9）证据回流
+
+外部发现按以下顺序处理：
+
+```text
+原始观察
+  -> Lab evidence.md
+  -> Proto UI issue / internal record
+  -> 实现或文档修正
+  -> 稳定事实提升到 P/T/M/HC/Adapter profile 或治理文档
+```
+
+不允许 Lab 成为第二套规范真理之源。Lab 可以引用 spec entity ID，但运行时不得依赖 Proto UI 源仓库中的 YAML。
+
+## 10）当前不做
+
+- 不在第一轮前设计完整 Lab 数据库、仪表盘或专用证据 schema。
+- 不要求首轮 API field study 覆盖全部组件和三个宿主。
+- 不把 Lab 宣传为官方生产就绪 Showcase。
+- 不建立统一跨宿主 UI DSL 来隐藏 React、Vue 与 WC 的实际使用差异。
+- 不强迫官网或 Workspace 达成“全部 UI 必须由 Proto UI 生成”的纯度目标。
+- 不把外部人工 journey 设为按时发布某个版本的必要门禁。
+
+## 11）工作顺序
+
+1. 创建公开 Lab Git 仓库与 Markdown evidence 模板。
+2. 建立独立 React + TypeScript + Vite 实验及 lockfile。
+3. 使用当前公开 package/CLI 路径完成 Shadcn API field study，形成改造前基线。
+4. 根据消费结果设计组件 API 文档模板并回填官网优先页面。
+5. 将安装、样式和本地化摩擦交给 CLI/Style Compiler 路线处理。
+6. React 路线稳定后，分别建立 Vue 与 Web Component 独立实验。
+7. 在下一 minor 首次完整执行 fresh install 与 previous-minor upgrade 两条车道。
+8. 外部证据出现后，选择真实阻塞链推进 Module/HC/Adapter 垂直编目。
+
+## 12）Open questions
+
+- Lab 仓库正式名称、CI 平台与默认 package manager。
+- 第一版组件 API 文档模板的字段和中英文投射方式。
+- 哪些 Markdown 观察应提升为 Lab 自动测试，哪些应提升为 Proto UI `T-*`。
+- 官网第一个适合 WC 渐进增强的 Starlight 组件。
+- WC adapter 是否需要一等“增强既有 SSR/light DOM”能力或 profile。
+- 专业 authoring canary 应在 Shadcn 本地化的哪个阶段开始。
+
+## 13）后续提升目标
+
+本记录中的稳定内容后续应分别提升到：
+
+- Lab 仓库 README、evidence template 与贡献约定。
+- Proto UI 官网贡献指南和内部应用 import policy。
+- 真实浏览器 conformance tests 与对应 `T-*` 实体。
+- WC adapter profile、Portal/SSR/host capability 实体。
+- 版本治理与 upgrade workflow。

--- a/internal/records/2026-07-20-local-styled-prototype-and-style-compiler-direction.zh-CN.md
+++ b/internal/records/2026-07-20-local-styled-prototype-and-style-compiler-direction.zh-CN.md
@@ -1,0 +1,301 @@
+# 2026-07-20 本地 Styled Prototype、Lucide 按需安装与 Style Compiler 方向记录
+
+> Internal record. Not normative. 本文记录 Proto UI 对 Base、Shadcn、Lucide、CLI 本地源码写入、Style token authoring grammar 与构建接入的一次阶段性产品/工程判断。稳定语义仍应提升到 D/P/C/T 实体、CLI 治理、公开文档或独立 Style Compiler 契约；本文不替代这些真相源，也不替代上游许可证。
+
+---
+
+## 1）背景
+
+Proto UI 当前公开三类原型库：
+
+- `@proto.ui/prototypes-base`：稳定交互语义与 headless protocol 基础。
+- `@proto.ui/prototypes-shadcn`：在 Base 之上叠加 Shadcn 风格、variant、size 与视觉 rule。
+- `@proto.ui/prototypes-lucide`：从 Lucide SVG 数据生成图标 prototype、render helper、manifest 与按图标 subpath。
+
+`0.2.0-rc.0` 的 CLI 默认安装 Adapter/Prototype package 并生成宿主组件 facade。它还能一次性生成 Shadcn theme、扫描 `tw(...)` 并写出针对 `data-pui-style` 的 CSS，但 styled prototype 仍来自 package，用户不能自然拥有和修改组件物料源码。
+
+此前 CLI 记录已经保留以下长期方向：
+
+```text
+base prototype = stable behavior kernel, npm dependency
+styled prototype = customizable style shell, optional local source
+component facade = adapter composition output, generated
+```
+
+相关既有记录：
+
+- `internal/records/2026-04-23-v0-cli-onboarding-decision.zh-CN.md`
+- `internal/records/2026-07-18-external-prototype-library-governance.zh-CN.md`
+- `internal/records/2026-07-19-prototype-family-import-boundary.zh-CN.md`
+- `internal/records/2026-07-20-0.2-rc-public-truth-and-attribution.zh-CN.md`
+
+## 2）用户角色分层
+
+当前产品策略区分三类主要作者：
+
+1. **应用开发者**：消费 React/Vue/WC 生成组件，使用宿主原生 props、events、children/slots 和样式入口，不要求学习 prototype authoring。
+2. **设计系统/组件物料作者**：维护 styled prototype、tokens、variant、size、anatomy 与视觉 rule；通常是企业体验团队、社区组件库作者或逐渐成为核心贡献者的人。
+3. **协议作者**：定义新的交互对象、状态、事件、context、module/host capability 与跨平台语义。
+
+Base 可以保持 unstyled，但不能要求普通应用开发者仅为改变颜色、尺寸或 variant 就理解完整协议层。普通 Quick Start 应优先提供 styled component；Base 更接近官方语义底座和面向专业用户的 headless 产品。
+
+## 3）当前本地化决定
+
+Shadcn styled prototype 的目标默认消费方式是由 CLI 按组件写入用户本地：
+
+- `proto-ui add <host> shadcn-<component>` 最终应默认创建本地 styled prototype 源码。
+- 首次 `add` 自动生成可运行的物理 CSS 与样式入口，不要求用户再主动执行一次 token 生成命令。
+- Base、Adapter、Runtime、Core、Module 等稳定内核继续使用同一 Proto UI 精确 release version 的 package。
+- CLI 生成的宿主 component facade 改为引用本地 styled prototype。
+- 用户拥有本地 styled 源码；常规编辑不需要回写 Proto UI 仓库。
+- 短期不实现自动覆盖、自动 merge 或“保护”本地文件。
+- 后续 `update` 只提供 upstream diff、来源版本与迁移信息，实际修改交给用户或其 Agent 完成。
+- Shadcn package runtime consumption 是 `0.2` 既有过渡路径，后续应尽早退出推荐消费方式。
+
+已经发布的 `0.2.0-rc.0` 不追溯改写。在哪一条后续 release train 切换默认行为，取决于本地 Button 垂直切片、自动样式接入和迁移说明是否成立。
+
+`@proto.ui/prototypes-shadcn` 后续是否继续作为模板来源、测试基线或公开源码发行物，不等同于是否继续提供 package runtime consumption；两者可在实施阶段分开处理。
+
+## 4）本地源码的编辑分层
+
+CLI 写入的源码应尽量把常规样式定制与高级协议修改分开，使用户可以渐进学习：
+
+```text
+proto-ui/
+  prototypes/
+    shadcn/
+      button/
+        button.proto.ts
+        button.styles.ts
+        index.ts
+  components/
+    react/
+      index.ts
+  styles/
+    theme.css
+    proto-ui.generated.css
+  THIRD_PARTY_NOTICES.md
+  provenance.json
+```
+
+概念边界：
+
+- `theme.css`：品牌色、radius、animation duration 等最常见定制。
+- `*.styles.ts`：utility tokens、variant、size 与有限视觉 recipe。
+- `*.proto.ts`：Base asHook、props、rule、template 与高级协议组合。
+- `components/<host>`：CLI 管理的 facade，不鼓励手改。
+
+具体文件名和拆分粒度仍需用 Shadcn Button 试点验证；“普通样式编辑不必先理解完整 prototype”是稳定目标。
+
+## 5）Proto Style authoring grammar
+
+### 5.1 作者 token 不允许包含 `:`
+
+原型作者直接写入 `tw(...)` 的 Proto Style utility token 不允许包含 `:`。Proto UI 不支持作者写：
+
+```ts
+tw('hover:bg-muted');
+tw('dark:bg-background');
+```
+
+原因不是 CSS 解析限制，而是这种字符串隐含假设了一个通用 `hover`、`dark` 或其他状态来源。Proto UI 要求作者提供正确的语义来源，并通过 rule 等结构清楚表达：
+
+```ts
+def.rule({
+  when: (query) => query.state(hovered).eq(true),
+  intent: (intent) => intent.feedback.style.use(tw('bg-muted')),
+});
+```
+
+Rule 的作用之一是让状态来源和视觉 intent 在运行时成为系统可读结构。Adapter 可以读取 rule 语义并进行优化，从而在 adapter 架构中获得过去常被认为只有静态 compiler 才能完成的优化机会。Proto UI 不通过 style token 字符串推测交互状态机。
+
+### 5.2 作者语法与最终产物相互独立
+
+作者 token 不含 `:`，不表示最终产物永远不含 `:`。当前 Web 优化可能把 rule 条件与基础 utility 降低为类似 Tailwind variant 的内部 selector-qualified key，例如带 `data-[…]:` 或 `dark:` 的序列化产物。
+
+这是预期行为，当前不计划为了让最终产物长得像作者语法而改造。需要明确区分：
+
+- **Author token**：作者声明的、无状态假设的 utility token。
+- **Rule semantics**：状态、props、meta 与其他条件来源。
+- **Internal lowering**：Adapter/Style Compiler 根据宿主能力选择的优化形式。
+- **Host projection**：DOM attribute、内部 style table、原生平台 style handle 或其他系统可读载体。
+
+内部 lowering 是否包含 `:`、是否进入 `data-pui-style`、是否对开发者可见，都不是 authoring grammar 的保证。
+
+最终带 `:` 的产物也不是必然出现：
+
+- 当状态拥有稳定 Web attribute 抓手时，Adapter 可以生成 selector-qualified 静态优化。
+- props 默认不会投射为 DOM attribute；props 驱动条件没有宿主抓手时，可能保留 runtime token application，而不生成带 props 条件的静态 token。
+- 非 Web 宿主不必把 style token 暴露在元素 attribute 上，甚至可以完全使用内部 style table 或平台原生结构。
+- Style token 产物只需要保证系统可读；对开发者可见有时只是调试价值，也可能成为噪音。
+
+因此，不应把 DOM 中的当前 `data-pui-style` 字符串形状提升为跨宿主协议，也不应让作者依赖内部 lowering 的命名。
+
+### 5.3 动态 token 边界
+
+Proto UI 应提供固定、可分析的动态 style 表达方式；作者不得用字符串拼接模拟动态 token：
+
+```ts
+tw(`bg-${color}`);
+```
+
+此类写法应产生诊断，并提示作者改用：
+
+- 有限枚举的 token map。
+- 明确 props/state/meta 来源的 rule。
+- Proto UI 正式提供的动态 token 语法。
+
+具体动态 token grammar 仍需后续契约化，但“不得靠任意字符串构造隐藏语义”是当前边界。
+
+## 6）Style Compiler 方向
+
+将现有 CLI 中的 token 提取和 CSS 生成提升为一个可复用 Style Compiler 核心。CLI 与构建工具只做接入，不复制 grammar 和 emitter：
+
+```text
+local prototype source / package manifest
+                  -> Style Compiler
+                     -> physical CSS
+                     -> diagnostics
+                     -> token/style manifest
+```
+
+当前目标：
+
+- AST 识别从 Proto UI style API 导入的 `tw` binding，而不是任意同名函数。
+- 不把扫描范围绑定到 `.proto.ts` 后缀，因为 token 可以抽到 `*.styles.ts`。
+- 支持有限字符串常量、数组、对象 map 与可判断 import；不执行用户源码。
+- 根据 rule/adapter 能力生成或保留宿主相关 lowering。
+- 生成确定性的物理 CSS 文件，供应用显式 import。
+- 首次 `add` 自动产生可用 CSS。
+- 提供 CLI `build/watch/check` 形态。
+- Vite/Astro 作为第一个自动增量与 HMR 接入；Webpack/Rollup 后续复用同一核心。
+- production build、CI 与 dev 使用同一 grammar 和 emitter。
+- 公开 Style Compiler 若使用 `@proto.ui/*` scope，则在 v0 遵守全局精确版本锁步。
+
+当前 `packages/cli/src/services/proto-style-css.ts` 与 legacy AST scanner 是可行性基础，不直接等同于最终 public compiler。
+
+## 7）诊断策略
+
+未知或不可静态解释的 author token 应产生 error，而不是只写入生成 CSS 注释。
+
+按环境区分阻塞行为：
+
+- Dev/watch：报告带文件、行列和建议的错误；服务可以继续运行并保留最后一次成功 CSS。
+- `styles check`：返回非零状态。
+- Production build：阻塞，避免发布缺少样式的组件。
+
+诊断至少应说明：
+
+- token 与源码位置。
+- 当前支持的 grammar 范围。
+- 是否疑似使用了含 `:` 的状态字符串。
+- 是否疑似动态拼接。
+- 推荐改用 rule、有限 token map 或正式动态语法。
+
+## 8）物理 CSS 与自动接入
+
+当前选择物理 CSS 作为用户可见输出，以便：
+
+- import 顺序显式。
+- SSR、测试与 production build 可检查。
+- 生成 diff 可审计。
+- 不依赖某一个 bundler 的 virtual module 语义。
+
+普通用户不应手动运行额外脚本才能得到第一次正确样式：
+
+- `init/add` 立即生成初始 theme 与 token CSS。
+- Vite/Astro 接入在本地 styled source 改动时自动重新生成并触发 HMR。
+- 非受支持 bundler 至少拥有 CLI watch/build fallback。
+
+插件是直接写物理文件、调用独立 watch service，还是通过其他方式保证文件更新，保留为实施 open question。
+
+## 9）Shadcn/Lucide provenance 与 attribution
+
+源码写入用户项目后，package-local notice 不再足够。CLI 应在本地维护可审计的聚合声明，例如：
+
+- `proto-ui/THIRD_PARTY_NOTICES.md`
+- `proto-ui/provenance.json`
+
+每次 `add` 幂等记录：
+
+- 来源项目与非官方状态。
+- 上游 package/version 或固定 repository revision/path。
+- 许可证与 notice。
+- Proto UI 模板/release version。
+- 写入的本地文件。
+
+Shadcn 与 Lucide 使用不同的上游声明，但复用同一 provenance/notice 管理机制。用户删除或迁移文件时如何回收无用 notice，可以后置；不得因为难以自动回收就省略首次 attribution。
+
+## 10）Lucide 独立安装断口
+
+当前 `@proto.ui/prototypes-lucide` 已有 `./icons/*` subpath，可让 bundler tree-shake 单图标运行时代码，但 npm 安装仍下载整个 package。CLI 也尚无 Lucide add 项。
+
+未来目标是参数化命令，而不是手写几千个 registry 白名单：
+
+```text
+proto-ui add lucide check
+proto-ui add lucide search
+```
+
+CLI 使用版本化 manifest：
+
+1. 校验 icon name。
+2. 取得对应的固定 prototype/render helper 与必要共享文件。
+3. 只写入请求的图标源码和本地 index。
+4. 更新 provenance 与 Lucide/Feather notices。
+5. 重复 add 保持幂等。
+
+如何按图标取得源码仍是独立 open question：
+
+- CLI 携带全量模板会增大 CLI。
+- 安装全量 Lucide prototype package 再复制，不能减少下载体积。
+- 远程 registry 需要可用性、版本固定和 integrity 设计。
+- 从 `lucide-static` 本地生成会引入上游依赖与生成器治理。
+
+Lucide 不阻塞 Shadcn Button 本地化与 Style Compiler 第一切片。
+
+## 11）当前不做
+
+- 不要求普通应用开发者学习完整 prototype authoring 才能改样式。
+- 不直接安装 Tailwind，也不把 Proto Style grammar 委托给 Tailwind 扫描器。
+- 不支持作者用含 `:` 字符串声明状态来源。
+- 不把当前 Web `data-pui-style` 形状提升为跨宿主 authoring contract。
+- 不在构建阶段执行任意 prototype setup 来发现 token。
+- 不在第一版实现自动合并或覆盖用户本地 styled source。
+- 不为每个 Lucide icon 手写 CLI registry entry。
+- 不同时从零开发 Vite、Webpack 与所有 bundler 插件。
+
+## 12）工作顺序
+
+1. 先用当前 `0.2.0-rc.0` package 模式完成外部 React API/样式消费基线。
+2. 抽离 Style Compiler 核心与严格诊断。
+3. 为 Shadcn Button 设计本地 style/prototype 文件结构。
+4. 实现默认本地 add 的最小垂直切片与物理 CSS 初始生成。
+5. 提供 Vite/Astro 自动增量和 HMR 接入。
+6. 在外部 React Lab 比较 package 基线与 local 模式。
+7. 用一个官网 Starlight/Web Component 切片验证消费者墙和样式接入。
+8. 再扩展到复合 Shadcn family、Vue、WC 与 update diff。
+9. 单独设计 Lucide manifest 驱动的按图标安装与来源传输。
+
+## 13）Open questions
+
+- 哪一条 release train 正式把 Shadcn local 设为默认并退出 package runtime 推荐路径。
+- `@proto.ui/prototypes-shadcn` 是否继续作为模板/测试/源码发行物。
+- 本地 `*.styles.ts` 与 `*.proto.ts` 的最小稳定拆分方式。
+- 物理 CSS 是否提交 Git，以及插件、watch service 与 build script 的职责分界。
+- Rule internal lowering 的结构化 manifest 与当前 AST 分析如何分工。
+- 正式动态 token grammar 与有限枚举表达。
+- Update diff 需要保存哪些 base hash、template revision 与本地修改信息。
+- Lucide 单图标源码的版本化传输方式。
+- 非 Web adapter 如何消费相同 visual intent，同时避免把 CSS utility 当成跨平台事实。
+
+## 14）后续提升目标
+
+稳定内容应分别提升到：
+
+- CLI add/update 与本地文件所有权治理。
+- Proto Style authoring grammar 的 D/C/T 实体。
+- Rule → style lowering 与 adapter conformance tests。
+- Shadcn/Lucide P 实体的 distribution/provenance criteria。
+- Style Compiler public API、诊断和 bundler integration 文档。
+- 官网“构建 styled library”和 Quick Start 的消费模式说明。


### PR DESCRIPTION
## Summary

- record the calendar-based minor release train and support lifecycle direction
- record the external consumer evidence Lab and internal dogfood boundaries
- record the local styled prototype, Lucide on-demand install, and Style Compiler direction

## Why

These discussions define the next-stage product and governance direction after the `0.2.0-rc.0` release. Capturing them as non-normative internal records preserves the current reasoning, explicit boundaries, open questions, and promotion targets before any rules move into governance documents, spec entities, CLI contracts, or public documentation.

## Impact

Documentation only. This PR does not change runtime behavior, release automation, registry state, or normative specifications.

## Validation

- `prettier --check` on all three records
- verified all referenced repository Markdown/YAML paths resolve
- `git diff --cached --check`
