### PR TITLE
fix: restore defaults when props are removed

### DIFF
--- a/internal/agent/PROJECT-UNDERSTANDING.zh-CN.md
+++ b/internal/agent/PROJECT-UNDERSTANDING.zh-CN.md
@@ -13,7 +13,7 @@
 | Version entity | [`V-PROTO-UI-0002`](../../spec/versions/V-PROTO-UI-0002.yaml) |
 | 工作区实体数 | 380 |
 | Workspace validation issues | 0 |
-| 工作区快照指纹 | `sha256:8a0d304817d49dc266d652a7182a082e311b080c099ab3c9c2c4b46e6849e496` |
+| 工作区快照指纹 | `sha256:8a571ea821a72011bf08c9ee312221862c9f695f51636f68a733348d20d619ee` |
 | 已发布 release snapshot digest | `sha256:accc1a869e2af1ca082fab4ae853862b9e00b13d021bcf866a03a294043a0bc4` |
 
 工作区快照指纹来自按 ID 排序、按当前版本过滤后的实体内容。它用于判断本文是否与当前检出版本一致；它不替代 `V-*` 中记录的不可变发布快照 digest。
@@ -373,7 +373,7 @@ Contract 是规范性规则的主要载体。下表按 ID 的主领域聚合；�
 | [`C-PROPS-0006`](../../spec/contracts/C-PROPS-0006.yaml) | `active` | Prop declaration descriptors have constrained shape | 8 | 1 | Incoming prop declarations must satisfy the minimal v0 descriptor shape for `type`, `empty`, enum `options`, `range`, and JSON-valued `default`. |
 | [`C-PROPS-0007`](../../spec/contracts/C-PROPS-0007.yaml) | `active` | Prop declaration merge preserves evolution safety | 8 | 1 | Prop declaration merging must reject breaking narrowing and keep widening changes traceable. |
 | [`C-PROPS-0008`](../../spec/contracts/C-PROPS-0008.yaml) | `active` | Runtime props resolution produces a declared-key resolved snapshot | 7 | 1 | `Resolved props` contain all and only declared keys, never expose `undefined`, and use `null` as the canonical empty value. |
-| [`C-PROPS-0009`](../../spec/contracts/C-PROPS-0009.yaml) | `active` | Empty and invalid prop values resolve through deterministic fallback | 8 | 1 | `Missing`, `empty`, and `invalid` prop values resolve through the configured `empty` behavior and fallback chain. |
+| [`C-PROPS-0009`](../../spec/contracts/C-PROPS-0009.yaml) | `active` | Missing, empty, and invalid prop values resolve through state-specific fallback | 9 | 1 | `Missing` input releases prior host values, while provided-empty and invalid values may recover through `prevValid` before defaults. |
 | [`C-PROPS-0010`](../../spec/contracts/C-PROPS-0010.yaml) | `active` | Failed declaration merge must not partially apply | 3 | 1 | Blocking diagnostics during `setup`-time prop declaration merge reject the merge transaction without partially applying changes. |
 | [`C-PROPS-0011`](../../spec/contracts/C-PROPS-0011.yaml) | `active` | Resolved props watchers observe resolved snapshot changes | 10 | 1 | Resolved props watchers fire from declared-key `resolved snapshot` diffs, skip `hydration`, may observe coalesced update windows, and preserve shared registration order. |
 | [`C-PROPS-0012`](../../spec/contracts/C-PROPS-0012.yaml) | `active` | Raw props APIs expose raw input as an escape hatch | 12 | 1 | `Raw props` APIs expose the adapter-supplied pre-resolution props snapshot as an escape hatch without extending portable props semantics. |
@@ -865,7 +865,7 @@ Test 实体连接可寻址 case、被验证的实体准则和仓库中的 execut
 | [`T-PROPS-0003`](../../spec/tests/T-PROPS-0003.yaml) | `active` | Prop declaration descriptor shape tests | 7 | `passing` 2 | `C-PROPS-0006` | `C-PROPS-0003` |
 | [`T-PROPS-0004`](../../spec/tests/T-PROPS-0004.yaml) | `active` | Prop declaration merge safety tests | 10 | `passing` 1 | `C-PROPS-0007`<br>`C-PROPS-0010` | `C-PROPS-0006` |
 | [`T-PROPS-0005`](../../spec/tests/T-PROPS-0005.yaml) | `active` | Resolved props snapshot shape tests | 7 | `active` 1<br>`passing` 8 | `C-PROPS-0008` | `C-PROPS-0003`<br>`C-PROPS-0004`<br>`C-PROPS-0009`<br>`C-CORE-VALUE-0001` |
-| [`T-PROPS-0006`](../../spec/tests/T-PROPS-0006.yaml) | `active` | Empty and fallback resolution tests | 8 | `passing` 3 | `C-PROPS-0009` | `C-PROPS-0004`<br>`C-PROPS-0008`<br>`C-CORE-VALUE-0001` |
+| [`T-PROPS-0006`](../../spec/tests/T-PROPS-0006.yaml) | `active` | Empty and fallback resolution tests | 9 | `passing` 3 | `C-PROPS-0009` | `C-PROPS-0004`<br>`C-PROPS-0008`<br>`C-CORE-VALUE-0001` |
 | [`T-PROPS-0007`](../../spec/tests/T-PROPS-0007.yaml) | `active` | Resolved props watcher tests | 10 | `passing` 3 | `C-PROPS-0011` | `C-PROPS-0008`<br>`C-PROPS-0009` |
 | [`T-PROPS-0008`](../../spec/tests/T-PROPS-0008.yaml) | `active` | Raw props escape hatch tests | 10 | `passing` 5 | `C-PROPS-0012` | `C-PROPS-0003`<br>`C-PROPS-0008`<br>`C-PROPS-0011`<br>`C-PROPS-0013` |
 | [`T-PROPS-0009`](../../spec/tests/T-PROPS-0009.yaml) | `active` | Props watcher run handle binding tests | 5 | `passing` 2 | `C-PROPS-0013` | `C-CORE-SYNTAX-0002`<br>`C-PROPS-0011`<br>`C-PROPS-0012` |

--- a/internal/agent/PROJECT-UNDERSTANDING.zh-CN.md
+++ b/internal/agent/PROJECT-UNDERSTANDING.zh-CN.md
@@ -13,7 +13,7 @@
 | Version entity | [`V-PROTO-UI-0002`](../../spec/versions/V-PROTO-UI-0002.yaml) |
 | 工作区实体数 | 380 |
 | Workspace validation issues | 0 |
-| 工作区快照指纹 | `sha256:8a571ea821a72011bf08c9ee312221862c9f695f51636f68a733348d20d619ee` |
+| 工作区快照指纹 | `sha256:a88e8753d31a211bf7a175f150eaceb8d2a61aa78ef0d12dd62c3aa3bb476ff3` |
 | 已发布 release snapshot digest | `sha256:accc1a869e2af1ca082fab4ae853862b9e00b13d021bcf866a03a294043a0bc4` |
 
 工作区快照指纹来自按 ID 排序、按当前版本过滤后的实体内容。它用于判断本文是否与当前检出版本一致；它不替代 `V-*` 中记录的不可变发布快照 digest。

--- a/internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
+++ b/internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
@@ -102,13 +102,23 @@ Props 值必须是 **JSON value**，即 JSON 能够表达的可移植数据：
 
 #### empty=fallback（默认）
 
-- missing / provided-empty / invalid → fallback 链
+- missing → 默认值 fallback 链
+- provided-empty / invalid → 可恢复 fallback 链
 
 #### empty=error
 
-- missing / provided-empty / invalid → 必须找到**非空合法 fallback**，否则抛错
+- missing → 必须找到**非空合法 default**，否则抛错
+- provided-empty / invalid → 必须找到**非空合法 fallback**，否则抛错
 
 ### 5.3 Fallback 链（顺序）
+
+`missing` 输入：
+
+1. setDefaults（后设优先）
+2. decl.default
+3. null（仅在 empty 非 error 时允许）
+
+provided-empty 或 invalid 输入进入 fallback 时：
 
 1. prevValid（上一轮非空合法值）
 2. setDefaults（后设优先）
@@ -120,7 +130,7 @@ Props 值必须是 **JSON value**，即 JSON 能够表达的可移植数据：
 - 只记录 **非空合法值**
 - `null` 不会写入 prevValid
 
-> 注意：missing 情况是否允许使用 prevValid，需要在实现中**与本契约对齐**。
+移除 prop 表示宿主撤回此前的 provided value；missing 不得使用 `prevValid`。
 
 ---
 

--- a/internal/contracts/props/base-text/02.resolve-fallback.v0.zh-CN.md
+++ b/internal/contracts/props/base-text/02.resolve-fallback.v0.zh-CN.md
@@ -50,22 +50,32 @@
 
 ### 4.2 empty=fallback（默认）
 
-- missing / provided-empty / invalid → fallback 链
+- missing → 默认值 fallback 链
+- provided-empty / invalid → 可恢复 fallback 链
 
 ### 4.3 empty=error
 
-- missing / provided-empty / invalid → 必须找到**非空合法 fallback**，否则抛错
+- missing → 必须找到**非空合法 default**，否则抛错
+- provided-empty / invalid → 必须找到**非空合法 fallback**，否则抛错
 
 ---
 
 ## 5. Fallback 链（顺序）
+
+`missing` 输入：
+
+1. setDefaults（后设优先）
+2. decl.default
+3. null（仅在 empty 非 error 时允许）
+
+provided-empty 或 invalid 输入进入 fallback 时：
 
 1. prevValid（上一轮非空合法值）
 2. setDefaults（后设优先）
 3. decl.default
 4. null（仅在 empty 非 error 时允许）
 
-> **确认点**：missing 场景是否允许使用 prevValid？当前实现中 missing 不使用 prevValid；若要维持现状，需要在实现中明确对齐。
+移除 prop 表示宿主撤回此前的 provided value；`prevValid` 只用于仍然 provided、但本轮为空或非法的输入恢复。
 
 ---
 

--- a/internal/contracts/props/resolve-fallback.v0.md
+++ b/internal/contracts/props/resolve-fallback.v0.md
@@ -53,20 +53,32 @@ For each declared key:
 
 ### 4.2 empty=fallback (default)
 
-- missing / provided-empty / invalid → fallback chain
+- missing → defaults-only fallback chain
+- provided-empty / invalid → recoverable fallback chain
 
 ### 4.3 empty=error
 
-- missing / provided-empty / invalid → must find a **non-empty valid fallback**, otherwise throw
+- missing → must find a **non-empty valid default**, otherwise throw
+- provided-empty / invalid → must find a **non-empty valid fallback**, otherwise throw
 
 ---
 
-## 5. Fallback Chain (order)
+## 5. Fallback Chains (order)
+
+For `missing` input:
+
+1. setDefaults (latest-first)
+2. decl.default
+3. null (only if empty != error)
+
+For provided-empty or invalid input entering fallback:
 
 1. prevValid (last non-empty valid value)
 2. setDefaults (latest-first)
 3. decl.default
 4. null (only if empty != error)
+
+Omitting a prop releases the previous host-provided value. `prevValid` is only a recovery candidate for a key that remains provided but is empty or invalid.
 
 ---
 

--- a/internal/releases/0.2.0-rc.2/release-notes.md
+++ b/internal/releases/0.2.0-rc.2/release-notes.md
@@ -1,0 +1,18 @@
+# Proto UI 0.2.0-rc.2
+
+> Unpublished draft. This candidate continues collecting findings from external `0.2.0-rc.1` trials; its complete release train has not opened yet, so current installation and trial instructions must remain pinned to the published `0.2.0-rc.1`.
+
+## Fixed
+
+### Prop removal restores defaults
+
+- Props resolution now treats `missing` as the host withdrawing that input. When a valid provided value becomes an omitted key, resolution no longer retains the withdrawn value through `prevValid`; it returns to `setDefaults`, declaration `default`, or canonical `null`.
+- `prevValid` remains available when a key is still provided but its current value is empty or invalid, keeping invalid-input recovery separate from prop-removal semantics.
+- React, Vue, and Web Component hosts share this behavior through the Props Kernel without adapter-specific exceptions.
+- Removing `disabled` from a React Shadcn Button restores the enabled state, while removing `variant` or `size` restores the corresponding default tokens.
+- Cross-adapter resolved-snapshot conformance, Base Button behavior tests, and Shadcn Button visual-token tests cover provided-to-missing transitions.
+
+## Still under validation
+
+- Additional installation, runtime, CSS, accessibility, bundle, and API findings from post-publication `0.2.0-rc.1` trials.
+- The complete `0.2.0-rc.2` release train will prepare its version entity, package versions, BOM, spec snapshot, and publication gates after the trial findings are collected together.

--- a/internal/releases/0.2.0-rc.2/release-notes.md
+++ b/internal/releases/0.2.0-rc.2/release-notes.md
@@ -10,6 +10,7 @@
 - `prevValid` remains available when a key is still provided but its current value is empty or invalid, keeping invalid-input recovery separate from prop-removal semantics.
 - React, Vue, and Web Component hosts share this behavior through the Props Kernel without adapter-specific exceptions.
 - Removing `disabled` from a React Shadcn Button restores the enabled state, while removing `variant` or `size` restores the corresponding default tokens.
+- Removing Lucide Icon visual props such as `size`, `strokeWidth`, or `stroke` restores protocol defaults such as 24, 2, and currentColor.
 - Cross-adapter resolved-snapshot conformance, Base Button behavior tests, and Shadcn Button visual-token tests cover provided-to-missing transitions.
 
 ## Still under validation

--- a/internal/releases/0.2.0-rc.2/release-notes.zh-CN.md
+++ b/internal/releases/0.2.0-rc.2/release-notes.zh-CN.md
@@ -10,6 +10,7 @@
 - `prevValid` 仍用于恢复“key 仍被提供、但本轮值为空或无效”的输入，避免删除语义与非法输入容错相互混淆。
 - React、Vue 与 Web Component 共享这一语义；修正位于 Props Kernel，不需要 Adapter 层的宿主特例。
 - React Shadcn Button 删除 `disabled` 后会恢复为 enabled，删除 `variant` 或 `size` 后会恢复对应 default tokens。
+- Lucide Icon 删除 `size`、`strokeWidth`、`stroke` 等 visual props 后会恢复 24、2、currentColor 等协议默认值。
 - 跨 Adapter resolved-snapshot 合约、Base Button 行为测试与 Shadcn Button visual-token 测试覆盖了 provided-to-missing 转换。
 
 ## 仍在验证

--- a/internal/releases/0.2.0-rc.2/release-notes.zh-CN.md
+++ b/internal/releases/0.2.0-rc.2/release-notes.zh-CN.md
@@ -1,0 +1,18 @@
+# Proto UI 0.2.0-rc.2
+
+> 未发布草稿。该候选版本继续收集 `0.2.0-rc.1` 仓库外人工试用发现；完整 release train 尚未开启，当前安装与试用仍应固定到已发布的 `0.2.0-rc.1`。
+
+## 已修正
+
+### 移除 props 后恢复默认值
+
+- Props resolution 现在会把 `missing` 解释为宿主撤回该输入：从合法 provided value 变为 omitted key 时，不再通过 `prevValid` 保留已撤回的值，而是重新采用 `setDefaults`、声明 `default` 或 canonical `null`。
+- `prevValid` 仍用于恢复“key 仍被提供、但本轮值为空或无效”的输入，避免删除语义与非法输入容错相互混淆。
+- React、Vue 与 Web Component 共享这一语义；修正位于 Props Kernel，不需要 Adapter 层的宿主特例。
+- React Shadcn Button 删除 `disabled` 后会恢复为 enabled，删除 `variant` 或 `size` 后会恢复对应 default tokens。
+- 跨 Adapter resolved-snapshot 合约、Base Button 行为测试与 Shadcn Button visual-token 测试覆盖了 provided-to-missing 转换。
+
+## 仍在验证
+
+- `0.2.0-rc.1` 后续人工试用发现的安装、运行时、CSS、a11y、bundle 与 API 问题。
+- 完整 `0.2.0-rc.2` release train 的版本实体、package 版本、BOM、spec snapshot 与发布门禁将在统一收集问题后单独准备。

--- a/packages/adapters/base/test-utils/resolved-snapshot-shape.ts
+++ b/packages/adapters/base/test-utils/resolved-snapshot-shape.ts
@@ -172,7 +172,7 @@ export function describeAdapterResolvedSnapshotShapeConformance(
 
         expect(observation?.resolved).toEqual({
           valid: 42,
-          missing: 'initial',
+          missing: 'missing-fallback',
           empty: null,
           invalid: false,
         });

--- a/packages/adapters/react/test/rule-props-style.test.ts
+++ b/packages/adapters/react/test/rule-props-style.test.ts
@@ -30,7 +30,7 @@ describe('adapter-react: rule props -> style', () => {
     expect(mounted.root?.classList.contains('opacity-50')).toBe(false);
     expect(mounted.root?.getAttribute('data-pui-style')).toBe('opacity-50');
 
-    mounted.update({ active: false });
+    mounted.update({});
     expect(mounted.root?.classList.contains('opacity-50')).toBe(false);
     expect(mounted.root?.hasAttribute('data-pui-style')).toBe(false);
 

--- a/packages/modules/props/src/kernel/kernel.ts
+++ b/packages/modules/props/src/kernel/kernel.ts
@@ -224,7 +224,8 @@ export class PropsKernel<P extends PropsBaseType> {
       const isProvidedEmpty = provided && (rawVal === null || rawVal === undefined);
       const isMissing = !provided;
 
-      // 1) Missing => fallback chain (may include prevValid)
+      // 1) Missing => defaults only. Omitting a key releases the previous
+      // host-provided value and must not revive it through prevValid.
       if (isMissing) {
         const requireNonEmpty = strict && eb === 'error';
         const fb = this.pickFallbackMissingOnly(k, decl, requireNonEmpty);
@@ -373,12 +374,6 @@ export class PropsKernel<P extends PropsBaseType> {
       if (!valid.ok) return { ok: false, usedDefault, isNonEmpty: false };
       return { ok: true, value: valid.value, usedDefault, isNonEmpty: true };
     };
-
-    if (hasOwn(this.prevValid, key)) {
-      const v = (this.prevValid as any)[key];
-      const r = tryTake(v, false);
-      if (r.ok) return r;
-    }
 
     // defaultStack latest-first
     for (const layer of this.defaultStack) {

--- a/packages/modules/props/test/contract/fallback-resolution.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/fallback-resolution.v0.contract.test.ts
@@ -16,6 +16,23 @@ describe('props: fallback resolution (T-PROPS-0006)', () => {
     expect(pm.get()).toEqual({ value: 1 });
   });
 
+  it('T-PROPS-0006-CASE-PROVIDED-TO-MISSING-RESET / C-PROPS-0009-I: missing input releases prevValid and restores defaults', () => {
+    const pm = new PropsKernel<{ value: number }>();
+
+    pm.define({
+      value: { type: 'number', default: 1 },
+    });
+    pm.setDefaults({ value: 9 });
+
+    pm.applyRaw({ value: 2 });
+    expect(pm.get()).toEqual({ value: 2 });
+
+    const { report } = pm.applyRaw({});
+    expect(pm.isProvided('value')).toBe(false);
+    expect(pm.get()).toEqual({ value: 9 });
+    expect(report?.changedAllResolved).toEqual(['value']);
+  });
+
   it('T-PROPS-0006-CASE-EMPTY-ACCEPT / C-PROPS-0009-B: empty accept resolves to null and does not update prevValid', () => {
     const pm = new PropsKernel<{ value: number | null }>();
 
@@ -30,7 +47,7 @@ describe('props: fallback resolution (T-PROPS-0006)', () => {
     expect(pm.get()).toEqual({ value: null });
 
     pm.applyRaw({});
-    expect(pm.get()).toEqual({ value: 2 });
+    expect(pm.get()).toEqual({ value: 1 });
   });
 
   it('T-PROPS-0006-CASE-EMPTY-FALLBACK / C-PROPS-0009-C: empty fallback enters fallback chain', () => {
@@ -59,21 +76,22 @@ describe('props: fallback resolution (T-PROPS-0006)', () => {
     expect(pm.get()).toEqual({ value: 1 });
   });
 
-  it('T-PROPS-0006-CASE-FALLBACK-ORDER / C-PROPS-0009-E: fallback order is prevValid, setDefaults, declaration default, then null', () => {
-    const prevValid = new PropsKernel<{ value: number }>();
-    prevValid.define({
+  it('T-PROPS-0006-CASE-FALLBACK-ORDER / C-PROPS-0009-E: fallback order depends on whether input is missing or unusable', () => {
+    const providedUnusable = new PropsKernel<{ value: number }>();
+    providedUnusable.define({
       value: { type: 'number', default: 1 },
     });
-    prevValid.setDefaults({ value: 9 });
-    prevValid.applyRaw({ value: 2 });
-    prevValid.applyRaw({});
-    expect(prevValid.get()).toEqual({ value: 2 });
+    providedUnusable.setDefaults({ value: 9 });
+    providedUnusable.applyRaw({ value: 2 });
+    providedUnusable.applyRaw({ value: null });
+    expect(providedUnusable.get()).toEqual({ value: 2 });
 
     const setDefaults = new PropsKernel<{ value: number }>();
     setDefaults.define({
       value: { type: 'number', default: 1 },
     });
     setDefaults.setDefaults({ value: 9 });
+    setDefaults.applyRaw({ value: 2 });
     setDefaults.applyRaw({});
     expect(setDefaults.get()).toEqual({ value: 9 });
 
@@ -118,9 +136,10 @@ describe('props: fallback resolution (T-PROPS-0006)', () => {
       value: { type: 'number', empty: 'error' },
     });
     withPrevValid.applyRaw({ value: 2 });
-    withPrevValid.applyRaw({});
+    withPrevValid.applyRaw({ value: null });
 
     expect(withPrevValid.get()).toEqual({ value: 2 });
+    expect(() => withPrevValid.applyRaw({})).toThrow(/empty="error"|missing/i);
   });
 
   it('T-PROPS-0006-CASE-PREV-VALID-NON-EMPTY / C-PROPS-0009-H: prevValid stores only non-empty valid values', () => {

--- a/packages/modules/props/test/contract/resolve-fallback.v0.contract.test.ts
+++ b/packages/modules/props/test/contract/resolve-fallback.v0.contract.test.ts
@@ -72,7 +72,7 @@ describe('props: resolve & fallback semantics (v0)', () => {
     expect(pm.get().a).toBe(10);
   });
 
-  it('PROP-V0-1300: empty="fallback" fallback chain order: prevValid > setDefaults > decl.default > null', () => {
+  it('PROP-V0-1300: fallback order distinguishes missing from provided-unusable input', () => {
     type P = { a: number };
     const pm = new PropsKernel<P>();
 
@@ -87,6 +87,10 @@ describe('props: resolve & fallback semantics (v0)', () => {
     // provided-empty => prevValid wins
     pm.applyRaw({ a: null } as any);
     expect(pm.get().a).toBe(2);
+
+    // missing releases prevValid and uses the declaration default
+    pm.applyRaw({} as any);
+    expect(pm.get().a).toBe(1);
 
     // clear situation: new kernel to test setDefaults > decl.default > null
     const pm2 = new PropsKernel<P>();
@@ -109,7 +113,7 @@ describe('props: resolve & fallback semantics (v0)', () => {
     expect(pm4.get().a).toBeNull();
   });
 
-  it('PROP-V0-1400: empty="error" throws when no non-empty fallback exists; but uses prevValid when available', () => {
+  it('PROP-V0-1400: empty="error" uses prevValid only for provided-unusable input', () => {
     type P = { a: number };
     const pm = new PropsKernel<P>();
 
@@ -130,6 +134,9 @@ describe('props: resolve & fallback semantics (v0)', () => {
 
     pm.applyRaw({ a: null } as any);
     expect(pm.get().a).toBe(2);
+
+    // missing never reuses prevValid
+    expect(() => pm.applyRaw({} as any)).toThrow(/empty="error"|missing/i);
   });
 
   it('PROP-V0-1500: prevValid stores only non-null values (accept-null MUST NOT write prevValid)', () => {

--- a/packages/prototypes/base/test/as-button.test.ts
+++ b/packages/prototypes/base/test/as-button.test.ts
@@ -133,16 +133,21 @@ describe('prototypes/base: asButton', () => {
       focusable: false,
     });
 
+    controller.applyRawProps({});
+    expect(ctx.getA11ySnapshot()?.states.disabled).toBe(false);
+    expect(exposes.disabled.get()).toBe(false);
+    expect(focusPort?.getFocusableConfig().disabled).toBe(false);
+
     ctx.rootTarget.dispatchEvent(new CustomEvent('pointer.enter'));
     ctx.rootTarget.dispatchEvent(new CustomEvent('host:focus'));
     ctx.rootTarget.dispatchEvent(new CustomEvent('pointer.down'));
     ctx.rootTarget.dispatchEvent(new CustomEvent('press.commit'));
 
-    expect(exposes.hovered.get()).toBe(false);
-    expect(exposes.focused.get()).toBe(false);
+    expect(exposes.hovered.get()).toBe(true);
+    expect(exposes.focused.get()).toBe(true);
     expect(exposes.focusVisible.get()).toBe(false);
     expect(exposes.pressed.get()).toBe(false);
-    expect(ctx.emitted).toEqual(['click']);
+    expect(ctx.emitted).toEqual(['click', 'click']);
   });
 
   it('prevents Space default action when focused', () => {

--- a/packages/prototypes/lucide/test/icon.test.ts
+++ b/packages/prototypes/lucide/test/icon.test.ts
@@ -100,9 +100,9 @@ describe('prototypes/lucide: icon', () => {
 
     const nextRoot = committed as any;
     expect(nextRoot.tag).toBe('svg');
-    expect(nextRoot.props.width).toBe(18);
-    expect(nextRoot.props.strokeWidth).toBe(1.25);
-    expect(nextRoot.props.stroke).toBe('red');
+    expect(nextRoot.props.width).toBe(24);
+    expect(nextRoot.props.strokeWidth).toBe(2);
+    expect(nextRoot.props.stroke).toBe('currentColor');
     expect(nextRoot.children?.tag).toBe('path');
   });
 

--- a/packages/prototypes/shadcn/test/button.test.ts
+++ b/packages/prototypes/shadcn/test/button.test.ts
@@ -71,6 +71,14 @@ describe('prototypes/shadcn: button', () => {
     controller.applyRawProps(rawProps as any);
     tokens = controller.getRuleStyleTokens();
     expect(tokens).toContain('border-border');
+
+    rawProps = {};
+    controller.applyRawProps(rawProps as any);
+    tokens = controller.getRuleStyleTokens();
+    expect(tokens).toContain('bg-primary');
+    expect(tokens).not.toContain('border-border');
+    expect(tokens).toContain('h-8');
+    expect(tokens).not.toContain('opacity-50');
   });
 
   it('derives hover/focus/press style rules from asButton state handles', () => {

--- a/spec/contracts/C-PROPS-0009.yaml
+++ b/spec/contracts/C-PROPS-0009.yaml
@@ -1,23 +1,23 @@
 id: C-PROPS-0009
 type: contract
-title: Empty and invalid prop values resolve through deterministic fallback
+title: Missing, empty, and invalid prop values resolve through state-specific fallback
 status: active
 since: 0.1.0
-summary: '`Missing`, `empty`, and `invalid` prop values resolve through the configured `empty` behavior and fallback chain.'
+summary: '`Missing` input releases prior host values, while provided-empty and invalid values may recover through `prevValid` before defaults.'
 statement:
   zh-CN: >-
-    当某个 prop key 的输入为 `missing`、`provided-empty` 或 `invalid` 时，Props resolution 必须根据该 key 的 `empty` 行为与 fallback 链产生确定的 resolved value。默认 `empty: "fallback"` 行为允许 fallback 链在没有可用非空候选值时最终产出 `null`；这表示 canonical empty result，而不是 typed prop 接受了 `null` 作为非空合法值。只有 `empty: "error"` 要求在没有非空 fallback 时失败。
+    当某个 prop key 的输入为 `missing`、`provided-empty` 或 `invalid` 时，Props resolution 必须根据输入状态、该 key 的 `empty` 行为与对应 fallback 链产生确定的 resolved value。`missing` 表示宿主撤回该 key，不得复用 `prevValid`，而是从 `setDefaults`、声明 `default` 与 canonical `null` 中解析；`provided-empty` 或 `invalid` 进入 fallback 时可以先复用 `prevValid`。只有 `empty: "error"` 要求对应 fallback 链必须找到非空合法结果。
 
 
   en: >-
-    When a prop key is `missing`, `provided-empty`, or `invalid`, Props resolution must produce a deterministic resolved value according to that key's `empty` behavior and fallback chain. The default `empty: "fallback"` behavior permits the fallback chain to produce `null` when no usable non-empty candidate exists; this is a canonical empty result, not typed acceptance of `null` as a non-empty valid value. Only `empty: "error"` requires failure when no non-empty fallback exists.
+    When a prop key is `missing`, `provided-empty`, or `invalid`, Props resolution must produce a deterministic resolved value according to the input state, that key's `empty` behavior, and the corresponding fallback chain. `Missing` means the host withdrew that key and must not reuse `prevValid`; it resolves from `setDefaults`, declaration `default`, and canonical `null`. `Provided-empty` or `invalid` input entering fallback may reuse `prevValid` first. Only `empty: "error"` requires the applicable fallback chain to find a non-empty valid result.
 
 
 criteria:
   - id: C-PROPS-0009-A
     text:
-      zh-CN: '`missing` 输入必须进入 fallback 链，而不是让该 key 从 `resolved snapshot` 中消失。'
-      en: '`Missing` input must enter the fallback chain instead of removing that key from the `resolved snapshot`.'
+      zh-CN: '`missing` 输入必须进入不含 `prevValid` 的默认值 fallback 链，而不是让该 key 从 `resolved snapshot` 中消失或保留已撤回的宿主值。'
+      en: '`Missing` input must enter the defaults-only fallback chain without `prevValid`, rather than removing the key from the `resolved snapshot` or retaining a withdrawn host value.'
   - id: C-PROPS-0009-B
     text:
       zh-CN: '`provided-empty` 输入在 `empty: "accept"` 时必须 resolve 为 `null`，且不得写入 `prevValid`。'
@@ -32,8 +32,8 @@ criteria:
       en: '`Provided-non-empty invalid` input must enter the fallback chain; it is not `provided-empty` and must not be directly accepted as `null` by `empty: "accept"`.'
   - id: C-PROPS-0009-E
     text:
-      zh-CN: 'fallback 链的候选顺序必须是 `prevValid`、`setDefaults`、声明中的 `default`、最后的 `null`。'
-      en: 'The fallback candidate order must be `prevValid`, `setDefaults`, declaration `default`, then final `null`.'
+      zh-CN: '`missing` 的 fallback 候选顺序必须是 `setDefaults`、声明中的 `default`、最后的 `null`；`provided-empty` 或 `invalid` 进入 fallback 时，候选顺序必须是 `prevValid`、`setDefaults`、声明中的 `default`、最后的 `null`。'
+      en: 'For `missing`, the fallback candidate order must be `setDefaults`, declaration `default`, then final `null`; when `provided-empty` or `invalid` enters fallback, the order must be `prevValid`, `setDefaults`, declaration `default`, then final `null`.'
   - id: C-PROPS-0009-F
     text:
       zh-CN: 'fallback 链最终落到 `null` 是允许的 canonical empty result；它不表示该 key 的声明类型把 `null` 视为非空合法输入。'
@@ -49,6 +49,10 @@ criteria:
     text:
       zh-CN: '`prevValid` 只记录非空且通过该 key 声明校验的值；`null` 不得成为 `prevValid`。'
       en: "`prevValid` records only non-empty values that pass that key's declaration validation; `null` must not become `prevValid`."
+  - id: C-PROPS-0009-I
+    text:
+      zh-CN: 当 raw props 从某个合法 provided value 更新为 `missing` 时，resolved value 必须释放该 provided value 并重新采用 `setDefaults`、声明 `default` 或 canonical `null`；若 resolved value 因此变化，必须产生可供相应 resolved watcher 消费的 change report。
+      en: When raw props update from a valid provided value to `missing`, the resolved value must release that provided value and return to `setDefaults`, declaration `default`, or canonical `null`; when this changes the resolved value, it must produce a change report consumable by the corresponding resolved watcher.
 sources:
   - path: internal/contracts/props/base-text/00.props-contract.v0.zh-CN.md
     sections:

--- a/spec/prototypes/P-BASE-BUTTON.yaml
+++ b/spec/prototypes/P-BASE-BUTTON.yaml
@@ -57,11 +57,12 @@ criteria:
         - C-PROPS-0003
   - id: P-BASE-BUTTON-PROP-DISABLED-CONTROLLED
     text:
-      zh-CN: 当 App Maker 更新 `disabled` props input 时，Button 必须同步自身 disabled state 与相关交互能力。
-      en: When the App Maker updates the `disabled` props input, Button must synchronize its disabled state and related interaction capabilities.
+      zh-CN: 当 App Maker 更新 `disabled` props input 时，Button 必须同步自身 disabled state 与相关交互能力；移除该 prop 必须释放此前的 provided value 并恢复默认 `false`。
+      en: When the App Maker updates the `disabled` props input, Button must synchronize its disabled state and related interaction capabilities; removing the prop must release the prior provided value and restore the default `false`.
     dependsOn:
       contracts:
         - C-PROPS-0001
+        - C-PROPS-0009
         - C-STATE-INTERACTION-0001
         - C-AS-FOCUSABLE-0001
   - id: P-BASE-BUTTON-DISABLED-EXPOSE

--- a/spec/prototypes/P-LUCIDE-ICON.yaml
+++ b/spec/prototypes/P-LUCIDE-ICON.yaml
@@ -32,10 +32,10 @@ criteria:
       en: Generated output must identify `lucide-static/icon-nodes.json` as its source, and the manifest must expose exact upstream package, version, and license metadata; updating the upstream version requires regeneration, verification, and a recorded P revision.
   - id: P-LUCIDE-ICON-NAME-BASED-PROPS
     text:
-      zh-CN: name-based entry 必须接受 `name`、`size`、`strokeWidth`、`stroke` 与 `fill`；默认值分别为 circle、24、2、currentColor 与 none，无效 name 必须回落到 circle。
-      en: The name-based entry must accept `name`, `size`, `strokeWidth`, `stroke`, and `fill` with defaults of circle, 24, 2, currentColor, and none respectively, and an invalid name must fall back to circle.
+      zh-CN: name-based entry 必须接受 `name`、`size`、`strokeWidth`、`stroke` 与 `fill`；默认值分别为 circle、24、2、currentColor 与 none，无效 name 必须回落到 circle，移除已提供的 visual prop 必须恢复其协议默认值。
+      en: The name-based entry must accept `name`, `size`, `strokeWidth`, `stroke`, and `fill` with defaults of circle, 24, 2, currentColor, and none respectively; an invalid name must fall back to circle, and removing a provided visual prop must restore its protocol default.
     dependsOn:
-      contracts: [C-PROPS-0001, C-PROPS-0003]
+      contracts: [C-PROPS-0001, C-PROPS-0003, C-PROPS-0009]
   - id: P-LUCIDE-ICON-FIXED-PROPS
     text:
       zh-CN: fixed-glyph entry 不接受可变 name，但必须接受与 name-based entry 一致的 `size`、`strokeWidth`、`stroke` 与 `fill` visual props。

--- a/spec/prototypes/P-SHADCN-BUTTON.yaml
+++ b/spec/prototypes/P-SHADCN-BUTTON.yaml
@@ -45,16 +45,16 @@ criteria:
       contracts: [C-CORE-SYNTAX-0003, C-TEMPLATE-0001]
   - id: P-SHADCN-BUTTON-VARIANT-PROP
     text:
-      zh-CN: 当前 passing API 必须提供 `variant`，可选 default、destructive、outline、secondary、ghost、link，默认 default；每个值必须投射对应的 shadcn-style surface tokens。
-      en: The current passing API must provide `variant` with default, destructive, outline, secondary, ghost, and link options and a default of default; each value must project its corresponding shadcn-style surface tokens.
+      zh-CN: 当前 passing API 必须提供 `variant`，可选 default、destructive、outline、secondary、ghost、link，默认 default；每个值必须投射对应的 shadcn-style surface tokens，移除该 prop 必须恢复 default tokens。
+      en: The current passing API must provide `variant` with default, destructive, outline, secondary, ghost, and link options and a default of default; each value must project its corresponding shadcn-style surface tokens, and removing the prop must restore the default tokens.
     dependsOn:
-      contracts: [C-PROPS-0001, C-PROPS-0003, C-RULE-INTENT-FEEDBACK-STYLE-0001]
+      contracts: [C-PROPS-0001, C-PROPS-0003, C-PROPS-0009, C-RULE-INTENT-FEEDBACK-STYLE-0001]
   - id: P-SHADCN-BUTTON-SIZE-PROP
     text:
-      zh-CN: 当前 passing API 必须提供 `size`，可选 default、sm、lg、icon，默认 default；每个值必须投射对应的尺寸与间距 tokens。
-      en: The current passing API must provide `size` with default, sm, lg, and icon options and a default of default; each value must project its corresponding size and spacing tokens.
+      zh-CN: 当前 passing API 必须提供 `size`，可选 default、sm、lg、icon，默认 default；每个值必须投射对应的尺寸与间距 tokens，移除该 prop 必须恢复 default tokens。
+      en: The current passing API must provide `size` with default, sm, lg, and icon options and a default of default; each value must project its corresponding size and spacing tokens, and removing the prop must restore the default tokens.
     dependsOn:
-      contracts: [C-PROPS-0001, C-PROPS-0003, C-RULE-INTENT-FEEDBACK-STYLE-0001]
+      contracts: [C-PROPS-0001, C-PROPS-0003, C-PROPS-0009, C-RULE-INTENT-FEEDBACK-STYLE-0001]
   - id: P-SHADCN-BUTTON-INTERACTION-STYLES
     text:
       zh-CN: Shadcn Button 必须从 inherited hovered、focusVisible、pressed 与 disabled state 派生 hover、focus ring、press offset 与 disabled visual rules；视觉 rule 不得成为另一套交互状态真相。

--- a/spec/tests/T-BASE-BUTTON-0001.yaml
+++ b/spec/tests/T-BASE-BUTTON-0001.yaml
@@ -6,14 +6,14 @@ since: 0.1.0
 summary: Contract test coverage for the Base Button prototype protocol and its asButton authoring entry.
 cases:
   - id: T-BASE-BUTTON-0001-CASE-DISABLED-CONTROLLED
-    title: disabled props synchronize disabled exposure and interaction capabilities
+    title: disabled props synchronize state and omission restores the enabled default
     covers:
       - P-BASE-BUTTON-PROP-DISABLED
       - P-BASE-BUTTON-PROP-DISABLED-CONTROLLED
       - P-BASE-BUTTON-DISABLED-EXPOSE
       - P-BASE-BUTTON-DISABLED-CLEAR-TRANSIENT
       - P-BASE-BUTTON-DISABLED-REJECT-FOCUS
-    expectation: disabled-props-synchronize-button-state-and-capabilities
+    expectation: disabled-props-synchronize-and-removal-restores-enabled-default
   - id: T-BASE-BUTTON-0001-CASE-INTERACTION-STATES
     title: pointer, focus, and press interactions are exposed as button state
     covers:

--- a/spec/tests/T-LUCIDE-ICON-0001.yaml
+++ b/spec/tests/T-LUCIDE-ICON-0001.yaml
@@ -17,13 +17,13 @@ cases:
       - P-LUCIDE-ICON-UPSTREAM-PROVENANCE
     expectation: lucide-manifest-records-exact-upstream-generation-baseline
   - id: T-LUCIDE-ICON-0001-CASE-PROPS-AND-SVG
-    title: name-based and fixed entries normalize visual props and project Lucide SVG structure
+    title: name-based and fixed entries normalize visual props, restore omitted defaults, and project Lucide SVG structure
     covers:
       - P-LUCIDE-ICON-NAME-BASED-PROPS
       - P-LUCIDE-ICON-FIXED-PROPS
       - P-LUCIDE-ICON-SVG-PROJECTION
       - P-LUCIDE-ICON-VISUAL-NORMALIZATION
-    expectation: lucide-visual-props-project-normalized-svg
+    expectation: lucide-visual-props-restore-defaults-and-project-normalized-svg
   - id: T-LUCIDE-ICON-0001-CASE-DISTRIBUTION
     title: manifest snippets static modules and dynamic loaders stay consistent
     covers:

--- a/spec/tests/T-PROPS-0005.yaml
+++ b/spec/tests/T-PROPS-0005.yaml
@@ -47,6 +47,7 @@ cases:
     expectation: one-key-state-does-not-change-other-key-resolution
     notes:
       - A missing, empty, or invalid value for one prop key must not invalidate the whole props record or alter other keys' resolved values.
+      - A key that transitions from provided to missing must independently return to its default rather than reuse `prevValid`.
   - id: T-PROPS-0005-CASE-RECORD-JSON-VALUES
     title: '`resolved snapshot` is a string-keyed record of JSON values'
     covers:

--- a/spec/tests/T-PROPS-0006.yaml
+++ b/spec/tests/T-PROPS-0006.yaml
@@ -3,16 +3,25 @@ type: test
 title: Empty and fallback resolution tests
 status: active
 since: 0.1.0
-summary: Tests that verify `missing`, `provided-empty`, and `invalid` prop values resolve through deterministic fallback behavior.
+summary: Tests that verify missing input releases previous host values while provided-empty and invalid values resolve through deterministic fallback behavior.
 cases:
   - id: T-PROPS-0006-CASE-MISSING-FALLBACK
     title: '`missing` input enters the fallback chain'
     covers:
       - C-PROPS-0009-A
     valueKind: missing-input
-    expectation: fallback-chain-used
+    expectation: defaults-only-fallback-chain-used
     notes:
       - A declared key must remain in the `resolved snapshot` even when raw props omit it.
+      - Missing input must not reuse `prevValid`.
+  - id: T-PROPS-0006-CASE-PROVIDED-TO-MISSING-RESET
+    title: A valid provided value resets to defaults when the host omits the key
+    covers:
+      - C-PROPS-0009-I
+    valueKind: provided-to-missing-transition
+    expectation: previous-host-value-released-and-default-restored
+    notes:
+      - This transition models prop removal in React, Vue, and Web Component hosts without host-specific adapter patches.
   - id: T-PROPS-0006-CASE-EMPTY-ACCEPT
     title: '`provided-empty` with `empty: "accept"` resolves to `null`'
     covers:
@@ -38,13 +47,14 @@ cases:
     notes:
       - Invalid non-empty input is not the same state as `provided-empty`.
   - id: T-PROPS-0006-CASE-FALLBACK-ORDER
-    title: Fallback order is `prevValid`, `setDefaults`, declaration `default`, then `null`
+    title: Fallback order distinguishes missing from provided-unusable input
     covers:
       - C-PROPS-0009-E
     valueKind: fallback-candidates
-    expectation: deterministic-candidate-order
+    expectation: deterministic-state-specific-candidate-order
     notes:
-      - '`prevValid` should win over configured defaults once established.'
+      - '`prevValid` should win over configured defaults only for provided-empty or invalid input entering fallback.'
+      - Missing input must start at `setDefaults`, then declaration `default`, then canonical `null`.
   - id: T-PROPS-0006-CASE-FALLBACK-TO-NULL
     title: Default fallback may end in `null` as canonical empty result
     covers:
@@ -60,7 +70,8 @@ cases:
     valueKind: error-empty-behavior
     expectation: throws-without-non-empty-fallback
     notes:
-      - '`empty: "error"` may still resolve through `prevValid` when a non-empty valid previous value exists.'
+      - '`empty: "error"` may still resolve provided-empty or invalid input through `prevValid` when a non-empty valid previous value exists.'
+      - 'Missing input must not use `prevValid`, even with `empty: "error"`.'
   - id: T-PROPS-0006-CASE-PREV-VALID-NON-EMPTY
     title: '`prevValid` stores only non-empty valid values'
     covers:
@@ -77,6 +88,7 @@ implementations:
     required: true
     consumesCases:
       - T-PROPS-0006-CASE-MISSING-FALLBACK
+      - T-PROPS-0006-CASE-PROVIDED-TO-MISSING-RESET
       - T-PROPS-0006-CASE-EMPTY-ACCEPT
       - T-PROPS-0006-CASE-EMPTY-FALLBACK
       - T-PROPS-0006-CASE-INVALID-FALLBACK
@@ -98,6 +110,7 @@ implementations:
     required: false
     consumesCases:
       - T-PROPS-0006-CASE-MISSING-FALLBACK
+      - T-PROPS-0006-CASE-PROVIDED-TO-MISSING-RESET
       - T-PROPS-0006-CASE-EMPTY-ACCEPT
       - T-PROPS-0006-CASE-EMPTY-FALLBACK
       - T-PROPS-0006-CASE-INVALID-FALLBACK
@@ -138,6 +151,7 @@ verifies:
         - C-PROPS-0009-F
         - C-PROPS-0009-G
         - C-PROPS-0009-H
+        - C-PROPS-0009-I
 exercises:
   contracts:
     - id: C-PROPS-0004

--- a/spec/tests/T-SHADCN-BUTTON-0001.yaml
+++ b/spec/tests/T-SHADCN-BUTTON-0001.yaml
@@ -14,11 +14,11 @@ cases:
       - P-SHADCN-BUTTON-DIRECT-ENTRY
     expectation: shadcn-button-direct-entry-inherits-as-button-protocol
   - id: T-SHADCN-BUTTON-0001-CASE-VARIANT-AND-SIZE
-    title: current variant and size props project the passing visual token subset
+    title: current variant and size props project tokens and omission restores defaults
     covers:
       - P-SHADCN-BUTTON-VARIANT-PROP
       - P-SHADCN-BUTTON-SIZE-PROP
-    expectation: shadcn-button-current-variant-and-size-matrix
+    expectation: shadcn-button-current-variant-size-and-removal-defaults
   - id: T-SHADCN-BUTTON-0001-CASE-INTERACTION-STYLES
     title: inherited Button facts drive hover focus press and disabled visual rules
     covers:


### PR DESCRIPTION
## Summary

- distinguish omitted props from provided-empty or invalid props in the Props fallback contract
- make `missing` release the previous host value and resolve from `setDefaults`, declaration defaults, or canonical `null`
- retain `prevValid` recovery for keys that remain provided but currently contain empty or invalid input
- update cross-adapter conformance, Base Button behavior, Shadcn Button visual behavior, spec entities, and legacy contract projections
- start bilingual unpublished `0.2.0-rc.2` release notes without changing `VERSION`, package manifests, BOM, or V entities

## Root cause

The active Props contract placed `prevValid` first in the fallback chain for every missing, empty, or invalid input. On a preserved component instance, removing a previously valid prop therefore resolved back to that withdrawn value. This made React props such as `disabled` and `variant` appear sticky after Fast Refresh or any ordinary parent update that omitted the key.

## User impact

React, Vue, and Web Component hosts now share normal prop-removal semantics through the Props Kernel. For example, removing `disabled` restores the enabled default, while removing Shadcn Button `variant` or `size` restores their default tokens. Event listener props remain on their existing host-specific event path.

## Validation

- `corepack pnpm@10.32.1 check:types`
- `corepack pnpm@10.32.1 test`
- `corepack pnpm@10.32.1 check:agent-doc`
- focused Props, React, Vue, Web Component, Base Button, and Shadcn Button regression suite: 17 files / 150 assertions
- `git diff --check`
