### PR TITLE
feat(base): add Live Region and Async Region accessibility primitives

### DIFF
--- a/apps/www/astro.config.mjs
+++ b/apps/www/astro.config.mjs
@@ -260,6 +260,16 @@ export default defineConfig({
                   translations: { en: 'Checkbox', 'zh-CN': 'Checkbox' },
                   slug: 'ui-libraries/base/checkbox',
                 },
+                {
+                  label: 'Live Region',
+                  translations: { en: 'Live Region', 'zh-CN': 'Live Region' },
+                  slug: 'ui-libraries/base/live-region',
+                },
+                {
+                  label: 'Async Region',
+                  translations: { en: 'Async Region', 'zh-CN': 'Async Region' },
+                  slug: 'ui-libraries/base/async-region',
+                },
               ],
             },
             {

--- a/apps/www/src/components/PrototypePreviewer/prototype-modules.ts
+++ b/apps/www/src/components/PrototypePreviewer/prototype-modules.ts
@@ -47,6 +47,14 @@ const manualPrototypeModules: Record<string, PrototypeModuleLoader> = {
     const mod = await import('@proto.ui/prototypes-base/separator');
     registerPrototype('base-separator-root', mod.default);
   },
+  'base-live-region-root': async () => {
+    const mod = await import('@proto.ui/prototypes-base/live-region');
+    registerPrototype('base-live-region-root', mod.default);
+  },
+  'base-async-region-root': async () => {
+    const mod = await import('@proto.ui/prototypes-base/async-region');
+    registerPrototype('base-async-region-root', mod.default);
+  },
   'brutalist-toggle': async () => {
     const mod = await import('../../../../../packages/prototypes/brutalist/src/toggle/index');
     registerPrototype('brutalist-toggle', mod.default);

--- a/apps/www/src/content/docs/en/ui-libraries/base/async-region.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/async-region.mdx
@@ -1,0 +1,42 @@
+---
+title: 'Async Region'
+desp: 'Async Region base prototype'
+description: 'Async Region base prototype'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+`base-async-region` is a narrow async accessibility primitive that projects governed `aria-busy` state and exposes the busy handle.
+
+<div>
+  <PrototypePreviewer demoId="demo-base-async-region" initialRuntime="wc" />
+</div>
+
+It owns a single `busy` prop (default `false`) that projects `aria-busy` and is exposed as the sole state handle:
+
+- `busy=false` (default) projects `aria-busy=false`
+- `busy=true` projects `aria-busy=true`
+
+Authored descendants and focus are preserved on prop-only transitions. The prototype declares no role, accessible name, loading timers, replacement state machine, announcements, action, event, command, or chat semantics.
+
+## Current v0 Boundary
+
+`base-async-region` currently includes:
+
+- governed aria-busy projection from the busy prop
+- busy state handle exposed via `getExposes().busy`
+- mounted prop transitions that update aria-busy and the expose handle synchronously
+- authored descendant and focus preservation across prop transitions
+
+It does not include:
+
+- role or accessible-name projection
+- loading timers or replacement state machines
+- announcement behavior (compose with Live Region at the application layer)
+- action, event, command, or chat semantics
+
+## References
+
+- Contract: [C-ASYNC-A11Y-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/contracts/C-ASYNC-A11Y-0001.yaml)
+- Source: [packages/prototypes/base/src/async-region](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/async-region)
+- Test: [async-region.test.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/async-region.test.ts)

--- a/apps/www/src/content/docs/en/ui-libraries/base/async-region.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/async-region.mdx
@@ -6,7 +6,7 @@ description: 'Async Region base prototype'
 
 import { PrototypePreviewer } from '@/components/PrototypePreviewer';
 
-`base-async-region` is a narrow async accessibility primitive that projects governed `aria-busy` state and exposes the busy handle.
+`base-async-region-root` is a narrow async accessibility primitive that projects governed `aria-busy` state and exposes the busy handle.
 
 <div>
   <PrototypePreviewer demoId="demo-base-async-region" initialRuntime="wc" />
@@ -21,7 +21,7 @@ Authored descendants and focus are preserved on prop-only transitions. The proto
 
 ## Current v0 Boundary
 
-`base-async-region` currently includes:
+`base-async-region-root` currently includes:
 
 - governed aria-busy projection from the busy prop
 - busy state handle exposed via `getExposes().busy`

--- a/apps/www/src/content/docs/en/ui-libraries/base/index.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/index.mdx
@@ -8,7 +8,9 @@ import { PrototypePreviewer } from '@/components/PrototypePreviewer';
 
 This page showcases the plain protocol-first base prototypes.
 
-At the base layer, a prototype should stop at interaction semantics that are broadly reusable. For dropdown-menu, that boundary is:
+Base admission is not limited to interaction, but every admitted prototype must own an independently testable cross-host information path. Separator owns decorative/semantic orientation projection; Live Region owns status/alert and atomic announcement semantics; Async Region owns busy-state projection. Visual-only carriers remain in styled libraries.
+
+For interactive families, the Base prototype should stop at semantics that are broadly reusable. For dropdown-menu, that boundary is:
 
 - overlay open/close coordination
 - collection ordering and item snapshots

--- a/apps/www/src/content/docs/en/ui-libraries/base/live-region.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/live-region.mdx
@@ -6,13 +6,13 @@ description: 'Live Region base prototype'
 
 import { PrototypePreviewer } from '@/components/PrototypePreviewer';
 
-`base-live-region` is a narrow async accessibility primitive that projects governed ARIA live-region semantics without interaction.
+`base-live-region-root` is a narrow async accessibility primitive that projects governed ARIA live-region semantics without interaction.
 
 <div>
   <PrototypePreviewer demoId="demo-base-live-region" initialRuntime="wc" />
 </div>
 
-It derives `role`, `aria-live`, and `aria-atomic` atomically from two props:
+It derives `role`, `aria-live`, and `aria-atomic` from two props:
 
 - `politeness`: `polite` (default) projects `role=status` + `aria-live=polite`; `assertive` projects `role=alert` + `aria-live=assertive`
 - `atomic`: `true` (default) projects `aria-atomic=true`; `false` projects `aria-atomic=false`
@@ -21,7 +21,7 @@ Authored child content is the announcement payload. The prototype declares no fo
 
 ## Current v0 Boundary
 
-`base-live-region` currently includes:
+`base-live-region-root` currently includes:
 
 - polite/assertive role and aria-live projection
 - atomic aria-atomic projection

--- a/apps/www/src/content/docs/en/ui-libraries/base/live-region.mdx
+++ b/apps/www/src/content/docs/en/ui-libraries/base/live-region.mdx
@@ -1,0 +1,42 @@
+---
+title: 'Live Region'
+desp: 'Live Region base prototype'
+description: 'Live Region base prototype'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+`base-live-region` is a narrow async accessibility primitive that projects governed ARIA live-region semantics without interaction.
+
+<div>
+  <PrototypePreviewer demoId="demo-base-live-region" initialRuntime="wc" />
+</div>
+
+It derives `role`, `aria-live`, and `aria-atomic` atomically from two props:
+
+- `politeness`: `polite` (default) projects `role=status` + `aria-live=polite`; `assertive` projects `role=alert` + `aria-live=assertive`
+- `atomic`: `true` (default) projects `aria-atomic=true`; `false` projects `aria-atomic=false`
+
+Authored child content is the announcement payload. The prototype declares no focus, event, command, selection, or accessible-name override channel; the exposes surface is empty.
+
+## Current v0 Boundary
+
+`base-live-region` currently includes:
+
+- polite/assertive role and aria-live projection
+- atomic aria-atomic projection
+- mounted prop transitions that update all three attributes synchronously
+- authored child content preservation across prop transitions
+
+It does not include:
+
+- `aria-relevant` granularity control
+- announcement timers or replacement state machines
+- accessible-name override
+- focus, event, command, or selection channels
+
+## References
+
+- Contract: [C-ASYNC-A11Y-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/contracts/C-ASYNC-A11Y-0001.yaml)
+- Source: [packages/prototypes/base/src/live-region](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/live-region)
+- Test: [live-region.test.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/live-region.test.ts)

--- a/apps/www/src/content/docs/zh-cn/demo-base-async-region.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-async-region.demo.ts
@@ -1,0 +1,18 @@
+export default {
+  type: 'demo',
+  root: {
+    kind: 'proto',
+    prototypeId: 'base-async-region-root',
+    className: 'rounded-md border bg-white px-4 py-3 text-sm',
+    props: { busy: true },
+    children: [
+      {
+        kind: 'box',
+        className: 'flex items-center gap-2',
+        children: [
+          { kind: 'box', className: 'text-slate-400', children: ['Loading results…'] },
+        ],
+      },
+    ],
+  },
+};

--- a/apps/www/src/content/docs/zh-cn/demo-base-live-region.demo.ts
+++ b/apps/www/src/content/docs/zh-cn/demo-base-live-region.demo.ts
@@ -1,0 +1,9 @@
+export default {
+  type: 'demo',
+  root: {
+    kind: 'proto',
+    prototypeId: 'base-live-region-root',
+    className: 'rounded-md border bg-white px-4 py-3 text-sm',
+    children: ['3 new notifications'],
+  },
+};

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/async-region.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/async-region.mdx
@@ -6,7 +6,7 @@ description: 'Async Region base prototype'
 
 import { PrototypePreviewer } from '@/components/PrototypePreviewer';
 
-`base-async-region` 是一个窄异步无障碍原语，投射受治理的 `aria-busy` 状态并暴露 busy handle。
+`base-async-region-root` 是一个窄异步无障碍原语，投射受治理的 `aria-busy` 状态并暴露 busy handle。
 
 <div>
   <PrototypePreviewer demoId="demo-base-async-region" initialRuntime="wc" />
@@ -21,7 +21,7 @@ Authored 后代与焦点在 prop-only 转换中保留。原型不声明 role、a
 
 ## 当前 v0 边界
 
-`base-async-region` 目前包含：
+`base-async-region-root` 目前包含：
 
 - 从 busy prop 受治理投射 aria-busy
 - 通过 `getExposes().busy` 暴露 busy state handle

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/async-region.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/async-region.mdx
@@ -1,0 +1,42 @@
+---
+title: 'Async Region'
+desp: 'Async Region base prototype'
+description: 'Async Region base prototype'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+`base-async-region` 是一个窄异步无障碍原语，投射受治理的 `aria-busy` 状态并暴露 busy handle。
+
+<div>
+  <PrototypePreviewer demoId="demo-base-async-region" initialRuntime="wc" />
+</div>
+
+它仅拥有单个 `busy` prop（默认 `false`），投射 `aria-busy` 并作为唯一的 state handle 暴露：
+
+- `busy=false`（默认）投射 `aria-busy=false`
+- `busy=true` 投射 `aria-busy=true`
+
+Authored 后代与焦点在 prop-only 转换中保留。原型不声明 role、accessible name、loading 定时器、替换状态机、announcement、action、event、command 或聊天语义。
+
+## 当前 v0 边界
+
+`base-async-region` 目前包含：
+
+- 从 busy prop 受治理投射 aria-busy
+- 通过 `getExposes().busy` 暴露 busy state handle
+- mounted prop 变更同步更新 aria-busy 与 expose handle
+- prop 转换中保留 authored 后代与焦点
+
+不包含：
+
+- role 或 accessible-name 投射
+- loading 定时器或替换状态机
+- announcement 行为（在应用层组合 Live Region 实现）
+- action、event、command 或聊天语义
+
+## 参考
+
+- 契约：[C-ASYNC-A11Y-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/contracts/C-ASYNC-A11Y-0001.yaml)
+- 源码：[packages/prototypes/base/src/async-region](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/async-region)
+- 测试：[async-region.test.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/async-region.test.ts)

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/index.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/index.mdx
@@ -8,7 +8,9 @@ import { PrototypePreviewer } from '@/components/PrototypePreviewer';
 
 当前页面用于展示更接近协议层的 base 原型。
 
-在 base 层，原型应当停在可被广泛复用的交互语义边界上。以 dropdown-menu 为例，目前边界是：
+Base 准入并不限于交互，但每个进入 Base 的原型都必须拥有可独立测试、可跨宿主迁移的信息通路。Separator 拥有 decorative/semantic orientation 投射；Live Region 拥有 status/alert 与 atomic 播报语义；Async Region 拥有 busy state 投射。仅承担视觉结构的 carrier 继续留在 styled library。
+
+对于交互 family，Base 原型应停在可广泛复用的语义边界。以 dropdown-menu 为例，目前边界是：
 
 - 浮层开合协作
 - collection 顺序与 item snapshot

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/live-region.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/live-region.mdx
@@ -6,13 +6,13 @@ description: 'Live Region base prototype'
 
 import { PrototypePreviewer } from '@/components/PrototypePreviewer';
 
-`base-live-region` 是一个窄异步无障碍原语，投射受治理的 ARIA live-region 语义，不声明交互通路。
+`base-live-region-root` 是一个窄异步无障碍原语，投射受治理的 ARIA live-region 语义，不声明交互通路。
 
 <div>
   <PrototypePreviewer demoId="demo-base-live-region" initialRuntime="wc" />
 </div>
 
-它从两个 props 原子地推导 `role`、`aria-live` 与 `aria-atomic`：
+它从两个 props 推导 `role`、`aria-live` 与 `aria-atomic`：
 
 - `politeness`：`polite`（默认）投射 `role=status` + `aria-live=polite`；`assertive` 投射 `role=alert` + `aria-live=assertive`
 - `atomic`：`true`（默认）投射 `aria-atomic=true`；`false` 投射 `aria-atomic=false`
@@ -21,7 +21,7 @@ Authored 子内容即为播报载荷。原型不声明 focus、event、command�
 
 ## 当前 v0 边界
 
-`base-live-region` 目前包含：
+`base-live-region-root` 目前包含：
 
 - polite/assertive role 与 aria-live 投射
 - atomic aria-atomic 投射

--- a/apps/www/src/content/docs/zh-cn/ui-libraries/base/live-region.mdx
+++ b/apps/www/src/content/docs/zh-cn/ui-libraries/base/live-region.mdx
@@ -1,0 +1,42 @@
+---
+title: 'Live Region'
+desp: 'Live Region base prototype'
+description: 'Live Region base prototype'
+---
+
+import { PrototypePreviewer } from '@/components/PrototypePreviewer';
+
+`base-live-region` 是一个窄异步无障碍原语，投射受治理的 ARIA live-region 语义，不声明交互通路。
+
+<div>
+  <PrototypePreviewer demoId="demo-base-live-region" initialRuntime="wc" />
+</div>
+
+它从两个 props 原子地推导 `role`、`aria-live` 与 `aria-atomic`：
+
+- `politeness`：`polite`（默认）投射 `role=status` + `aria-live=polite`；`assertive` 投射 `role=alert` + `aria-live=assertive`
+- `atomic`：`true`（默认）投射 `aria-atomic=true`；`false` 投射 `aria-atomic=false`
+
+Authored 子内容即为播报载荷。原型不声明 focus、event、command、selection 或 accessible-name override 通路；exposes surface 为空。
+
+## 当前 v0 边界
+
+`base-live-region` 目前包含：
+
+- polite/assertive role 与 aria-live 投射
+- atomic aria-atomic 投射
+- mounted prop 变更同步更新全部三个 attribute
+- prop 转换中保留 authored 子内容
+
+不包含：
+
+- `aria-relevant` 粒度控制
+- announcement 定时器或替换状态机
+- accessible-name override
+- focus、event、command 或 selection 通路
+
+## 参考
+
+- 契约：[C-ASYNC-A11Y-0001](https://github.com/Proto-UI/Proto-UI/blob/main/spec/contracts/C-ASYNC-A11Y-0001.yaml)
+- 源码：[packages/prototypes/base/src/live-region](https://github.com/Proto-UI/Proto-UI/tree/main/packages/prototypes/base/src/live-region)
+- 测试：[live-region.test.ts](https://github.com/Proto-UI/Proto-UI/blob/main/packages/prototypes/base/test/live-region.test.ts)

--- a/internal/contracts/types/prototype-family-exports.contract.v0.type-test.ts
+++ b/internal/contracts/types/prototype-family-exports.contract.v0.type-test.ts
@@ -1,4 +1,6 @@
 import { button } from '@proto.ui/prototypes-base/button';
+import { asyncRegionRoot } from '@proto.ui/prototypes-base/async-region';
+import { liveRegionRoot } from '@proto.ui/prototypes-base/live-region';
 import {
   dialogClose,
   dialogContent,
@@ -70,6 +72,8 @@ import { shadcnToggle } from '@proto.ui/prototypes-shadcn/toggle';
 // The CLI registry consumes these exact named exports from family subpaths.
 void [
   button,
+  liveRegionRoot,
+  asyncRegionRoot,
   toggle,
   transition,
   switchRoot,

--- a/internal/records/2026-08-01-base-async-accessibility-boundary.zh-CN.md
+++ b/internal/records/2026-08-01-base-async-accessibility-boundary.zh-CN.md
@@ -1,6 +1,6 @@
 # 2026-08-01 Base 异步无障碍边界：Live Region 与 Async Region
 
-> Internal record. Not normative. 本记录整理 OpenWebUI 应用探针发现的异步无障碍缺口、Base 层窄边界原语的建模判断与后续实体规划。稳定结论已提升到 `C-ASYNC-A11Y-0001`、`P-BASE-LIVE-REGION`、`P-BASE-ASYNC-REGION`、`T-BASE-LIVE-REGION-0001` 与 `T-BASE-ASYNC-REGION-0001`；本文不替代这些真相源。
+> Internal record. Not normative. 本记录整理 OpenWebUI 应用探针发现的异步无障碍缺口、Base 层窄边界原语的建模判断与后续实体规划。当前编目方向已进入 draft `C-ASYNC-A11Y-0001`、`P-BASE-LIVE-REGION`、`P-BASE-ASYNC-REGION`、`T-BASE-LIVE-REGION-0001` 与 `T-BASE-ASYNC-REGION-0001`；本文不替代这些真相源。
 
 ---
 
@@ -17,7 +17,7 @@ OpenWebUI 应用探针在组合消息状态反馈（"正在生成…"、"3 条�
 
 ### 2.1 不引入第二个 `BaseXxxRoot` 命名约定
 
-遵循 `separatorRoot`、`scrollAreaRoot` 等既有模式：默认导出 prototype，命名导出 `liveRegionRoot` / `asyncRegionRoot`，as-hook 导出 `asLiveRegionRoot` / `asAsyncRegionRoot`。不引入 `BaseLiveRegionRoot` / `BaseAsyncRegionRoot` PascalCase 包装。
+Package prototype export 遵循 `separatorRoot`、`scrollAreaRoot` 等既有模式：默认导出 prototype，命名导出 `liveRegionRoot` / `asyncRegionRoot`，as-hook 导出 `asLiveRegionRoot` / `asAsyncRegionRoot`。不在 prototype package 中引入 `BaseLiveRegionRoot` / `BaseAsyncRegionRoot` PascalCase 包装；CLI 生成的 adapter facade 继续遵循既有 PascalCase 约定。
 
 ### 2.2 Live Region 不是 status 组件
 
@@ -30,6 +30,10 @@ Async Region 与 Brutalist Skeleton 有本质区别：Skeleton 是 styled-only�
 ### 2.4 Web a11y 投影扩展
 
 `packages/modules/a11y/src/web.ts` 的 `ARIA_STATE_ATTRS` 新增 `live → aria-live`、`atomic → aria-atomic`、`busy → aria-busy` 三个受治理映射。这遵循既有 `ARIA_STATE_ATTRS` 模式（`checked → aria-checked` 等），不改变 `hidden` 的特殊处理逻辑。
+
+### 2.5 公开消费面
+
+两个原语分别通过 `@proto.ui/prototypes-base/live-region` 与 `@proto.ui/prototypes-base/async-region` 提供默认 export、命名 root export 与 as-hook，并进入 CLI 的 `base-live-region` / `base-async-region` 组件注册表。Async Region 的 `busy` expose 继续遵循既有 Web state 序列化，供 styled family 使用 `data-[busy]` variant；不新增公开 package，也不改变 rc.7 BOM package 数量。
 
 ## 3）实体规划
 

--- a/internal/records/2026-08-01-base-async-accessibility-boundary.zh-CN.md
+++ b/internal/records/2026-08-01-base-async-accessibility-boundary.zh-CN.md
@@ -1,0 +1,62 @@
+# 2026-08-01 Base 异步无障碍边界：Live Region 与 Async Region
+
+> Internal record. Not normative. 本记录整理 OpenWebUI 应用探针发现的异步无障碍缺口、Base 层窄边界原语的建模判断与后续实体规划。稳定结论已提升到 `C-ASYNC-A11Y-0001`、`P-BASE-LIVE-REGION`、`P-BASE-ASYNC-REGION`、`T-BASE-LIVE-REGION-0001` 与 `T-BASE-ASYNC-REGION-0001`；本文不替代这些真相源。
+
+---
+
+## 1）背景
+
+OpenWebUI 应用探针在组合消息状态反馈（"正在生成…"、"3 条新通知"、"加载完成"）时，发现 Base 层缺少两个窄语义原语：
+
+1. **Live Region**：应用需要一个受治理的 ARIA live-region 容器，将 authored 文本内容作为播报载荷，并通过 `politeness`（polite/assertive）与 `atomic` props 控制 `role`、`aria-live`、`aria-atomic` 的投射。应用层不应自行拼写 ARIA attribute 或维护 role/live 的一致性。
+2. **Async Region**：应用需要一个受治理的 `aria-busy` 容器，在异步操作期间标记区域忙碌状态，并暴露 `busy` state handle 供 styled 表面（Card/Badge）读取。应用层不应自行管理 `aria-busy` attribute 的生命周期。
+
+两者均不涉及 focus 管理、event 路由、command 通路、announcement 定时器、替换状态机或聊天语义。这些责任由应用层或更高层 styled family 拥有。
+
+## 2）边界判断
+
+### 2.1 不引入第二个 `BaseXxxRoot` 命名约定
+
+遵循 `separatorRoot`、`scrollAreaRoot` 等既有模式：默认导出 prototype，命名导出 `liveRegionRoot` / `asyncRegionRoot`，as-hook 导出 `asLiveRegionRoot` / `asAsyncRegionRoot`。不引入 `BaseLiveRegionRoot` / `BaseAsyncRegionRoot` PascalCase 包装。
+
+### 2.2 Live Region 不是 status 组件
+
+Live Region 是语义容器，不是状态机。它不拥有 `loading | success | error` 状态枚举，不拥有 announcement 定时器，不拥有替换策略。应用层在 styled Card/Badge 表面中组合 Live Region，并自行决定何时更新 authored 文本内容。
+
+### 2.3 Async Region 不是 skeleton
+
+Async Region 与 Brutalist Skeleton 有本质区别：Skeleton 是 styled-only、passive、contentless 视觉原语（`aria-hidden=true`，不渲染后代）；Async Region 是语义容器（投射 `aria-busy`，保留 authored 后代与焦点）。两者不共享 prototype 身份。
+
+### 2.4 Web a11y 投影扩展
+
+`packages/modules/a11y/src/web.ts` 的 `ARIA_STATE_ATTRS` 新增 `live → aria-live`、`atomic → aria-atomic`、`busy → aria-busy` 三个受治理映射。这遵循既有 `ARIA_STATE_ATTRS` 模式（`checked → aria-checked` 等），不改变 `hidden` 的特殊处理逻辑。
+
+## 3）实体规划
+
+本轮按一个垂直语义切片新增：
+
+- `C-ASYNC-A11Y-0001`：异步无障碍边界契约，治理 Live Region 与 Async Region 的投射规则与禁止通路。
+- `P-BASE-LIVE-REGION`：Live Region prototype 实体。
+- `P-BASE-ASYNC-REGION`：Async Region prototype 实体。
+- `T-BASE-LIVE-REGION-0001`：Live Region 可执行测试映射。
+- `T-BASE-ASYNC-REGION-0001`：Async Region 可执行测试映射。
+- 修订 `T-A11Y-0001`：新增 `T-A11Y-0001-CASE-LIVE-ATOMIC-BUSY` 覆盖 Web adapter 的 live/atomic/busy 投射。
+
+所有新实体保持 `draft`，通过关系链与 executable tests 形成一个 coherent slice。
+
+## 4）仍需决定的问题
+
+- Live Region 是否需要 `relevant` prop（`aria-relevant`）以控制 additions/removals/text 的播报粒度。
+- Async Region 是否需要 `live` prop 以在 busy 状态变化时触发播报（当前设计不包含，由应用层组合 Live Region 实现）。
+- 是否需要 `P-BASE-LIVE-REGION` 的 `inherits.prototypes` 关系以支持 styled family 继承。
+
+---
+
+## 参考
+
+- `spec/contracts/C-ASYNC-A11Y-0001.yaml`
+- `spec/prototypes/P-BASE-LIVE-REGION.yaml`
+- `spec/prototypes/P-BASE-ASYNC-REGION.yaml`
+- `spec/contracts/C-A11Y-0001.yaml`
+- `packages/modules/a11y/src/web.ts`
+- `internal/records/2026-07-29-scroll-area-boundary-and-host-projection.zh-CN.md`

--- a/internal/releases/0.2.0-rc.7/release-notes.md
+++ b/internal/releases/0.2.0-rc.7/release-notes.md
@@ -29,7 +29,7 @@
 ### Separator protocol and Skeleton visual prototype
 
 - Base Separator now has explicit horizontal/vertical orientation, decorative-versus-semantic accessibility behavior, live post-mount projection, and no semantic-only orientation in decorative mode.
-- The private `@proto.ui/prototypes-brutalist` workspace package adds a Separator projection and a direct styled-only Skeleton source subpath. Skeleton is passive, contentless, aria-hidden, and consumer-sized; the parent loading region retains busy state, announcements, replacement timing, and focus continuity. These candidates remain outside the 37-package rc.7 BOM and add no public Brutalist `proto-ui add` entries.
+- The private `@proto.ui/prototypes-brutalist` workspace package adds a Separator projection and a direct styled-only Skeleton source subpath. Skeleton is passive, contentless, aria-hidden, and consumer-sized; the parent loading region retains busy state, announcements, replacement timing, and focus continuity. These candidates remain outside the 38-package rc.7 BOM and add no public Brutalist `proto-ui add` entries.
 
 ### Live Region and Async Region accessibility boundaries
 
@@ -39,12 +39,12 @@
 
 ## Build and release
 
-### Executable artifacts for all 37 public packages
+### Executable artifacts for all 38 public packages
 
-- All 37 public `@proto.ui/*` packages now produce `dist/*.js` and `dist/*.d.ts` before publication. Package exports point separately to the JavaScript runtime and declaration outputs instead of publishing `.ts` source as an npm runtime entry that requires a TypeScript loader.
+- All 38 public `@proto.ui/*` packages now produce `dist/*.js` and `dist/*.d.ts` before publication. Package exports point separately to the JavaScript runtime and declaration outputs instead of publishing `.ts` source as an npm runtime entry that requires a TypeScript loader.
 - Every public package now has a package-local `build` and `prepack` contract. The root `build:packages` command builds selected packages and their upstream closure in production-dependency order, validates every export target, and runs import smoke tests in native Node ESM without loading TypeScript.
 - Release staging now reuses and copies the same locally verified `dist` output used by development and CI instead of maintaining a second temporary compilation path that could drift.
-- A generator now maintains public manifest `dist` exports, `files` allowlists, and build scripts consistently. Source and tests remain repository inputs but are excluded from the default npm payload; test files across the 37 tarballs were reduced from 1,031,558 B to 0 B.
+- A generator now maintains public manifest `dist` exports, `files` allowlists, and build scripts consistently. Source and tests remain repository inputs but are excluded from the default npm payload; test files across the 38 tarballs were reduced from 1,031,558 B to 0 B.
 
 ### Bundle, documentation, and CI feedback
 
@@ -56,8 +56,8 @@
 ## Validation
 
 - The trigger-group and Tabs v4 style-fidelity changes pass the complete workspace test suite: 239 test files and 1,077 tests passed, together with the prototype catalog, style preset, type checks, generated Agent-document check, and the shared Web Component/React/Vue Dialog conformance journey.
-- The delivery optimization has validated builds, export targets, native Node ESM imports, release staging, and `npm publish --dry-run` for 37/37 public packages. Package-manifest, bundle-budget, type, test, Astro check, and documentation-build gates also passed.
-- The development Demo Matrix was verified with 27 demos and 81 simultaneously mounted previewers, 27 each for Web Component, React, and Vue. Its English and Chinese routes are absent from the 150-page production build, sitemap, and Pagefind index; the development-only and three-adapter side-by-side policies are now covered by the 37 release tests.
+- The delivery optimization has validated builds, export targets, native Node ESM imports, release staging, and `npm publish --dry-run` for 38/38 public packages. Package-manifest, bundle-budget, type, test, Astro check, and documentation-build gates also passed.
+- The development Demo Matrix was verified with 27 demos and 81 simultaneously mounted previewers, 27 each for Web Component, React, and Vue. Its English and Chinese routes are absent from the 150-page production build, sitemap, and Pagefind index; the development-only and three-adapter side-by-side policies are now covered by the 38 release tests.
 
 ## Upgrade notes
 
@@ -66,4 +66,4 @@
 
 ## Release preparation still required
 
-- This draft does not mean rc.7 is installable. The draft version entity, aligned public package manifests, and 37-package BOM exist; the complete release rehearsal, immutable spec snapshot, Git tag, GitHub prerelease, and npm publication still require separate verification before activation.
+- This draft does not mean rc.7 is installable. The draft version entity, aligned public package manifests, and 38-package BOM exist; the complete release rehearsal, immutable spec snapshot, Git tag, GitHub prerelease, and npm publication still require separate verification before activation.

--- a/internal/releases/0.2.0-rc.7/release-notes.md
+++ b/internal/releases/0.2.0-rc.7/release-notes.md
@@ -57,7 +57,7 @@
 
 - The trigger-group and Tabs v4 style-fidelity changes pass the complete workspace test suite: 239 test files and 1,077 tests passed, together with the prototype catalog, style preset, type checks, generated Agent-document check, and the shared Web Component/React/Vue Dialog conformance journey.
 - The delivery optimization has validated builds, export targets, native Node ESM imports, release staging, and `npm publish --dry-run` for 38/38 public packages. Package-manifest, bundle-budget, type, test, Astro check, and documentation-build gates also passed.
-- The development Demo Matrix was verified with 27 demos and 81 simultaneously mounted previewers, 27 each for Web Component, React, and Vue. Its English and Chinese routes are absent from the 150-page production build, sitemap, and Pagefind index; the development-only and three-adapter side-by-side policies are now covered by the 38 release tests.
+- The development Demo Matrix was verified with 27 demos and 81 simultaneously mounted previewers, 27 each for Web Component, React, and Vue. Its English and Chinese routes are absent from the 150-page production build, sitemap, and Pagefind index; the development-only and three-adapter side-by-side policies are now covered by the 37 release tests.
 
 ## Upgrade notes
 

--- a/internal/releases/0.2.0-rc.7/release-notes.md
+++ b/internal/releases/0.2.0-rc.7/release-notes.md
@@ -31,6 +31,12 @@
 - Base Separator now has explicit horizontal/vertical orientation, decorative-versus-semantic accessibility behavior, live post-mount projection, and no semantic-only orientation in decorative mode.
 - The private `@proto.ui/prototypes-brutalist` workspace package adds a Separator projection and a direct styled-only Skeleton source subpath. Skeleton is passive, contentless, aria-hidden, and consumer-sized; the parent loading region retains busy state, announcements, replacement timing, and focus continuity. These candidates remain outside the 37-package rc.7 BOM and add no public Brutalist `proto-ui add` entries.
 
+### Live Region and Async Region accessibility boundaries
+
+- Base Live Region adds a content-preserving status/alert boundary with governed `politeness` and `atomic` props. It synchronizes `role`, `aria-live`, and `aria-atomic` without owning focus, events, commands, announcement timing, or replacement behavior.
+- Base Async Region adds a content- and focus-preserving `busy` boundary. It projects `aria-busy`, exposes only the governed `busy` state, and leaves loading visuals, announcements, replacement state, and chat semantics to consumers.
+- The Web accessibility projection now maps `live`, `atomic`, and `busy` state keys to their ARIA attributes. Both Base families have public package subpaths and `proto-ui add` entries; they add no package to the current rc.7 BOM.
+
 ## Build and release
 
 ### Executable artifacts for all 37 public packages

--- a/internal/releases/0.2.0-rc.7/release-notes.zh-CN.md
+++ b/internal/releases/0.2.0-rc.7/release-notes.zh-CN.md
@@ -31,6 +31,12 @@
 - Base Separator 现已明确横向/纵向 orientation、decorative 与 semantic accessibility 行为、mounted 后的实时投影，并确保 decorative 模式不残留仅属于语义模式的 orientation。
 - 私有 workspace package `@proto.ui/prototypes-brutalist` 新增 Separator 视觉投射与直接定义的 styled-only Skeleton source subpath。Skeleton 是 passive、contentless、aria-hidden 且尺寸由消费端拥有的视觉原型；父级 loading region 继续拥有 busy 状态、announcement、替换时机与焦点连续性。这些候选不进入 rc.7 的 37-package BOM，也不新增公开 Brutalist `proto-ui add` 条目。
 
+### Live Region 与 Async Region 无障碍边界
+
+- Base Live Region 新增保留内容的 status/alert 边界，通过受治理的 `politeness` 与 `atomic` props 同步投射 `role`、`aria-live` 与 `aria-atomic`，但不拥有 focus、event、command、announcement 时序或替换行为。
+- Base Async Region 新增保留内容与焦点的 `busy` 边界，投射 `aria-busy` 且仅暴露受治理的 `busy` state；loading 视觉、announcement、替换状态与聊天语义仍由消费端拥有。
+- Web accessibility 投射新增 `live`、`atomic` 与 `busy` state key 到对应 ARIA attribute 的映射。两个 Base family 均拥有公开 package subpath 与 `proto-ui add` 条目，不会向当前 rc.7 BOM 新增 package。
+
 ## 构建与发布
 
 ### 37 个公开 package 交付可执行产物

--- a/internal/releases/0.2.0-rc.7/release-notes.zh-CN.md
+++ b/internal/releases/0.2.0-rc.7/release-notes.zh-CN.md
@@ -57,7 +57,7 @@
 
 - Trigger group 与 Tabs v4 样式还原通过完整工作区测试：239 个测试文件、1,077 个测试通过；prototype catalog、style preset、类型检查、Agent 文档生成检查与 Web Component/React/Vue 共享 Dialog conformance journey 通过。
 - 构建优化已验证 38/38 公开 package 的完整构建、export target、原生 Node ESM import、release stage 与 `npm publish --dry-run`；package manifest、bundle budget、类型、测试、Astro check 与文档构建门禁均通过。
-- Demo Matrix 开发路由实测同时挂载 27 个 demo、81 个 previewer，Web Component、React 与 Vue 各 27 个；生产构建的 150 个页面、sitemap 与 Pagefind index 均不包含其中英文 Demo Matrix 路由。新增的 development-only 与三 adapter 并排 policy 已进入 38 条 release tests。
+- Demo Matrix 开发路由实测同时挂载 27 个 demo、81 个 previewer，Web Component、React 与 Vue 各 27 个；生产构建的 150 个页面、sitemap 与 Pagefind index 均不包含其中英文 Demo Matrix 路由。新增的 development-only 与三 adapter 并排 policy 已进入 37 条 release tests。
 
 ## 升级提示
 

--- a/internal/releases/0.2.0-rc.7/release-notes.zh-CN.md
+++ b/internal/releases/0.2.0-rc.7/release-notes.zh-CN.md
@@ -29,7 +29,7 @@
 ### Separator 协议与 Skeleton 视觉原型
 
 - Base Separator 现已明确横向/纵向 orientation、decorative 与 semantic accessibility 行为、mounted 后的实时投影，并确保 decorative 模式不残留仅属于语义模式的 orientation。
-- 私有 workspace package `@proto.ui/prototypes-brutalist` 新增 Separator 视觉投射与直接定义的 styled-only Skeleton source subpath。Skeleton 是 passive、contentless、aria-hidden 且尺寸由消费端拥有的视觉原型；父级 loading region 继续拥有 busy 状态、announcement、替换时机与焦点连续性。这些候选不进入 rc.7 的 37-package BOM，也不新增公开 Brutalist `proto-ui add` 条目。
+- 私有 workspace package `@proto.ui/prototypes-brutalist` 新增 Separator 视觉投射与直接定义的 styled-only Skeleton source subpath。Skeleton 是 passive、contentless、aria-hidden 且尺寸由消费端拥有的视觉原型；父级 loading region 继续拥有 busy 状态、announcement、替换时机与焦点连续性。这些候选不进入 rc.7 的 38-package BOM，也不新增公开 Brutalist `proto-ui add` 条目。
 
 ### Live Region 与 Async Region 无障碍边界
 
@@ -39,12 +39,12 @@
 
 ## 构建与发布
 
-### 37 个公开 package 交付可执行产物
+### 38 个公开 package 交付可执行产物
 
-- 全部 37 个公开 `@proto.ui/*` package 现在都会在发布前生成 `dist/*.js` 与 `dist/*.d.ts`，package exports 分别指向 JavaScript runtime 与 declaration output，不再把需要 TypeScript loader 的 `.ts` 源码直接作为 npm runtime entry 发布。
+- 全部 38 个公开 `@proto.ui/*` package 现在都会在发布前生成 `dist/*.js` 与 `dist/*.d.ts`，package exports 分别指向 JavaScript runtime 与 declaration output，不再把需要 TypeScript loader 的 `.ts` 源码直接作为 npm runtime entry 发布。
 - 每个公开 package 现在都有 package-local `build` 与 `prepack` contract；根级 `build:packages` 按生产依赖拓扑构建所选 package 及其上游闭包，验证全部 export targets，并在不加载 TypeScript 的原生 Node ESM 环境中执行 import smoke。
 - Release staging 现在复用并复制开发与 CI 已验证的同一份本地 `dist`，不再维护另一条可能漂移的临时编译路径。
-- 公开 manifest 通过生成器统一维护 `dist` exports、`files` 白名单和 build scripts。源码与测试保留为仓库输入，但不再进入默认 npm payload；37 个 tarball 中的测试文件总量由 1,031,558 B 降至 0 B。
+- 公开 manifest 通过生成器统一维护 `dist` exports、`files` 白名单和 build scripts。源码与测试保留为仓库输入，但不再进入默认 npm payload；38 个 tarball 中的测试文件总量由 1,031,558 B 降至 0 B。
 
 ### Bundle、文档与 CI 反馈
 
@@ -56,8 +56,8 @@
 ## 验证
 
 - Trigger group 与 Tabs v4 样式还原通过完整工作区测试：239 个测试文件、1,077 个测试通过；prototype catalog、style preset、类型检查、Agent 文档生成检查与 Web Component/React/Vue 共享 Dialog conformance journey 通过。
-- 构建优化已验证 37/37 公开 package 的完整构建、export target、原生 Node ESM import、release stage 与 `npm publish --dry-run`；package manifest、bundle budget、类型、测试、Astro check 与文档构建门禁均通过。
-- Demo Matrix 开发路由实测同时挂载 27 个 demo、81 个 previewer，Web Component、React 与 Vue 各 27 个；生产构建的 150 个页面、sitemap 与 Pagefind index 均不包含其中英文 Demo Matrix 路由。新增的 development-only 与三 adapter 并排 policy 已进入 37 条 release tests。
+- 构建优化已验证 38/38 公开 package 的完整构建、export target、原生 Node ESM import、release stage 与 `npm publish --dry-run`；package manifest、bundle budget、类型、测试、Astro check 与文档构建门禁均通过。
+- Demo Matrix 开发路由实测同时挂载 27 个 demo、81 个 previewer，Web Component、React 与 Vue 各 27 个；生产构建的 150 个页面、sitemap 与 Pagefind index 均不包含其中英文 Demo Matrix 路由。新增的 development-only 与三 adapter 并排 policy 已进入 38 条 release tests。
 
 ## 升级提示
 
@@ -66,4 +66,4 @@
 
 ## 仍待发布准备
 
-- 本草案不代表 rc.7 已可安装。draft version entity、已对齐的公开 package manifest 与 37-package BOM 已存在；完整 release rehearsal、不可变 spec snapshot、Git tag、GitHub prerelease 与 npm publication 仍需在激活前单独验证。
+- 本草案不代表 rc.7 已可安装。draft version entity、已对齐的公开 package manifest 与 38-package BOM 已存在；完整 release rehearsal、不可变 spec snapshot、Git tag、GitHub prerelease 与 npm publication 仍需在激活前单独验证。

--- a/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
+++ b/packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
@@ -172,4 +172,56 @@ describe('contract: adapter-web-component / a11y projection (v0)', () => {
     el.getExposes().setDescription('tooltip-b');
     expect(el.getAttribute('aria-describedby')).toBe('host-help tooltip-b');
   });
+
+  it('A11Y-WC-0300: projects live, atomic, and busy a11y states to host attributes', () => {
+    // T-A11Y-0001-CASE-LIVE-ATOMIC-BUSY
+    const P = definePrototype({
+      name: 'x-a11y-wc-live-atomic-busy',
+      setup(def) {
+        const live = def.state.string('live', 'polite');
+        const atomic = def.state.bool('atomic', true);
+        const busy = def.state.bool('busy', false);
+        def.a11y.state('live', live);
+        def.a11y.state('atomic', atomic);
+        def.a11y.state('busy', busy);
+        def.expose.method('setLive', (value: string) => live.set(value));
+        def.expose.method('setAtomic', (value: boolean) => atomic.set(value));
+        def.expose.method('setBusy', (value: boolean) => busy.set(value));
+        return (r) => r.el('div', 'region');
+      },
+    });
+
+    if (!customElements.get(P.name)) {
+      customElements.define(
+        P.name,
+        AdaptToWebComponent(P, { register: false, registerAs: P.name })
+      );
+    }
+
+    const el = document.createElement(P.name) as HTMLElement & {
+      getExposes(): {
+        setLive(value: string): void;
+        setAtomic(value: boolean): void;
+        setBusy(value: boolean): void;
+      };
+    };
+    document.body.appendChild(el);
+
+    expect(el.getAttribute('aria-live')).toBe('polite');
+    expect(el.getAttribute('aria-atomic')).toBe('true');
+    expect(el.getAttribute('aria-busy')).toBe('false');
+
+    el.getExposes().setLive('assertive');
+    expect(el.getAttribute('aria-live')).toBe('assertive');
+
+    el.getExposes().setAtomic(false);
+    expect(el.getAttribute('aria-atomic')).toBe('false');
+
+    el.getExposes().setBusy(true);
+    expect(el.getAttribute('aria-busy')).toBe('true');
+
+    el.getExposes().setBusy(false);
+    expect(el.getAttribute('aria-busy')).toBe('false');
+    el.remove();
+  });
 });

--- a/packages/cli/src/registry/components.ts
+++ b/packages/cli/src/registry/components.ts
@@ -465,6 +465,18 @@ export const COMPONENT_REGISTRY: Record<string, ComponentEntry> = {
   ]),
 
   'base-separator': base('base-separator', 'Base Separator', 'separatorRoot', 'BaseSeparatorRoot'),
+  'base-live-region': base(
+    'base-live-region',
+    'Base Live Region',
+    'liveRegionRoot',
+    'BaseLiveRegionRoot'
+  ),
+  'base-async-region': base(
+    'base-async-region',
+    'Base Async Region',
+    'asyncRegionRoot',
+    'BaseAsyncRegionRoot'
+  ),
   'base-dialog': baseCompound('base-dialog', 'base Dialog', [
     {
       prototypeImport: 'dialogRoot',

--- a/packages/cli/src/services/prototype-style-tokens.ts
+++ b/packages/cli/src/services/prototype-style-tokens.ts
@@ -459,6 +459,10 @@ function resolveKnownAsHookStateHandles(node) {
     ]);
   }
 
+  if (hookName === 'asAsyncRegionRoot') {
+    return new Map([['busy', 'data-[busy]']]);
+  }
+
   if (hookName === 'asSeparatorRoot') {
     return new Map([['orientation', 'data-[orientation]']]);
   }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -127,6 +127,48 @@ describe('@proto.ui/cli', () => {
     });
   });
 
+  it('materializes Base Live Region and Async Region facades for every adapter', () => {
+    const componentIds = ['base-live-region', 'base-async-region'];
+
+    for (const host of ['react', 'vue'] as const) {
+      const source = renderHostIndex(host, componentIds);
+      expect(source).toContain(
+        `import { liveRegionRoot } from '@proto.ui/prototypes-base/live-region';`
+      );
+      expect(source).toContain(
+        `import { asyncRegionRoot } from '@proto.ui/prototypes-base/async-region';`
+      );
+      expect(source).toContain('export const BaseLiveRegionRoot = adapt(liveRegionRoot);');
+      expect(source).toContain('export const BaseAsyncRegionRoot = adapt(asyncRegionRoot);');
+    }
+
+    const wc = renderHostIndex('wc', componentIds);
+    expect(wc).toContain(
+      `export const BaseLiveRegionRootElement = AdaptToWebComponent(liveRegionRoot, { registerAs: 'proto-ui-base-live-region' });`
+    );
+    expect(wc).toContain(
+      `export const BaseAsyncRegionRootElement = AdaptToWebComponent(asyncRegionRoot, { registerAs: 'proto-ui-base-async-region' });`
+    );
+
+    const root = renderRootIndex({
+      react: componentIds,
+      vue: componentIds,
+      wc: componentIds,
+    });
+    expect(root).toContain(
+      `export { BaseLiveRegionRoot as ReactBaseLiveRegionRoot } from './react';`
+    );
+    expect(root).toContain(
+      `export { BaseAsyncRegionRoot as ReactBaseAsyncRegionRoot } from './react';`
+    );
+    expect(root).toContain(`export { BaseLiveRegionRoot as VueBaseLiveRegionRoot } from './vue';`);
+    expect(root).toContain(
+      `export { BaseAsyncRegionRoot as VueBaseAsyncRegionRoot } from './vue';`
+    );
+    expect(root).toContain(`export { BaseLiveRegionRootElement } from './wc';`);
+    expect(root).toContain(`export { BaseAsyncRegionRootElement } from './wc';`);
+  });
+
   it('materializes the replaceable shadcn Switch Thumb preset for every adapter', () => {
     const react = renderHostIndex('react', ['shadcn-switch']);
     expect(react).toContain('export const ShadcnSwitchRoot = adapt(shadcnSwitchRoot);');

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -96,6 +96,37 @@ describe('@proto.ui/cli', () => {
     }
   });
 
+  it('registers Base Live Region and Async Region public facades', () => {
+    expect(COMPONENT_REGISTRY['base-live-region']).toMatchObject({
+      packageName: '@proto.ui/prototypes-base',
+      importPath: '@proto.ui/prototypes-base/live-region',
+      stylePreset: null,
+      items: [
+        {
+          prototypeImport: 'liveRegionRoot',
+          reactExport: 'BaseLiveRegionRoot',
+          vueExport: 'BaseLiveRegionRoot',
+          wcExport: 'BaseLiveRegionRootElement',
+          elementName: 'proto-ui-base-live-region',
+        },
+      ],
+    });
+    expect(COMPONENT_REGISTRY['base-async-region']).toMatchObject({
+      packageName: '@proto.ui/prototypes-base',
+      importPath: '@proto.ui/prototypes-base/async-region',
+      stylePreset: null,
+      items: [
+        {
+          prototypeImport: 'asyncRegionRoot',
+          reactExport: 'BaseAsyncRegionRoot',
+          vueExport: 'BaseAsyncRegionRoot',
+          wcExport: 'BaseAsyncRegionRootElement',
+          elementName: 'proto-ui-base-async-region',
+        },
+      ],
+    });
+  });
+
   it('materializes the replaceable shadcn Switch Thumb preset for every adapter', () => {
     const react = renderHostIndex('react', ['shadcn-switch']);
     expect(react).toContain('export const ShadcnSwitchRoot = adapt(shadcnSwitchRoot);');

--- a/packages/cli/test/prototype-style-tokens.test.ts
+++ b/packages/cli/test/prototype-style-tokens.test.ts
@@ -125,4 +125,31 @@ describe('collectProtoStyleTokens', () => {
     expect(tokens).toContain('data-[orientation=vertical]:h-12');
     expect(tokens).toContain('data-[orientation=vertical]:w-0.5');
   });
+
+  it('maps asAsyncRegionRoot busy rules to the data-busy web serialization', async () => {
+    await writeFile(
+      path.join(dir, 'async-region.proto.ts'),
+      [
+        "import { definePrototype, tw } from '@proto.ui/core';",
+        "import { asAsyncRegionRoot } from '@proto.ui/prototypes-base/async-region';",
+        '',
+        'const asyncRegion = definePrototype({',
+        "  name: 'styled-async-region',",
+        '  setup(def) {',
+        '    const { busy } = asAsyncRegionRoot().stateHandles;',
+        '    def.rule({',
+        '      when: (w) => w.state(busy).eq(true),',
+        "      intent: (i) => i.feedback.style.use(tw('opacity-50 cursor-wait')),",
+        '    });',
+        '  },',
+        '});',
+        'export default asyncRegion;',
+      ].join('\n')
+    );
+
+    const tokens = await collectProtoStyleTokens(dir);
+
+    expect(tokens).toContain('data-[busy]:opacity-50');
+    expect(tokens).toContain('data-[busy]:cursor-wait');
+  });
 });

--- a/packages/modules/a11y/src/web.ts
+++ b/packages/modules/a11y/src/web.ts
@@ -3,11 +3,14 @@ import type { A11ySemanticObjectSnapshot } from '@proto.ui/core';
 import type { A11yProjector } from './caps';
 
 const ARIA_STATE_ATTRS: Record<string, string> = {
+  atomic: 'aria-atomic',
+  busy: 'aria-busy',
   checked: 'aria-checked',
   disabled: 'aria-disabled',
   expanded: 'aria-expanded',
   hasPopup: 'aria-haspopup',
   invalid: 'aria-invalid',
+  live: 'aria-live',
   orientation: 'aria-orientation',
   pressed: 'aria-pressed',
   selected: 'aria-selected',

--- a/packages/prototypes/base/package.json
+++ b/packages/prototypes/base/package.json
@@ -96,6 +96,16 @@
       "types": "./dist/scroll-area/index.d.ts",
       "import": "./dist/scroll-area/index.js",
       "default": "./dist/scroll-area/index.js"
+    },
+    "./live-region": {
+      "types": "./dist/live-region/index.d.ts",
+      "import": "./dist/live-region/index.js",
+      "default": "./dist/live-region/index.js"
+    },
+    "./async-region": {
+      "types": "./dist/async-region/index.d.ts",
+      "import": "./dist/async-region/index.js",
+      "default": "./dist/async-region/index.js"
     }
   },
   "description": "Base Proto UI prototype library for reusable interaction prototypes.",

--- a/packages/prototypes/base/src/async-region/index.ts
+++ b/packages/prototypes/base/src/async-region/index.ts
@@ -1,4 +1,4 @@
-export { asAsyncRegionRoot, default as asyncRegionRoot } from './root.proto';
+export { asAsyncRegionRoot, default, default as asyncRegionRoot } from './root.proto';
 export type {
   AsyncRegionRootProps,
   AsyncRegionRootExposes,

--- a/packages/prototypes/base/src/async-region/index.ts
+++ b/packages/prototypes/base/src/async-region/index.ts
@@ -1,0 +1,7 @@
+export { asAsyncRegionRoot, default as asyncRegionRoot } from './root.proto';
+export type {
+  AsyncRegionRootProps,
+  AsyncRegionRootExposes,
+  AsyncRegionRootStateHandles,
+  AsyncRegionRootAsHookContract,
+} from './root.proto';

--- a/packages/prototypes/base/src/async-region/root.proto.ts
+++ b/packages/prototypes/base/src/async-region/root.proto.ts
@@ -1,4 +1,4 @@
-import type { DefHandle } from '@proto.ui/core';
+import type { DefHandle, RenderFn } from '@proto.ui/core';
 import { defineAsHook, definePrototype } from '@proto.ui/core';
 import type {
   AsyncRegionRootAsHookContract,
@@ -13,7 +13,9 @@ export type {
   AsyncRegionRootAsHookContract,
 } from './types';
 
-function setupAsyncRegionRoot(def: DefHandle<AsyncRegionRootProps, AsyncRegionRootExposes>) {
+function setupAsyncRegionRoot(
+  def: DefHandle<AsyncRegionRootProps, AsyncRegionRootExposes>
+): RenderFn {
   // P-BASE-ASYNC-REGION-BUSY
   def.props.define({
     busy: { type: 'boolean', empty: 'fallback' },
@@ -42,5 +44,8 @@ export const asAsyncRegionRoot = defineAsHook<
   AsyncRegionRootAsHookContract
 >({ name: 'as-async-region-root', setup: setupAsyncRegionRoot });
 
-const asyncRegionRoot = definePrototype({ name: 'base-async-region-root', setup: setupAsyncRegionRoot });
+const asyncRegionRoot = definePrototype({
+  name: 'base-async-region-root',
+  setup: setupAsyncRegionRoot,
+});
 export default asyncRegionRoot;

--- a/packages/prototypes/base/src/async-region/root.proto.ts
+++ b/packages/prototypes/base/src/async-region/root.proto.ts
@@ -1,0 +1,46 @@
+import type { DefHandle } from '@proto.ui/core';
+import { defineAsHook, definePrototype } from '@proto.ui/core';
+import type {
+  AsyncRegionRootAsHookContract,
+  AsyncRegionRootExposes,
+  AsyncRegionRootProps,
+} from './types';
+
+export type {
+  AsyncRegionRootProps,
+  AsyncRegionRootExposes,
+  AsyncRegionRootStateHandles,
+  AsyncRegionRootAsHookContract,
+} from './types';
+
+function setupAsyncRegionRoot(def: DefHandle<AsyncRegionRootProps, AsyncRegionRootExposes>) {
+  // P-BASE-ASYNC-REGION-BUSY
+  def.props.define({
+    busy: { type: 'boolean', empty: 'fallback' },
+  });
+  def.props.setDefaults({ busy: false });
+
+  // P-BASE-ASYNC-REGION-BUSY
+  const busy = def.state.bool('busy', false);
+  def.expose.state('busy', busy);
+  def.a11y.state('busy', busy);
+
+  // P-BASE-ASYNC-REGION-BUSY, P-BASE-ASYNC-REGION-DYNAMIC
+  const sync = (props: Readonly<AsyncRegionRootProps>) => {
+    busy.set(props.busy ?? false, 'reason: async region busy');
+  };
+  def.lifecycle.onCreated((run) => sync(run.props.get()));
+  def.props.watchAll((_run, next) => sync(next));
+  // P-BASE-ASYNC-REGION-CONTENT: authored descendants and focus are preserved on prop-only transitions.
+  return (r) => r.slot();
+}
+
+// P-BASE-ASYNC-REGION-NO-INTERACTION: no focus, event, command, or announcement channel.
+export const asAsyncRegionRoot = defineAsHook<
+  AsyncRegionRootProps,
+  AsyncRegionRootExposes,
+  AsyncRegionRootAsHookContract
+>({ name: 'as-async-region-root', setup: setupAsyncRegionRoot });
+
+const asyncRegionRoot = definePrototype({ name: 'base-async-region-root', setup: setupAsyncRegionRoot });
+export default asyncRegionRoot;

--- a/packages/prototypes/base/src/async-region/types.ts
+++ b/packages/prototypes/base/src/async-region/types.ts
@@ -1,0 +1,16 @@
+import type { ExposeState, State } from '@proto.ui/core';
+
+export interface AsyncRegionRootProps {
+  busy?: boolean;
+}
+
+// P-BASE-ASYNC-REGION-BUSY: only the governed busy state is exposed.
+export type AsyncRegionRootExposes = {
+  busy: ExposeState<boolean>;
+};
+
+export type AsyncRegionRootStateHandles = {
+  busy: State<boolean>;
+};
+
+export type AsyncRegionRootAsHookContract = { state: AsyncRegionRootStateHandles };

--- a/packages/prototypes/base/src/index.ts
+++ b/packages/prototypes/base/src/index.ts
@@ -23,3 +23,7 @@ export * from './separator';
 export { default as separatorRoot } from './separator';
 export * from './scroll-area';
 export { default as scrollAreaRoot } from './scroll-area';
+export * from './live-region';
+export { default as liveRegionRoot } from './live-region';
+export * from './async-region';
+export { default as asyncRegionRoot } from './async-region';

--- a/packages/prototypes/base/src/live-region/index.ts
+++ b/packages/prototypes/base/src/live-region/index.ts
@@ -1,4 +1,4 @@
-export { asLiveRegionRoot, default as liveRegionRoot } from './root.proto';
+export { asLiveRegionRoot, default, default as liveRegionRoot } from './root.proto';
 export type {
   LiveRegionPoliteness,
   LiveRegionRootProps,

--- a/packages/prototypes/base/src/live-region/index.ts
+++ b/packages/prototypes/base/src/live-region/index.ts
@@ -1,0 +1,8 @@
+export { asLiveRegionRoot, default as liveRegionRoot } from './root.proto';
+export type {
+  LiveRegionPoliteness,
+  LiveRegionRootProps,
+  LiveRegionRootExposes,
+  LiveRegionRootStateHandles,
+  LiveRegionRootAsHookContract,
+} from './root.proto';

--- a/packages/prototypes/base/src/live-region/root.proto.ts
+++ b/packages/prototypes/base/src/live-region/root.proto.ts
@@ -1,4 +1,4 @@
-import type { DefHandle } from '@proto.ui/core';
+import type { DefHandle, RenderFn } from '@proto.ui/core';
 import { defineAsHook, definePrototype } from '@proto.ui/core';
 import type {
   LiveRegionRootAsHookContract,
@@ -14,7 +14,7 @@ export type {
   LiveRegionRootAsHookContract,
 } from './types';
 
-function setupLiveRegionRoot(def: DefHandle<LiveRegionRootProps, LiveRegionRootExposes>) {
+function setupLiveRegionRoot(def: DefHandle<LiveRegionRootProps, LiveRegionRootExposes>): RenderFn {
   // P-BASE-LIVE-REGION-POLITENESS, P-BASE-LIVE-REGION-ATOMIC
   def.props.define({
     politeness: { type: 'enum', empty: 'fallback', options: ['polite', 'assertive'] },
@@ -51,5 +51,8 @@ export const asLiveRegionRoot = defineAsHook<
   LiveRegionRootAsHookContract
 >({ name: 'as-live-region-root', setup: setupLiveRegionRoot });
 
-const liveRegionRoot = definePrototype({ name: 'base-live-region-root', setup: setupLiveRegionRoot });
+const liveRegionRoot = definePrototype({
+  name: 'base-live-region-root',
+  setup: setupLiveRegionRoot,
+});
 export default liveRegionRoot;

--- a/packages/prototypes/base/src/live-region/root.proto.ts
+++ b/packages/prototypes/base/src/live-region/root.proto.ts
@@ -1,0 +1,55 @@
+import type { DefHandle } from '@proto.ui/core';
+import { defineAsHook, definePrototype } from '@proto.ui/core';
+import type {
+  LiveRegionRootAsHookContract,
+  LiveRegionRootExposes,
+  LiveRegionRootProps,
+} from './types';
+
+export type {
+  LiveRegionPoliteness,
+  LiveRegionRootProps,
+  LiveRegionRootExposes,
+  LiveRegionRootStateHandles,
+  LiveRegionRootAsHookContract,
+} from './types';
+
+function setupLiveRegionRoot(def: DefHandle<LiveRegionRootProps, LiveRegionRootExposes>) {
+  // P-BASE-LIVE-REGION-POLITENESS, P-BASE-LIVE-REGION-ATOMIC
+  def.props.define({
+    politeness: { type: 'enum', empty: 'fallback', options: ['polite', 'assertive'] },
+    atomic: { type: 'boolean', empty: 'fallback' },
+  });
+  def.props.setDefaults({ politeness: 'polite', atomic: true });
+
+  // P-BASE-LIVE-REGION-SEMANTICS
+  const role = def.state.string('role', 'status');
+  const live = def.state.string('live', 'polite');
+  const atomic = def.state.bool('atomic', true);
+  def.a11y.role(role);
+  def.a11y.state('live', live);
+  def.a11y.state('atomic', atomic);
+
+  // P-BASE-LIVE-REGION-SEMANTICS, P-BASE-LIVE-REGION-DYNAMIC
+  const sync = (props: Readonly<LiveRegionRootProps>) => {
+    const nextPoliteness = props.politeness ?? 'polite';
+    const nextAtomic = props.atomic ?? true;
+    role.set(nextPoliteness === 'assertive' ? 'alert' : 'status', 'reason: live region role');
+    live.set(nextPoliteness, 'reason: live region politeness');
+    atomic.set(nextAtomic, 'reason: live region atomic');
+  };
+  def.lifecycle.onCreated((run) => sync(run.props.get()));
+  def.props.watchAll((_run, next) => sync(next));
+  // P-BASE-LIVE-REGION-CONTENT: authored descendants are the announcement payload.
+  return (r) => r.slot();
+}
+
+// P-BASE-LIVE-REGION-NO-INTERACTION: no focus, event, or command channel.
+export const asLiveRegionRoot = defineAsHook<
+  LiveRegionRootProps,
+  LiveRegionRootExposes,
+  LiveRegionRootAsHookContract
+>({ name: 'as-live-region-root', setup: setupLiveRegionRoot });
+
+const liveRegionRoot = definePrototype({ name: 'base-live-region-root', setup: setupLiveRegionRoot });
+export default liveRegionRoot;

--- a/packages/prototypes/base/src/live-region/types.ts
+++ b/packages/prototypes/base/src/live-region/types.ts
@@ -1,0 +1,15 @@
+import type { State } from '@proto.ui/core';
+
+export type LiveRegionPoliteness = 'polite' | 'assertive';
+
+export interface LiveRegionRootProps {
+  politeness?: LiveRegionPoliteness;
+  atomic?: boolean;
+}
+
+// P-BASE-LIVE-REGION-NO-INTERACTION: no exposes surface.
+export type LiveRegionRootExposes = {};
+
+export type LiveRegionRootStateHandles = {};
+
+export type LiveRegionRootAsHookContract = { state: LiveRegionRootStateHandles };

--- a/packages/prototypes/base/src/live-region/types.ts
+++ b/packages/prototypes/base/src/live-region/types.ts
@@ -1,5 +1,3 @@
-import type { State } from '@proto.ui/core';
-
 export type LiveRegionPoliteness = 'polite' | 'assertive';
 
 export interface LiveRegionRootProps {

--- a/packages/prototypes/base/test/async-region.test.ts
+++ b/packages/prototypes/base/test/async-region.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
 import asyncRegionRoot from '../src/async-region';
 import type { State } from '@proto.ui/core';
-import type {
-  AsyncRegionRootExposes,
-  AsyncRegionRootStateHandles,
-} from '../src/async-region';
+import type { AsyncRegionRootExposes, AsyncRegionRootStateHandles } from '../src/async-region';
 
 type StateValue<T> =
   T extends State<infer V> ? V : T extends { kind: 'state'; state: State<infer V> } ? V : never;
@@ -15,12 +12,8 @@ AdaptToWebComponent(asyncRegionRoot);
 describe('prototypes/base: async-region', () => {
   it('preserves the boolean busy type across public state handles', () => {
     // T-BASE-ASYNC-REGION-0001-CASE-TYPED-BUSY
-    expectTypeOf<
-      StateValue<AsyncRegionRootExposes['busy']>
-    >().toEqualTypeOf<boolean>();
-    expectTypeOf<
-      StateValue<AsyncRegionRootStateHandles['busy']>
-    >().toEqualTypeOf<boolean>();
+    expectTypeOf<StateValue<AsyncRegionRootExposes['busy']>>().toEqualTypeOf<boolean>();
+    expectTypeOf<StateValue<AsyncRegionRootStateHandles['busy']>>().toEqualTypeOf<boolean>();
   });
 
   it('defaults to not-busy semantics with governed busy expose and no interaction', async () => {
@@ -32,6 +25,7 @@ describe('prototypes/base: async-region', () => {
     await Promise.resolve();
 
     expect(el.getAttribute('aria-busy')).toBe('false');
+    expect(el.hasAttribute('data-busy')).toBe(false);
     expect(el.hasAttribute('role')).toBe(false);
     expect(el.hasAttribute('aria-label')).toBe(false);
     expect(el.tabIndex).toBe(-1);
@@ -43,13 +37,12 @@ describe('prototypes/base: async-region', () => {
   it('projects aria-busy true when busy prop is set', async () => {
     // T-BASE-ASYNC-REGION-0001-CASE-BUSY-TRUE
     const el = document.createElement('base-async-region-root');
+    setElementProps(el, { busy: true });
     document.body.appendChild(el);
     await Promise.resolve();
 
-    setElementProps(el, { busy: true });
-    await Promise.resolve();
-    await Promise.resolve();
     expect(el.getAttribute('aria-busy')).toBe('true');
+    expect(el.hasAttribute('data-busy')).toBe(true);
     el.remove();
   });
 
@@ -64,15 +57,13 @@ describe('prototypes/base: async-region', () => {
     expect(el.getExposes().busy.get()).toBe(false);
 
     setElementProps(el, { busy: true });
-    await Promise.resolve();
-    await Promise.resolve();
     expect(el.getAttribute('aria-busy')).toBe('true');
+    expect(el.hasAttribute('data-busy')).toBe(true);
     expect(el.getExposes().busy.get()).toBe(true);
 
     setElementProps(el, { busy: false });
-    await Promise.resolve();
-    await Promise.resolve();
     expect(el.getAttribute('aria-busy')).toBe('false');
+    expect(el.hasAttribute('data-busy')).toBe(false);
     expect(el.getExposes().busy.get()).toBe(false);
     el.remove();
   });
@@ -85,20 +76,20 @@ describe('prototypes/base: async-region', () => {
     el.appendChild(button);
     document.body.appendChild(el);
     await Promise.resolve();
+    button.focus();
+    expect(document.activeElement).toBe(button);
 
     expect(el.textContent).toBe('Retry');
 
     setElementProps(el, { busy: true });
-    await Promise.resolve();
-    await Promise.resolve();
     expect(el.textContent).toBe('Retry');
     expect(el.getAttribute('aria-busy')).toBe('true');
+    expect(document.activeElement).toBe(button);
 
     setElementProps(el, { busy: false });
-    await Promise.resolve();
-    await Promise.resolve();
     expect(el.textContent).toBe('Retry');
     expect(el.getAttribute('aria-busy')).toBe('false');
+    expect(document.activeElement).toBe(button);
     el.remove();
   });
 });

--- a/packages/prototypes/base/test/async-region.test.ts
+++ b/packages/prototypes/base/test/async-region.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
+import asyncRegionRoot from '../src/async-region';
+import type { State } from '@proto.ui/core';
+import type {
+  AsyncRegionRootExposes,
+  AsyncRegionRootStateHandles,
+} from '../src/async-region';
+
+type StateValue<T> =
+  T extends State<infer V> ? V : T extends { kind: 'state'; state: State<infer V> } ? V : never;
+
+AdaptToWebComponent(asyncRegionRoot);
+
+describe('prototypes/base: async-region', () => {
+  it('preserves the boolean busy type across public state handles', () => {
+    // T-BASE-ASYNC-REGION-0001-CASE-TYPED-BUSY
+    expectTypeOf<
+      StateValue<AsyncRegionRootExposes['busy']>
+    >().toEqualTypeOf<boolean>();
+    expectTypeOf<
+      StateValue<AsyncRegionRootStateHandles['busy']>
+    >().toEqualTypeOf<boolean>();
+  });
+
+  it('defaults to not-busy semantics with governed busy expose and no interaction', async () => {
+    // T-BASE-ASYNC-REGION-0001-CASE-DEFAULTS
+    const el = document.createElement('base-async-region-root') as HTMLElement & {
+      getExposes(): Record<string, unknown>;
+    };
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    expect(el.getAttribute('aria-busy')).toBe('false');
+    expect(el.hasAttribute('role')).toBe(false);
+    expect(el.hasAttribute('aria-label')).toBe(false);
+    expect(el.tabIndex).toBe(-1);
+    expect(Object.keys(el.getExposes()).sort()).toEqual(['busy']);
+    expect(el.hasAttribute('data-pui-a11y-actions')).toBe(false);
+    el.remove();
+  });
+
+  it('projects aria-busy true when busy prop is set', async () => {
+    // T-BASE-ASYNC-REGION-0001-CASE-BUSY-TRUE
+    const el = document.createElement('base-async-region-root');
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    setElementProps(el, { busy: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.getAttribute('aria-busy')).toBe('true');
+    el.remove();
+  });
+
+  it('updates aria-busy and the busy expose handle on mounted prop transitions', async () => {
+    // T-BASE-ASYNC-REGION-0001-CASE-DYNAMIC-BUSY
+    const el = document.createElement('base-async-region-root') as HTMLElement & {
+      getExposes(): { busy: { get(): boolean } };
+    };
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    expect(el.getExposes().busy.get()).toBe(false);
+
+    setElementProps(el, { busy: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.getAttribute('aria-busy')).toBe('true');
+    expect(el.getExposes().busy.get()).toBe(true);
+
+    setElementProps(el, { busy: false });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.getAttribute('aria-busy')).toBe('false');
+    expect(el.getExposes().busy.get()).toBe(false);
+    el.remove();
+  });
+
+  it('preserves authored descendants and focus on prop-only transitions', async () => {
+    // T-BASE-ASYNC-REGION-0001-CASE-CONTENT-PRESERVATION
+    const el = document.createElement('base-async-region-root');
+    const button = document.createElement('button');
+    button.textContent = 'Retry';
+    el.appendChild(button);
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    expect(el.textContent).toBe('Retry');
+
+    setElementProps(el, { busy: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.textContent).toBe('Retry');
+    expect(el.getAttribute('aria-busy')).toBe('true');
+
+    setElementProps(el, { busy: false });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.textContent).toBe('Retry');
+    expect(el.getAttribute('aria-busy')).toBe('false');
+    el.remove();
+  });
+});

--- a/packages/prototypes/base/test/live-region.test.ts
+++ b/packages/prototypes/base/test/live-region.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { AdaptToWebComponent, setElementProps } from '@proto.ui/adapter-web-component';
+import liveRegionRoot from '../src/live-region';
+import type { State } from '@proto.ui/core';
+import type {
+  LiveRegionPoliteness,
+  LiveRegionRootExposes,
+  LiveRegionRootStateHandles,
+} from '../src/live-region';
+
+type StateValue<T> =
+  T extends State<infer V> ? V : T extends { kind: 'state'; state: State<infer V> } ? V : never;
+
+AdaptToWebComponent(liveRegionRoot);
+
+describe('prototypes/base: live-region', () => {
+  it('preserves the politeness literal union across public type surfaces', () => {
+    // T-BASE-LIVE-REGION-0001-CASE-TYPED-POLITENESS
+    expectTypeOf<LiveRegionPoliteness>().toEqualTypeOf<'polite' | 'assertive'>();
+    expectTypeOf<LiveRegionRootStateHandles>().toEqualTypeOf<{}>();
+    expectTypeOf<LiveRegionRootExposes>().toEqualTypeOf<{}>();
+  });
+
+  it('defaults to polite status semantics with atomic true and no interaction', async () => {
+    // T-BASE-LIVE-REGION-0001-CASE-DEFAULTS
+    const el = document.createElement('base-live-region-root') as HTMLElement & {
+      getExposes(): Record<string, unknown>;
+    };
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    expect(el.getAttribute('role')).toBe('status');
+    expect(el.getAttribute('aria-live')).toBe('polite');
+    expect(el.getAttribute('aria-atomic')).toBe('true');
+    expect(el.tabIndex).toBe(-1);
+    expect(Object.keys(el.getExposes())).toEqual([]);
+    expect(el.hasAttribute('data-pui-a11y-actions')).toBe(false);
+    el.remove();
+  });
+
+  it('projects alert role and assertive aria-live for assertive politeness', async () => {
+    // T-BASE-LIVE-REGION-0001-CASE-ASSERTIVE
+    const el = document.createElement('base-live-region-root');
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    setElementProps(el, { politeness: 'assertive' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.getAttribute('role')).toBe('alert');
+    expect(el.getAttribute('aria-live')).toBe('assertive');
+    expect(el.getAttribute('aria-atomic')).toBe('true');
+    el.remove();
+  });
+
+  it('projects aria-atomic false when atomic prop is false', async () => {
+    // T-BASE-LIVE-REGION-0001-CASE-ATOMIC-FALSE
+    const el = document.createElement('base-live-region-root');
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    setElementProps(el, { atomic: false });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.getAttribute('aria-atomic')).toBe('false');
+    expect(el.getAttribute('role')).toBe('status');
+    expect(el.getAttribute('aria-live')).toBe('polite');
+    el.remove();
+  });
+
+  it('updates role, aria-live, and aria-atomic atomically on mounted prop transitions', async () => {
+    // T-BASE-LIVE-REGION-0001-CASE-DYNAMIC-SEMANTICS
+    const el = document.createElement('base-live-region-root');
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    setElementProps(el, { politeness: 'assertive', atomic: false });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.getAttribute('role')).toBe('alert');
+    expect(el.getAttribute('aria-live')).toBe('assertive');
+    expect(el.getAttribute('aria-atomic')).toBe('false');
+
+    setElementProps(el, { politeness: 'polite', atomic: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.getAttribute('role')).toBe('status');
+    expect(el.getAttribute('aria-live')).toBe('polite');
+    expect(el.getAttribute('aria-atomic')).toBe('true');
+    el.remove();
+  });
+
+  it('preserves authored child content as the announcement payload across prop transitions', async () => {
+    // T-BASE-LIVE-REGION-0001-CASE-CONTENT-PRESERVATION
+    const el = document.createElement('base-live-region-root');
+    const text = document.createTextNode('3 new notifications');
+    el.appendChild(text);
+    document.body.appendChild(el);
+    await Promise.resolve();
+
+    expect(el.textContent).toBe('3 new notifications');
+
+    setElementProps(el, { politeness: 'assertive' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.textContent).toBe('3 new notifications');
+    expect(el.getAttribute('role')).toBe('alert');
+
+    setElementProps(el, { politeness: 'polite', atomic: false });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(el.textContent).toBe('3 new notifications');
+    expect(el.getAttribute('role')).toBe('status');
+    expect(el.getAttribute('aria-atomic')).toBe('false');
+    el.remove();
+  });
+});

--- a/packages/prototypes/base/test/live-region.test.ts
+++ b/packages/prototypes/base/test/live-region.test.ts
@@ -41,12 +41,10 @@ describe('prototypes/base: live-region', () => {
   it('projects alert role and assertive aria-live for assertive politeness', async () => {
     // T-BASE-LIVE-REGION-0001-CASE-ASSERTIVE
     const el = document.createElement('base-live-region-root');
+    setElementProps(el, { politeness: 'assertive' });
     document.body.appendChild(el);
     await Promise.resolve();
 
-    setElementProps(el, { politeness: 'assertive' });
-    await Promise.resolve();
-    await Promise.resolve();
     expect(el.getAttribute('role')).toBe('alert');
     expect(el.getAttribute('aria-live')).toBe('assertive');
     expect(el.getAttribute('aria-atomic')).toBe('true');
@@ -56,34 +54,28 @@ describe('prototypes/base: live-region', () => {
   it('projects aria-atomic false when atomic prop is false', async () => {
     // T-BASE-LIVE-REGION-0001-CASE-ATOMIC-FALSE
     const el = document.createElement('base-live-region-root');
+    setElementProps(el, { atomic: false });
     document.body.appendChild(el);
     await Promise.resolve();
 
-    setElementProps(el, { atomic: false });
-    await Promise.resolve();
-    await Promise.resolve();
     expect(el.getAttribute('aria-atomic')).toBe('false');
     expect(el.getAttribute('role')).toBe('status');
     expect(el.getAttribute('aria-live')).toBe('polite');
     el.remove();
   });
 
-  it('updates role, aria-live, and aria-atomic atomically on mounted prop transitions', async () => {
+  it('updates role, aria-live, and aria-atomic synchronously on mounted prop transitions', async () => {
     // T-BASE-LIVE-REGION-0001-CASE-DYNAMIC-SEMANTICS
     const el = document.createElement('base-live-region-root');
     document.body.appendChild(el);
     await Promise.resolve();
 
     setElementProps(el, { politeness: 'assertive', atomic: false });
-    await Promise.resolve();
-    await Promise.resolve();
     expect(el.getAttribute('role')).toBe('alert');
     expect(el.getAttribute('aria-live')).toBe('assertive');
     expect(el.getAttribute('aria-atomic')).toBe('false');
 
     setElementProps(el, { politeness: 'polite', atomic: true });
-    await Promise.resolve();
-    await Promise.resolve();
     expect(el.getAttribute('role')).toBe('status');
     expect(el.getAttribute('aria-live')).toBe('polite');
     expect(el.getAttribute('aria-atomic')).toBe('true');

--- a/packages/prototypes/base/test/live-region.test.ts
+++ b/packages/prototypes/base/test/live-region.test.ts
@@ -33,6 +33,7 @@ describe('prototypes/base: live-region', () => {
     expect(el.getAttribute('aria-live')).toBe('polite');
     expect(el.getAttribute('aria-atomic')).toBe('true');
     expect(el.tabIndex).toBe(-1);
+    expect(el.hasAttribute('aria-label')).toBe(false);
     expect(Object.keys(el.getExposes())).toEqual([]);
     expect(el.hasAttribute('data-pui-a11y-actions')).toBe(false);
     el.remove();

--- a/spec/contracts/C-ASYNC-A11Y-0001.yaml
+++ b/spec/contracts/C-ASYNC-A11Y-0001.yaml
@@ -3,26 +3,30 @@ type: contract
 title: Async accessibility boundary contracts
 status: draft
 since: 0.2.0-rc.7
-summary: Live Region and Async Region define the narrow async accessibility boundary: governed ARIA live/atomic/busy projection without interaction, announcements, or replacement state machines.
+summary: >-
+  Live Region and Async Region define the narrow async accessibility boundary: governed ARIA live/atomic/busy projection without interaction, announcements, or replacement state machines.
+
+
 statement:
   zh-CN: >-
-    Live Region 与 Async Region 构成异步无障碍边界：Live Region 通过受治理的 politeness/atomic
-    props 原子地投射 role、aria-live 与 aria-atomic，authored 子内容即为播报载荷；Async Region
-    通过受治理的 busy prop 投射 aria-busy 并暴露 busy state handle。两者均不声明 focus、event、
-    command、announcement 定时器、替换状态机或聊天语义；应用层负责在 styled Card/Badge 表面中组合
-    这些语义原语。
+    Live Region 与 Async Region 构成异步无障碍边界：Live Region 通过受治理的 politeness/atomic props 投射 role、aria-live 与 aria-atomic，authored 子内容即为播报载荷；Async Region 通过受治理的 busy prop 投射 aria-busy 并暴露 busy state handle。两者均不声明 focus、event、 command、announcement 定时器、替换状态机或聊天语义；应用层负责在 styled Card/Badge 表面中组合 这些语义原语。
+
+
   en: >-
-    Live Region and Async Region form the async accessibility boundary: Live Region atomically projects
-    role, aria-live, and aria-atomic from governed politeness/atomic props, with authored child content
-    as the announcement payload; Async Region projects aria-busy from a governed busy prop and exposes
-    the busy state handle. Neither declares focus, event, command, announcement timers, replacement
-    state machines, or chat semantics; applications compose these semantic primitives inside styled
-    Card/Badge surfaces.
+    Live Region and Async Region form the async accessibility boundary: Live Region projects role, aria-live, and aria-atomic from governed politeness/atomic props, with authored child content as the announcement payload; Async Region projects aria-busy from a governed busy prop and exposes the busy state handle. Neither declares focus, event, command, announcement timers, replacement state machines, or chat semantics; applications compose these semantic primitives inside styled Card/Badge surfaces.
+
+
 criteria:
   - id: C-ASYNC-A11Y-0001-A
     text:
-      zh-CN: Live Region 必须从 politeness prop 原子地推导 role 与 aria-live：polite 对应 role=status + aria-live=polite，assertive 对应 role=alert + aria-live=assertive。
-      en: Live Region must atomically derive role and aria-live from the politeness prop: polite maps to role=status + aria-live=polite, assertive maps to role=alert + aria-live=assertive.
+      zh-CN: >-
+        Live Region 必须从 politeness prop 成对推导 role 与 aria-live：polite 对应 role=status + aria-live=polite，assertive 对应 role=alert + aria-live=assertive。
+
+
+      en: >-
+        Live Region must derive role and aria-live together from the politeness prop: polite maps to role=status + aria-live=polite, assertive maps to role=alert + aria-live=assertive.
+
+
   - id: C-ASYNC-A11Y-0001-B
     text:
       zh-CN: Live Region 必须将 atomic prop 投射为 aria-atomic，默认 true，mounted prop 变更必须同步更新 role、aria-live 与 aria-atomic。

--- a/spec/contracts/C-ASYNC-A11Y-0001.yaml
+++ b/spec/contracts/C-ASYNC-A11Y-0001.yaml
@@ -4,16 +4,16 @@ title: Async accessibility boundary contracts
 status: draft
 since: 0.2.0-rc.7
 summary: >-
-  Live Region and Async Region define the narrow async accessibility boundary: governed ARIA live/atomic/busy projection without interaction, announcements, or replacement state machines.
+  Live Region and Async Region define the narrow async accessibility boundary: governed ARIA live/atomic/busy projection without interaction, announcement scheduling, or replacement state machines.
 
 
 statement:
   zh-CN: >-
-    Live Region 与 Async Region 构成异步无障碍边界：Live Region 通过受治理的 politeness/atomic props 投射 role、aria-live 与 aria-atomic，authored 子内容即为播报载荷；Async Region 通过受治理的 busy prop 投射 aria-busy 并暴露 busy state handle。两者均不声明 focus、event、 command、announcement 定时器、替换状态机或聊天语义；应用层负责在 styled Card/Badge 表面中组合 这些语义原语。
+    Live Region 与 Async Region 构成异步无障碍边界：Live Region 通过受治理的 politeness/atomic props 投射 role、aria-live 与 aria-atomic，authored 子内容即为播报载荷；Async Region 通过受治理的 busy prop 投射 aria-busy 并暴露 busy state handle。两者均不声明 focus、event、command、announcement 调度或定时、替换状态机或聊天语义；应用层负责在 styled Card/Badge 表面中组合这些语义原语。
 
 
   en: >-
-    Live Region and Async Region form the async accessibility boundary: Live Region projects role, aria-live, and aria-atomic from governed politeness/atomic props, with authored child content as the announcement payload; Async Region projects aria-busy from a governed busy prop and exposes the busy state handle. Neither declares focus, event, command, announcement timers, replacement state machines, or chat semantics; applications compose these semantic primitives inside styled Card/Badge surfaces.
+    Live Region and Async Region form the async accessibility boundary: Live Region projects role, aria-live, and aria-atomic from governed politeness/atomic props, with authored child content as the announcement payload; Async Region projects aria-busy from a governed busy prop and exposes the busy state handle. Neither declares focus, event, command, announcement scheduling, replacement state machines, or chat semantics; applications compose these semantic primitives inside styled Card/Badge surfaces.
 
 
 criteria:

--- a/spec/contracts/C-ASYNC-A11Y-0001.yaml
+++ b/spec/contracts/C-ASYNC-A11Y-0001.yaml
@@ -1,0 +1,76 @@
+id: C-ASYNC-A11Y-0001
+type: contract
+title: Async accessibility boundary contracts
+status: draft
+since: 0.2.0-rc.7
+summary: Live Region and Async Region define the narrow async accessibility boundary: governed ARIA live/atomic/busy projection without interaction, announcements, or replacement state machines.
+statement:
+  zh-CN: >-
+    Live Region 与 Async Region 构成异步无障碍边界：Live Region 通过受治理的 politeness/atomic
+    props 原子地投射 role、aria-live 与 aria-atomic，authored 子内容即为播报载荷；Async Region
+    通过受治理的 busy prop 投射 aria-busy 并暴露 busy state handle。两者均不声明 focus、event、
+    command、announcement 定时器、替换状态机或聊天语义；应用层负责在 styled Card/Badge 表面中组合
+    这些语义原语。
+  en: >-
+    Live Region and Async Region form the async accessibility boundary: Live Region atomically projects
+    role, aria-live, and aria-atomic from governed politeness/atomic props, with authored child content
+    as the announcement payload; Async Region projects aria-busy from a governed busy prop and exposes
+    the busy state handle. Neither declares focus, event, command, announcement timers, replacement
+    state machines, or chat semantics; applications compose these semantic primitives inside styled
+    Card/Badge surfaces.
+criteria:
+  - id: C-ASYNC-A11Y-0001-A
+    text:
+      zh-CN: Live Region 必须从 politeness prop 原子地推导 role 与 aria-live：polite 对应 role=status + aria-live=polite，assertive 对应 role=alert + aria-live=assertive。
+      en: Live Region must atomically derive role and aria-live from the politeness prop: polite maps to role=status + aria-live=polite, assertive maps to role=alert + aria-live=assertive.
+  - id: C-ASYNC-A11Y-0001-B
+    text:
+      zh-CN: Live Region 必须将 atomic prop 投射为 aria-atomic，默认 true，mounted prop 变更必须同步更新 role、aria-live 与 aria-atomic。
+      en: Live Region must project the atomic prop as aria-atomic, defaulting to true; mounted prop changes must update role, aria-live, and aria-atomic synchronously.
+  - id: C-ASYNC-A11Y-0001-C
+    text:
+      zh-CN: Live Region 的 authored 子内容必须作为播报载荷保留；不得声明 accessible-name override、focus、event、command 或 selection 通路。
+      en: Live Region authored child content must be preserved as the announcement payload; no accessible-name override, focus, event, command, or selection channel may be declared.
+  - id: C-ASYNC-A11Y-0001-D
+    text:
+      zh-CN: Async Region 必须将 busy prop 投射为 aria-busy，默认 false，并仅暴露受治理的 busy state handle。
+      en: Async Region must project the busy prop as aria-busy, defaulting to false, and expose only the governed busy state handle.
+  - id: C-ASYNC-A11Y-0001-E
+    text:
+      zh-CN: Async Region 不得声明 role、accessible name、loading 定时器、替换状态机、announcement、action、event、command 或聊天语义；authored 后代与焦点在 prop-only 转换中必须保留。
+      en: Async Region must declare no role, accessible name, loading timers, replacement state machine, announcements, action, event, command, or chat semantics; authored descendants and focus must be preserved on prop-only transitions.
+  - id: C-ASYNC-A11Y-0001-F
+    text:
+      zh-CN: Web adapter 必须将 a11y state key live、atomic、busy 分别投射为 aria-live、aria-atomic、aria-busy host attribute，并随 state 值变化更新。
+      en: The Web adapter must project a11y state keys live, atomic, and busy to aria-live, aria-atomic, and aria-busy host attributes respectively, updating as state values change.
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0003
+    - C-PROPS-0001
+    - C-STATE-0001
+    - C-EXPOSE-STATE-0001
+    - C-AS-HOOK-0001
+    - C-A11Y-0001
+verifies:
+  tests:
+    - T-BASE-LIVE-REGION-0001
+    - T-BASE-ASYNC-REGION-0001
+sources:
+  - path: packages/prototypes/base/src/live-region/root.proto.ts
+  - path: packages/prototypes/base/src/live-region/types.ts
+  - path: packages/prototypes/base/src/async-region/root.proto.ts
+  - path: packages/prototypes/base/src/async-region/types.ts
+  - path: packages/modules/a11y/src/web.ts
+  - path: packages/adapters/web-component/test/contract/a11y.v0.contract.test.ts
+  - path: https://www.w3.org/TR/wai-aria-1.2/
+    label: WAI-ARIA 1.2
+revisions:
+  - version: 0.2.0-rc.7
+    change: introduced
+    summary: Introduced the async accessibility boundary contract for Live Region and Async Region.
+tags:
+  - a11y
+  - accessibility
+  - live-region
+  - async-region
+  - base

--- a/spec/prototypes/P-BASE-ASYNC-REGION.yaml
+++ b/spec/prototypes/P-BASE-ASYNC-REGION.yaml
@@ -5,8 +5,14 @@ status: draft
 since: 0.2.0-rc.7
 summary: Base Async Region projects governed aria-busy state and exposes the busy handle; authored descendants and focus are preserved on prop-only transitions.
 statement:
-  zh-CN: Base Async Region 仅拥有 busy 语义：将 busy prop（默认 false）投射为 aria-busy，并暴露受治理的 busy state handle。不声明 role、accessible name、loading 定时器、替换状态机、announcement、action、event、command 或聊天语义；authored 后代与焦点在 prop-only 转换中保留。
-  en: Base Async Region owns only busy semantics: it projects the busy prop (default false) as aria-busy and exposes the governed busy state handle. No role, accessible name, loading timers, replacement state machine, announcements, action, event, command, or chat semantics are declared; authored descendants and focus are preserved on prop-only transitions.
+  zh-CN: >-
+    Base Async Region 仅拥有 busy 语义：将 busy prop（默认 false）投射为 aria-busy，并暴露受治理的 busy state handle。不声明 role、accessible name、loading 定时器、替换状态机、announcement、 action、event、command 或聊天语义；authored 后代与焦点在 prop-only 转换中保留。
+
+
+  en: >-
+    Base Async Region owns only busy semantics: it projects the busy prop (default false) as aria-busy and exposes the governed busy state handle. No role, accessible name, loading timers, replacement state machine, announcements, action, event, command, or chat semantics are declared; authored descendants and focus are preserved on prop-only transitions.
+
+
 criteria:
   - id: P-BASE-ASYNC-REGION-BUSY
     text:

--- a/spec/prototypes/P-BASE-ASYNC-REGION.yaml
+++ b/spec/prototypes/P-BASE-ASYNC-REGION.yaml
@@ -1,0 +1,45 @@
+id: P-BASE-ASYNC-REGION
+type: prototype
+title: Base Async Region protocol
+status: draft
+since: 0.2.0-rc.7
+summary: Base Async Region projects governed aria-busy state and exposes the busy handle; authored descendants and focus are preserved on prop-only transitions.
+statement:
+  zh-CN: Base Async Region 仅拥有 busy 语义：将 busy prop（默认 false）投射为 aria-busy，并暴露受治理的 busy state handle。不声明 role、accessible name、loading 定时器、替换状态机、announcement、action、event、command 或聊天语义；authored 后代与焦点在 prop-only 转换中保留。
+  en: Base Async Region owns only busy semantics: it projects the busy prop (default false) as aria-busy and exposes the governed busy state handle. No role, accessible name, loading timers, replacement state machine, announcements, action, event, command, or chat semantics are declared; authored descendants and focus are preserved on prop-only transitions.
+criteria:
+  - id: P-BASE-ASYNC-REGION-BUSY
+    text:
+      zh-CN: busy 必须默认为 false，投射为 aria-busy，并作为唯一的 exposes state handle 暴露。
+      en: busy must default to false, project as aria-busy, and be exposed as the sole exposes state handle.
+  - id: P-BASE-ASYNC-REGION-DYNAMIC
+    text:
+      zh-CN: mounted prop 变更必须同步更新 aria-busy 与 busy expose handle。
+      en: Mounted prop changes must synchronously update aria-busy and the busy expose handle.
+  - id: P-BASE-ASYNC-REGION-CONTENT
+    text:
+      zh-CN: authored 后代与焦点在 prop-only 转换中必须保留，不得被 busy 变更清除或替换。
+      en: Authored descendants and focus must be preserved on prop-only transitions and must not be cleared or replaced by busy changes.
+  - id: P-BASE-ASYNC-REGION-NO-INTERACTION
+    text:
+      zh-CN: Async Region 不得声明 role、accessible name、focus、tab stop、event、command、announcement 定时器、替换状态机或聊天语义通路。
+      en: Async Region must declare no role, accessible name, focus, tab-stop, event, command, announcement timer, replacement state machine, or chat semantics channel.
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0003
+    - C-PROPS-0001
+    - C-STATE-0001
+    - C-EXPOSE-STATE-0001
+    - C-AS-HOOK-0001
+    - C-A11Y-0001
+    - C-ASYNC-A11Y-0001
+verifies:
+  tests: [T-BASE-ASYNC-REGION-0001]
+sources:
+  - path: packages/prototypes/base/src/async-region/root.proto.ts
+  - path: packages/prototypes/base/src/async-region/types.ts
+revisions:
+  - version: 0.2.0-rc.7
+    change: introduced
+    summary: Introduced the Base Async Region protocol as a narrow async accessibility primitive.
+tags: [prototype, base, async-region, a11y]

--- a/spec/prototypes/P-BASE-LIVE-REGION.yaml
+++ b/spec/prototypes/P-BASE-LIVE-REGION.yaml
@@ -1,0 +1,52 @@
+id: P-BASE-LIVE-REGION
+type: prototype
+title: Base Live Region protocol
+status: draft
+since: 0.2.0-rc.7
+summary: Base Live Region defines governed ARIA live-region semantics (role, aria-live, aria-atomic) without interaction; authored child content is the announcement payload.
+statement:
+  zh-CN: Base Live Region 仅拥有 politeness（polite/assertive）与 atomic 语义；polite 投射 role=status + aria-live=polite，assertive 投射 role=alert + aria-live=assertive，atomic 默认 true 并投射 aria-atomic。authored 子内容为播报载荷；不声明 focus、event、command、selection 或 accessible-name override。
+  en: Base Live Region owns only politeness (polite/assertive) and atomic semantics; polite projects role=status + aria-live=polite, assertive projects role=alert + aria-live=assertive, atomic defaults true and projects aria-atomic. Authored child content is the announcement payload; no focus, event, command, selection, or accessible-name override is declared.
+criteria:
+  - id: P-BASE-LIVE-REGION-POLITENESS
+    text:
+      zh-CN: politeness 必须默认为 polite 并支持 assertive。
+      en: politeness must default to polite and support assertive.
+  - id: P-BASE-LIVE-REGION-ATOMIC
+    text:
+      zh-CN: atomic 必须默认为 true 并支持 false。
+      en: atomic must default to true and support false.
+  - id: P-BASE-LIVE-REGION-SEMANTICS
+    text:
+      zh-CN: politeness=polite 必须投射 role=status + aria-live=polite；politeness=assertive 必须投射 role=alert + aria-live=assertive；atomic 必须投射 aria-atomic。
+      en: politeness=polite must project role=status + aria-live=polite; politeness=assertive must project role=alert + aria-live=assertive; atomic must project aria-atomic.
+  - id: P-BASE-LIVE-REGION-DYNAMIC
+    text:
+      zh-CN: mounted prop 变更必须同步更新 role、aria-live 与 aria-atomic。
+      en: Mounted prop changes must synchronously update role, aria-live, and aria-atomic.
+  - id: P-BASE-LIVE-REGION-CONTENT
+    text:
+      zh-CN: authored 子内容必须作为播报载荷保留，不得被 prop 转换清除。
+      en: Authored child content must be preserved as the announcement payload and must not be cleared by prop transitions.
+  - id: P-BASE-LIVE-REGION-NO-INTERACTION
+    text:
+      zh-CN: Live Region 不得声明 focus、tab stop、event、command、activation、selection 或 accessible-name override 通路；exposes surface 必须为空。
+      en: Live Region must declare no focus, tab-stop, event, command, activation, selection, or accessible-name override channel; the exposes surface must be empty.
+dependsOn:
+  contracts:
+    - C-CORE-SYNTAX-0003
+    - C-PROPS-0001
+    - C-STATE-0001
+    - C-AS-HOOK-0001
+    - C-A11Y-0001
+    - C-ASYNC-A11Y-0001
+verifies:
+  tests: [T-BASE-LIVE-REGION-0001]
+sources:
+  - path: packages/prototypes/base/src/live-region/root.proto.ts
+  - path: packages/prototypes/base/src/live-region/types.ts
+revisions:
+  - version: 0.2.0-rc.7
+    change: introduced
+    summary: Introduced the Base Live Region protocol as a narrow async accessibility primitive.
+tags: [prototype, base, live-region, a11y]

--- a/spec/tests/T-A11Y-0001.yaml
+++ b/spec/tests/T-A11Y-0001.yaml
@@ -113,6 +113,7 @@ verifies:
         - C-A11Y-0001-L
         - C-A11Y-0001-M
     - id: C-ASYNC-A11Y-0001
+      since: 0.2.0-rc.7
       anchors:
         - C-ASYNC-A11Y-0001-F
   hostCaps:

--- a/spec/tests/T-A11Y-0001.yaml
+++ b/spec/tests/T-A11Y-0001.yaml
@@ -60,6 +60,14 @@ cases:
       - C-A11Y-0001-M
       - HC-A11Y-0001-A
     expectation: optional-web-a11y-state-removes-and-restores-host-attribute
+  - id: T-A11Y-0001-CASE-LIVE-ATOMIC-BUSY
+    title: Web adapter projects live, atomic, and busy a11y state keys to host attributes
+    covers:
+      - C-A11Y-0001-G
+      - C-ASYNC-A11Y-0001-F
+      - HC-A11Y-0001-A
+      - HC-A11Y-0001-B
+    expectation: web-a11y-live-atomic-busy-projection
 implementations:
   - id: runtime-a11y-contract
     kind: runtime-test
@@ -86,6 +94,7 @@ implementations:
       - T-A11Y-0001-CASE-ADDITIVE-RELATION
       - T-A11Y-0001-CASE-DYNAMIC-TREE
       - T-A11Y-0001-CASE-OPTIONAL-STATE
+      - T-A11Y-0001-CASE-LIVE-ATOMIC-BUSY
 verifies:
   contracts:
     - id: C-A11Y-0001
@@ -103,6 +112,9 @@ verifies:
         - C-A11Y-0001-K
         - C-A11Y-0001-L
         - C-A11Y-0001-M
+    - id: C-ASYNC-A11Y-0001
+      anchors:
+        - C-ASYNC-A11Y-0001-F
   hostCaps:
     - id: HC-A11Y-0001
       anchors:
@@ -120,7 +132,7 @@ revisions:
     summary: Added runtime coverage for state-backed semantic role projection.
   - version: 0.2.0-rc.7
     change: refined
-    summary: Added additive relation ownership, dynamic semantic tree projection, and optional Web state omission coverage.
+    summary: Added additive relation ownership, dynamic semantic tree projection, optional Web state omission, and live/atomic/busy Web projection coverage.
 tags:
   - a11y
   - accessibility

--- a/spec/tests/T-BASE-ASYNC-REGION-0001.yaml
+++ b/spec/tests/T-BASE-ASYNC-REGION-0001.yaml
@@ -1,0 +1,71 @@
+id: T-BASE-ASYNC-REGION-0001
+type: test
+title: Base Async Region behavior tests
+status: draft
+since: 0.2.0-rc.7
+summary: Web Component coverage for aria-busy projection, busy expose handle, mounted transitions, content preservation, and non-interaction.
+cases:
+  - id: T-BASE-ASYNC-REGION-0001-CASE-TYPED-BUSY
+    title: Public busy handles preserve the boolean type across exposes and state surfaces
+    covers:
+      - P-BASE-ASYNC-REGION-BUSY
+    expectation: async-region-public-handles-preserve-boolean-busy
+  - id: T-BASE-ASYNC-REGION-0001-CASE-DEFAULTS
+    title: Async Region defaults to not-busy with governed busy expose and no interaction
+    covers:
+      - P-BASE-ASYNC-REGION-BUSY
+      - P-BASE-ASYNC-REGION-NO-INTERACTION
+    expectation: not-busy-default-with-governed-busy-expose-and-no-interaction
+  - id: T-BASE-ASYNC-REGION-0001-CASE-BUSY-TRUE
+    title: busy=true projects aria-busy true
+    covers:
+      - P-BASE-ASYNC-REGION-BUSY
+    expectation: busy-true-projects-aria-busy-true
+  - id: T-BASE-ASYNC-REGION-0001-CASE-DYNAMIC-BUSY
+    title: Mounted prop transitions update aria-busy and the busy expose handle synchronously
+    covers:
+      - P-BASE-ASYNC-REGION-BUSY
+      - P-BASE-ASYNC-REGION-DYNAMIC
+    expectation: mounted-prop-transitions-update-aria-busy-and-expose-handle
+  - id: T-BASE-ASYNC-REGION-0001-CASE-CONTENT-PRESERVATION
+    title: Authored descendants and focus are preserved on prop-only transitions
+    covers:
+      - P-BASE-ASYNC-REGION-CONTENT
+      - P-BASE-ASYNC-REGION-DYNAMIC
+    expectation: authored-descendants-preserved-on-prop-only-transitions
+implementations:
+  - id: prototypes-base-async-region-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/async-region.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-ASYNC-REGION-0001-CASE-TYPED-BUSY
+      - T-BASE-ASYNC-REGION-0001-CASE-DEFAULTS
+      - T-BASE-ASYNC-REGION-0001-CASE-BUSY-TRUE
+      - T-BASE-ASYNC-REGION-0001-CASE-DYNAMIC-BUSY
+      - T-BASE-ASYNC-REGION-0001-CASE-CONTENT-PRESERVATION
+    exercises:
+      - P-BASE-ASYNC-REGION
+verifies:
+  prototypes:
+    - id: P-BASE-ASYNC-REGION
+      anchors:
+        - P-BASE-ASYNC-REGION-BUSY
+        - P-BASE-ASYNC-REGION-DYNAMIC
+        - P-BASE-ASYNC-REGION-CONTENT
+        - P-BASE-ASYNC-REGION-NO-INTERACTION
+  contracts:
+    - id: C-ASYNC-A11Y-0001
+      anchors:
+        - C-ASYNC-A11Y-0001-D
+        - C-ASYNC-A11Y-0001-E
+exercises:
+  prototypes: [P-BASE-ASYNC-REGION]
+sources:
+  - path: packages/prototypes/base/test/async-region.test.ts
+revisions:
+  - version: 0.2.0-rc.7
+    change: introduced
+    summary: Added executable Async Region protocol coverage.
+tags: [base, async-region, a11y, test]

--- a/spec/tests/T-BASE-LIVE-REGION-0001.yaml
+++ b/spec/tests/T-BASE-LIVE-REGION-0001.yaml
@@ -31,13 +31,13 @@ cases:
       - P-BASE-LIVE-REGION-SEMANTICS
     expectation: atomic-false-projects-aria-atomic-false
   - id: T-BASE-LIVE-REGION-0001-CASE-DYNAMIC-SEMANTICS
-    title: Mounted prop transitions update role, aria-live, and aria-atomic atomically
+    title: Mounted prop transitions update role, aria-live, and aria-atomic synchronously
     covers:
       - P-BASE-LIVE-REGION-POLITENESS
       - P-BASE-LIVE-REGION-ATOMIC
       - P-BASE-LIVE-REGION-SEMANTICS
       - P-BASE-LIVE-REGION-DYNAMIC
-    expectation: mounted-prop-transitions-update-all-three-attributes-atomically
+    expectation: mounted-prop-transitions-update-all-three-attributes-synchronously
   - id: T-BASE-LIVE-REGION-0001-CASE-CONTENT-PRESERVATION
     title: Authored child content is preserved as the announcement payload across prop transitions
     covers:

--- a/spec/tests/T-BASE-LIVE-REGION-0001.yaml
+++ b/spec/tests/T-BASE-LIVE-REGION-0001.yaml
@@ -1,0 +1,86 @@
+id: T-BASE-LIVE-REGION-0001
+type: test
+title: Base Live Region behavior tests
+status: draft
+since: 0.2.0-rc.7
+summary: Web Component coverage for polite/assertive role and aria-live projection, atomic projection, mounted transitions, content preservation, and non-interaction.
+cases:
+  - id: T-BASE-LIVE-REGION-0001-CASE-TYPED-POLITENESS
+    title: Public politeness type preserves the polite and assertive literal union
+    covers:
+      - P-BASE-LIVE-REGION-POLITENESS
+    expectation: live-region-public-types-preserve-politeness-literals
+  - id: T-BASE-LIVE-REGION-0001-CASE-DEFAULTS
+    title: Live Region defaults to polite status semantics with atomic true and no interaction
+    covers:
+      - P-BASE-LIVE-REGION-POLITENESS
+      - P-BASE-LIVE-REGION-ATOMIC
+      - P-BASE-LIVE-REGION-SEMANTICS
+      - P-BASE-LIVE-REGION-NO-INTERACTION
+    expectation: polite-status-with-atomic-true-and-empty-exposes
+  - id: T-BASE-LIVE-REGION-0001-CASE-ASSERTIVE
+    title: Assertive politeness projects alert role and assertive aria-live
+    covers:
+      - P-BASE-LIVE-REGION-POLITENESS
+      - P-BASE-LIVE-REGION-SEMANTICS
+    expectation: assertive-projects-alert-role-and-assertive-aria-live
+  - id: T-BASE-LIVE-REGION-0001-CASE-ATOMIC-FALSE
+    title: atomic=false projects aria-atomic false while preserving polite status semantics
+    covers:
+      - P-BASE-LIVE-REGION-ATOMIC
+      - P-BASE-LIVE-REGION-SEMANTICS
+    expectation: atomic-false-projects-aria-atomic-false
+  - id: T-BASE-LIVE-REGION-0001-CASE-DYNAMIC-SEMANTICS
+    title: Mounted prop transitions update role, aria-live, and aria-atomic atomically
+    covers:
+      - P-BASE-LIVE-REGION-POLITENESS
+      - P-BASE-LIVE-REGION-ATOMIC
+      - P-BASE-LIVE-REGION-SEMANTICS
+      - P-BASE-LIVE-REGION-DYNAMIC
+    expectation: mounted-prop-transitions-update-all-three-attributes-atomically
+  - id: T-BASE-LIVE-REGION-0001-CASE-CONTENT-PRESERVATION
+    title: Authored child content is preserved as the announcement payload across prop transitions
+    covers:
+      - P-BASE-LIVE-REGION-CONTENT
+      - P-BASE-LIVE-REGION-DYNAMIC
+    expectation: authored-content-preserved-across-prop-transitions
+implementations:
+  - id: prototypes-base-live-region-contract
+    kind: module-test
+    status: passing
+    path: packages/prototypes/base/test/live-region.test.ts
+    required: true
+    consumesCases:
+      - T-BASE-LIVE-REGION-0001-CASE-TYPED-POLITENESS
+      - T-BASE-LIVE-REGION-0001-CASE-DEFAULTS
+      - T-BASE-LIVE-REGION-0001-CASE-ASSERTIVE
+      - T-BASE-LIVE-REGION-0001-CASE-ATOMIC-FALSE
+      - T-BASE-LIVE-REGION-0001-CASE-DYNAMIC-SEMANTICS
+      - T-BASE-LIVE-REGION-0001-CASE-CONTENT-PRESERVATION
+    exercises:
+      - P-BASE-LIVE-REGION
+verifies:
+  prototypes:
+    - id: P-BASE-LIVE-REGION
+      anchors:
+        - P-BASE-LIVE-REGION-POLITENESS
+        - P-BASE-LIVE-REGION-ATOMIC
+        - P-BASE-LIVE-REGION-SEMANTICS
+        - P-BASE-LIVE-REGION-DYNAMIC
+        - P-BASE-LIVE-REGION-CONTENT
+        - P-BASE-LIVE-REGION-NO-INTERACTION
+  contracts:
+    - id: C-ASYNC-A11Y-0001
+      anchors:
+        - C-ASYNC-A11Y-0001-A
+        - C-ASYNC-A11Y-0001-B
+        - C-ASYNC-A11Y-0001-C
+exercises:
+  prototypes: [P-BASE-LIVE-REGION]
+sources:
+  - path: packages/prototypes/base/test/live-region.test.ts
+revisions:
+  - version: 0.2.0-rc.7
+    change: introduced
+    summary: Added executable Live Region protocol coverage.
+tags: [base, live-region, a11y, test]

--- a/spec/versions/V-PROTO-UI-0007.yaml
+++ b/spec/versions/V-PROTO-UI-0007.yaml
@@ -3,7 +3,7 @@ type: version
 title: Proto UI 0.2.0-rc.7
 status: draft
 since: 0.2.0-rc.7
-summary: Seventh globally exact release candidate (draft) tracking executable-artifact production for all 37 public packages, continuous-trigger-group merge boundary, and the repository-side Neo-Brutalist foundation prior to publication.
+summary: Seventh globally exact release candidate (draft) tracking executable-artifact production for all 38 public packages, continuous-trigger-group merge boundary, and the repository-side Neo-Brutalist foundation prior to publication.
 statement:
   en: Proto UI 0.2.0-rc.7 is one ecosystem release identity that will be shared exactly by every public @proto.ui package and the corresponding immutable spec snapshot once published.
   zh-CN: Proto UI 0.2.0-rc.7 是将由全部公开 @proto.ui package 与对应不可变 spec snapshot 在发布后精确共享的一次生态发行身份。


### PR DESCRIPTION
## Summary

- add protocol-first Base Live Region with governed `politeness` and `atomic` props, paired status/alert + `aria-live` projection, and authored-content preservation
- add protocol-first Base Async Region with governed `busy` projection, a readonly busy expose, and `data-busy` serialization for styled composition
- add public family subpaths and CLI facades for Web Component, React, and Vue; add bilingual docs/demos and complete C/P/T catalog evidence
- extend Web accessibility projection for `live`, `atomic`, and `busy` without adding a package to the current 38-package rc.7 BOM

## Boundary

Both primitives are passive semantic containers. They do not own focus, events, commands, selection, announcement scheduling, replacement timing, status state machines, loading visuals, or chat semantics. Async Region remains distinct from the contentless, aria-hidden Brutalist Skeleton.

Catalog direction is draft under `C-ASYNC-A11Y-0001`, `P-BASE-LIVE-REGION`, and `P-BASE-ASYNC-REGION`.

## Verification

- `corepack pnpm@10.32.1 test`: 264 files passed, 3 skipped; 1,188 tests passed, 34 todo
- `corepack pnpm@10.32.1 check:types`: 124 Astro files, 0 errors/warnings/hints
- `corepack pnpm@10.32.1 check:agent-doc`: current, 482 entities
- production docs build: 182 pages built, 180 indexed by Pagefind
- `@proto.ui/prototypes-base` build: 8-package dependency closure passed; built ESM subpath imports smoked successfully
- real `proto-ui add wc base-live-region` and `base-async-region` generation smoked successfully
- browser verification: Live Region and Async Region rendered authored children and governed ARIA/state projection across Web Component, React, and Vue demos
- release assets: rc.7, 38 packages, notes present; prototype catalog: 110 declarations, 152 static entries, 109 P entities, 0 known debt