### PR TITLE
docs(governance): establish DCO and contribution provenance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## Summary
+
+<!-- What does this PR change? -->
+
+## Related context
+
+- Issue:
+- Spec / contract / prototype entity:
+- Related upstream:
+
+## Contribution provenance
+
+Select every applicable item. Original, third-party, AI-assisted, and employer or client considerations may coexist.
+
+- [ ] This contribution was created by me and I have the right to submit it.
+- [ ] This contribution adapts or derives from third-party material.
+- [ ] This contribution includes material AI-assisted generation or transformation.
+- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
+- [ ] No third-party source disclosure is required.
+
+### Third-party or upstream sources
+
+| Source | Version / commit | License | Material used | Required attribution |
+| ------ | ---------------- | ------- | ------------- | -------------------- |
+|        |                  |         |               |                      |
+
+### AI assistance
+
+<!-- Tool or model category, scope of assistance, human review, and any third-party or private source material provided to it. Remove if not applicable. -->
+
+## DCO
+
+Every commit in this PR must contain a valid `Signed-off-by` trailer.
+
+This checkbox is only a reminder; it does not replace commit sign-off.
+
+- [ ] I have checked the DCO status of this PR.
+
+## Validation
+
+<!-- Commands, tests, screenshots, or manual verification. -->

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ node_modules
 dist
 *.min.js
 pnpm-lock.yaml
+# Verbatim legal text; formatting would alter the official DCO 1.1 copy.
+DCO.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,74 @@ If you are unsure, open an Issue first. You do not need to join [Discord](https:
 
 ---
 
+## Contribution license
+
+Proto UI is currently licensed under the [MIT License](./LICENSE). You retain the copyright in contributions you create. By submitting a contribution, you represent that you have the right to provide it under the repository's current license. This policy does not require a copyright assignment.
+
+Third-party material remains subject to its original license, attribution, notice, and other applicable requirements. Your contribution must identify and preserve those obligations.
+
+---
+
+## Developer Certificate of Origin
+
+All new contributions, including documentation and small changes, must comply with the [Developer Certificate of Origin 1.1](./DCO.md). The DCO applies to commits: every human-authored commit entering a pull request must contain a valid sign-off trailer. A pull request checkbox or comment does not replace commit sign-off, and the configured DCO GitHub App is the authoritative automated merge check.
+
+Create a signed-off commit with:
+
+```bash
+git commit --signoff -m "feat: describe the change"
+```
+
+To sign off the latest existing commit:
+
+```bash
+git commit --amend --signoff --no-edit
+git push --force-with-lease
+```
+
+To sign off multiple local commits that are not on `origin/main`:
+
+```bash
+git fetch origin
+git rebase --signoff origin/main
+git push --force-with-lease
+```
+
+A valid trailer has this form:
+
+```text
+Signed-off-by: Contributor Name <email@example.com>
+```
+
+The name and email must represent the person making the certification. A DCO sign-off is different from a cryptographic GPG or SSH commit signature. Do not copy another person's `Signed-off-by` trailer, and expect maintainers to ask you to amend your own commits rather than signing on your behalf.
+
+As an optional local convenience, you can define a repository or user-level alias yourself:
+
+```bash
+git config alias.cs "commit --signoff"
+git cs -m "feat: describe the change"
+```
+
+Proto UI does not install hooks or change contributor Git configuration to add sign-offs automatically. The sign-off must be an intentional statement by the contributor.
+
+This policy applies to contributions first submitted on or after August 2, 2026. It does not require contributors to rewrite commits that were already merged before that date.
+
+---
+
+## Contribution provenance
+
+Read the [contribution provenance policy](./internal/governance/contribution-provenance.md) before opening a pull request. Disclose material that was copied, adapted, generated, or otherwise constrained, including:
+
+- code copied or rewritten from another project;
+- third-party design systems that were referenced or ported;
+- external images, icons, fonts, test data, and documentation;
+- substantial AI-generated or AI-transformed content; and
+- contributions that an employer or client may own or restrict.
+
+Disclosure helps reviewers verify rights and required attribution; it does not by itself establish that material may be submitted. If provenance cannot be confirmed, maintainers may pause the review, request evidence, or require the material to be removed.
+
+---
+
 ## Architectural expectations
 
 - **Contracts first**: implementations should follow existing contracts. If behavior is unclear, propose updates or add contract tests.

--- a/DCO.md
+++ b/DCO.md
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/apps/www/src/content/docs/en/build/contribute.md
+++ b/apps/www/src/content/docs/en/build/contribute.md
@@ -7,6 +7,12 @@ description: 'Contribution paths, entry points, and practical advice for the cur
 
 If you're new to Proto UI, the simplest first step is to browse [Good First Issues](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — they're scoped with clear acceptance criteria. Comment on the issue before starting. If the scope or approach isn't clear, ask in [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions).
 
+## Contribution rights and provenance
+
+Proto UI accepts contributions under its current [MIT License](https://github.com/Proto-UI/Proto-UI/blob/main/LICENSE), and contributors retain copyright in original work. Every new commit, including documentation and small fixes, must carry a DCO 1.1 `Signed-off-by` trailer. Third-party or materially AI-assisted content must be disclosed so reviewers can verify its source and usage rights.
+
+The repository policies are authoritative. Read [CONTRIBUTING.md](https://github.com/Proto-UI/Proto-UI/blob/main/CONTRIBUTING.md), the verbatim [DCO 1.1](https://github.com/Proto-UI/Proto-UI/blob/main/DCO.md), and the [contribution provenance policy](https://github.com/Proto-UI/Proto-UI/blob/main/internal/governance/contribution-provenance.md) before opening a pull request.
+
 ## Choose a path
 
 ### Prototype

--- a/apps/www/src/content/docs/zh-cn/build/contribute.md
+++ b/apps/www/src/content/docs/zh-cn/build/contribute.md
@@ -7,6 +7,12 @@ description: 'Proto UI 当前阶段的贡献入口、主要路径与实践建议
 
 如果你刚接触 Proto UI，最简单的第一步是浏览 [Good First Issue](https://github.com/Proto-UI/Proto-UI/issues?q=is%3Aopen+label%3A%22good+first+issue%22)——每个 issue 都有明确的范围和验收标准。开始前先在 issue 下留言说明。如果对范围或方案不确定，到 [GitHub Discussions](https://github.com/Proto-UI/Proto-UI/discussions) 提问。
 
+## 贡献权利与来源
+
+Proto UI 按当前的 [MIT License](https://github.com/Proto-UI/Proto-UI/blob/main/LICENSE) 接受贡献，贡献者保留其原创内容的著作权。每个新提交（包括文档和小修复）都必须带有 DCO 1.1 `Signed-off-by` trailer。第三方内容和具有实质影响的 AI 辅助内容必须披露，以便 reviewer 核实来源和使用权利。
+
+仓库治理文档是详细规则的权威来源。提交 PR 前请阅读 [CONTRIBUTING.md](https://github.com/Proto-UI/Proto-UI/blob/main/CONTRIBUTING.md)、未经修改的 [DCO 1.1](https://github.com/Proto-UI/Proto-UI/blob/main/DCO.md) 和[贡献来源治理政策](https://github.com/Proto-UI/Proto-UI/blob/main/internal/governance/contribution-provenance.md)。
+
 ## 选择你的路径
 
 ### Prototype（原型）

--- a/internal/governance/contribution-provenance.md
+++ b/internal/governance/contribution-provenance.md
@@ -1,0 +1,91 @@
+# Contribution provenance policy
+
+This policy defines the source information that contributors must provide and the review steps maintainers use when contribution rights are unclear. It applies to contributions first submitted on or after August 2, 2026. It does not require rewriting Git history that was already merged before that date.
+
+The [Developer Certificate of Origin 1.1](../../DCO.md) applies to every human-authored commit in a pull request. The signer remains responsible for the submitted content. Provenance disclosure supplements the DCO; it does not replace sign-off or prove that material may be submitted.
+
+## Original contributions
+
+For an original contribution, the contributor states that they created the material and have the right to submit it under Proto UI's current [MIT License](../../LICENSE). The contributor retains copyright in their original work; Proto UI does not require copyright assignment.
+
+## Derived or ported contributions
+
+For copied, adapted, translated, generated-from, or ported material, record enough information for a reviewer to locate and evaluate the actual source:
+
+- upstream project or source name;
+- exact source location, such as a repository URL and file path;
+- upstream release, version, or commit;
+- upstream license;
+- the scope copied, transformed, or referenced;
+- the scope of the changes made for Proto UI; and
+- required `NOTICE`, attribution, or license copies.
+
+Saying only that a contribution was "inspired by" or "referenced" another project is not sufficient when implementation or assets were derived from it. If multiple sources were used, identify each source separately.
+
+## Third-party design systems
+
+For Shadcn, Brutalist, Lucide, or any other design language, component system, or resource collection, distinguish among:
+
+- observing public interaction or visual behavior without copying source material;
+- rewriting or adapting public source code;
+- copying style tokens;
+- copying icons, images, fonts, or other assets; and
+- using trademarks or brand names.
+
+Public visibility does not remove copyright, trademark, license, attribution, or notice requirements. Record the relevant upstream version and material even when the resulting Proto UI implementation is substantially modified.
+
+## AI-assisted contributions
+
+The DCO signer remains responsible for all submitted content, including AI-assisted content. Disclose AI use that had a material effect on the contribution, for example when AI:
+
+- generated a substantial portion of an implementation;
+- migrated or rewrote an implementation from another codebase;
+- generated tests, documentation, or static assets; or
+- used external material whose authorization status the contributor cannot confirm.
+
+Routine completion, spelling corrections, and localized refactoring suggestions do not require disclosure.
+
+When disclosure is required, state at least:
+
+- the tool or model category used;
+- the approximate work performed by AI;
+- the human review and validation performed; and
+- whether third-party or private code was provided to the model.
+
+AI disclosure does not establish that generated content can legally be submitted. The contributor must still identify sources, confirm rights, and satisfy applicable licenses.
+
+## Employer and client ownership
+
+Contributors are responsible for confirming whether:
+
+- their employment agreement assigns related work to an employer;
+- work created during working hours or on company equipment requires permission;
+- client-project code may be published; and
+- the contribution contains trade secrets, internal APIs, or non-public implementations.
+
+Proto UI does not routinely require an employer authorization letter for every contribution. Maintainers may request confirmation or supporting authorization when there is a reasonable ownership concern.
+
+## Unacceptable sources
+
+Proto UI will not accept:
+
+- copied code whose source cannot be determined;
+- material under a license incompatible with the repository's use;
+- proprietary code submitted without permission;
+- implementations copied from an employer's or client's internal repository;
+- material whose source cannot be explained solely because it was produced by AI; or
+- material from which author, copyright, license, or attribution information was deliberately removed.
+
+## Reviewer process
+
+When a reviewer identifies a provenance concern:
+
+1. Pause the merge without assuming malicious intent.
+2. Identify the specific material or claim that requires clarification in the pull request.
+3. Request the relevant source, license, attribution, or authorization information.
+4. When the questionable material can be isolated, ask the contributor to remove or replace it.
+5. Record material third-party sources in the appropriate `NOTICE`, package metadata, spec entity, or governance document.
+6. Do not merge if the contribution's provenance or submission rights cannot be confirmed.
+7. Add the `provenance-review` label for significant or repeated concerns.
+
+The reviewer should keep the request proportional to the concern and preserve a clear, auditable record in the pull request.


### PR DESCRIPTION
## Summary

- add the verbatim Developer Certificate of Origin 1.1 at the repository root
- define MIT inbound licensing, per-commit sign-off, provenance disclosure, and reviewer handling
- add a provenance-aware pull request template
- sync the English and Chinese public contribution entry points without duplicating the full policy
- keep DCO enforcement outside the existing GitHub Actions CI workflow

The policy applies to contributions first submitted on or after 2026-08-02 and does not require rewriting already merged history.

## Related context

- Issue: none
- Spec / contract / prototype entity: no catalog entity currently covers repository-wide contribution intake governance
- Related upstream: [Developer Certificate of Origin 1.1](https://developercertificate.org/)

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [x] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [ ] No third-party source disclosure is required.

### Third-party or upstream sources

| Source | Version / commit | License / permission | Material used | Required attribution |
| --- | --- | --- | --- | --- |
| developercertificate.org | DCO 1.1 | Verbatim copying permitted; changing is not allowed | Complete `DCO.md` text | Embedded Linux Foundation copyright and copying notice preserved verbatim |

### AI assistance

OpenAI Codex, a coding-agent/model tool, drafted and applied the repository changes from the maintainer-provided implementation plan. Codex also inspected repository governance context and ran the validation listed below. The maintainer supplied the repository workspace and the policy requirements; the official DCO text was retrieved from developercertificate.org. No private third-party code was knowingly provided. Final human review is still required before merge.

## DCO

Every commit in this PR contains a `Signed-off-by: guangliang2019 <guangliang2018@foxmail.com>` trailer.

This checkbox is only a reminder; it does not replace commit sign-off.

- [x] I have checked the DCO trailers in both commits.
- [x] The installed DCO GitHub App reported `DCO: SUCCESS` on this PR.

## Validation

- `corepack pnpm@10.32.1 exec prettier --check CONTRIBUTING.md DCO.md internal/governance/contribution-provenance.md .github/pull_request_template.md apps/www/src/content/docs/en/build/contribute.md apps/www/src/content/docs/zh-cn/build/contribute.md`
- `corepack pnpm@10.32.1 docs:build`
- `corepack pnpm@10.32.1 spec:docs:agent`
- `corepack pnpm@10.32.1 check:agent-doc`
- byte-for-byte comparison of local `DCO.md` with the official DCO 1.1 `<pre>` text: exact match (1366 bytes)
- local and projected repository link targets checked
- confirmed `.github/workflows/**` is unchanged
- live DCO App test on PR #359: the `DCO` check completed successfully for both signed-off commits

The docs build completed successfully. It emitted existing warnings about duplicate content ids, font resolution, and large chunks.

## Administrator follow-up

These settings are intentionally not implemented in repository code:

- **DCO App:** the installation is working on this PR. Keep `Proto-UI/Proto-UI` in the app's repository access scope and confirm future pull requests continue to receive the `DCO` check.
- **Web sign-off:** in repository settings, enable **Require contributors to sign off on web-based commits** so commits created in GitHub's UI can comply.
- **Required status check:** add the exact `DCO` check to the `main` ruleset's required checks. Do not substitute the existing CI workflow or a custom validator.
- Confirm the ruleset blocks merging when the `DCO` check fails or is missing.
- Create the `provenance-review` label for significant or repeated source-review concerns if it does not already exist.
