### PR TITLE
fix(wc): rematerialize tabs content

### DIFF
--- a/internal/agent/PROJECT-UNDERSTANDING.zh-CN.md
+++ b/internal/agent/PROJECT-UNDERSTANDING.zh-CN.md
@@ -13,7 +13,7 @@
 | Version entity | [`V-PROTO-UI-0003`](../../spec/versions/V-PROTO-UI-0003.yaml) |
 | 工作区实体数 | 391 |
 | Workspace validation issues | 0 |
-| 工作区快照指纹 | `sha256:a8d71a15524a5f4ba26f621b7501ea39287223e054441204c30349a21db1bae2` |
+| 工作区快照指纹 | `sha256:4dbe0e1ee3d9b173f7edd8770d6045d413763e9b3323885b944aa2940239fd38` |
 | 已发布 release snapshot digest | `sha256:a7b0a99b3071ef53d55933265ce0bb6c47d2d9e913fea0ee1ee00f83d5db6c2d` |
 
 工作区快照指纹来自按 ID 排序、按当前版本过滤后的实体内容。它用于判断本文是否与当前检出版本一致；它不替代 `V-*` 中记录的不可变发布快照 digest。
@@ -701,14 +701,14 @@ Test 实体连接可寻址 case、被验证的实体准则和仓库中的 execut
 | Status    | 数量 |
 | --------- | ---: |
 | `active`  |   18 |
-| `passing` |  257 |
+| `passing` |  259 |
 | `planned` |   14 |
 
 ### Implementation 类型
 
 | Kind              | 数量 |
 | ----------------- | ---: |
-| `adapter-test`    |   71 |
+| `adapter-test`    |   73 |
 | `fixture`         |   17 |
 | `module-test`     |  124 |
 | `runtime-test`    |   70 |
@@ -798,7 +798,7 @@ Test 实体连接可寻址 case、被验证的实体准则和仓库中的 execut
 | [`T-BASE-SWITCH-0001`](../../spec/tests/T-BASE-SWITCH-0001.yaml) | `draft` | Base Switch root protocol contract tests | 8 | `passing` 1 | `P-BASE-SWITCH` | `P-BASE-SWITCH` |
 | [`T-BASE-SWITCH-THUMB-0001`](../../spec/tests/T-BASE-SWITCH-THUMB-0001.yaml) | `draft` | Base Switch Thumb indicator protocol contract tests | 4 | `passing` 1 | `P-BASE-SWITCH-THUMB` | `P-BASE-SWITCH-THUMB` |
 | [`T-BASE-TABS-0001`](../../spec/tests/T-BASE-TABS-0001.yaml) | `draft` | Base Tabs root and compound protocol contract tests | 5 | `passing` 3 | `P-BASE-TABS` | `P-BASE-TABS`<br>`P-BASE-TABS-LIST`<br>`P-BASE-TABS-TRIGGER`<br>`P-BASE-TABS-CONTENT` |
-| [`T-BASE-TABS-CONTENT-0001`](../../spec/tests/T-BASE-TABS-CONTENT-0001.yaml) | `draft` | Base Tabs Content protocol contract tests | 3 | `passing` 2 | `P-BASE-TABS-CONTENT` | `P-BASE-TABS-CONTENT` |
+| [`T-BASE-TABS-CONTENT-0001`](../../spec/tests/T-BASE-TABS-CONTENT-0001.yaml) | `draft` | Base Tabs Content protocol contract tests | 3 | `passing` 3 | `P-BASE-TABS-CONTENT` | `P-BASE-TABS-CONTENT` |
 | [`T-BASE-TABS-INDICATOR-0001`](../../spec/tests/T-BASE-TABS-INDICATOR-0001.yaml) | `draft` | Base Tabs Indicator protocol contract tests | 2 | `passing` 1 | `P-BASE-TABS-INDICATOR` | `P-BASE-TABS-INDICATOR` |
 | [`T-BASE-TABS-LIST-0001`](../../spec/tests/T-BASE-TABS-LIST-0001.yaml) | `draft` | Base Tabs List protocol contract tests | 5 | `passing` 3 | `P-BASE-TABS-LIST`<br>`D-FOCUS-ROVING-NAVIGATION-OWNERSHIP-0001` | `P-BASE-TABS-LIST` |
 | [`T-BASE-TABS-TRIGGER-0001`](../../spec/tests/T-BASE-TABS-TRIGGER-0001.yaml) | `draft` | Base Tabs Trigger protocol contract tests | 3 | `passing` 1 | `P-BASE-TABS-TRIGGER` | `P-BASE-TABS-TRIGGER` |
@@ -944,7 +944,7 @@ Test 实体连接可寻址 case、被验证的实体准则和仓库中的 execut
 | [`T-SHADCN-SWITCH-0001`](../../spec/tests/T-SHADCN-SWITCH-0001.yaml) | `draft` | Shadcn Switch Root delta protocol contract tests | 4 | `passing` 2 | `C-FEEDBACK-STYLE-0003`<br>`P-SHADCN-SWITCH` | `P-SHADCN-SWITCH`<br>`P-BASE-SWITCH` |
 | [`T-SHADCN-SWITCH-THUMB-0001`](../../spec/tests/T-SHADCN-SWITCH-THUMB-0001.yaml) | `draft` | Shadcn Switch Thumb delta protocol contract tests | 3 | `passing` 1 | `P-SHADCN-SWITCH-THUMB` | `P-SHADCN-SWITCH-THUMB`<br>`P-BASE-SWITCH-THUMB` |
 | [`T-SHADCN-TABS-0001`](../../spec/tests/T-SHADCN-TABS-0001.yaml) | `draft` | Shadcn Tabs Root delta protocol contract tests | 2 | `passing` 1 | `P-SHADCN-TABS` | `P-SHADCN-TABS`<br>`P-BASE-TABS` |
-| [`T-SHADCN-TABS-CONTENT-0001`](../../spec/tests/T-SHADCN-TABS-CONTENT-0001.yaml) | `draft` | Shadcn Tabs Content delta protocol contract tests | 2 | `passing` 1 | `P-SHADCN-TABS-CONTENT` | `P-SHADCN-TABS-CONTENT`<br>`P-BASE-TABS-CONTENT` |
+| [`T-SHADCN-TABS-CONTENT-0001`](../../spec/tests/T-SHADCN-TABS-CONTENT-0001.yaml) | `draft` | Shadcn Tabs Content delta protocol contract tests | 3 | `passing` 2 | `P-SHADCN-TABS-CONTENT` | `P-SHADCN-TABS-CONTENT`<br>`P-BASE-TABS-CONTENT` |
 | [`T-SHADCN-TABS-LIST-0001`](../../spec/tests/T-SHADCN-TABS-LIST-0001.yaml) | `draft` | Shadcn Tabs List delta protocol contract tests | 2 | `passing` 1 | `P-SHADCN-TABS-LIST` | `P-SHADCN-TABS-LIST`<br>`P-BASE-TABS-LIST` |
 | [`T-SHADCN-TABS-TRIGGER-0001`](../../spec/tests/T-SHADCN-TABS-TRIGGER-0001.yaml) | `draft` | Shadcn Tabs Trigger delta protocol contract tests | 2 | `passing` 1 | `P-SHADCN-TABS-TRIGGER` | `P-SHADCN-TABS-TRIGGER`<br>`P-BASE-TABS-TRIGGER` |
 | [`T-SHADCN-TOGGLE-0001`](../../spec/tests/T-SHADCN-TOGGLE-0001.yaml) | `draft` | Shadcn Toggle delta protocol contract tests | 4 | `passing` 1 | `P-SHADCN-TOGGLE` | `P-SHADCN-TOGGLE`<br>`P-BASE-TOGGLE` |

--- a/internal/records/2026-07-24-wc-tabs-content-rematerialization.zh-CN.md
+++ b/internal/records/2026-07-24-wc-tabs-content-rematerialization.zh-CN.md
@@ -1,0 +1,34 @@
+# Web Component Tabs Content 重物化缺陷记录
+
+日期：2026-07-24
+
+## 现象
+
+Web Component Adapter 下的 `shadcn-tabs-content` 在默认 `keepMounted=false` 时可以完成首次切换，但已经显示过的 content 在执行 `current -> inactive -> current` 后仍带有原生 `hidden` 属性。此时 Proto instance、`current` state 和新的 view epoch 均已恢复，宿主却继续被浏览器隐藏，表现为 content 消失。
+
+## 引入范围
+
+该回归由 commit `c20eae99`（`fix(adapters): merge nested trigger host surfaces`）引入，并包含在 `v0.2.0-rc.3` 的准备分支中。该提交让 WC a11y 与 focus 共用经过 `isViewReady()` 限制的 trigger surface target；限制对 focus 是必要的，但阻止了重物化首帧在 reveal barrier 内完成 a11y 快照投射。
+
+## 根因
+
+WC owner 使用 `data-pui-view-detached` 作为 L1 detached shell 与新 view epoch 首次 commit 前的视觉屏障。重物化时：
+
+1. Tabs context 先把 content 的 `hidden` state 更新为 `false`，再请求 `setPresent(true)`。
+2. 新 view epoch 在视觉屏障仍存在时完成 render/commit。
+3. a11y projector 将 `isViewReady() === false` 解释为没有 target，因此没有把最新 `hidden=false` 投射到宿主。
+4. Adapter 随后移除视觉屏障，但 a11y target 没有再次变化，旧 view epoch 留下的原生 `hidden` 属性因此持续存在。
+
+这违反 `C-LIFECYCLE-0008-J`：新 view 在揭示前应完成 view effects，而不是等到揭示后才允许投射。
+
+## 修复
+
+WC view modules 将 target readiness 分为两层：
+
+- a11y 使用已连接的 logical trigger surface，可以在 reveal barrier 内投射首帧语义与属性；
+- focus 继续要求 `isViewReady()`，避免 detached 或尚未揭示的 view 提前参与焦点交互。
+
+新增两层回归覆盖：
+
+- 通用 L1 测试验证重物化前更新的 a11y state 会在揭示前重放；
+- Shadcn Tabs WC 集成测试验证 `A -> B -> A` 后 content 恢复、移除 `hidden` 且保留内容。

--- a/internal/releases/0.2.0-rc.4/release-notes.md
+++ b/internal/releases/0.2.0-rc.4/release-notes.md
@@ -1,0 +1,17 @@
+# Proto UI 0.2.0-rc.4
+
+> Unpublished draft. This candidate collects findings from external `0.2.0-rc.3` trials; its complete release train has not opened yet, so current installation and trial instructions must remain pinned to the published `0.2.0-rc.3`.
+
+## Fixed
+
+### Web Component Tabs Content rematerialization
+
+- Web Component Tabs Content now becomes visible again after a previously visited panel follows the default `current -> inactive -> current` L1 lifecycle.
+- The affected Proto instance and its `current` state were already preserved correctly. The disappearing panel was caused by a stale native `hidden` attribute left on the persistent custom-element owner when a fresh view epoch was revealed.
+- Web Component accessibility projection may now apply the latest semantic snapshot while a rematerialized host is still protected by the reveal barrier. Focus projection remains gated until that host is ready for interaction.
+- Generic L1 accessibility replay coverage and a Shadcn Tabs `A -> B -> A` Web Component integration test protect both the lifecycle boundary and the reported user path.
+
+## Still under validation
+
+- Additional installation, runtime, CSS, accessibility, bundle, composition, and API findings from post-publication `0.2.0-rc.3` trials.
+- The complete `0.2.0-rc.4` release train will prepare its version entity, package versions, BOM, spec snapshot, and publication gates after the trial findings are collected together.

--- a/internal/releases/0.2.0-rc.4/release-notes.zh-CN.md
+++ b/internal/releases/0.2.0-rc.4/release-notes.zh-CN.md
@@ -1,0 +1,17 @@
+# Proto UI 0.2.0-rc.4
+
+> 未发布草稿。该候选版本用于收集 `0.2.0-rc.3` 仓库外人工试用发现；完整 release train 尚未开启，当前安装与试用仍应固定到已发布的 `0.2.0-rc.3`。
+
+## 已修正
+
+### Web Component Tabs Content 重物化
+
+- Web Component Tabs Content 现在可以在已经访问过的 panel 经历默认 `current -> inactive -> current` L1 生命周期后重新正常显示。
+- 受影响的 Proto instance 与 `current` state 原本已被正确保留；panel 消失是因为新 view epoch 揭示时，持久 custom-element owner 上仍残留旧的原生 `hidden` 属性。
+- Web Component a11y projection 现在可以在重物化宿主仍受 reveal barrier 保护时投射最新 semantic snapshot；focus projection 仍需等待宿主真正可交互。
+- 通用 L1 a11y replay 测试与 Shadcn Tabs `A -> B -> A` Web Component 集成测试分别保护生命周期边界和本次人工试用路径。
+
+## 仍在验证
+
+- `0.2.0-rc.3` 发布后试用继续发现的安装、运行时、CSS、a11y、bundle、组合与 API 问题。
+- 完整 `0.2.0-rc.4` release train 的版本实体、package 版本、BOM、spec snapshot 与发布门禁将在统一收集问题后单独准备。

--- a/packages/adapters/web-component/src/runtime/modules.ts
+++ b/packages/adapters/web-component/src/runtime/modules.ts
@@ -263,11 +263,14 @@ export function createWebComponentModules<Props extends PropsBaseType>(args: {
   let mountedEl: HTMLElement | null = null;
   let originalParent: Node | null = null;
   let originalNext: Node | null = null;
-  const getTriggerSurface = () => {
+  const getConnectedTriggerSurface = () => {
     const target = getLogicalTriggerSurfaceRoot(instanceToken);
     const surface = resolveWebComponentTriggerSurface(el, target);
-    return args.isViewReady() && surface?.isConnected ? surface : null;
+    return surface?.isConnected ? surface : null;
   };
+  // A11y must project while the rematerialized host is still behind the reveal
+  // barrier; focus remains gated until that host is ready for interaction.
+  const getTriggerSurface = () => (args.isViewReady() ? getConnectedTriggerSurface() : null);
   const subscribeFocusTarget = (listener: () => void) => {
     const offReady = args.subscribeTargetReady(listener);
     const offSurface = subscribeLogicalTriggerSurface(instanceToken, listener);
@@ -283,7 +286,7 @@ export function createWebComponentModules<Props extends PropsBaseType>(args: {
     .use('a11y', [
       [
         A11Y_PROJECT_CAP,
-        createWebA11yProjector(getTriggerSurface, (listener) =>
+        createWebA11yProjector(getConnectedTriggerSurface, (listener) =>
           subscribeLogicalTriggerSurface(instanceToken, listener)
         ),
       ],

--- a/packages/adapters/web-component/test/lifecycle-view-intent.test.ts
+++ b/packages/adapters/web-component/test/lifecycle-view-intent.test.ts
@@ -129,4 +129,55 @@ describe('adapter-web-component: L1 view intent', () => {
     el.remove();
     await flushReconciliation();
   });
+
+  it('projects the latest a11y state before revealing a rematerialized view', async () => {
+    let run!: RunHandle<any>;
+    const proto = definePrototype({
+      name: 'x-wc-view-intent-a11y-replay',
+      setup(def) {
+        const hidden = def.state.bool('hidden', true);
+        def.a11y.state('hidden', hidden);
+        def.lifecycle.onCreated((nextRun) => {
+          run = nextRun;
+          run.lifecycle.setPresent(false);
+        });
+        def.expose('view', {
+          show: () => {
+            hidden.set(false);
+            run.lifecycle.setPresent(true);
+          },
+          hide: () => {
+            hidden.set(true);
+            run.lifecycle.setPresent(false);
+          },
+        });
+      },
+    });
+
+    AdaptToWebComponent(proto, { schedule: (task) => task() });
+    const el = document.createElement(proto.name) as HTMLElement & {
+      getExposes(): { view: { show(): void; hide(): void } };
+    };
+    document.body.appendChild(el);
+
+    el.getExposes().view.show();
+    await flushReconciliation();
+    expect(el.hasAttribute('data-pui-view-detached')).toBe(false);
+    expect(el.hasAttribute('hidden')).toBe(false);
+    expect(el.getAttribute('aria-hidden')).toBe('false');
+
+    el.getExposes().view.hide();
+    await flushReconciliation();
+    expect(el.hasAttribute('data-pui-view-detached')).toBe(true);
+    expect(el.hasAttribute('hidden')).toBe(true);
+
+    el.getExposes().view.show();
+    await flushReconciliation();
+    expect(el.hasAttribute('data-pui-view-detached')).toBe(false);
+    expect(el.hasAttribute('hidden')).toBe(false);
+    expect(el.getAttribute('aria-hidden')).toBe('false');
+
+    el.remove();
+    await flushReconciliation();
+  });
 });

--- a/packages/adapters/web-component/test/tabs.test.ts
+++ b/packages/adapters/web-component/test/tabs.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { tabsContent, tabsList, tabsRoot, tabsTrigger } from '../../../prototypes/shadcn/src/tabs';
+import { AdaptToWebComponent } from '../src/adapt';
+import { setElementProps } from '../src/props';
+
+async function flushReconciliation() {
+  for (let index = 0; index < 8; index += 1) await Promise.resolve();
+}
+
+describe('adapter-web-component: tabs content presence', () => {
+  it('rematerializes a previously visited content after switching away and back', async () => {
+    AdaptToWebComponent(tabsRoot, { registerAs: 'x-wc-tabs-root-remount' });
+    AdaptToWebComponent(tabsList, { registerAs: 'x-wc-tabs-list-remount' });
+    AdaptToWebComponent(tabsTrigger, { registerAs: 'x-wc-tabs-trigger-remount' });
+    AdaptToWebComponent(tabsContent, { registerAs: 'x-wc-tabs-content-remount' });
+
+    const root = document.createElement('x-wc-tabs-root-remount') as any;
+    setElementProps(root, { defaultValue: 'a' });
+
+    const list = document.createElement('x-wc-tabs-list-remount');
+    const triggerA = document.createElement('x-wc-tabs-trigger-remount');
+    setElementProps(triggerA, { value: 'a' });
+    triggerA.textContent = 'A';
+    const triggerB = document.createElement('x-wc-tabs-trigger-remount');
+    setElementProps(triggerB, { value: 'b' });
+    triggerB.textContent = 'B';
+    list.append(triggerA, triggerB);
+
+    const contentA = document.createElement('x-wc-tabs-content-remount') as any;
+    setElementProps(contentA, { value: 'a' });
+    contentA.textContent = 'A panel';
+    const contentB = document.createElement('x-wc-tabs-content-remount') as any;
+    setElementProps(contentB, { value: 'b' });
+    contentB.textContent = 'B panel';
+    root.append(list, contentA, contentB);
+    document.body.appendChild(root);
+    await flushReconciliation();
+
+    expect(contentA.getExposes().current.get()).toBe(true);
+    expect(contentA.hasAttribute('data-pui-view-detached')).toBe(false);
+    expect(contentA.textContent).toBe('A panel');
+
+    triggerB.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushReconciliation();
+
+    expect(contentA.hasAttribute('data-pui-view-detached')).toBe(true);
+    expect(contentB.hasAttribute('data-pui-view-detached')).toBe(false);
+    expect(contentB.textContent).toBe('B panel');
+
+    triggerA.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flushReconciliation();
+
+    expect(contentA.getExposes().current.get()).toBe(true);
+    expect(contentA.hasAttribute('data-pui-view-detached')).toBe(false);
+    expect(contentA.hasAttribute('hidden')).toBe(false);
+    expect(contentA.textContent).toBe('A panel');
+
+    root.remove();
+    await flushReconciliation();
+  });
+});

--- a/spec/tests/T-BASE-TABS-CONTENT-0001.yaml
+++ b/spec/tests/T-BASE-TABS-CONTENT-0001.yaml
@@ -53,6 +53,15 @@ implementations:
       - T-BASE-TABS-CONTENT-0001-CASE-PRESENCE-POLICY
     exercises:
       - P-BASE-TABS-CONTENT
+  - id: adapter-web-component-tabs-content-presence
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-TABS-CONTENT-0001-CASE-PRESENCE-POLICY
+    exercises:
+      - P-BASE-TABS-CONTENT
 verifies:
   prototypes:
     - id: P-BASE-TABS-CONTENT

--- a/spec/tests/T-SHADCN-TABS-CONTENT-0001.yaml
+++ b/spec/tests/T-SHADCN-TABS-CONTENT-0001.yaml
@@ -25,6 +25,15 @@ cases:
         P-SHADCN-TABS-CONTENT-AS-CHILD-OMISSION,
       ]
     expectation: shadcn-tabs-content-current-panel-with-bounded-presence-parity
+  - id: T-SHADCN-TABS-CONTENT-0001-CASE-WC-REMATERIALIZATION
+    title: Web Component content rematerializes after selection returns and clears stale hidden projection
+    covers:
+      [
+        P-SHADCN-TABS-CONTENT-BASE-INHERITANCE,
+        P-SHADCN-TABS-CONTENT-CURRENT-BASE-DEVIATIONS,
+        P-SHADCN-TABS-CONTENT-HIDDEN-PROJECTION,
+      ]
+    expectation: shadcn-tabs-content-wc-rematerializes-with-current-a11y-state
 implementations:
   - id: prototypes-shadcn-tabs-content-contract
     kind: module-test
@@ -39,6 +48,14 @@ implementations:
     exercises: [P-SHADCN-TABS-CONTENT, P-BASE-TABS-CONTENT]
     notes:
       - Positive tests cover context-derived current state, inactive host hiding, selection switching, and current tokens; forceMount mapping and exact parity remain bounded by the centralized question.
+  - id: adapter-web-component-shadcn-tabs-content-rematerialization
+    kind: adapter-test
+    status: passing
+    path: packages/adapters/web-component/test/tabs.test.ts
+    required: true
+    consumesCases:
+      - T-SHADCN-TABS-CONTENT-0001-CASE-WC-REMATERIALIZATION
+    exercises: [P-SHADCN-TABS-CONTENT, P-BASE-TABS-CONTENT]
 verifies:
   prototypes:
     - id: P-SHADCN-TABS-CONTENT


### PR DESCRIPTION
## Summary

- fix Web Component Tabs Content rematerialization after an `A -> B -> A` selection cycle
- keep accessibility projection available behind the reveal barrier while preserving focus readiness gating
- add generic L1 a11y replay and Shadcn Tabs WC integration regression coverage
- connect the new adapter evidence to the Base and Shadcn Tabs Content test entities
- add bilingual unpublished `0.2.0-rc.4` release-note drafts and a dated diagnosis record

## Root cause

Commit `c20eae99` made WC accessibility and focus projection share an `isViewReady()`-gated trigger-surface target. During rematerialization, the newest `hidden=false` accessibility snapshot was blocked while `data-pui-view-detached` still protected the first commit. The reveal barrier was then removed without another target change, leaving the previous native `hidden` attribute on the persistent custom-element owner.

The fix separates the two readiness levels: accessibility can project to a connected logical surface before reveal, while focus remains gated until the view is interactive.

## User impact

A previously visited Shadcn Tabs panel now reappears correctly when selected again in the Web Component adapter. The Proto instance and state continue to survive the default L1 detach behavior.

## Release note boundary

The rc.4 notes are explicitly unpublished drafts. This PR does not change `VERSION`, package versions, the version entity, BOM, or publication assets.

## Validation

- `corepack pnpm@10.32.1 test` — 237 files passed, 3 skipped; 1063 tests passed
- `corepack pnpm@10.32.1 check:types` — 0 errors, warnings, or hints
- `corepack pnpm@10.32.1 check:prototype-catalog`
- `corepack pnpm@10.32.1 check:release-version`
- `corepack pnpm@10.32.1 release:assets:check`
- `corepack pnpm@10.32.1 check:agent-doc`
- focused WC lifecycle, a11y, Base Tabs, and Shadcn Tabs tests