### PR TITLE
docs: remove redundant card frame around diagram

### DIFF
--- a/apps/www/src/styles/markdown.css
+++ b/apps/www/src/styles/markdown.css
@@ -194,6 +194,16 @@
     @apply leading-relaxed;
   }
 
+  /* 该 SVG 自带圆角、描边与内边距，无需外层卡片 */
+  main[data-pagefind-body]
+    .enhanced-image-wrapper:has(.enhanced-image[src$='/diagrams/information-flow-model.svg'])
+    .enhanced-image-container {
+    padding: 0;
+    border-radius: 0;
+    box-shadow: none;
+    border: none;
+  }
+
   /* 响应式调整 */
   @media (max-width: 768px) {
     main[data-pagefind-body] .enhanced-image-wrapper {
@@ -205,12 +215,6 @@
       width: calc(100vw - 4rem);
       max-width: calc(100vw - 4rem);
       margin-inline: 0;
-    }
-
-    main[data-pagefind-body]
-      .enhanced-image-wrapper:has(.enhanced-image[src$='/diagrams/information-flow-model.svg'])
-      .enhanced-image-container {
-      padding: 0.5rem;
     }
 
     main[data-pagefind-body] .enhanced-image-container {


### PR DESCRIPTION
Follow-up to #358's review feedback on image spacing.

**Problem**: the information-flow diagram was wrapped in a generic image "card" (`rounded-xl` + `shadow-lg`/`shadow-xl` + padding + border) that only had its background and border stripped for SVGs. The SVG is already self-framed — it carries its own dark gradient background, `rx="28"` rounded corners, a 2px stroke, and an internal 8px margin — so the outer layer rendered as a redundant "card around a card".

**Change** (`apps/www/src/styles/markdown.css`):
- Drop padding, border-radius, box-shadow, and border for this diagram's container on desktop (the mobile media query already treated it as a full-bleed figure, so desktop and mobile are now consistent).
- Remove the now-unneeded mobile `:has()` padding override.

**Verified**:
- `astro check`: 0 errors / 0 warnings.
- Rendered page computed styles: `padding: 0`, `border-radius: 0`, `box-shadow: none`, `border: none`; diagram renders at 672×851 flush without a halo in both light and dark themes.