### PR TITLE
chore(github): allow individual DCO remediation

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+allowRemediationCommits:
+  individual: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ Select every applicable item. Original, third-party, AI-assisted, and employer o
 
 ## DCO
 
-Every commit in this PR must contain a valid `Signed-off-by` trailer.
+Every human-authored commit in this PR must have a valid DCO sign-off. Prefer a `Signed-off-by` trailer on the commit itself; an unsigned published commit may instead be covered by an individual remediation commit from its original author.
 
 This checkbox is only a reminder; it does not replace commit sign-off.
 

--- a/internal/governance/contribution-provenance.md
+++ b/internal/governance/contribution-provenance.md
@@ -2,7 +2,28 @@
 
 This policy defines the source information that contributors must provide and the review steps maintainers use when contribution rights are unclear. It applies to contributions first submitted on or after August 2, 2026. It does not require rewriting Git history that was already merged before that date.
 
-The [Developer Certificate of Origin 1.1](../../DCO.md) applies to every human-authored commit in a pull request. The signer remains responsible for the submitted content. Provenance disclosure supplements the DCO; it does not replace sign-off or prove that material may be submitted.
+The [Developer Certificate of Origin 1.1](../../DCO.md) applies to every human-authored commit in a pull request. Each commit requires either its own valid `Signed-off-by` trailer or an individual remediation from that commit's original author as described below. The signer remains responsible for the submitted content. Provenance disclosure supplements the DCO; it does not replace sign-off or prove that material may be submitted.
+
+## Individual DCO remediation
+
+Contributors should normally add `Signed-off-by` while creating each commit, for example with `git commit -s`. When an open pull request already contains an unsigned commit, the commit's original author may add an individual remediation commit instead of rewriting published history. This preserves existing commit identities and cryptographic signatures while leaving an auditable certification in the pull request.
+
+An individual remediation commit must:
+
+- be authored by the same name and email as the unsigned commit;
+- identify every remediated commit by its full commit SHA using the exact form required by the DCO App;
+- contain a matching `Signed-off-by` trailer for the remediation commit itself; and
+- remediate only commits authored by that signer.
+
+Use one certification line per unsigned commit, followed by the remediation commit's own trailer:
+
+```text
+I, Example Author <author@example.com>, hereby add my Signed-off-by to this commit: FULL_COMMIT_SHA
+
+Signed-off-by: Example Author <author@example.com>
+```
+
+Third-party remediation remains disabled. A maintainer must not sign on behalf of another contributor, copy another contributor's trailer, or use the DCO override button as a substitute for author certification. Individual remediation is a recovery mechanism for published history, not the default contribution workflow.
 
 ## Original contributions
 


### PR DESCRIPTION
## Summary

- enable DCO App individual remediation commits while keeping third-party remediation disabled
- document the author, commit SHA, and sign-off requirements for remediation
- update the pull request template so published unsigned commits can use the governed recovery path

## Related context

- PR: #356
- Spec / contract / prototype entity: none; this is repository governance under `internal/governance/**`
- Related upstream: https://github.com/dcoapp/app#individual-remediation-commit-support

## Contribution provenance

- [x] This contribution was created by me and I have the right to submit it.
- [ ] This contribution adapts or derives from third-party material.
- [x] This contribution includes material AI-assisted generation or transformation.
- [ ] This contribution may be subject to employer or client ownership, and I have confirmed that I may submit it.
- [x] No third-party source disclosure is required.

### Third-party or upstream sources

| Source | Version / commit | License | Material used | Required attribution |
| ------ | ---------------- | ------- | ------------- | -------------------- |
| DCO App | current `main` documentation and tests | ISC | configuration key and remediation message protocol | none |

### AI assistance

Codex inspected the failing DCO check and upstream DCO App behavior, then drafted the configuration and governance wording. The maintainer selected the individual-remediation strategy. The diff was checked locally; no private or unrelated third-party code was provided to the model.

## DCO

- [x] I have checked the DCO status of this PR.

## Validation

- parsed `.github/dco.yml` with the workspace YAML parser
- `corepack pnpm@10.32.1 exec prettier --check .github/dco.yml .github/pull_request_template.md internal/governance/contribution-provenance.md`
- `git diff --check`
