### PR TITLE
fix(www): point GitHub link to canonical repository

### DIFF
--- a/shared/links.json
+++ b/shared/links.json
@@ -1,5 +1,5 @@
 {
   "website": "https://proto-ui.com",
-  "github": "https://github.com/guangliang2019/Proto-UI",
+  "github": "https://github.com/Proto-UI/Proto-UI",
   "discord": "https://discord.gg/MrWQd7h34R"
 }


### PR DESCRIPTION
Fixes #347

Updates the shared GitHub URL used by the documentation header.

Tested:
- `pnpm exec astro build`
- verified the generated English and Chinese headers use the canonical URL